### PR TITLE
Add enter_accept to immediately execute an accepted command

### DIFF
--- a/atuin-client/config.toml
+++ b/atuin-client/config.toml
@@ -123,3 +123,7 @@
 ## 4. Slack webhooks
 ## 5. Stripe live/test keys
 # secrets_filter = true
+
+## Defaults to true. If enabled, upon hitting enter Atuin will immediately execute the command. Press tab to return to the shell and edit.
+# This applies for new installs. Old installs will keep the old behaviour unless configured otherwise.
+enter_accept = true

--- a/atuin-client/src/settings.rs
+++ b/atuin-client/src/settings.rs
@@ -359,8 +359,8 @@ impl Settings {
             .set_default("sync_frequency", "10m")?
             .set_default("search_mode", "fuzzy")?
             .set_default("filter_mode", "global")?
-            .set_default("style", "compact")?
-            .set_default("inline_height", 40)?
+            .set_default("style", "auto")?
+            .set_default("inline_height", 0)?
             .set_default("show_preview", false)?
             .set_default("max_preview_height", 4)?
             .set_default("show_help", true)?

--- a/atuin-client/src/settings.rs
+++ b/atuin-client/src/settings.rs
@@ -179,6 +179,7 @@ pub struct Settings {
 
     pub network_connect_timeout: u64,
     pub network_timeout: u64,
+    pub enter_accept: bool,
 
     // This is automatically loaded when settings is created. Do not set in
     // config! Keep secrets and settings apart.
@@ -358,8 +359,8 @@ impl Settings {
             .set_default("sync_frequency", "10m")?
             .set_default("search_mode", "fuzzy")?
             .set_default("filter_mode", "global")?
-            .set_default("style", "auto")?
-            .set_default("inline_height", 0)?
+            .set_default("style", "compact")?
+            .set_default("inline_height", 40)?
             .set_default("show_preview", false)?
             .set_default("max_preview_height", 4)?
             .set_default("show_help", true)?
@@ -378,6 +379,12 @@ impl Settings {
             .set_default("secrets_filter", true)?
             .set_default("network_connect_timeout", 5)?
             .set_default("network_timeout", 30)?
+            // enter_accept defaults to false here, but true in the default config file. The dissonance is
+            // intentional!
+            // Existing users will get the default "False", so we don't mess with any potential
+            // muscle memory.
+            // New users will get the new default, that is more similar to what they are used to.
+            .set_default("enter_accept", false)?
             .add_source(
                 Environment::with_prefix("atuin")
                     .prefix_separator("_")
@@ -391,6 +398,7 @@ impl Settings {
 
         create_dir_all(&config_dir)
             .wrap_err_with(|| format!("could not create dir {config_dir:?}"))?;
+
         create_dir_all(&data_dir).wrap_err_with(|| format!("could not create dir {data_dir:?}"))?;
 
         let mut config_file = if let Ok(p) = std::env::var("ATUIN_CONFIG_DIR") {

--- a/atuin-common/src/utils.rs
+++ b/atuin-common/src/utils.rs
@@ -113,6 +113,11 @@ pub fn get_current_dir() -> String {
     }
 }
 
+pub fn is_zsh() -> bool {
+    // only set on zsh
+    env::var("ZSH_VERSION").is_ok()
+}
+
 #[cfg(test)]
 mod tests {
     use time::Month;

--- a/atuin/src/command/client/search/interactive.rs
+++ b/atuin/src/command/client/search/interactive.rs
@@ -3,6 +3,7 @@ use std::{
     time::Duration,
 };
 
+use atuin_common::utils;
 use crossterm::{
     event::{
         self, DisableMouseCapture, EnableMouseCapture, Event, KeyCode, KeyEvent, KeyModifiers,
@@ -702,7 +703,7 @@ pub async fn history(
 
     if index < results.len() {
         let mut command = results.swap_remove(index).command;
-        if accept {
+        if accept && utils::is_zsh() {
             command = String::from("__atuin_accept__:") + &command;
         }
         // index is in bounds so we return that entry

--- a/atuin/src/command/client/search/interactive.rs
+++ b/atuin/src/command/client/search/interactive.rs
@@ -596,7 +596,7 @@ impl Write for Stdout {
 // this is a big blob of horrible! clean it up!
 // for now, it works. But it'd be great if it were more easily readable, and
 // modular. I'd like to add some more stats and stuff at some point
-#[allow(clippy::cast_possible_truncation)]
+#[allow(clippy::cast_possible_truncation, clippy::too_many_lines)]
 pub async fn history(
     query: &[String],
     settings: &Settings,

--- a/atuin/src/command/client/search/interactive.rs
+++ b/atuin/src/command/client/search/interactive.rs
@@ -135,7 +135,10 @@ impl State {
                 return Some(self.results_state.selected());
             }
             KeyCode::Enter => {
-                self.accept = true;
+                if settings.enter_accept {
+                    self.accept = true;
+                }
+
                 return Some(self.results_state.selected());
             }
             KeyCode::Char('y') if ctrl => {

--- a/atuin/src/command/init.rs
+++ b/atuin/src/command/init.rs
@@ -9,6 +9,10 @@ pub struct Cmd {
     disable_ctrl_r: bool,
 
     /// Disable the binding of the Up Arrow key to atuin
+    /// Now the default, but left here to avoid breaking shells
+    ///
+    /// Originally we bound the up arrow by default, but due to pretty constant questions I'm
+    /// changing the default
     #[clap(long)]
     disable_up_arrow: bool,
 }

--- a/atuin/src/command/init.rs
+++ b/atuin/src/command/init.rs
@@ -9,10 +9,6 @@ pub struct Cmd {
     disable_ctrl_r: bool,
 
     /// Disable the binding of the Up Arrow key to atuin
-    /// Now the default, but left here to avoid breaking shells
-    ///
-    /// Originally we bound the up arrow by default, but due to pretty constant questions I'm
-    /// changing the default
     #[clap(long)]
     disable_up_arrow: bool,
 }

--- a/atuin/src/shell/atuin.zsh
+++ b/atuin/src/shell/atuin.zsh
@@ -36,12 +36,18 @@ _atuin_search() {
     # shellcheck disable=SC2048
     output=$(ATUIN_LOG=error atuin search $* -i -- $BUFFER 3>&1 1>&2 2>&3)
 
+    zle reset-prompt
+
     if [[ -n $output ]]; then
         RBUFFER=""
         LBUFFER=$output
     fi
 
-    zle reset-prompt
+    if [[ $LBUFFER == __atuin_accept__:* ]]
+    then
+        LBUFFER=${LBUFFER#__atuin_accept__:}
+        zle accept-line
+    fi
 }
 
 _atuin_up_search() {

--- a/docs/docs/config/config.md
+++ b/docs/docs/config/config.md
@@ -305,3 +305,16 @@ Default: 5
 
 The max time (in seconds) we wait for a connection to become established with a
 remote sync server. Any longer than this and the request will fail.
+
+## enter_accept
+Default: false
+
+Only supported on Bash.
+
+When set to true, Atuin will default to immediately executing a command rather
+than the user having to press enter twice. Pressing tab will return to the
+shell and give the user a chance to edit.
+
+This technically defaults to true for new users, but false for existing. We
+have set `enter_accept = true` in the default config file. This is likely to
+change to be the default for everyone in a later release.

--- a/docs/docs/config/config.md
+++ b/docs/docs/config/config.md
@@ -309,7 +309,7 @@ remote sync server. Any longer than this and the request will fail.
 ## enter_accept
 Default: false
 
-Only supported on Bash.
+Only supported on Zsh.
 
 When set to true, Atuin will default to immediately executing a command rather
 than the user having to press enter twice. Pressing tab will return to the


### PR DESCRIPTION
`enter_accept` will make Atuin immediately accept an execute a command
when selected. It defaults to false in our binary, but the default
config enables it.

This means that users who already use atuin will not default to the new
behaviour unless they opt in, but new users will have it by default.

Thanks to @davidhewitt for the patch and bulk of this implementation!
Currently we have it just for zsh, but I'll follow up with other shells
(unless anyone beats me to it :D)

This also uses "tab" to select and edit a command
