### PR TITLE
Disable enter-accept for bash

### DIFF
--- a/atuin/src/command/client/search/interactive.rs
+++ b/atuin/src/command/client/search/interactive.rs
@@ -64,8 +64,10 @@ struct StyleState {
 impl State {
     async fn query_results(&mut self, db: &mut dyn Database) -> Result<Vec<History>> {
         let results = self.engine.query(&self.search, db).await?;
+
         self.results_state.select(0);
         self.results_len = results.len();
+
         Ok(results)
     }
 
@@ -703,7 +705,7 @@ pub async fn history(
 
     if index < results.len() {
         let mut command = results.swap_remove(index).command;
-        if accept && (utils::is_zsh() || utils::is_fish() || utils::is_bash()) {
+        if accept && (utils::is_zsh() || utils::is_fish()) {
             command = String::from("__atuin_accept__:") + &command;
         }
 

--- a/atuin/src/shell/atuin.bash
+++ b/atuin/src/shell/atuin.bash
@@ -28,6 +28,7 @@ __atuin_history() {
     then
       HISTORY=${HISTORY#__atuin_accept__:}
       # Reprint the prompt, accounting for multiple lines
+      # shellcheck disable=SC2046
       tput cuu $(echo -n "${PS1@P}" | tr -cd '\n' | wc -c)
       echo "${PS1@P}$HISTORY"
 
@@ -49,6 +50,7 @@ __atuin_history() {
             fi
           fi
         done
+        # shellcheck disable=SC2154
         __bp_set_ret_value "$preexec_ret_value" "$__bp_last_argument_prev_command" 
       fi
       eval "$HISTORY"


### PR DESCRIPTION
Ref #1384, #1372

It doesn't look like we will be able to get this to a point where it works well on bash. If this happens, we can enable it again