### PR TITLE
Fix index tail leak

### DIFF
--- a/atuin-server-postgres/src/lib.rs
+++ b/atuin-server-postgres/src/lib.rs
@@ -437,7 +437,7 @@ impl Database for Postgres {
     }
 
     async fn tail_records(&self, user: &User) -> DbResult<RecordIndex> {
-        const TAIL_RECORDS_SQL: &str = "select host, tag, client_id from records rp where (select count(1) from records where parent=rp.client_id and user_id = $1) = 0;";
+        const TAIL_RECORDS_SQL: &str = "select host, tag, client_id from records rp where (select count(1) from records where parent=rp.client_id and user_id = $1) = 0 and user_id = $1;";
 
         let res = sqlx::query_as(TAIL_RECORDS_SQL)
             .bind(user.id)


### PR DESCRIPTION
Under some sync circumstances, the record tails were being listed for other users. Beyond the existence of the tail, no data leaked

1. When actually trying to fetch the record, the server responds with a 401
2. Even if the above was not true, the client would not be able to decrypt the data

Tldr is that the index was not permissioned 100% correctly, but now is