### PR TITLE
Use alpine as base for Docker image

### DIFF
--- a/docs/docs/self-hosting/docker.md
+++ b/docs/docs/self-hosting/docker.md
@@ -24,8 +24,9 @@ Create a `docker-compose.yml`:
 version: '3.5'
 services:
   atuin:
-    restart: always
     image: ghcr.io/atuinsh/atuin:main
+    restart: always
+    user: ${UID:-1000}:${GID:-1000}
     command: server start
     volumes:
       - "./config:/config"
@@ -38,8 +39,9 @@ services:
       ATUIN_OPEN_REGISTRATION: "true"
       ATUIN_DB_URI: postgres://$ATUIN_DB_USERNAME:$ATUIN_DB_PASSWORD@db/atuin
   postgresql:
-    image: postgres:14
-    restart: unless-stopped
+    image: postgres:14-alpine
+    restart: always
+    user: ${UID:-1000}:${GID:-1000}
     volumes: # Don't remove permanent storage for index database files!
       - "./database:/var/lib/postgresql/data/"
     environment:


### PR DESCRIPTION
Alpine based images are 35mb while debian:bullseye-20230502-slim is 135mb. 

Docker-compose could use postgres:14-alpine for another reduction in size. 

Also added UID/GID to the docker-compose. This is a best practice. Otherwise the container will run with whatever user is running docker, which could be root. The Dockerfile was also modified to run with a user/group of 1000/1000 which also seems to be a common practice. (Ideally, the perms would be fixed as part of the entrypoint/cwd at runtime as well, to match the env vars, but I didn't do that) 