### PR TITLE
fix(bash): fix loss of the last output line with enter_accept

### DIFF
--- a/atuin/src/shell/atuin.bash
+++ b/atuin/src/shell/atuin.bash
@@ -29,8 +29,11 @@ __atuin_history() {
     then
       HISTORY=${HISTORY#__atuin_accept__:}
       # Reprint the prompt, accounting for multiple lines
-      # shellcheck disable=SC2046
-      tput cuu $(echo -n "${PS1@P}" | tr -cd '\n' | wc -c)
+      local __atuin_prompt_offset
+      __atuin_prompt_offset=$(echo -n "${PS1@P}" | tr -cd '\n' | wc -c)
+      if ((__atuin_prompt_offset > 0)); then
+        tput cuu "$__atuin_prompt_offset"
+      fi
       echo "${PS1@P}$HISTORY"
 
       if [[ -n "${BLE_VERSION-}" ]]; then


### PR DESCRIPTION
With a single-line prompt, the last line of the output of the previous command is overwritten by the prompt rendered by `enter_accept` in Bash. I confirmed this behavior in all the terminals I tried, including xterm, lxterminal, terminology, terminator, mlterm, screen.

With the single-line prompt, `tput cuu` receives 0 as the parameter, but `tput cuu 0` emits the control sequence `\e[0A`, which *moves the cursor above by one line* unexpectedly.  This is because the parameter 0 for CUU means *the default value*, 1.

In this PR, to avoid moving the cursor when the prompt offset is 0, we check the offset value before running `tput cuu`.