### PR TITLE
allow binding server to hostname

### DIFF
--- a/atuin-server/src/lib.rs
+++ b/atuin-server/src/lib.rs
@@ -1,9 +1,6 @@
 #![forbid(unsafe_code)]
 
-use std::{
-    future::Future,
-    net::{IpAddr, SocketAddr, TcpListener},
-};
+use std::{future::Future, net::TcpListener};
 
 use atuin_server_database::Database;
 use axum::Server;
@@ -43,13 +40,12 @@ async fn shutdown_signal() {
 
 pub async fn launch<Db: Database>(
     settings: Settings<Db::Settings>,
-    host: String,
+    host: &str,
     port: u16,
 ) -> Result<()> {
-    let host = host.parse::<IpAddr>()?;
     launch_with_listener::<Db>(
         settings,
-        TcpListener::bind(SocketAddr::new(host, port)).context("could not connect to socket")?,
+        TcpListener::bind((host, port)).context("could not connect to socket")?,
         shutdown_signal(),
     )
     .await

--- a/atuin/src/command/server.rs
+++ b/atuin/src/command/server.rs
@@ -37,12 +37,10 @@ impl Cmd {
         match self {
             Self::Start { host, port } => {
                 let settings = Settings::new().wrap_err("could not load server settings")?;
-                let host = host
-                    .as_ref()
-                    .map_or(settings.host.clone(), std::string::ToString::to_string);
-                let port = port.map_or(settings.port, |p| p);
+                let host = host.as_ref().unwrap_or(&settings.host).clone();
+                let port = port.unwrap_or(settings.port);
 
-                launch::<Postgres>(settings, host, port).await
+                launch::<Postgres>(settings, &host, port).await
             }
             Self::DefaultConfig => {
                 println!("{}", example_config());


### PR DESCRIPTION
I was sent a message with:
> `host = "mithril"`: `Error: invalid IP address syntax` why's it called host if it wants an IP

This makes the host field support more than just IPs, doing a getaddrinfo lookup if necessary