### PR TITLE
feat(shell): support high-resolution duration if available

### DIFF
--- a/atuin/src/command/client/history.rs
+++ b/atuin/src/command/client/history.rs
@@ -34,6 +34,8 @@ pub enum Cmd {
         id: String,
         #[arg(long, short)]
         exit: i64,
+        #[arg(long, short, default_value = "-1")]
+        duration: i64,
     },
 
     /// List all items in history
@@ -272,6 +274,7 @@ impl Cmd {
         settings: &Settings,
         id: &str,
         exit: i64,
+        duration: i64,
     ) -> Result<()> {
         if id.trim() == "" {
             return Ok(());
@@ -290,8 +293,12 @@ impl Cmd {
         }
 
         h.exit = exit;
-        h.duration = i64::try_from((OffsetDateTime::now_utc() - h.timestamp).whole_nanoseconds())
-            .context("command took over 292 years")?;
+        h.duration = if duration >= 0 {
+            duration
+        } else {
+            i64::try_from((OffsetDateTime::now_utc() - h.timestamp).whole_nanoseconds())
+                .context("command took over 292 years")?
+        };
 
         db.update(&h).await?;
 
@@ -366,7 +373,7 @@ impl Cmd {
 
         match self {
             Self::Start { command } => Self::handle_start(db, settings, &command).await,
-            Self::End { id, exit } => Self::handle_end(db, settings, &id, exit).await,
+            Self::End { id, exit, duration } => Self::handle_end(db, settings, &id, exit, duration).await,
             Self::List {
                 session,
                 cwd,

--- a/atuin/src/command/client/history.rs
+++ b/atuin/src/command/client/history.rs
@@ -34,8 +34,8 @@ pub enum Cmd {
         id: String,
         #[arg(long, short)]
         exit: i64,
-        #[arg(long, short, default_value = "-1")]
-        duration: i64,
+        #[arg(long, short)]
+        duration: Option<i64>,
     },
 
     /// List all items in history
@@ -274,7 +274,7 @@ impl Cmd {
         settings: &Settings,
         id: &str,
         exit: i64,
-        duration: i64,
+        duration: Option<i64>,
     ) -> Result<()> {
         if id.trim() == "" {
             return Ok(());
@@ -293,11 +293,10 @@ impl Cmd {
         }
 
         h.exit = exit;
-        h.duration = if duration >= 0 {
-            duration
-        } else {
-            i64::try_from((OffsetDateTime::now_utc() - h.timestamp).whole_nanoseconds())
-                .context("command took over 292 years")?
+        h.duration = match duration {
+            Some(value) => value,
+            None => i64::try_from((OffsetDateTime::now_utc() - h.timestamp).whole_nanoseconds())
+                .context("command took over 292 years")?,
         };
 
         db.update(&h).await?;

--- a/atuin/src/command/client/history.rs
+++ b/atuin/src/command/client/history.rs
@@ -372,7 +372,9 @@ impl Cmd {
 
         match self {
             Self::Start { command } => Self::handle_start(db, settings, &command).await,
-            Self::End { id, exit, duration } => Self::handle_end(db, settings, &id, exit, duration).await,
+            Self::End { id, exit, duration } => {
+                Self::handle_end(db, settings, &id, exit, duration).await
+            }
             Self::List {
                 session,
                 cwd,

--- a/atuin/src/command/client/history.rs
+++ b/atuin/src/command/client/history.rs
@@ -35,7 +35,7 @@ pub enum Cmd {
         #[arg(long, short)]
         exit: i64,
         #[arg(long, short)]
-        duration: Option<i64>,
+        duration: Option<u64>,
     },
 
     /// List all items in history
@@ -274,7 +274,7 @@ impl Cmd {
         settings: &Settings,
         id: &str,
         exit: i64,
-        duration: Option<i64>,
+        duration: Option<u64>,
     ) -> Result<()> {
         if id.trim() == "" {
             return Ok(());
@@ -294,7 +294,7 @@ impl Cmd {
 
         h.exit = exit;
         h.duration = match duration {
-            Some(value) => value,
+            Some(value) => i64::try_from(value).context("command took over 292 years")?,
             None => i64::try_from((OffsetDateTime::now_utc() - h.timestamp).whole_nanoseconds())
                 .context("command took over 292 years")?,
         };

--- a/atuin/src/command/client/search/duration.rs
+++ b/atuin/src/command/client/search/duration.rs
@@ -29,6 +29,7 @@ pub fn format_duration_into(dur: Duration, f: &mut fmt::Formatter<'_>) -> fmt::R
         let seconds = day_secs % 60;
 
         let millis = nanos / 1_000_000;
+        let micros = nanos / 1_000;
 
         // a difference from our impl than the original is that
         // we only care about the most-significant segment of the duration.
@@ -41,6 +42,8 @@ pub fn format_duration_into(dur: Duration, f: &mut fmt::Formatter<'_>) -> fmt::R
         item("m", minutes)?;
         item("s", seconds)?;
         item("ms", u64::from(millis))?;
+        item("us", u64::from(micros))?;
+        item("ns", u64::from(nanos))?;
         ControlFlow::Continue(())
     }
 

--- a/atuin/src/shell/atuin.bash
+++ b/atuin/src/shell/atuin.bash
@@ -13,7 +13,16 @@ __atuin_precmd() {
 
     [[ -z "${ATUIN_HISTORY_ID}" ]] && return
 
-    (ATUIN_LOG=error atuin history end --exit "${EXIT}" -- "${ATUIN_HISTORY_ID}" &) >/dev/null 2>&1
+    local duration=""
+    # shellcheck disable=SC2154,SC2309
+    if [[ -n "${BLE_ATTACHED-}" && _ble_bash -ge 50000 && -n "${_ble_exec_time_ata-}" ]]; then
+      # We use the high-resolution duration based on EPOCHREALTIME (bash >=
+      # 5.0) that is recorded by ble.sh. The shell variable
+      # `_ble_exec_time_ata` contains the execution time in microseconds.
+      duration=${_ble_exec_time_ata}000
+    fi
+
+    (ATUIN_LOG=error atuin history end --exit "${EXIT}" ${duration:+--duration "$duration"} -- "${ATUIN_HISTORY_ID}" &) >/dev/null 2>&1
     export ATUIN_HISTORY_ID=""
 }
 


### PR DESCRIPTION
This is a suggestion for a feature. If this is something you don't want, please don't hesitate to reject the PR.

ble.sh internally measures the command execution time using the builtin features of Bash. In particular, in bash >= 5.0, ble.sh uses `$EPOCHREALTIME` to measure the high-resolution execution time. The measured result is available in the shell variable `$_ble_exec_time_ata` in the `PRECMD` hook. `_ble_exec_time_ata` contains the execution time in the unit of microseconds.

In this patch, I suggest using this information for atuin to measure the command execution time, since the current duration measurement of atuin includes the fork time of atuin itself. Also, I added the units (us and ns) to display short duration in the search view.

In the second commit, I also implement support for the high-resolution execution time measurement for zsh using `EPOCHREALTIME` provided by module `zsh/datetime`.
