### PR TITLE
fix(nu): disable the up-arrow keybinding for Nushell

### DIFF
--- a/atuin/src/command/init.rs
+++ b/atuin/src/command/init.rs
@@ -109,20 +109,22 @@ bind -M insert \e\[A _atuin_bind_up";
             event: { send: executehostcommand cmd: (_atuin_search_cmd) }
         }
     )
-)
-"#;
-            const BIND_UP_ARROW: &str = r#"$env.config = (
-    $env.config | upsert keybindings (
-        $env.config.keybindings
-        | append {
-            name: atuin
-            modifier: none
-            keycode: up
-            mode: [emacs, vi_normal, vi_insert]
-            event: { send: executehostcommand cmd: (_atuin_search_cmd '--shell-up-key-binding') }
-        }
-    )
-)
+)"#;
+            const BIND_UP_ARROW: &str = r#"
+# The up arrow keybinding has surprising behavior in Nu, and is disabled by default.
+# See https://github.com/atuinsh/atuin/issues/1025 for details
+# $env.config = (
+#     $env.config | upsert keybindings (
+#         $env.config.keybindings
+#         | append {
+#             name: atuin
+#             modifier: none
+#             keycode: up
+#             mode: [emacs, vi_normal, vi_insert]
+#             event: { send: executehostcommand cmd: (_atuin_search_cmd '--shell-up-key-binding') }
+#         }
+#     )
+# )
 "#;
             if !self.disable_ctrl_r {
                 println!("{BIND_CTRL_R}");

--- a/docs/docs/key-binding.md
+++ b/docs/docs/key-binding.md
@@ -50,6 +50,8 @@ eval "$(atuin init zsh)"
 
 You can then choose to bind Atuin if needed, do this after the call to init.
 
+**Nushell Only**: The up-arrow keybinding is disabled by default for Nushell until [#1025](https://github.com/atuinsh/atuin/issues/1025) is resolved.
+
 ## <kbd>Ctrl-n</kbd> key shortcuts
 
 macOS does not have an <kbd>Alt</kbd> key, although terminal emulators can often be configured to map the <kbd>Option</kbd> key to be used as <kbd>Alt</kbd>. *However*, remapping <kbd>Option</kbd> this way may prevent typing some characters, such as using <kbd>Option-3</kbd> to type `#` on the British English layout. For such a scenario, set the `ctrl_n_shortcuts` option to `true` in your config file to replace <kbd>Alt-0</kbd> to <kbd>Alt-9</kbd> shortcuts with <kbd>Ctrl-0</kbd> to <kbd>Ctrl-9</kbd> instead:


### PR DESCRIPTION
The up-arrow keybinding triggers anytime the key is pressed, including in menus or multi-line commands. Disabling it by default for new users. See #1025 for additional context.

This leaves the binding in the init script but commented out, so users can enable it easily if needed.