### PR TITLE
Fix bogus error message

### DIFF
--- a/crates/atuin-client/src/encryption.rs
+++ b/crates/atuin-client/src/encryption.rs
@@ -140,7 +140,7 @@ pub fn decrypt(mut encrypted_history: EncryptedHistory, key: &Key) -> Result<His
             &[],
             &mut encrypted_history.ciphertext,
         )
-        .map_err(|_| eyre!("could not encrypt"))?;
+        .map_err(|_| eyre!("could not decrypt history"))?;
     let plaintext = encrypted_history.ciphertext;
 
     let history = decode(&plaintext)?;


### PR DESCRIPTION
This PR is related to #1199, but does *not* fix it. It only corrects the error message: the operation is an attempt to decrypt and is failing, but the error thrown says something about encrypting. Whatever is causing the error remanis unresolved, but at least the confusing/contradictory message can be fixed.