### PR TITLE
fix(fish): clean up the fish script options

### DIFF
--- a/atuin/src/shell/atuin.fish
+++ b/atuin/src/shell/atuin.fish
@@ -2,12 +2,12 @@ set -gx ATUIN_SESSION (atuin uuid)
 
 function _atuin_preexec --on-event fish_preexec
     if not test -n "$fish_private_mode"
-        set -gx ATUIN_HISTORY_ID (atuin history start -- "$argv[1]")
+        set -g ATUIN_HISTORY_ID (atuin history start -- "$argv[1]")
     end
 end
 
 function _atuin_postexec --on-event fish_postexec
-    set s $status
+    set -l s $status
 
     if test -n "$ATUIN_HISTORY_ID"
         ATUIN_LOG=error atuin history end --exit $s -- $ATUIN_HISTORY_ID &>/dev/null &
@@ -18,22 +18,22 @@ function _atuin_postexec --on-event fish_postexec
 end
 
 function _atuin_search
-    set h (ATUIN_SHELL_FISH=t ATUIN_LOG=error atuin search $argv -i -- (commandline -b) 3>&1 1>&2 2>&3)
+    set -l ATUIN_H (ATUIN_SHELL_FISH=t ATUIN_LOG=error atuin search $argv -i -- (commandline -b) 3>&1 1>&2 2>&3)
 
-    if test -n "$h"
-        if string match -qg '__atuin_accept__:*' "$h"
-          set hist (string match -r '__atuin_accept__:(.*|\s*)' "$h"  | awk 'NR == 2')
-          echo $hist
+    if test -n "$ATUIN_H"
+        if string match --quiet '__atuin_accept__:*' "$ATUIN_H"
+          set -l ATUIN_HIST (string match --regex '__atuin_accept__:(.*|\s*)' "$ATUIN_H"  | awk 'NR == 2')
+          echo $ATUIN_HIST
           # Need to run the pre/post exec functions manually
-          _atuin_preexec $hist
-          eval $hist
+          _atuin_preexec $ATUIN_HIST
+          eval $ATUIN_HIST
           _atuin_postexec
           # Allow space for repainting the prompt, this will work for prompts up to 2 lines
           echo
           echo
           commandline -r ""
         else
-          commandline -r "$h"
+          commandline -r "$ATUIN_H"
         end
     end
 


### PR DESCRIPTION
Closes #1368 

I reviewed and updated the options we use in the fish script, fixing several issues:

1. Removing the `--groups` option as reported in #1368, it's not needed if we're only testing whether the match exists.
2. Setting the correct scoping for variables. Setting all local variables to be local, `-l`, and removing the `-x` (export) setting for ATUIN_HISTORY_ID as it's unnecessary. The non-local variables (`s`, `h`, `hist`) were clobbering any user-defined variables with the same name.
3. Renaming `h` and `hist` to have an `ATUIN_` prefix, as those variables are accessible from user-defined code. Without this, using `enter_accept` with the history item `echo $h` would have given the user the script value of `$h` instead of their own.