### PR TITLE
Dissallow deletion if the '--limit' flag is present

### DIFF
--- a/atuin/src/command/client/search.rs
+++ b/atuin/src/command/client/search.rs
@@ -104,6 +104,18 @@ pub struct Cmd {
 
 impl Cmd {
     pub async fn run(self, db: impl Database, settings: &mut Settings) -> Result<()> {
+        if (self.delete_it_all || self.delete) && self.limit.is_some() {
+            // Because of how deletion is implemented, it will always delete all matches
+            // and disregard the limit option. It is also not clear what deletion with a
+            // limit would even mean. Deleting the LIMIT most recent entries that match
+            // the search query would make sense, but that wouldn't match what's displayed
+            // when running the equivalent search, but deleting those entries that are
+            // displayed with the search would leave any duplicates of those lines which may
+            // or may not have been intended to be deleted.
+            println!("\"--limit\" is not compatible with deletion.");
+            return Ok(());
+        }
+
         if self.delete && self.query.is_empty() {
             println!("Please specify a query to match the items you wish to delete. If you wish to delete all history, pass --delete-it-all");
             return Ok(());


### PR DESCRIPTION
Thanks for writing and supporting atuin!

I ran into a bug where if you combine the --limit and --deletion flags it would delete all of the matching entries instead of some limited number. For example:

```
user@nixos:~/ > cat asdf.txt 
user@nixos:~/ > qwerty1
qwerty1: command not found
user@nixos:~/ > qwerty2
qwerty2: command not found
user@nixos:~/ > qwerty3
qwerty3: command not found
user@nixos:~/ > atuin search qwerty
2023-12-10 19:08:42     qwerty1 39ms
2023-12-10 19:08:47     qwerty2 37ms
2023-12-10 19:08:52     qwerty3 37ms
2023-12-10 19:09:10     atuin search qwerty     0s
user@nixos:~/ > atuin search --delete qwerty --limit 1
deleting 018c5522b1447c778a2261d68cdfc6d4
deleting 018c552226ef71fc8a0efe9a9c376f6c
deleting 018c5521ddec717cbcac7581a229b6c6
deleting 018c5521cc1b79cfb69b6d7431810fbf
deleting 018c5521b90871ffaa304eea46b79649
user@nixos:~/ > atuin search qwerty
2023-12-10 19:10:07     atuin search qwerty     0s
```

Unfortunately I had searched for `"*"` so all my history is gone, luckily on a relatively new computer so not a critical loss.

This is on nixos with atuin version 17.0.1, but the relevant code hasn't meaningfully changed since.

Looking at the code it wasn't obvious what combining "--limit" and "--delete" would even mean, so I put together this change to disallow them from being combined and a comment explaining why.

I tested that the combination of flags does print the message saying they're not compatible and exits.