### PR TITLE
fix: reenable enter_accept for bash

### DIFF
--- a/atuin/src/command/client/search/interactive.rs
+++ b/atuin/src/command/client/search/interactive.rs
@@ -705,7 +705,7 @@ pub async fn history(
 
     if index < results.len() {
         let mut command = results.swap_remove(index).command;
-        if accept && (utils::is_zsh() || utils::is_fish()) {
+        if accept && (utils::is_zsh() || utils::is_fish() || utils::is_bash()) {
             command = String::from("__atuin_accept__:") + &command;
         }
 

--- a/atuin/src/shell/atuin.bash
+++ b/atuin/src/shell/atuin.bash
@@ -54,12 +54,16 @@ __atuin_history() {
         # shellcheck disable=SC2154
         __bp_set_ret_value "$preexec_ret_value" "$__bp_last_argument_prev_command" 
       fi
-      # Juggle the stty so that the command can be executed
-      local stty_bkup=$(stty -g)
+      # Juggle the terminal settings so that the command can be interacted with
+      local stty_backup
+      stty_backup=$(stty -g)
       stty "$ATUIN_STTY"
+
       eval "$HISTORY"
       exit_status=$?
-      stty "$stty_bkup"
+
+      stty "$stty_backup"
+
       # Execute preprompt commands
       __atuin_set_ret_value "$exit_status" "$HISTORY"
       eval "$PROMPT_COMMAND"

--- a/atuin/src/shell/atuin.bash
+++ b/atuin/src/shell/atuin.bash
@@ -1,4 +1,5 @@
 ATUIN_SESSION=$(atuin uuid)
+ATUIN_STTY=$(stty -g)
 export ATUIN_SESSION
 
 __atuin_preexec() {
@@ -53,8 +54,12 @@ __atuin_history() {
         # shellcheck disable=SC2154
         __bp_set_ret_value "$preexec_ret_value" "$__bp_last_argument_prev_command" 
       fi
+      # Juggle the stty so that the command can be executed
+      local stty_bkup=$(stty -g)
+      stty "$ATUIN_STTY"
       eval "$HISTORY"
       exit_status=$?
+      stty "$stty_bkup"
       # Execute preprompt commands
       __atuin_set_ret_value "$exit_status" "$HISTORY"
       eval "$PROMPT_COMMAND"


### PR DESCRIPTION
I was looking through old issues, and found this: https://github.com/atuinsh/atuin/issues/78#issuecomment-1555949322. It appears that @yannickulrich may have already implemented a fix for our bash `enter_accept` input issue back in their initial suggestion. 

It does work for me for some of the previously broken commands. `ssh` works fine, as does `read -p "Say something?" tosay; echo "Say: $tosay"`. I do not know if there are limitations.

I have intentionally made this a draft PR because I think it should be tested a bit more first (and there's probably some doc updates that need to happen). I don't know what issues there might be and we should probably test this out a bit before we re-enable it for everyone. We don't want to be causing further confusion if we can help it.

List of the issues I could find, might be a good idea to ping some threads if this turns out to be a real fix: #1372, #1390, #1379