### PR TITLE
fix(enter_accept): clear old cmd snippet

### DIFF
--- a/atuin/src/shell/atuin.bash
+++ b/atuin/src/shell/atuin.bash
@@ -29,6 +29,8 @@ __atuin_history() {
       eval "$HISTORY"
       _atuin_precmd
       echo
+      READLINE_LINE=""
+      READLINE_POINT=${#READLINE_LINE}
     else
       READLINE_LINE=${HISTORY}
       READLINE_POINT=${#READLINE_LINE}

--- a/atuin/src/shell/atuin.fish
+++ b/atuin/src/shell/atuin.fish
@@ -31,6 +31,7 @@ function _atuin_search
           # Allow space for repainting the prompt, this will work for prompts up to 2 lines
           echo
           echo
+          commandline -r ""
         else
           commandline -r "$h"
         end


### PR DESCRIPTION
Followup for #1341 and #1342. This clears the prompt of any command snippet the user entered before opening the atuin history search.

Both prompts still have issues with how the fake command looks after we've run it. Bash overwrite the whole prompt line with the command (See #1342), and I wasn't able to figure out how to clear the pre-existing cmd snippet from fish.

For the fish problem, as an example if you type `ech`, then hit ctrl+r and select `echo here` it will appear like this:

```
$ echecho here
here

$ 
```

I'm not sure how solid these fixes actually are, both shell's will cause a bit of confusion for users but I think it's the best we can do at the moment :shrug: 