### PR TITLE
Fix selecting complex fish commands

### DIFF
--- a/atuin/src/shell/atuin.fish
+++ b/atuin/src/shell/atuin.fish
@@ -18,7 +18,7 @@ function _atuin_search
     set h (RUST_LOG=error atuin search $argv -i -- (commandline -b) 3>&1 1>&2 2>&3)
     commandline -f repaint
     if test -n "$h"
-        commandline -r $h
+        commandline -r "$h"
     end
 end
 


### PR DESCRIPTION
This was failing for commands that spanned multiple lines, and contained a backslash.

Thanks to @saulrh for suggesting the fix! I just tested and pushed it.

Resolves #1211
Resolves #1232