### PR TITLE
Use github runners for unit tests (for now)

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -42,7 +42,8 @@ jobs:
       run: cargo build --all --locked --release && strip target/release/atuin
 
   unit-test:
-    runs-on: [self-hosted, ARM64, macOS]
+    #runs-on: [self-hosted, ARM64, macOS]
+    runs-on: ubuntu-latest
 
     steps:
     - uses: actions/checkout@v3


### PR DESCRIPTION
My self hosted runner is much faster, but my house was hit by lightning and the internet is down. I'm a few thousand miles away atm so won't be able to sort it for a while.

Tests broken by _nature_.