### PR TITLE
feat(ui): delete history by Shift+Del

### DIFF
--- a/docs/docs/key-binding.md
+++ b/docs/docs/key-binding.md
@@ -143,6 +143,7 @@ $env.config = (
 | alt + 1 to alt + 9                        | Select item by the number located near it                                     |
 | ctrl + c / ctrl + d / ctrl + g / esc      | Return original                                                               |
 | ctrl + y                                  | Copy selected item to clipboard                                               |
+| shift + delete                            | Delete selected item from history                                             |
 | ctrl + ⬅︎ / alt + b                       | Move the cursor to the previous word                                          |
 | ctrl + ➡️ / alt + f                       | Move the cursor to the next word                                              |
 | ctrl + h / ctrl + b / ⬅︎                  | Move the cursor to the left                                                   |


### PR DESCRIPTION
This is the same key as Firefox urlbar completion.

This allows the user to get rid of whatever they don't want to appear in the list as they see it.

I changed those magic usize consts to an enum for better semantics.