### PR TITLE
fix(nushell): Ignore stderr messages

### DIFF
--- a/atuin/src/shell/atuin.nu
+++ b/atuin/src/shell/atuin.nu
@@ -20,7 +20,8 @@ let _atuin_pre_prompt = {||
         return
     }
     with-env { ATUIN_LOG: error } {
-        atuin history end $'--exit=($last_exit)' -- $env.ATUIN_HISTORY_ID | null
+        do { atuin history end $'--exit=($last_exit)' -- $env.ATUIN_HISTORY_ID | null } | null
+
     }
     hide-env ATUIN_HISTORY_ID
 }


### PR DESCRIPTION
Redirects stderr to null in nushell, following instructions at https://www.nushell.sh/book/stdout_stderr_exit_codes.html#stderr

The other shell scripts already redirect stderr for the `atuin history end` call, so this is matching their functionality.

I've tested this locally but I have not written nushell before, so this may not be idiomatic.

Closes #1214