### PR TITLE
Explicitly use buster image for cargo-chef, mitigates #1204

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM lukemathwalker/cargo-chef:latest-rust-1.72.0 AS chef
+FROM lukemathwalker/cargo-chef:latest-rust-1.72.0-buster AS chef
 WORKDIR app
 
 FROM chef AS planner


### PR DESCRIPTION
This mitigates #1204 but isn't really a permanent fix.