### PR TITLE
fix(fish): accept multiline commands

### DIFF
--- a/atuin/src/shell/atuin.fish
+++ b/atuin/src/shell/atuin.fish
@@ -18,11 +18,11 @@ function _atuin_postexec --on-event fish_postexec
 end
 
 function _atuin_search
-    set -l ATUIN_H (ATUIN_SHELL_FISH=t ATUIN_LOG=error atuin search $argv -i -- (commandline -b) 3>&1 1>&2 2>&3)
+    set -l ATUIN_H "$(ATUIN_SHELL_FISH=t ATUIN_LOG=error atuin search $argv -i -- (commandline -b) 3>&1 1>&2 2>&3)"
 
     if test -n "$ATUIN_H"
         if string match --quiet '__atuin_accept__:*' "$ATUIN_H"
-          set -l ATUIN_HIST (string match --regex '__atuin_accept__:(.*|\s*)' "$ATUIN_H"  | awk 'NR == 2')
+          set -l ATUIN_HIST "$(string replace "__atuin_accept__:" "" -- "$ATUIN_H")"
           commandline -r "$ATUIN_HIST"
           commandline -f repaint
           commandline -f execute


### PR DESCRIPTION
Closes #1404

This fixes the multiline handling in fish, and as a side effect it also removes the dependency on awk. We need to directly capture the command substitution into a string to preserve the newlines instead of setting it to a variable directly.