### PR TITLE
feat: add semver checking to client requests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -219,6 +219,7 @@ dependencies = [
  "rand",
  "regex",
  "reqwest",
+ "reqwest-middleware",
  "rmp",
  "rusty_paserk",
  "rusty_paseto",
@@ -243,8 +244,10 @@ name = "atuin-common"
 version = "17.1.0"
 dependencies = [
  "eyre",
+ "lazy_static",
  "pretty_assertions",
  "rand",
+ "semver",
  "serde",
  "sqlx",
  "time",
@@ -1822,6 +1825,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
+name = "mime_guess"
+version = "2.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4192263c238a5f0d0c6bfd21f336a313a4ce1c450542449ca191bb657b4642ef"
+dependencies = [
+ "mime",
+ "unicase",
+]
+
+[[package]]
 name = "minimal-lexical"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2459,6 +2472,7 @@ dependencies = [
  "js-sys",
  "log",
  "mime",
+ "mime_guess",
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
@@ -2477,6 +2491,21 @@ dependencies = [
  "wasm-bindgen-futures",
  "web-sys",
  "winreg",
+]
+
+[[package]]
+name = "reqwest-middleware"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88a3e86aa6053e59030e7ce2d2a3b258dd08fc2d337d52f73f6cb480f5858690"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "http",
+ "reqwest",
+ "serde",
+ "task-local-extensions",
+ "thiserror",
 ]
 
 [[package]]
@@ -3301,6 +3330,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "task-local-extensions"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba323866e5d033818e3240feeb9f7db2c4296674e4d9e16b97b7bf8f490434e8"
+dependencies = [
+ "pin-utils",
+]
+
+[[package]]
 name = "tempfile"
 version = "3.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3654,6 +3692,15 @@ name = "typenum"
 version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
+
+[[package]]
+name = "unicase"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7d2d4dafb69621809a81864c9c1b864479e1235c0dd4e199924b9742439ed89"
+dependencies = [
+ "version_check",
+]
 
 [[package]]
 name = "unicode-bidi"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -219,7 +219,6 @@ dependencies = [
  "rand",
  "regex",
  "reqwest",
- "reqwest-middleware",
  "rmp",
  "rusty_paserk",
  "rusty_paseto",
@@ -1825,16 +1824,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
-name = "mime_guess"
-version = "2.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4192263c238a5f0d0c6bfd21f336a313a4ce1c450542449ca191bb657b4642ef"
-dependencies = [
- "mime",
- "unicase",
-]
-
-[[package]]
 name = "minimal-lexical"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2472,7 +2461,6 @@ dependencies = [
  "js-sys",
  "log",
  "mime",
- "mime_guess",
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
@@ -2491,21 +2479,6 @@ dependencies = [
  "wasm-bindgen-futures",
  "web-sys",
  "winreg",
-]
-
-[[package]]
-name = "reqwest-middleware"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88a3e86aa6053e59030e7ce2d2a3b258dd08fc2d337d52f73f6cb480f5858690"
-dependencies = [
- "anyhow",
- "async-trait",
- "http",
- "reqwest",
- "serde",
- "task-local-extensions",
- "thiserror",
 ]
 
 [[package]]
@@ -3330,15 +3303,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "task-local-extensions"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba323866e5d033818e3240feeb9f7db2c4296674e4d9e16b97b7bf8f490434e8"
-dependencies = [
- "pin-utils",
-]
-
-[[package]]
 name = "tempfile"
 version = "3.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3692,15 +3656,6 @@ name = "typenum"
 version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
-
-[[package]]
-name = "unicase"
-version = "2.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7d2d4dafb69621809a81864c9c1b864479e1235c0dd4e199924b9742439ed89"
-dependencies = [
- "version_check",
-]
 
 [[package]]
 name = "unicode-bidi"

--- a/atuin-client/Cargo.toml
+++ b/atuin-client/Cargo.toml
@@ -62,7 +62,6 @@ rusty_paserk = { version = "0.3.0", default-features = false, features = [
 # sync
 urlencoding = { version = "2.1.0", optional = true }
 reqwest = { workspace = true, optional = true }
-reqwest-middleware = "0.2.4"
 hex = { version = "0.4", optional = true }
 sha2 = { version = "0.10", optional = true }
 

--- a/atuin-client/Cargo.toml
+++ b/atuin-client/Cargo.toml
@@ -62,6 +62,7 @@ rusty_paserk = { version = "0.3.0", default-features = false, features = [
 # sync
 urlencoding = { version = "2.1.0", optional = true }
 reqwest = { workspace = true, optional = true }
+reqwest-middleware = "0.2.4"
 hex = { version = "0.4", optional = true }
 sha2 = { version = "0.10", optional = true }
 

--- a/atuin-client/src/api_client.rs
+++ b/atuin-client/src/api_client.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 use std::env;
 use std::time::Duration;
 
-use eyre::{bail, eyre, Result};
+use eyre::{bail, Result};
 use reqwest::{
     header::{HeaderMap, AUTHORIZATION, USER_AGENT},
     Response, StatusCode, Url,
@@ -133,7 +133,7 @@ pub fn ensure_version(response: &Response) -> Result<bool> {
     if version.major != ATUIN_VERSION.major {
         println!("Atuin version mismatch! In order to successfully sync, the client and the server must run the same *major* version");
         println!("Client: {}", ATUIN_CARGO_VERSION);
-        println!("Server: {}", version.to_string());
+        println!("Server: {}", version);
 
         return Ok(false);
     }

--- a/atuin-client/src/api_client.rs
+++ b/atuin-client/src/api_client.rs
@@ -130,8 +130,9 @@ pub fn ensure_version(response: &Response) -> Result<bool> {
         Version::parse("17.1.0")
     }?;
 
-    if version.major != ATUIN_VERSION.major {
-        println!("Atuin version mismatch! In order to successfully sync, the client and the server must run the same *major* version");
+    // If the client is newer than the server
+    if version.major < ATUIN_VERSION.major {
+        println!("Atuin version mismatch! In order to successfully sync, the server needs to run a newer version of Atuin");
         println!("Client: {}", ATUIN_CARGO_VERSION);
         println!("Server: {}", version);
 

--- a/atuin-client/src/api_client.rs
+++ b/atuin-client/src/api_client.rs
@@ -55,6 +55,7 @@ pub async fn register(
     let resp = client
         .post(url)
         .header(USER_AGENT, APP_USER_AGENT)
+        .header(ATUIN_HEADER_VERSION, ATUIN_CARGO_VERSION)
         .json(&map)
         .send()
         .await?;

--- a/atuin-common/Cargo.toml
+++ b/atuin-common/Cargo.toml
@@ -20,6 +20,9 @@ rand = { workspace = true }
 typed-builder = { workspace = true }
 eyre = { workspace = true }
 sqlx = { workspace = true }
+semver = { workspace = true }
+
+lazy_static = "1.4.0"
 
 [dev-dependencies]
 pretty_assertions = { workspace = true }

--- a/atuin-common/src/api.rs
+++ b/atuin-common/src/api.rs
@@ -1,6 +1,17 @@
+use lazy_static::lazy_static;
+use semver::Version;
 use serde::{Deserialize, Serialize};
 use std::borrow::Cow;
 use time::OffsetDateTime;
+
+// the usage of X- has been deprecated for quite along time, it turns out
+pub static ATUIN_HEADER_VERSION: &str = "Atuin-Version";
+pub static ATUIN_CARGO_VERSION: &str = env!("CARGO_PKG_VERSION");
+
+lazy_static! {
+    pub static ref ATUIN_VERSION: Version =
+        Version::parse(ATUIN_CARGO_VERSION).expect("failed to parse self semver");
+}
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct UserResponse {

--- a/atuin-server/src/router.rs
+++ b/atuin-server/src/router.rs
@@ -1,5 +1,5 @@
 use async_trait::async_trait;
-use atuin_common::api::{ErrorResponse, ATUIN_CARGO_VERSION, ATUIN_HEADER_VERSION, ATUIN_VERSION};
+use atuin_common::api::{ErrorResponse, ATUIN_CARGO_VERSION, ATUIN_HEADER_VERSION};
 use axum::{
     extract::FromRequestParts,
     http::Request,
@@ -9,11 +9,9 @@ use axum::{
     Router,
 };
 use eyre::Result;
-use http::{header::USER_AGENT, request::Parts};
-use semver::Version;
+use http::request::Parts;
 use tower::ServiceBuilder;
 use tower_http::trace::TraceLayer;
-use tracing::error;
 
 use super::handlers;
 use crate::{

--- a/atuin-server/src/router.rs
+++ b/atuin-server/src/router.rs
@@ -97,6 +97,7 @@ async fn semver<B>(request: Request<B>, next: Next<B>) -> Response {
     response
         .headers_mut()
         .insert(ATUIN_HEADER_VERSION, ATUIN_CARGO_VERSION.parse().unwrap());
+
     response
 }
 

--- a/atuin-server/src/router.rs
+++ b/atuin-server/src/router.rs
@@ -1,5 +1,5 @@
 use async_trait::async_trait;
-use atuin_common::api::ErrorResponse;
+use atuin_common::api::{ErrorResponse, ATUIN_CARGO_VERSION, ATUIN_HEADER_VERSION, ATUIN_VERSION};
 use axum::{
     extract::FromRequestParts,
     http::Request,
@@ -9,9 +9,11 @@ use axum::{
     Router,
 };
 use eyre::Result;
-use http::request::Parts;
+use http::{header::USER_AGENT, request::Parts};
+use semver::Version;
 use tower::ServiceBuilder;
 use tower_http::trace::TraceLayer;
+use tracing::error;
 
 use super::handlers;
 use crate::{
@@ -91,6 +93,15 @@ async fn clacks_overhead<B>(request: Request<B>, next: Next<B>) -> Response {
     response
 }
 
+/// Ensure that we only try and sync with clients on the same major version
+async fn semver<B>(request: Request<B>, next: Next<B>) -> Response {
+    let mut response = next.run(request).await;
+    response
+        .headers_mut()
+        .insert(ATUIN_HEADER_VERSION, ATUIN_CARGO_VERSION.parse().unwrap());
+    response
+}
+
 #[derive(Clone)]
 pub struct AppState<DB: Database> {
     pub database: DB,
@@ -126,6 +137,7 @@ pub fn router<DB: Database>(database: DB, settings: Settings<DB::Settings>) -> R
         ServiceBuilder::new()
             .layer(axum::middleware::from_fn(clacks_overhead))
             .layer(TraceLayer::new_for_http())
-            .layer(axum::middleware::from_fn(metrics::track_metrics)),
+            .layer(axum::middleware::from_fn(metrics::track_metrics))
+            .layer(axum::middleware::from_fn(semver)),
     )
 }


### PR DESCRIPTION
This ensured that the client cannot try and sync while running a greater major version than the server

So far, servers have been backwards compatible with _all_ clients. Clients have not been forwards compatible with all servers. The former is much easier to achieve than the latter.

Instead of clients reporting weird errors when servers don't respond as they should, ensure that servers are kept up to date.