### PR TITLE
Fix cargo deb usage

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -181,7 +181,7 @@ jobs:
       if: startsWith(matrix.job.os, 'ubuntu')
       run: |
         cargo install cargo-deb
-        cargo deb -p atuin
+        cargo deb --deb-revision="" -p atuin
 
         case ${{ matrix.job.target }} in
           aarch64-*-linux-*) DPKG_ARCH=arm64 ;;


### PR DESCRIPTION
v2.0.0 of cargo deb added the revision number. I'd rather not change the output name of our file, so force cargo-deb to stick to the "old" behaviour