### PR TITLE
fix(server): Teapot is a cup of coffee

### DIFF
--- a/atuin-server/src/router.rs
+++ b/atuin-server/src/router.rs
@@ -53,7 +53,7 @@ where
 }
 
 async fn teapot() -> impl IntoResponse {
-    (http::StatusCode::IM_A_TEAPOT, "☕")
+    (http::StatusCode::IM_A_TEAPOT, "🫖")
 }
 
 #[derive(Clone)]


### PR DESCRIPTION
The fallback route handler `teapot()` responded with `HTTP 418` responses with an invalid response body "`☕`".

This PR fixes this urgent issue by replacing the response body with an actual teapot "`🫖`".