### PR TITLE
docs: add docs for zsh-autosuggestion integration

### DIFF
--- a/docs/docs/integrations.md
+++ b/docs/docs/integrations.md
@@ -1,0 +1,7 @@
+# Integrations
+
+## zsh-autosuggestions
+
+Atuin automatically adds itself as an [autosuggest strategy](https://github.com/zsh-users/zsh-autosuggestions#suggestion-strategy).
+
+If you'd like to override this, add your own config after "$(atuin init zsh)" in your zshrc.


### PR DESCRIPTION
I've added an integrations page to the docs. We can maintain a list of such integrations