### PR TITLE
Add support for `max_preview_height` setting

### DIFF
--- a/atuin-client/src/settings.rs
+++ b/atuin-client/src/settings.rs
@@ -151,6 +151,7 @@ pub struct Settings {
     pub inline_height: u16,
     pub invert: bool,
     pub show_preview: bool,
+    pub max_preview_height: u16,
     pub show_help: bool,
     pub exit_mode: ExitMode,
     pub word_jump_mode: WordJumpMode,
@@ -358,6 +359,7 @@ impl Settings {
             .set_default("style", "auto")?
             .set_default("inline_height", 0)?
             .set_default("show_preview", false)?
+            .set_default("max_preview_height", 4)?
             .set_default("show_help", true)?
             .set_default("invert", false)?
             .set_default("exit_mode", "return-original")?

--- a/atuin/src/command/client/search/interactive.rs
+++ b/atuin/src/command/client/search/interactive.rs
@@ -288,7 +288,10 @@ impl State {
                     settings.max_preview_height,
                     v.command
                         .split('\n')
-                        .map(|line| (line.len() as u16 + preview_width - 1 - border_size) / (preview_width - border_size))
+                        .map(|line| {
+                            (line.len() as u16 + preview_width - 1 - border_size)
+                                / (preview_width - border_size)
+                        })
                         .sum(),
                 )
             }) + border_size * 2
@@ -475,13 +478,15 @@ impl State {
         } else {
             use itertools::Itertools as _;
             let s = &results[selected].command;
-            s.split('\n').flat_map(|line|
-                line.char_indices()
-                    .step_by(preview_width.into())
-                    .map(|(i, _)| i)
-                    .chain(Some(line.len()))
-                    .tuple_windows()
-                    .map(|(a, b)| &line[a..b]))
+            s.split('\n')
+                .flat_map(|line| {
+                    line.char_indices()
+                        .step_by(preview_width.into())
+                        .map(|(i, _)| i)
+                        .chain(Some(line.len()))
+                        .tuple_windows()
+                        .map(|(a, b)| &line[a..b])
+                })
                 .join("\n")
         };
         let preview = if compact {

--- a/atuin/src/command/client/search/interactive.rs
+++ b/atuin/src/command/client/search/interactive.rs
@@ -285,9 +285,11 @@ impl State {
                 .max_by(|h1, h2| h1.command.len().cmp(&h2.command.len()));
             longest_command.map_or(0, |v| {
                 std::cmp::min(
-                    4,
-                    (v.command.len() as u16 + preview_width - 1 - border_size)
-                        / (preview_width - border_size),
+                    settings.max_preview_height,
+                    v.command
+                        .split('\n')
+                        .map(|line| (line.len() as u16 + preview_width - 1 - border_size) / (preview_width - border_size))
+                        .sum(),
                 )
             }) + border_size * 2
         } else if compact {
@@ -473,12 +475,13 @@ impl State {
         } else {
             use itertools::Itertools as _;
             let s = &results[selected].command;
-            s.char_indices()
-                .step_by(preview_width.into())
-                .map(|(i, _)| i)
-                .chain(Some(s.len()))
-                .tuple_windows()
-                .map(|(a, b)| &s[a..b])
+            s.split('\n').flat_map(|line|
+                line.char_indices()
+                    .step_by(preview_width.into())
+                    .map(|(i, _)| i)
+                    .chain(Some(line.len()))
+                    .tuple_windows()
+                    .map(|(a, b)| &line[a..b]))
                 .join("\n")
         };
         let preview = if compact {

--- a/docs/docs/config/config.md
+++ b/docs/docs/config/config.md
@@ -196,6 +196,14 @@ Configure whether or not to show a preview of the selected command.
 
 Useful when the command is longer than the terminal width and is cut off.
 
+### `max_preview_height`
+
+Configure the maximum height of the preview to show.
+
+Useful when you have long scripts in your history that you want to distinguish by more than the first few lines.
+
+Defaults to `4`.
+
 ### `show_help`
 
 Configure whether or not to show the help row, which includes the current Atuin version (and whether an update is available), a keymap hint, and the total amount of commands in your history.


### PR DESCRIPTION
This allows for more configuration around `show_preview`, specifically in the case where someone has shell commands spanning more than 4 lines in their history and need to differentiate between them with something other than the first few lines.

This change makes the following supporting changes:

- Update the preview renderer to split _lines_ when they go past the preview width, rather than splitting the whole string - this means that the preview is cleanly rendered even in cases where there are newlines
- Update the preview height size calculator to take into account existing newlines

A couple of other notes here:
- I've never written rust before, so very open to being told I've done something iffy here
- I think this strips out empty lines from the preview - I'm not sure the best way to fix it given my lack of Rust experience, but given that any more than 4 lines was cut off before, I'm not sure there'll be any visible regression

# Screenshots

```toml
style = "compact"
show_preview = true
max_preview_height = 6
```

## Short command with longer commands in history

![image](https://github.com/ellie/atuin/assets/4550158/9935215a-4dd6-43e8-a3ec-d4e4fcf05e6c)

## Long command, longer than `4` lines but shorter than `max_preview_height`

![image](https://github.com/ellie/atuin/assets/4550158/0290ab7f-ecc3-4ed5-b9f2-2e4c4b835f07)

## Longest command in history, longer than `max_preview_height`

![image](https://github.com/ellie/atuin/assets/4550158/b4de9f0d-8bbe-44d0-8968-a7a7a7d8a618)

-----

```toml
style = "full"
show_preview = true
max_preview_height = 6
```

## Short command with longer commands in history

![image](https://github.com/ellie/atuin/assets/4550158/6c768d93-1821-463c-bdca-e567cbb71786)

## Long command, longer than `4` lines but shorter than `max_preview_height`

![image](https://github.com/ellie/atuin/assets/4550158/1f40b7e8-db59-4b28-8e92-43899e46c0db)

## Longest command in history, longer than `max_preview_height`

![image](https://github.com/ellie/atuin/assets/4550158/8052284b-cef0-4ac7-ad59-1454e645c4e2)