### PR TITLE
Remove terminal mode switching

### DIFF
--- a/atuin/src/shell/atuin.bash
+++ b/atuin/src/shell/atuin.bash
@@ -16,10 +16,8 @@ _atuin_precmd() {
 }
 
 __atuin_history() {
-    tput rmkx
     # shellcheck disable=SC2048,SC2086
     HISTORY="$(RUST_LOG=error atuin search $* -i -- "${READLINE_LINE}" 3>&1 1>&2 2>&3)"
-    tput smkx
 
     READLINE_LINE=${HISTORY}
     READLINE_POINT=${#READLINE_LINE}

--- a/atuin/src/shell/atuin.zsh
+++ b/atuin/src/shell/atuin.zsh
@@ -30,13 +30,10 @@ _atuin_search() {
     emulate -L zsh
     zle -I
 
-    # Switch to cursor mode, then back to application
-    echoti rmkx
     # swap stderr and stdout, so that the tui stuff works
     # TODO: not this
     # shellcheck disable=SC2048
     output=$(RUST_LOG=error atuin search $* -i -- $BUFFER 3>&1 1>&2 2>&3)
-    echoti smkx
 
     if [[ -n $output ]]; then
         RBUFFER=""


### PR DESCRIPTION
This was initially in place for when we used a different terminal backend. That backend required that the terminal be in a specific mode, or otherwise key modifiers would not be correctly recognized. It was super frustrating.

Since the move to crossterm, we automatically switch to raw mode: https://github.com/atuinsh/atuin/blob/b48de9bd9d89fb9b6a0044a1b251e5b2ff116387/atuin/src/command/client/search/interactive.rs#L528

Should resolve #987, #650, #909, #492, #996

Should also supercede #1149