### PR TITLE
Allow activating workspaces without making them the default everywhere

### DIFF
--- a/atuin-client/config.toml
+++ b/atuin-client/config.toml
@@ -42,10 +42,17 @@
 ## in any directory within a git repositiry tree (default: false)
 # workspaces = false
 
+## If a workspace was detected, Atuin will default to the workspace filter
+# filter_mode_prefer_workspaces = true
+
 ## which filter mode to use when atuin is invoked from a shell up-key binding
 ## the accepted values are identical to those of "filter_mode"
 ## leave unspecified to use same mode set in "filter_mode"
 # filter_mode_shell_up_key_binding = "global"
+
+## If a workspace was detected, Atuin will default to the workspace filter 
+## from the shell up-key binding
+# filter_mode_shell_up_key_binding_prefer_workspaces = true
 
 ## which search mode to use when atuin is invoked from a shell up-key binding
 ## the accepted values are identical to those of "search_mode"

--- a/atuin-client/src/settings.rs
+++ b/atuin-client/src/settings.rs
@@ -175,7 +175,9 @@ pub struct Settings {
     pub session_path: String,
     pub search_mode: SearchMode,
     pub filter_mode: FilterMode,
+    pub filter_mode_prefer_workspaces: bool,
     pub filter_mode_shell_up_key_binding: Option<FilterMode>,
+    pub filter_mode_shell_up_key_binding_prefer_workspaces: Option<bool>,
     pub search_mode_shell_up_key_binding: Option<SearchMode>,
     pub shell_up_key_binding: bool,
     pub inline_height: u16,
@@ -383,6 +385,7 @@ impl Settings {
             .set_default("sync_frequency", "10m")?
             .set_default("search_mode", "fuzzy")?
             .set_default("filter_mode", "global")?
+            .set_default("filter_mode_prefer_workspaces", true)?
             .set_default("style", "auto")?
             .set_default("inline_height", 0)?
             .set_default("show_preview", false)?

--- a/atuin/src/command/client/search.rs
+++ b/atuin/src/command/client/search.rs
@@ -204,7 +204,11 @@ async fn run_non_interactive(
     };
 
     let dir = dir.unwrap_or_else(|| "/".to_string());
-    let filter_mode = if settings.workspaces && utils::has_git_dir(dir.as_str()) {
+
+    let filter_mode = if settings.workspaces
+        && settings.filter_mode_prefer_workspaces
+        && utils::has_git_dir(dir.as_str())
+    {
         FilterMode::Workspace
     } else {
         settings.filter_mode


### PR DESCRIPTION
Hey there 👋 
While I love the workspaces feature, I don’t want it to always be the default.
This way you can disable that workspaces is the default filter if a workspace is found.

This is the first time ever I wrote rust code, so this might be really wrong. Let me know if I can improve something!


PS: Thanks for Atuin and all the great work around it, I really like it.

