### PR TITLE
Interactive delete

### DIFF
--- a/atuin-client/src/database.rs
+++ b/atuin-client/src/database.rs
@@ -385,7 +385,7 @@ impl Database for Sqlite {
             SearchMode::Prefix => sql.and_where_like_left("command", query),
             SearchMode::FullText => sql.and_where_like_any("command", query),
             SearchMode::Strict => sql.and_where_eq("command", &quote(query)),
-                _ => {
+            _ => {
                 // don't recompile the regex on successive calls!
                 lazy_static! {
                     static ref SPLIT_REGEX: Regex = Regex::new(r" +").unwrap();

--- a/atuin-client/src/database.rs
+++ b/atuin-client/src/database.rs
@@ -384,7 +384,8 @@ impl Database for Sqlite {
         match search_mode {
             SearchMode::Prefix => sql.and_where_like_left("command", query),
             SearchMode::FullText => sql.and_where_like_any("command", query),
-            _ => {
+            SearchMode::Strict => sql.and_where_eq("command", &quote(query)),
+                _ => {
                 // don't recompile the regex on successive calls!
                 lazy_static! {
                     static ref SPLIT_REGEX: Regex = Regex::new(r" +").unwrap();

--- a/atuin-client/src/settings.rs
+++ b/atuin-client/src/settings.rs
@@ -27,6 +27,9 @@ pub enum SearchMode {
     #[clap(aliases = &["fulltext"])]
     FullText,
 
+    #[serde(rename = "strict")]
+    Strict,
+
     #[serde(rename = "fuzzy")]
     Fuzzy,
 
@@ -39,6 +42,7 @@ impl SearchMode {
         match self {
             SearchMode::Prefix => "PREFIX",
             SearchMode::FullText => "FULLTXT",
+            SearchMode::Strict => "STRICT",
             SearchMode::Fuzzy => "FUZZY",
             SearchMode::Skim => "SKIM",
         }
@@ -50,6 +54,7 @@ impl SearchMode {
             SearchMode::FullText if settings.search_mode == SearchMode::Skim => SearchMode::Skim,
             // otherwise fuzzy.
             SearchMode::FullText => SearchMode::Fuzzy,
+            SearchMode::Strict => SearchMode::Strict,
             SearchMode::Fuzzy | SearchMode::Skim => SearchMode::Prefix,
         }
     }

--- a/atuin/src/command/client/search/interactive.rs
+++ b/atuin/src/command/client/search/interactive.rs
@@ -614,7 +614,7 @@ pub async fn history(
             let query = &history
                 .command
                 .split(' ')
-                .map(|e| e.to_owned())
+                .map(std::borrow::ToOwned::to_owned)
                 .collect::<Vec<String>>();
 
             let mut entries =


### PR DESCRIPTION
closes #854 

This implements if you press `Alt + d` on a entry. It will delete all of the entries matching that exactly.
> Note: this keybinding is subject to comments and change. 

To do this I added a `Strict` search mode. 

Todo:
- [ ] Add some sort of confirmation
- [ ] Only enable when deletion is enabled
- [ ] Improve ui (should not exit when after deletion)