### PR TITLE
Bash `enter_accept` best effort fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,16 +248,30 @@ antigen bundle atuinsh/atuin@main
 
 ### bash
 
-We need to setup some hooks, so first install bash-preexec:
+#### [ble.sh](https://github.com/akinomyoga/ble.sh)
 
+Atuin works best in bash when using [ble.sh](https://github.com/akinomyoga/ble.sh).
+
+With ble.sh installed, just add atuin to your .bashrc
+
+```bash
+echo 'eval "$(atuin init bash)"' >> ~/.bashrc
 ```
+
+#### [bash-preexec](https://github.com/rcaloras/bash-preexec)
+
+[Bash-preexec](https://github.com/rcaloras/bash-preexec) can also be used, but you may experience some minor problems with the recorded duration and exit status of some commands.
+
+To use bash-preexec, download and initialize it
+
+```bash
 curl https://raw.githubusercontent.com/rcaloras/bash-preexec/master/bash-preexec.sh -o ~/.bash-preexec.sh
 echo '[[ -f ~/.bash-preexec.sh ]] && source ~/.bash-preexec.sh' >> ~/.bashrc
 ```
 
 Then setup Atuin
 
-```
+```bash
 echo 'eval "$(atuin init bash)"' >> ~/.bashrc
 ```
 

--- a/atuin/src/shell/atuin.bash
+++ b/atuin/src/shell/atuin.bash
@@ -1,19 +1,23 @@
 ATUIN_SESSION=$(atuin uuid)
 export ATUIN_SESSION
 
-_atuin_preexec() {
+__atuin_preexec() {
     local id
     id=$(atuin history start -- "$1")
     export ATUIN_HISTORY_ID="${id}"
 }
 
-_atuin_precmd() {
+__atuin_precmd() {
     local EXIT="$?"
 
     [[ -z "${ATUIN_HISTORY_ID}" ]] && return
 
     (ATUIN_LOG=error atuin history end --exit "${EXIT}" -- "${ATUIN_HISTORY_ID}" &) >/dev/null 2>&1
     export ATUIN_HISTORY_ID=""
+}
+
+__atuin_set_ret_value() {
+    return ${1:+"$1"}
 }
 
 __atuin_history() {
@@ -23,25 +27,61 @@ __atuin_history() {
     if [[ $HISTORY == __atuin_accept__:* ]]
     then
       HISTORY=${HISTORY#__atuin_accept__:}
-      echo "$HISTORY"
-      # Need to run the pre/post exec functions manually
-      _atuin_preexec "$HISTORY"
+      # Reprint the prompt, accounting for multiple lines
+      tput cuu $(echo -n "${PS1@P}" | tr -cd '\n' | wc -c)
+      echo "${PS1@P}$HISTORY"
+
+      if [[ -n "${BLE_VERSION-}" ]]; then
+        blehook/invoke PREEXEC "$HISTORY"
+      else
+        # Assuming bash-preexec
+        # Invoke every function in the preexec array
+        local preexec_function
+        local preexec_function_ret_value
+        local preexec_ret_value=0
+        for preexec_function in "${preexec_functions[@]:-}"; do
+          if type -t "$preexec_function" 1>/dev/null; then
+            __bp_set_ret_value "${__bp_last_ret_value:-}"
+            "$preexec_function" "$HISTORY"
+            preexec_function_ret_value="$?"
+            if [[ "$preexec_function_ret_value" != 0 ]]; then
+              preexec_ret_value="$preexec_function_ret_value"
+            fi
+          fi
+        done
+        __bp_set_ret_value "$preexec_ret_value" "$__bp_last_argument_prev_command" 
+      fi
       eval "$HISTORY"
-      _atuin_precmd
-      echo
+      exit_status=$?
+      # Execute preprompt commands
+      __atuin_set_ret_value "$exit_status" "$HISTORY"
+      eval "$PROMPT_COMMAND"
+      # Need to reexecute the blehook
+      if [[ -n "${BLE_VERSION-}" ]]; then
+        __atuin_set_ret_value "$exit_status" "$HISTORY"
+        blehook/invoke PRECMD "$?"
+      fi
+      # Add it to the bash history
+      history -s "$HISTORY"
+      # Bash will redraw only the line with the prompt after we finish,
+      # so to work for a multiline prompt we need to print it ourselves,
+      # then move up a line
+      __atuin_set_ret_value "$exit_status" "$HISTORY"
+      echo "${PS1@P}"
+      tput cuu 1
+      __atuin_set_ret_value "$exit_status" "$HISTORY"
       READLINE_LINE=""
       READLINE_POINT=${#READLINE_LINE}
     else
       READLINE_LINE=${HISTORY}
       READLINE_POINT=${#READLINE_LINE}
     fi
-
 }
 
 if [[ -n "${BLE_VERSION-}" ]]; then
-    blehook PRECMD-+=_atuin_precmd
-    blehook PREEXEC-+=_atuin_preexec
+    blehook PRECMD-+=__atuin_precmd
+    blehook PREEXEC-+=__atuin_preexec
 else
-    precmd_functions+=(_atuin_precmd)
-    preexec_functions+=(_atuin_preexec)
+    precmd_functions+=(__atuin_precmd)
+    preexec_functions+=(__atuin_preexec)
 fi

--- a/docs/docs/advanced-install.md
+++ b/docs/docs/advanced-install.md
@@ -112,16 +112,30 @@ antigen bundle atuinsh/atuin@main
 
 ### bash
 
-We need to setup some hooks, so first install bash-preexec:
+#### [ble.sh](https://github.com/akinomyoga/ble.sh)
 
+Atuin works best in bash when using [ble.sh](https://github.com/akinomyoga/ble.sh).
+
+With ble.sh installed, just add atuin to your .bashrc
+
+```bash
+echo 'eval "$(atuin init bash)"' >> ~/.bashrc
 ```
+
+#### [bash-preexec](https://github.com/rcaloras/bash-preexec)
+
+[Bash-preexec](https://github.com/rcaloras/bash-preexec) can also be used, but you may experience some minor problems with the recorded duration and exit status of some commands.
+
+To use bash-preexec, download and initialize it
+
+```bash
 curl https://raw.githubusercontent.com/rcaloras/bash-preexec/master/bash-preexec.sh -o ~/.bash-preexec.sh
 echo '[[ -f ~/.bash-preexec.sh ]] && source ~/.bash-preexec.sh' >> ~/.bashrc
 ```
 
 Then setup Atuin
 
-```
+```bash
 echo 'eval "$(atuin init bash)"' >> ~/.bashrc
 ```
 


### PR DESCRIPTION
This is a fairly large rewrite of the bash integration using `enter_accept`. This improves the feature in bash, redrawing the prompt correctly, running the preexec/precmd functions, and adding the command to the bash history.

**Note that this does not fix #1372, which is not fixable in bash.** It would only be fixable if we can find an equivalent of `zle accept-line` in ble.sh. I worked on this change hoping that I would be able to find a fix but I was unable to find one.

Despite putting in a bit of effort to clean this up, I think we should remove the `enter_accept` feature on bash, or at least disable it by default, until we can find a solution to #1372. It is very surprising behavior and will confuse anyone using this in bash. @ellie?

I did identify a separate issue with bash-preexec in my testing that is also not fixed by this change, though this change does not make it worse. When pressing ctrl+r, bash-preexec will execute the preexec when you press ctrl+r using the previous command entered, and it will not execute preexec again for that prompt. This means we're getting extra `atuin history start` commands for the same entry, which can end up causing problems with our recorded history. I'm not sure how fixable that bug is as it is some problem with the bash-preexec hooks.

Docs have also been updated to point users towards using ble.sh and warn of that bug, as I didn't find any of the same problems using that.

