### PR TITLE
Add bash support to `enter_accept`

### DIFF
--- a/atuin-common/src/utils.rs
+++ b/atuin-common/src/utils.rs
@@ -119,8 +119,13 @@ pub fn is_zsh() -> bool {
 }
 
 pub fn is_fish() -> bool {
-    // only set on zsh
+    // only set on fish
     env::var("ATUIN_SHELL_FISH").is_ok()
+}
+
+pub fn is_bash() -> bool {
+    // only set on bash
+    env::var("ATUIN_SHELL_BASH").is_ok()
 }
 
 #[cfg(test)]

--- a/atuin/src/command/client/search/interactive.rs
+++ b/atuin/src/command/client/search/interactive.rs
@@ -703,7 +703,7 @@ pub async fn history(
 
     if index < results.len() {
         let mut command = results.swap_remove(index).command;
-        if accept && (utils::is_zsh() || utils::is_fish()) {
+        if accept && (utils::is_zsh() || utils::is_fish() || utils::is_bash()) {
             command = String::from("__atuin_accept__:") + &command;
         }
 

--- a/atuin/src/shell/atuin.bash
+++ b/atuin/src/shell/atuin.bash
@@ -18,10 +18,18 @@ _atuin_precmd() {
 
 __atuin_history() {
     # shellcheck disable=SC2048,SC2086
-    HISTORY="$(ATUIN_LOG=error atuin search $* -i -- "${READLINE_LINE}" 3>&1 1>&2 2>&3)"
+    HISTORY="$(ATUIN_SHELL_BASH=t ATUIN_LOG=error atuin search $* -i -- "${READLINE_LINE}" 3>&1 1>&2 2>&3)"
 
-    READLINE_LINE=${HISTORY}
-    READLINE_POINT=${#READLINE_LINE}
+    if [[ $HISTORY == __atuin_accept__:* ]]
+    then
+      HISTORY=${HISTORY#__atuin_accept__:}
+
+      eval "$HISTORY"
+    else
+      READLINE_LINE=${HISTORY}
+      READLINE_POINT=${#READLINE_LINE}
+    fi
+
 }
 
 if [[ -n "${BLE_VERSION-}" ]]; then


### PR DESCRIPTION
It's a little less smooth than ZSH or Fish. The actual text to execute isn't entered before being eval-d like on the other shells, and if I try and set it then the command is inserted _after_ it is evaluated. ew.

Maybe explore BLE or similar in the future