### PR TITLE
fix(zsh): Only trigger up-arrow on first line

### DIFF
--- a/atuin/src/shell/atuin.zsh
+++ b/atuin/src/shell/atuin.zsh
@@ -50,8 +50,8 @@ _atuin_search() {
 }
 
 _atuin_up_search() {
-    # Only trigger on the first line of the buffer
-    if [[ ! $LBUFFER == *$'\n'* ]]; then
+    # Only trigger if the buffer is a single line
+    if [[ ! $BUFFER == *$'\n'* ]]; then
         _atuin_search --shell-up-key-binding
     else
         zle up-line

--- a/atuin/src/shell/atuin.zsh
+++ b/atuin/src/shell/atuin.zsh
@@ -50,7 +50,12 @@ _atuin_search() {
 }
 
 _atuin_up_search() {
-    _atuin_search --shell-up-key-binding
+    # Only trigger on the first line of the buffer
+    if [[ ! $LBUFFER == *$'\n'* ]]; then
+        _atuin_search --shell-up-key-binding
+    else
+        zle up-line
+    fi
 }
 
 add-zsh-hook preexec _atuin_preexec


### PR DESCRIPTION
Fixes #1351

This adds a check so that the up-arrow keybinding only triggers if it is on the first line of a buffer. This fixes the case where we are moving in a multiline command.

Alternatively: ZSH's builtin command for this, `up-line-or-search`, disables history entirely when the command is multiple lines. We could simply match that behavior instead.