### PR TITLE
Re-enable `linux/arm64` platform in CI docker build

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -54,7 +54,7 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          platforms: linux/amd64 #,linux/arm64
+          platforms: linux/amd64,linux/arm64
           cache-from: type=gha
           cache-to: type=gha,mode=max
           build-args: RUST_BACKTRACE=1


### PR DESCRIPTION
This was previously enabled in #616 and then reverted in #730.

The `ghcr.io/atuinsh/atuin:main` docker image doesn't provide an arm variant, making it harder to self-host on arm using docker.