### PR TITLE
fix(bash): improve output of `enter_accept`

### DIFF
--- a/atuin/src/shell/atuin.bash
+++ b/atuin/src/shell/atuin.bash
@@ -23,8 +23,12 @@ __atuin_history() {
     if [[ $HISTORY == __atuin_accept__:* ]]
     then
       HISTORY=${HISTORY#__atuin_accept__:}
-
+      echo "$HISTORY"
+      # Need to run the pre/post exec functions manually
+      _atuin_preexec "$HISTORY"
       eval "$HISTORY"
+      _atuin_precmd
+      echo
     else
       READLINE_LINE=${HISTORY}
       READLINE_POINT=${#READLINE_LINE}


### PR DESCRIPTION
Very similar change to #1341, but for bash.

Bash's behavior here is worse than fish, as it only redraws the prompt line that has input (why we only need to add 1 additional line after the eval). It also does not show the prompt line at all on an echo. There's not really a way to get this to look normal AFAICT, aside from trying to redraw everything ourselves.

As an example, this is what running `ls`, `echo here`, then selecting `echo here` from the atuin menu will look like:

1 line prompt:
``` bash
$ ls
code downloads

$ echo here
here

echo here
here

$ cursor
```

2 line prompt:
``` bash
~promptfirstline/
$ ls
code downloads

~promptfirstline/
$ echo here
here

~promptfirstline/
echo here
here

$ cursor
```