### PR TITLE
fix(zsh): bind in the most popular modes

### DIFF
--- a/atuin/src/command/init.rs
+++ b/atuin/src/command/init.rs
@@ -32,9 +32,16 @@ impl Cmd {
         println!("{base}");
 
         if std::env::var("ATUIN_NOBIND").is_err() {
-            const BIND_CTRL_R: &str = "bindkey '^r' _atuin_search_widget";
-            const BIND_UP_ARROW: &str = "bindkey '^[[A' _atuin_up_search_widget
-bindkey '^[OA' _atuin_up_search_widget";
+            const BIND_CTRL_R: &str = r#"bindkey -M emacs '^r' _atuin_search_widget
+bindkey -M vicmd '^r' _atuin_search_widget
+bindkey -M viins '^r' _atuin_search_widget"#;
+            const BIND_UP_ARROW: &str = r#"bindkey -M emacs '^[[A' _atuin_up_search_widget
+bindkey -M vicmd '^[[A' _atuin_up_search_widget
+bindkey -M viins '^[[A' _atuin_up_search_widget
+bindkey -M emacs '^[OA' _atuin_up_search_widget
+bindkey -M vicmd '^[OA' _atuin_up_search_widget
+bindkey -M viins '^[OA' _atuin_up_search_widget
+bindkey -M vicmd 'k' _atuin_up_search_widget"#;
             if !self.disable_ctrl_r {
                 println!("{BIND_CTRL_R}");
             }


### PR DESCRIPTION
Improves the zsh keybindings so that we bind to the most common modes in ZSH.

Without this change we are only binding in the default keymap, and zsh's builtin history search would trigger in the others.

This also binds to 'k' in the vicmd map, since 'k' is the up key in that mode (and already bound to zsh's builtin `up-line-or-search` command).