### PR TITLE
fix(bash,zsh): fix quirks on search cancel

### DIFF
--- a/atuin/src/shell/atuin.bash
+++ b/atuin/src/shell/atuin.bash
@@ -86,6 +86,9 @@ __atuin_history() {
     # shellcheck disable=SC2048,SC2086
     HISTORY="$(ATUIN_SHELL_BASH=t ATUIN_LOG=error atuin search $* -i -- "${READLINE_LINE}" 3>&1 1>&2 2>&3)"
 
+    # We do nothing when the search is canceled.
+    [[ $HISTORY ]] || return 0
+
     if [[ $HISTORY == __atuin_accept__:* ]]
     then
       HISTORY=${HISTORY#__atuin_accept__:}

--- a/atuin/src/shell/atuin.zsh
+++ b/atuin/src/shell/atuin.zsh
@@ -49,12 +49,12 @@ _atuin_search() {
     if [[ -n $output ]]; then
         RBUFFER=""
         LBUFFER=$output
-    fi
 
-    if [[ $LBUFFER == __atuin_accept__:* ]]
-    then
-        LBUFFER=${LBUFFER#__atuin_accept__:}
-        zle accept-line
+        if [[ $LBUFFER == __atuin_accept__:* ]]
+        then
+            LBUFFER=${LBUFFER#__atuin_accept__:}
+            zle accept-line
+        fi
     fi
 }
 


### PR DESCRIPTION
This PR contains two fixes related to the cancellation of the atuin search in the command line. One is for Bash, and the other is for Zsh.

## Line loss in Bash (commit 79913ead)

I've noticed a quirk, which is specific to the Bash integration.

In the current implementation for Bash, the line content is lost when the user cancels the atuin search by pressing <kbd>ESC</kbd>, <kbd>C-g</kbd>, or <kbd>down</kbd> at the bottom line.  This is because the line content is set to the empty string returned by atuin on the cancellation of the search.

In the integrations for other shells, zsh and fish, the empty output is properly handled so that the line content is preserved:

https://github.com/atuinsh/atuin/blob/5bef19ba4cca71f90094f9d7c3c7d25a6d8af8a3/atuin/src/shell/atuin.zsh#L48-L50

https://github.com/atuinsh/atuin/blob/5bef19ba4cca71f90094f9d7c3c7d25a6d8af8a3/atuin/src/shell/atuin.fish#L22-L24

This patch makes the behavior in Bash consistent with that in zsh and fish, i.e., we do nothing when the atuin search returns an empty output.

## Unexpected execution in Zsh (commit 3cc0e312)

Another is a hypothetical quirk in the Zsh integration. When the original content of the command line has the form `__atuin_accept__:<some-string>` and the atuin search is canceled, the string `<some-string>` is unexpectedly executed as a command. We should check the prefix `__atuin_accept__` inside the if-statement of non-empty `$output`.

This patch doesn't perfectly solve the problem in the case where the command history contains an entry `__atuin_accept__:*`. However, this is anyway a hypothetical situation, and the perfect solution would require changing the output format of `atuin search`, so I wouldn't try to fix this remaining situation.
