### PR TITLE
fix(stats): time now_local not working on Linux

### DIFF
--- a/atuin-client/src/settings.rs
+++ b/atuin-client/src/settings.rs
@@ -219,7 +219,13 @@ pub struct Settings {
 
     // This is automatically loaded when settings is created. Do not set in
     // config! Keep secrets and settings apart.
+    #[serde(skip)]
     pub session_token: String,
+
+    // This is determined at startup and cached.
+    // This is due to non-threadsafe get-env limitations.
+    #[serde(skip)]
+    pub local_tz: Option<time::UtcOffset>,
 }
 
 impl Settings {
@@ -487,6 +493,8 @@ impl Settings {
         } else {
             settings.session_token = String::from("not logged in");
         }
+
+        settings.local_tz = time::UtcOffset::current_local_offset().ok();
 
         Ok(settings)
     }

--- a/atuin/src/command/client/stats.rs
+++ b/atuin/src/command/client/stats.rs
@@ -83,31 +83,31 @@ impl Cmd {
             self.period.join(" ")
         };
 
+        let now = OffsetDateTime::now_utc();
+        let now = settings.local_tz.map_or(now, |local| now.to_offset(local));
+        let last_night = now.replace_time(Time::MIDNIGHT);
+
         let history = if words.as_str() == "all" {
             db.list(FilterMode::Global, &context, None, false, false)
                 .await?
         } else if words.trim() == "today" {
-            let start = OffsetDateTime::now_local()?.replace_time(Time::MIDNIGHT);
+            let start = last_night;
             let end = start + Duration::days(1);
             db.range(start, end).await?
         } else if words.trim() == "month" {
-            let end = OffsetDateTime::now_local()?.replace_time(Time::MIDNIGHT);
+            let end = last_night;
             let start = end - Duration::days(31);
             db.range(start, end).await?
         } else if words.trim() == "week" {
-            let end = OffsetDateTime::now_local()?.replace_time(Time::MIDNIGHT);
+            let end = last_night;
             let start = end - Duration::days(7);
             db.range(start, end).await?
         } else if words.trim() == "year" {
-            let end = OffsetDateTime::now_local()?.replace_time(Time::MIDNIGHT);
+            let end = last_night;
             let start = end - Duration::days(365);
             db.range(start, end).await?
         } else {
-            let start = parse_date_string(
-                &words,
-                OffsetDateTime::now_local()?,
-                settings.dialect.into(),
-            )?;
+            let start = parse_date_string(&words, now, settings.dialect.into())?;
             let end = start + Duration::days(1);
             db.range(start, end).await?
         };


### PR DESCRIPTION
On many platforms, getting local timezone requires a call to get_env which is not thread safe. This means it conservatively doesn't work if a thread has been spawned (I believe sqlite is using a separate thread here).

Attempt to fix by acquiring the local tz as early as possible.