### PR TITLE
Checkout repo so the manifest publish step can read git

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -109,6 +109,10 @@ jobs:
     runs-on: ubuntu-latest
     needs: [publish_x86, publish_aarch64]
     steps:
+    - uses: actions/checkout@master
+      with:
+        repository: atuinsh/atuin
+        path: "./"
 
     - name: Get Repo Owner
       id: get_repo_owner


### PR DESCRIPTION
I wish the CI dev loop was nicer.