### PR TITLE
fix(bash): improve the support for `enter_accept` with `ble.sh`

### DIFF
--- a/README.md
+++ b/README.md
@@ -274,13 +274,15 @@ antigen bundle atuinsh/atuin@main
 
 #### [ble.sh](https://github.com/akinomyoga/ble.sh)
 
-Atuin works best in bash when using [ble.sh](https://github.com/akinomyoga/ble.sh).
+Atuin works best in bash when using [ble.sh](https://github.com/akinomyoga/ble.sh) >= 0.4.
 
-With ble.sh installed, just add atuin to your .bashrc
+With ble.sh (>= 0.4) installed, just add atuin to your .bashrc
 
 ```bash
 echo 'eval "$(atuin init bash)"' >> ~/.bashrc
 ```
+
+Please make sure that the above line comes after sourcing ble.sh so atuin knows the presence of ble.sh.
 
 #### [bash-preexec](https://github.com/rcaloras/bash-preexec)
 

--- a/atuin/src/shell/atuin.bash
+++ b/atuin/src/shell/atuin.bash
@@ -94,9 +94,7 @@ __atuin_history() {
 
 # shellcheck disable=SC2154
 if [[ -n "${BLE_VERSION-}" ]] && ((_ble_version >= 400)); then
-    blehook PRECMD-+=__atuin_precmd
-    blehook PREEXEC-+=__atuin_preexec
-else
-    precmd_functions+=(__atuin_precmd)
-    preexec_functions+=(__atuin_preexec)
+    ble-import contrib/integration/bash-preexec
 fi
+precmd_functions+=(__atuin_precmd)
+preexec_functions+=(__atuin_preexec)

--- a/atuin/src/shell/atuin.bash
+++ b/atuin/src/shell/atuin.bash
@@ -92,7 +92,8 @@ __atuin_history() {
     fi
 }
 
-if [[ -n "${BLE_VERSION-}" ]]; then
+# shellcheck disable=SC2154
+if [[ -n "${BLE_VERSION-}" ]] && ((_ble_version >= 400)); then
     blehook PRECMD-+=__atuin_precmd
     blehook PREEXEC-+=__atuin_preexec
 else

--- a/atuin/src/shell/atuin.bash
+++ b/atuin/src/shell/atuin.bash
@@ -28,17 +28,19 @@ __atuin_history() {
     if [[ $HISTORY == __atuin_accept__:* ]]
     then
       HISTORY=${HISTORY#__atuin_accept__:}
-      # Reprint the prompt, accounting for multiple lines
-      local __atuin_prompt_offset
-      __atuin_prompt_offset=$(echo -n "${PS1@P}" | tr -cd '\n' | wc -c)
-      if ((__atuin_prompt_offset > 0)); then
-        tput cuu "$__atuin_prompt_offset"
-      fi
-      echo "${PS1@P}$HISTORY"
 
-      if [[ -n "${BLE_VERSION-}" ]]; then
-        blehook/invoke PREEXEC "$HISTORY"
+      if [[ -n "${BLE_ATTACHED-}" ]]; then
+        ble-edit/content/reset-and-check-dirty "$HISTORY"
+        ble/widget/accept-line
       else
+        # Reprint the prompt, accounting for multiple lines
+        local __atuin_prompt_offset
+        __atuin_prompt_offset=$(echo -n "${PS1@P}" | tr -cd '\n' | wc -c)
+        if ((__atuin_prompt_offset > 0)); then
+          tput cuu "$__atuin_prompt_offset"
+        fi
+        echo "${PS1@P}$HISTORY"
+
         # Assuming bash-preexec
         # Invoke every function in the preexec array
         local preexec_function
@@ -46,7 +48,7 @@ __atuin_history() {
         local preexec_ret_value=0
         for preexec_function in "${preexec_functions[@]:-}"; do
           if type -t "$preexec_function" 1>/dev/null; then
-            __bp_set_ret_value "${__bp_last_ret_value:-}"
+            __atuin_set_ret_value "${__bp_last_ret_value:-}"
             "$preexec_function" "$HISTORY"
             preexec_function_ret_value="$?"
             if [[ "$preexec_function_ret_value" != 0 ]]; then
@@ -55,35 +57,32 @@ __atuin_history() {
           fi
         done
         # shellcheck disable=SC2154
-        __bp_set_ret_value "$preexec_ret_value" "$__bp_last_argument_prev_command" 
-      fi
-      # Juggle the terminal settings so that the command can be interacted with
-      local stty_backup
-      stty_backup=$(stty -g)
-      stty "$ATUIN_STTY"
+        __atuin_set_ret_value "$preexec_ret_value" "$__bp_last_argument_prev_command"
 
-      eval "$HISTORY"
-      exit_status=$?
+        # Juggle the terminal settings so that the command can be interacted with
+        local stty_backup
+        stty_backup=$(stty -g)
+        stty "$ATUIN_STTY"
 
-      stty "$stty_backup"
+        eval "$HISTORY"
+        exit_status=$?
 
-      # Execute preprompt commands
-      __atuin_set_ret_value "$exit_status" "$HISTORY"
-      eval "$PROMPT_COMMAND"
-      # Need to reexecute the blehook
-      if [[ -n "${BLE_VERSION-}" ]]; then
+        stty "$stty_backup"
+
+        # Execute preprompt commands
         __atuin_set_ret_value "$exit_status" "$HISTORY"
-        blehook/invoke PRECMD "$?"
+        eval "$PROMPT_COMMAND"
+        # Add it to the bash history
+        history -s "$HISTORY"
+        # Bash will redraw only the line with the prompt after we finish,
+        # so to work for a multiline prompt we need to print it ourselves,
+        # then move up a line
+        __atuin_set_ret_value "$exit_status" "$HISTORY"
+        echo "${PS1@P}"
+        tput cuu 1
+        __atuin_set_ret_value "$exit_status" "$HISTORY"
       fi
-      # Add it to the bash history
-      history -s "$HISTORY"
-      # Bash will redraw only the line with the prompt after we finish,
-      # so to work for a multiline prompt we need to print it ourselves,
-      # then move up a line
-      __atuin_set_ret_value "$exit_status" "$HISTORY"
-      echo "${PS1@P}"
-      tput cuu 1
-      __atuin_set_ret_value "$exit_status" "$HISTORY"
+
       READLINE_LINE=""
       READLINE_POINT=${#READLINE_LINE}
     else


### PR DESCRIPTION
There are three commits: 1) the check for the ble.sh version, 2) the ble.sh's adapter to the bash-preexec interface, and 3) the `accept-line` widget to run the accepted command. A detailed description can be found in each commit message.
