### PR TITLE
rebase: fix: nushell empty hooks

### DIFF
--- a/atuin/src/shell/atuin.nu
+++ b/atuin/src/shell/atuin.nu
@@ -35,10 +35,14 @@ def _atuin_search_cmd [...flags: string] {
     ] | str join "\n"
 }
 
+$env.config = ($env | default {} config).config
+$env.config = ($env.config | default {} hooks)
 $env.config = (
     $env.config | upsert hooks (
         $env.config.hooks
-        | upsert pre_execution ($env.config.hooks.pre_execution | append $_atuin_pre_execution)
-        | upsert pre_prompt ($env.config.hooks.pre_prompt | append $_atuin_pre_prompt)
+        | upsert pre_execution (
+            $env.config.hooks | get -i pre_execution | default [] | append $_atuin_pre_execution)
+        | upsert pre_prompt (
+            $env.config.hooks | get -i pre_prompt | default [] | append $_atuin_pre_prompt)
     )
 )


### PR DESCRIPTION
Fixes https://github.com/atuinsh/atuin/issues/928.

This is a rebase of https://github.com/atuinsh/atuin/pull/929 on top of `main`, resolving conflicts with the changes at https://github.com/atuinsh/atuin/pull/1080/files 