### PR TITLE
Update nix flake to specify version

### DIFF
--- a/atuin.nix
+++ b/atuin.nix
@@ -4,18 +4,19 @@
 #     https://github.com/NixOS/nixpkgs/blob/master/pkgs/tools/misc/atuin/default.nix
 #
 # Helpful documentation: https://github.com/NixOS/nixpkgs/blob/master/doc/languages-frameworks/rust.section.md
-{
-  lib,
-  stdenv,
-  installShellFiles,
-  rustPlatform,
-  libiconv,
-  Security,
-  SystemConfiguration,
-  AppKit,
+{ lib
+, stdenv
+, installShellFiles
+, rustPlatform
+, libiconv
+, Security
+, SystemConfiguration
+, AppKit
+,
 }:
 rustPlatform.buildRustPackage {
   name = "atuin";
+  version = "17.0.1";
 
   src = lib.cleanSource ./.;
 
@@ -25,9 +26,9 @@ rustPlatform.buildRustPackage {
     allowBuiltinFetchGit = true;
   };
 
-  nativeBuildInputs = [installShellFiles];
+  nativeBuildInputs = [ installShellFiles ];
 
-  buildInputs = lib.optionals stdenv.isDarwin [libiconv Security SystemConfiguration AppKit];
+  buildInputs = lib.optionals stdenv.isDarwin [ libiconv Security SystemConfiguration AppKit ];
 
   postInstall = ''
     installShellCompletion --cmd atuin \


### PR DESCRIPTION
Currently, the flake doesn't specify a version, resulting in `home-manager packages` reporting a blank version. 

Stretch goal for this would be to automatically bump the flake version number on a release, but that would be release workflow and I didn't want to touch that too much. 

