### PR TITLE
docs: document the available format options of History list command

### DIFF
--- a/atuin/src/command/client/history.rs
+++ b/atuin/src/command/client/history.rs
@@ -51,7 +51,7 @@ pub enum Cmd {
         #[arg(long)]
         cmd_only: bool,
 
-        /// Available variables: {command}, {directory}, {duration}, {user}, {host} and {time}.
+        /// Available variables: {command}, {directory}, {duration}, {user}, {host}, {exit} and {time}.
         /// Example: --format "{time} - [{duration}] - {directory}$\t{command}"
         #[arg(long, short)]
         format: Option<String>,


### PR DESCRIPTION
Adding {exit} to available History List command format options. Although implemented, it was not shown in the Help Screen. 
#1230 
```
atuin history list --help
List all items in history

Usage: atuin history list [OPTIONS]

Options:
  -c, --cwd
  -s, --session
      --human
      --cmd-only         Show only the text of the command
  -f, --format <FORMAT>  Available variables: {command}, {directory}, {duration}, {user}, {host}, {exit} and {time}. Example: --format "{time} - [{duration}] - {directory}$\t{command}"
  -h, --help             Print help
```
```
atuin history list --format '{directory}\t{command}\t{exit}'
/home cargo install --path . --target-dir target	0
/home atuin history list --help	0
```

