### PR TITLE
feat(zsh): try to go to the position in zsh's history

### DIFF
--- a/crates/atuin/src/shell/atuin.zsh
+++ b/crates/atuin/src/shell/atuin.zsh
@@ -68,6 +68,8 @@ _atuin_search() {
         then
             LBUFFER=${LBUFFER#__atuin_accept__:}
             zle accept-line
+        else
+            zle infer-next-history && zle up-history
         fi
     fi
 }


### PR DESCRIPTION
by using infer-next-history and then up-history.

This is very helpful to execute consecutive commands with accept-line-and-down-history.