### PR TITLE
Fix deleted history count

### DIFF
--- a/atuin-client/src/database.rs
+++ b/atuin-client/src/database.rs
@@ -346,12 +346,13 @@ impl Database for Sqlite {
     }
 
     async fn history_count(&self, include_deleted: bool) -> Result<i64> {
-        let exclude_deleted: &str = if include_deleted { "" } else { "not" };
-        let query = format!(
-            "select count(1) from history where deleted_at is {} null",
-            exclude_deleted
-        );
-        let res: (i64,) = sqlx::query_as(&query).fetch_one(&self.pool).await?;
+        let query = if include_deleted {
+            "select count(1) from history"
+        } else {
+            "select count(1) from history where deleted_at is null"
+        };
+
+        let res: (i64,) = sqlx::query_as(query).fetch_one(&self.pool).await?;
         Ok(res.0)
     }
 

--- a/atuin/src/command/client/sync/status.rs
+++ b/atuin/src/command/client/sync/status.rs
@@ -14,6 +14,7 @@ pub async fn run(settings: &Settings, db: &impl Database) -> Result<()> {
     let status = client.status().await?;
     let last_sync = Settings::last_sync()?;
     let local_count = db.history_count(false).await?;
+    let deleted_count = db.history_count(true).await? - local_count;
 
     println!("Atuin v{VERSION} - Build rev {SHA}\n");
 
@@ -24,7 +25,8 @@ pub async fn run(settings: &Settings, db: &impl Database) -> Result<()> {
         println!("Last sync: {last_sync}");
     }
 
-    println!("History count: {local_count}\n");
+    println!("History count: {local_count}");
+    println!("Deleted history count: {deleted_count}\n");
 
     if settings.auto_sync {
         println!("{}", "[Remote]".green());


### PR DESCRIPTION
Introduced in #1272 

`history_count(false)` would result in counting _just_ the history that has been deleted. When it should be all history that has **not** been deleted.

I've also updated the status command so it's a bit clearer what is going on