### PR TITLE
Revert "Use github runners for unit tests (for now)"

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -42,8 +42,7 @@ jobs:
       run: cargo build --all --locked --release && strip target/release/atuin
 
   unit-test:
-    #runs-on: [self-hosted, ARM64, macOS]
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, ARM64, macOS]
 
     steps:
     - uses: actions/checkout@v3


### PR DESCRIPTION
Reverts atuinsh/atuin#1279

Brought my runner back online woohoo