### PR TITLE
fix(nix): Add Appkit to the package build

### DIFF
--- a/atuin.nix
+++ b/atuin.nix
@@ -12,7 +12,7 @@
   libiconv,
   Security,
   SystemConfiguration,
-  Appkit,
+  AppKit,
 }:
 rustPlatform.buildRustPackage {
   name = "atuin";
@@ -27,7 +27,7 @@ rustPlatform.buildRustPackage {
 
   nativeBuildInputs = [installShellFiles];
 
-  buildInputs = lib.optionals stdenv.isDarwin [libiconv Security SystemConfiguration Appkit];
+  buildInputs = lib.optionals stdenv.isDarwin [libiconv Security SystemConfiguration AppKit];
 
   postInstall = ''
     installShellCompletion --cmd atuin \

--- a/atuin.nix
+++ b/atuin.nix
@@ -12,6 +12,7 @@
   libiconv,
   Security,
   SystemConfiguration,
+  Appkit,
 }:
 rustPlatform.buildRustPackage {
   name = "atuin";
@@ -26,7 +27,7 @@ rustPlatform.buildRustPackage {
 
   nativeBuildInputs = [installShellFiles];
 
-  buildInputs = lib.optionals stdenv.isDarwin [libiconv Security SystemConfiguration];
+  buildInputs = lib.optionals stdenv.isDarwin [libiconv Security SystemConfiguration Appkit];
 
   postInstall = ''
     installShellCompletion --cmd atuin \

--- a/flake.nix
+++ b/flake.nix
@@ -17,7 +17,7 @@
       pkgs = nixpkgs.outputs.legacyPackages.${system};
     in {
       packages.atuin = pkgs.callPackage ./atuin.nix {
-        inherit (pkgs.darwin.apple_sdk.frameworks) Security SystemConfiguration Appkit;
+        inherit (pkgs.darwin.apple_sdk.frameworks) Security SystemConfiguration AppKit;
       };
       packages.default = self.outputs.packages.${system}.atuin;
 

--- a/flake.nix
+++ b/flake.nix
@@ -17,7 +17,7 @@
       pkgs = nixpkgs.outputs.legacyPackages.${system};
     in {
       packages.atuin = pkgs.callPackage ./atuin.nix {
-        inherit (pkgs.darwin.apple_sdk.frameworks) Security SystemConfiguration;
+        inherit (pkgs.darwin.apple_sdk.frameworks) Security SystemConfiguration Appkit;
       };
       packages.default = self.outputs.packages.${system}.atuin;
 


### PR DESCRIPTION
Atuin v17 relies on Appkit to build on Mac. This was pointed out in discord and found in the [Nixpkgs PR](https://github.com/NixOS/nixpkgs/pull/263530)