### PR TITLE
fix(perf): Move DB writes off the critical path

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -159,6 +159,7 @@ dependencies = [
  "directories",
  "env_logger",
  "eyre",
+ "fork",
  "fs-err",
  "futures-util",
  "fuzzy-matcher",
@@ -1121,6 +1122,15 @@ name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "fork"
+version = "0.1.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf2ca97a59201425e7ee4d197c9c4fea282fe87a97d666a580bda889b95b8e88"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "form_urlencoded"

--- a/atuin/Cargo.toml
+++ b/atuin/Cargo.toml
@@ -73,6 +73,7 @@ colored = "2.0.4"
 ratatui = "0.23"
 tracing = "0.1"
 cli-clipboard = "0.4.0"
+fork = "0.1.22"
 
 
 [dependencies.tracing-subscriber]


### PR DESCRIPTION
**Status**: The code is definitely not ready here (fork crate only supports x86 linux/mac?), but opening this in case there's feedback. I've started dogfooding this on my own machines as it seems to be functional.

This moves the DB writes that occur on the critical path off into their own child processes. This will help in cases like Nushell which doesn't support backgrounding tasks, and in cases like #952 where writes to the filesystem are delayed for some other reason. With this new architecture the user won't be waiting on any filesystem writes to complete during normal operation.