### PR TITLE
Fix no-exec commands not making it into the history 

### DIFF
--- a/atuin/src/shell/atuin.zsh
+++ b/atuin/src/shell/atuin.zsh
@@ -28,11 +28,13 @@ export ATUIN_SESSION=$(atuin uuid)
 ATUIN_HISTORY_ID=""
 
 _atuin_preexec() {
+    # remove ^J from end of $1 as it's passed by zshaddhistory
+    local cmd="${1[0, -2]}"
     # skip history for empty calls
     # remove space, \t, \n, and literal '\'
     [[ -n "${${1//[[:space:]]/}//\\/}" ]] || return
     local id
-    id=$(atuin history start -- "$1")
+    id=$(atuin history start -- "$cmd")
     export ATUIN_HISTORY_ID="$id"
     __atuin_preexec_time=${EPOCHREALTIME-}
 }

--- a/atuin/src/shell/atuin.zsh
+++ b/atuin/src/shell/atuin.zsh
@@ -1,3 +1,4 @@
+# shellcheck shell=bash # doesn't know about zsh
 # shellcheck disable=SC2034,SC2153,SC2086,SC2155
 
 # Above line is because shellcheck doesn't support zsh, per
@@ -32,6 +33,7 @@ _atuin_preexec() {
     local cmd="${1[0, -2]}"
     # skip history for empty calls
     # remove space, \t, \n, and literal '\'
+    # shellcheck disable=SC2299 # shellcheck doesn't know about zsh
     [[ -n "${${1//[[:space:]]/}//\\/}" ]] || return
     local id
     id=$(atuin history start -- "$cmd")

--- a/atuin/src/shell/atuin.zsh
+++ b/atuin/src/shell/atuin.zsh
@@ -93,7 +93,7 @@ _atuin_up_search_viins() {
     _atuin_up_search --keymap-mode=vim-insert
 }
 
-add-zsh-hook preexec _atuin_preexec
+add-zsh-hook zshaddhistory _atuin_preexec
 add-zsh-hook precmd _atuin_precmd
 
 zle -N atuin-search _atuin_search

--- a/atuin/src/shell/atuin.zsh
+++ b/atuin/src/shell/atuin.zsh
@@ -28,6 +28,9 @@ export ATUIN_SESSION=$(atuin uuid)
 ATUIN_HISTORY_ID=""
 
 _atuin_preexec() {
+    # skip history for empty calls
+    # remove space, \t, \n, and literal '\'
+    [[ -n "${${1//[[:space:]]/}//\\/}" ]] || return
     local id
     id=$(atuin history start -- "$1")
     export ATUIN_HISTORY_ID="$id"


### PR DESCRIPTION
Fixes https://github.com/atuinsh/atuin/issues/467
Uses the same as zsh-histdb.
This will fix not adding to the history:

* when you start a command with `#` so `#echo asdf` will be stored in the history, even if you are using zsh `setopt interactivecomments`
* when you have a typo in your CLI, it should also now end up in the history, before atuin would only successfully store anything that could be executed

https://github.com/larkery/zsh-histdb/blob/30797f0c50c31c8d8de32386970c5d480e5ab35d/sqlite-history.zsh#L175C14-L175C27

Link to official zsh docs on this

https://zsh.sourceforge.io/Doc/Release/Functions.html#:~:text=is%20being%20executed.-,zshaddhistory,-Executed%20when%20a