### PR TITLE
Enable multiple command stats to be shown

### DIFF
--- a/atuin/src/command/client/stats.rs
+++ b/atuin/src/command/client/stats.rs
@@ -286,4 +286,12 @@ mod tests {
             ["foo ", " bar baz \\| quux"]
         );
     }
+
+    #[test]
+    fn emoji() {
+        assert_eq!(
+            split_at_pipe("git commit -m \"🚀\""),
+            ["git commit -m \"🚀\""]
+        );
+    }
 }


### PR DESCRIPTION
These changes extend the `stats` subcommand with an `--ngram-size` argument, which supports providing statistics for combinations of commands. I have found this useful for identifying the most common combinations of commands as candidates for further automation.