### PR TITLE
Bug/fix gh action aarch64 tarball

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -34,7 +34,7 @@ jobs:
       run: |
         case ${{ matrix.job.target }} in
           arm-unknown-linux-gnueabihf) sudo apt-get -y update ; sudo apt-get -y install gcc-arm-linux-gnueabihf ;;
-          aarch64-unknown-linux-gnu) sudo apt-get -y update ; sudo apt-get -y install gcc-aarch64-linux-gnu ;;
+          aarch64-unknown-linux-gnu) sudo apt-get -y update ; sudo apt-get -y install gcc-aarch64-linux-gnu qemu-user;;
           x86_64-unknown-linux-musl) sudo apt-get -y update ; sudo apt-get -y install musl-tools ;;
         esac
 
@@ -65,7 +65,11 @@ jobs:
         rustc -V
 
     - name: Build
-      run: cargo build --locked --release --target=${{ matrix.job.target }}
+      run: |
+        case ${{ matrix.job.target }} in
+          aarch64-unknown-linux-gnu) export RUSTFLAGS="-C linker=aarch64-linux-gnu-gcc";;
+        esac;
+        cargo build --locked --release --target=${{ matrix.job.target }}
 
     - name: Strip debug information from executable
       id: strip
@@ -124,9 +128,14 @@ jobs:
         # README, LICENSE and CHANGELOG files
         cp "README.md" "LICENSE" "$ARCHIVE_DIR"
 
+        QEMU_PREFIX=""
+        case ${{ matrix.job.target }} in
+          aarch64-unknown-linux-gnu) QEMU_PREFIX="qemu-aarch64 -L /usr/aarch64-linux-gnu" ;;
+        esac;
+
         # Shell completions
         for sh in 'bash' 'fish' 'zsh'; do
-          "${{ steps.strip.outputs.BIN_PATH }}" gen-completions -s $sh -o "${ARCHIVE_DIR}/completions"
+          $QEMU_PREFIX "${{ steps.strip.outputs.BIN_PATH }}" gen-completions -s $sh -o "${ARCHIVE_DIR}/completions"
         done
 
         # base compressed package


### PR DESCRIPTION


this PR is going to fix a bug that github action will not create aarch arm64 tar file correctly.

you can see the error here https://github.com/ellie/atuin/actions/runs/4584398463/jobs/8095857446
![image](https://user-images.githubusercontent.com/16236902/231742927-4ba48b30-98bc-462b-ac06-2578a761dd0e.png)

#### how to fix
 the first commit will fix this problem.  just add a RUSTFLAGS to set linker aarch64-linux-gnu-gcc
`RUSTFLAGS=-C linker=aarch64-linux-gnu-gcc`

the second commit is to bypass generate completion job because you can't run arm format on a Github hosted runner which is x86-64. we need to discuss how to fix the completion file. 

here's result:

![image](https://user-images.githubusercontent.com/16236902/231744121-d61ff3cc-2665-4d4c-bd46-5028b884d8ef.png)

FYI:

https://crates.io/crates/grb/1.3.0
https://users.rust-lang.org/t/unable-to-compile-to-aarch64-unknown-linux-gnu/53517

