### PR TITLE
Use `case` for Linux distro choice in `install.sh`

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -92,14 +92,15 @@ __atuin_install_linux(){
   else
     OS=$(lsb_release -i | awk '{ print $3 }' | tr '[:upper:]' '[:lower:]')
   fi
-	if [ "$OS" == "arch" ] || [ "$OS" == "manjarolinux" ] || [ "$OS" == "endeavouros" ]; then
-		__atuin_install_arch
-  elif [ "$OS" == "ubuntu" ] || [ "$OS" == "ubuntuwsl" ] || [ "$OS" == "debian" ] || [ "$OS" == "linuxmint" ] || [ "$OS" == "parrot" ] || [ "$OS" == "kali" ] || [ "$OS" == "elementary" ] || [ "$OS" == "pop" ]; then
-		__atuin_install_ubuntu
-	else
-		# TODO: download a binary or smth
-		__atuin_install_unsupported
-	fi
+	case "$OS" in
+		"arch" | "manjarolinux" | "endeavouros")
+			__atuin_install_arch;;
+		"ubuntu" | "ubuntuwsl" | "debian" | "linuxmint" | "parrot" | "kali" | "elementary" | "pop")
+			__atuin_install_ubuntu;;
+		*)
+			# TODO: download a binary or smth
+			__atuin_install_unsupported;;
+	esac
 }
 
 __atuin_install_mac(){


### PR DESCRIPTION
Just a small stylistic cleanup. I was looking inside `install.sh` and spotted this `if` which can be less noisy as a `case`.