### PR TITLE
Document that the self-hosted port is TCP

### DIFF
--- a/docs/docs/self-hosting/self-hosting.md
+++ b/docs/docs/self-hosting/self-hosting.md
@@ -34,7 +34,7 @@ ATUIN_DB_URI="postgres://user:password@hostname/database"
 | Parameter           | Description                                                                   |
 | ------------------- | ----------------------------------------------------------------------------- |
 | `host`              | The host to listen on (default: 127.0.0.1)                                    |
-| `port`              | The port to listen on (default: 8888)                                         |
+| `port`              | The TCP port to listen on (default: 8888)                                         |
 | `open_registration` | If `true`, accept new user registrations (default: false)                     |
 | `db_uri`            | A valid PostgreSQL URI, for saving history (default: false)                   |
 | `path`              | A path to prepend to all routes of the server (default: false)                |


### PR DESCRIPTION
For configuring a firewall you need to know if it's TCP or UDP.