### PR TITLE
handle missing entries (fixes #1236)

### DIFF
--- a/atuin-client/src/history.rs
+++ b/atuin-client/src/history.rs
@@ -210,9 +210,11 @@ mod tests {
     // Test that we don't save history where necessary
     #[test]
     fn privacy_test() {
-        let mut settings = Settings::default();
-        settings.cwd_filter = RegexSet::new(["^/supasecret"]).unwrap();
-        settings.history_filter = RegexSet::new(["^psql"]).unwrap();
+        let settings = Settings {
+            cwd_filter: RegexSet::new(["^/supasecret"]).unwrap(),
+            history_filter: RegexSet::new(["^psql"]).unwrap(),
+            ..Settings::default()
+        };
 
         let normal_command: History = History::capture()
             .timestamp(time::OffsetDateTime::now_utc())
@@ -258,8 +260,10 @@ mod tests {
 
     #[test]
     fn disable_secrets() {
-        let mut settings = Settings::default();
-        settings.secrets_filter = false;
+        let settings = Settings {
+            secrets_filter: false,
+            ..Settings::default()
+        };
 
         let stripe_key: History = History::capture()
             .timestamp(time::OffsetDateTime::now_utc())

--- a/atuin-client/src/secrets.rs
+++ b/atuin-client/src/secrets.rs
@@ -46,7 +46,7 @@ mod tests {
     fn test_secrets() {
         for (name, regex, test) in SECRET_PATTERNS {
             let re =
-                Regex::new(regex).expect(format!("Failed to compile regex for {name}").as_str());
+                Regex::new(regex).unwrap_or_else(|_| panic!("Failed to compile regex for {name}"));
 
             assert!(re.is_match(test), "{name} test failed!");
         }

--- a/atuin-client/src/sync.rs
+++ b/atuin-client/src/sync.rs
@@ -109,7 +109,7 @@ async fn sync_download(
     for i in remote_status.deleted {
         // we will update the stored history to have this data
         // pretty much everything can be nullified
-        if let Ok(h) = db.load(i.as_str()).await {
+        if let Some(h) = db.load(i.as_str()).await? {
             db.delete(h).await?;
         } else {
             info!(


### PR DESCRIPTION
`atuin history end` errors if the ID doesn't exist. This can happen if the user changes their database setting mid-command.

Fix: ignore these errors, and log a warning.
Additional: Removes all potential missing entry database queries and handles the options appropriately