### PR TITLE
Fix keybinding link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ I wanted to. And I **really** don't want to.
 - [Cloud history sync](https://atuin.sh/docs/commands/sync)
 - [History stats](https://atuin.sh/docs/commands/stats)
 - [Self host Atuin server](https://atuin.sh/docs/self-hosting)
-- [Key binding](https://atuin.sh/docs/config/key-binding)
+- [Key binding](https://atuin.sh/docs/key-binding)
 - [Shell completions](https://atuin.sh/docs/commands/shell-completions)
 
 ## Supported Shells


### PR DESCRIPTION
Hello! This was pointing to the wrong (maybe an old?) location.