### PR TITLE
fix(docs): List all presently documented commands

### DIFF
--- a/docs/docs/commands/commands.md
+++ b/docs/docs/commands/commands.md
@@ -2,4 +2,11 @@
 title: Commands
 ---
 
-- [`atuin import`](../../docs/commands/import)
+- [`atuin import`](../../docs/commands/import): Import shell history from file
+- [`atuin history list`](../../docs/commands/list): List all items in history
+- [`atuin search`](../../commands/search): Interactive history search
+- [`atuin server`](../../commands/server): Start an atuin server
+- [`atuin gen-completions`](../../commands/shell-completions): Generate shell completions
+- [`atuin stats`](../../commands/stats): Calculate statistics for your history
+- [`atuin sync`](../../commands/sync): Sync with the configured server
+


### PR DESCRIPTION
This PR adds the remaining (presently existing) sub-pages with command descriptions to the menu / commands overview list at https://atuin.sh/docs/commands/ 

There's a whole bunch of commands not documented at yet, but this is a start! 

Fixes https://github.com/atuinsh/atuin/issues/1139