### PR TITLE
fix(clippy): ignore struct_field_names

### DIFF
--- a/atuin/src/command/client/search.rs
+++ b/atuin/src/command/client/search.rs
@@ -18,7 +18,7 @@ mod history_list;
 mod interactive;
 pub use duration::{format_duration, format_duration_into};
 
-#[allow(clippy::struct_excessive_bools)]
+#[allow(clippy::struct_excessive_bools, clippy::struct_field_names)]
 #[derive(Parser, Debug)]
 pub struct Cmd {
     /// Filter search result by directory

--- a/atuin/src/command/client/search/interactive.rs
+++ b/atuin/src/command/client/search/interactive.rs
@@ -41,6 +41,7 @@ const RETURN_ORIGINAL: usize = usize::MAX;
 const RETURN_QUERY: usize = usize::MAX - 1;
 const COPY_QUERY: usize = usize::MAX - 2;
 
+#[allow(clippy::struct_field_names)]
 struct State {
     history_count: i64,
     update_needed: Option<Version>,


### PR DESCRIPTION
In these cases, I think that's a _little_ too pedantic.