### PR TITLE
Make `atuin account delete` void session + key

### DIFF
--- a/atuin/src/command/client/account/delete.rs
+++ b/atuin/src/command/client/account/delete.rs
@@ -1,9 +1,11 @@
 use atuin_client::{api_client, settings::Settings};
 use eyre::{bail, Result};
+use std::fs::remove_file;
 use std::path::PathBuf;
 
 pub async fn run(settings: &Settings) -> Result<()> {
     let session_path = settings.session_path.as_str();
+    let key_path = settings.key_path.as_str();
 
     if !PathBuf::from(session_path).exists() {
         bail!("You are not logged in");
@@ -17,6 +19,15 @@ pub async fn run(settings: &Settings) -> Result<()> {
     )?;
 
     client.delete().await?;
+
+    // Fixes stale session+key when account is deleted via CLI.
+    if PathBuf::from(session_path).exists() {
+        remove_file(PathBuf::from(session_path))?;
+    }
+
+    if PathBuf::from(key_path).exists() {
+        remove_file(PathBuf::from(key_path))?;
+    }
 
     println!("Your account is deleted");
 


### PR DESCRIPTION
When I deleted my Atuin.sh account, I found the command did not delete the key or session files.

This caused `bail!`s from Atuin when querying the session status, or synchronising.

Of course, one shouldn't expect Atuin to be able to synchronise or query with the server when the account is deleted, but the relevant files were still present, so the behaviour was different to what we'd expect.

I discussed this with @ellie on Discord, and we came to the conclusion that I should open a PR, and submit a patch.

I'm not sure how well this PR fits in with the borrow checker, but I've run tests, a Nix build, and a Cargo build - all goes well. I have not tested on macOS or Windows; only NixOS.