### PR TITLE
fix(import/zsh): zsh use a special format to escape some characters

### DIFF
--- a/atuin-client/src/import/zsh.rs
+++ b/atuin-client/src/import/zsh.rs
@@ -1,8 +1,8 @@
 // import old shell history!
 // automatically hoover up all that we can find
 
-use std::path::PathBuf;
 use std::borrow::Cow;
+use std::path::PathBuf;
 
 use async_trait::async_trait;
 use directories::UserDirs;
@@ -212,8 +212,8 @@ cargo update
 
     #[tokio::test]
     async fn test_parse_metafied() {
-        let bytes = b"echo \xe4\xbd\x83\x80\xe5\xa5\xbd\nls ~/\xe9\x83\xbf\xb3\xe4\xb9\x83\xb0\n"
-        .to_vec();
+        let bytes =
+            b"echo \xe4\xbd\x83\x80\xe5\xa5\xbd\nls ~/\xe9\x83\xbf\xb3\xe4\xb9\x83\xb0\n".to_vec();
 
         let mut zsh = Zsh { bytes };
         assert_eq!(zsh.entries().await.unwrap(), 2);
@@ -223,10 +223,7 @@ cargo update
 
         assert_equal(
             loader.buf.iter().map(|h| h.command.as_str()),
-            [
-                "echo 你好",
-                "ls ~/音乐",
-            ],
+            ["echo 你好", "ls ~/音乐"],
         );
     }
 }


### PR DESCRIPTION
unescape those correctly rather than throw them away.

zsh side code:
https://github.com/zsh-users/zsh/blob/9f57ca4ac8ae071727b1d77cbb8c4c0d893b9099/Src/utils.c#L4889-L4900

I've finally found out what is missing in my atuin's view of history.