### PR TITLE
fix(fish): improve output for `enter_accept`

### DIFF
--- a/atuin/src/shell/atuin.fish
+++ b/atuin/src/shell/atuin.fish
@@ -24,7 +24,13 @@ function _atuin_search
         if string match -qg '__atuin_accept__:*' "$h"
           set hist (string match -r '__atuin_accept__:(.*|\s*)' "$h"  | awk 'NR == 2')
           echo $hist
+          # Need to run the pre/post exec functions manually
+          _atuin_preexec $hist
           eval $hist
+          _atuin_postexec
+          # Allow space for repainting the prompt, this will work for prompts up to 2 lines
+          echo
+          echo
         else
           commandline -r "$h"
         end


### PR DESCRIPTION
Fixes 2 issues with the fish shell prompt when using `enter_accept`
1. Runs pre/post exec so the command is added to the atuin history.
2. Adds padding so that the repainting of the shell prompt doesn't overwrite the output.

This adds 2 lines of padding to account for prompts up to 2 lines tall, larger prompts will still cause repainting problems and smaller prompts will be getting an extra line. I don't think there's a way to know how tall the prompt is.

I haven't looked at whether zsh/bash have similar problems.