### PR TITLE
Revert "Re-enable `linux/arm64` platform in CI docker build"

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -54,7 +54,7 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/amd64 #,linux/arm64
           cache-from: type=gha
           cache-to: type=gha,mode=max
           build-args: RUST_BACKTRACE=1


### PR DESCRIPTION
Reverts atuinsh/atuin#1276

Sorry, this is taking more than an hour to build. I'll pay for + setup a ARM machine for the next release, but it's pretty untenable as is