### PR TITLE
Automatically filter out secrets

### DIFF
--- a/atuin-client/src/lib.rs
+++ b/atuin-client/src/lib.rs
@@ -15,4 +15,5 @@ pub mod import;
 pub mod kv;
 pub mod ordering;
 pub mod record;
+pub mod secrets;
 pub mod settings;

--- a/atuin-client/src/secrets.rs
+++ b/atuin-client/src/secrets.rs
@@ -1,0 +1,54 @@
+// This file will probably trigger a lot of scanners. Sorry.
+
+// A list of (name, regex, test), where test should match against regex
+pub static SECRET_PATTERNS: &[(&str, &str, &str)] = &[
+    (
+        "AWS Access Key ID",
+        "AKIA[0-9A-Z]{16}",
+        "AKIAIOSFODNN7EXAMPLE",
+    ),
+    (
+        "GitHub PAT (old)",
+        "^ghp_[a-zA-Z0-9]{36}$",
+        "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", // legit, I expired it
+    ),
+    (
+        "GitHub PAT (new)",
+        "^github_pat_[a-zA-Z0-9]{22}_[a-zA-Z0-9]{59}$",
+        "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", // also legit, also expired
+    ),
+    (
+        "Slack OAuth v2 bot",
+        "xoxb-[0-9]{11}-[0-9]{11}-[0-9a-zA-Z]{24}",
+        "xoxb-17653672481-19874698323-pdFZKVeTuE8sk7oOcBrzbqgy",
+    ),
+    (
+        "Slack OAuth v2 user token",
+        "xoxp-[0-9]{11}-[0-9]{11}-[0-9a-zA-Z]{24}",
+        "xoxp-17653672481-19874698323-pdFZKVeTuE8sk7oOcBrzbqgy",
+    ),
+    (
+        "Slack webhook",
+        "T[a-zA-Z0-9_]{8}/B[a-zA-Z0-9_]{8}/[a-zA-Z0-9_]{24}",
+        "https://hooks.slack.com/services/T00000000/B00000000/XXXXXXXXXXXXXXXXXXXXXXXX",
+    ),
+    ("Stripe test key", "sk_test_[0-9a-zA-Z]{24}", "sk_test_1234567890abcdefghijklmnop"),
+    ("Stripe live key", "sk_live_[0-9a-zA-Z]{24}", "sk_live_1234567890abcdefghijklmnop"),
+];
+
+#[cfg(test)]
+mod tests {
+    use regex::Regex;
+
+    use crate::secrets::SECRET_PATTERNS;
+
+    #[test]
+    fn test_secrets() {
+        for (name, regex, test) in SECRET_PATTERNS {
+            let re =
+                Regex::new(regex).expect(format!("Failed to compile regex for {name}").as_str());
+
+            assert!(re.is_match(test), "{name} test failed!");
+        }
+    }
+}

--- a/atuin/src/command/client/history.rs
+++ b/atuin/src/command/client/history.rs
@@ -191,16 +191,9 @@ impl Cmd {
     ) -> Result<()> {
         let command = command.join(" ");
 
-        if command.starts_with(' ') || settings.history_filter.is_match(&command) {
-            return Ok(());
-        }
-
         // It's better for atuin to silently fail here and attempt to
         // store whatever is ran, than to throw an error to the terminal
         let cwd = utils::get_current_dir();
-        if !cwd.is_empty() && settings.cwd_filter.is_match(&cwd) {
-            return Ok(());
-        }
 
         let h: History = History::capture()
             .timestamp(chrono::Utc::now())
@@ -208,6 +201,10 @@ impl Cmd {
             .cwd(cwd)
             .build()
             .into();
+
+        if !h.should_save(settings) {
+            return Ok(());
+        }
 
         // print the ID
         // we use this as the key for calling end

--- a/docs/docs/config/config.md
+++ b/docs/docs/config/config.md
@@ -250,6 +250,20 @@ history_filter = [
 ]
 ```
 
+### secrets_filter
+
+```
+secrets_filter = true
+```
+
+Defaults to true. This matches history against a set of default regex, and will not save it if we get a match. Defaults include
+
+1. AWS key id
+2. Github pat (old and new)
+3. Slack oauth tokens (bot, user)
+4. Slack webhooks
+5. Stripe live/test keys
+
 ## macOS <kbd>Ctrl-n</kbd> key shortcuts
 
 macOS does not have an <kbd>Alt</kbd> key, although terminal emulators can often be configured to map the <kbd>Option</kbd> key to be used as <kbd>Alt</kbd>. *However*, remapping <kbd>Option</kbd> this way may prevent typing some characters, such as using <kbd>Option-3</kbd> to type `#` on the British English layout. For such a scenario, set the `ctrl_n_shortcuts` option to `true` in your config file to replace <kbd>Alt-0</kbd> to <kbd>Alt-9</kbd> shortcuts with <kbd>Ctrl-0</kbd> to <kbd>Ctrl-9</kbd> instead:


### PR DESCRIPTION
I'd like to extend the regex list here very soon, but start off by automatically filtering out secrets. Do not store them in history!

I've included regex for:

1. AWS key id
2. Github pat (old and new)
3. Slack oauth tokens (bot, user)
4. Slack webhooks
5. Stripe live/test keys

#806 will need rebasing