### PR TITLE
wip: Highlights results

### DIFF
--- a/src/command/client/search.rs
+++ b/src/command/client/search.rs
@@ -141,7 +141,20 @@ impl Cmd {
                             .await?;
                 }
             } else {
-                super::history::print_list(&entries, list_mode, self.format.as_deref());
+                let search_mode = {
+                    if let Some(search_mode) = self.search_mode {
+                        Some(search_mode)
+                    } else {
+                        Some(settings.search_mode)
+                    }
+                };
+                super::history::print_list(
+                    &entries,
+                    list_mode,
+                    self.format.as_deref(),
+                    Some(&self.query.join(" ")),
+                    search_mode,
+                );
             }
         };
         Ok(())

--- a/src/command/client/search/interactive.rs
+++ b/src/command/client/search/interactive.rs
@@ -280,7 +280,12 @@ impl State {
         let stats = self.build_stats();
         f.render_widget(stats, header_chunks[2]);
 
-        let results_list = Self::build_results_list(compact, results);
+        let results_list = Self::build_results_list(
+            compact,
+            results,
+            self.search.input.as_str(),
+            self.search_mode,
+        );
         f.render_stateful_widget(results_list, chunks[1], &mut self.results_state);
 
         let input = self.build_input(compact, chunks[2].width.into());
@@ -337,11 +342,16 @@ impl State {
         stats
     }
 
-    fn build_results_list(compact: bool, results: &[History]) -> HistoryList {
+    fn build_results_list<'a>(
+        compact: bool,
+        results: &'a [History],
+        query: &'a str,
+        search_mode: SearchMode,
+    ) -> HistoryList<'a> {
         let results_list = if compact {
-            HistoryList::new(results)
+            HistoryList::new(results, query, search_mode)
         } else {
-            HistoryList::new(results).block(
+            HistoryList::new(results, query, search_mode).block(
                 Block::default()
                     .borders(Borders::TOP | Borders::LEFT | Borders::RIGHT)
                     .border_type(BorderType::Rounded),


### PR DESCRIPTION
Hello!
I'm opening this PR to introduce the idea and get your opinion on this!
 
~I started with the idea of highlighting the output for fzf (which I currently use), while at that, I saw that is possible to use the same strategy to highlight TUI output too. Though I'm not sure if I should keep both on the same PR.~

~What it is somewhat working right now:
`atuin search --fzf-mode QUERY | fzf --ansi`
--fzf-mode invert the order of the output (fzf style : the first line is the most relevant) and highlight the result's~
![image](https://user-images.githubusercontent.com/29334790/204063042-49dfd581-512e-4d1b-b915-94e3bcb4b736.png)

~The current tui `atuin search -i`~
![image](https://user-images.githubusercontent.com/29334790/204063107-bcb42c00-2070-4f24-aae3-f07d329ff631.png)

Update : I'm working on this again with the goal to only highlight on both tui and --cmd-only
