### PR TITLE
Add --print0 to `history list`

### DIFF
--- a/atuin/src/command/client/history.rs
+++ b/atuin/src/command/client/history.rs
@@ -311,6 +311,7 @@ impl Cmd {
     }
 
     #[allow(clippy::too_many_arguments)]
+    #[allow(clippy::fn_params_excessive_bools)]
     async fn handle_list(
         db: &mut impl Database,
         settings: &Settings,

--- a/atuin/src/command/client/search.rs
+++ b/atuin/src/command/client/search.rs
@@ -169,7 +169,13 @@ impl Cmd {
                             .await?;
                 }
             } else {
-                super::history::print_list(&entries, list_mode, self.format.as_deref(), true);
+                super::history::print_list(
+                    &entries,
+                    list_mode,
+                    self.format.as_deref(),
+                    false,
+                    true,
+                );
             }
         };
         Ok(())


### PR DESCRIPTION
Adding this enables tools like fzf to handle multiline commands, in the
same way that `find -print0 | fzf --read0` does.

I'm happy to add documentation and changelog entries to this as suits you; just
let me know where to put them.