### PR TITLE
fix(bash): Add the `enter_accept` command to the bash history

### DIFF
--- a/atuin/src/shell/atuin.bash
+++ b/atuin/src/shell/atuin.bash
@@ -29,6 +29,8 @@ __atuin_history() {
       eval "$HISTORY"
       _atuin_precmd
       echo
+      # Add the command to the bash history
+      history -s "$HISTORY"
       READLINE_LINE=""
       READLINE_POINT=${#READLINE_LINE}
     else


### PR DESCRIPTION
Continues evolving the `enter_accept` bash prompt by adding the command to the bash history itself.

A good number of users disable the up-arrow key and rely on their shell history for that functionality. This leads to surprising behavior when using `enter_accept`. See  https://github.com/atuinsh/atuin/issues/1003#issuecomment-1805224058