### PR TITLE
feat(nix): Add a nixpkgs overlay

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -31,5 +31,10 @@
           ];
         RUST_SRC_PATH = "${pkgs.rustPlatform.rustLibSrc}";
       });
-    });
+    })
+    // {
+      overlays.default = final: prev: {
+        inherit (self.packages.${final.system}) atuin;
+      };
+    };
 }


### PR DESCRIPTION
This adds a [Nix overlay](https://nixos.wiki/wiki/Overlays) for the Atuin flake.

This makes it easier for a consumer to directly use the repo instead of the packaged version in nixpkgs, and it is fairly standard for this setup. The simple explanation is it lets you overlay the git version of Atuin on top of the standard list of packages.