### PR TITLE
docs(readme): add repology badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,13 @@ Then restart your shell!
 
 ## Install
 
+<details>
+<summary>Packaging status</summary>
+<a href="https://repology.org/project/atuin/versions">
+    <img src="https://repology.org/badge/vertical-allrepos/atuin.svg?columns=3" alt="Packaging status">
+</a>
+</details>
+
 ### Script (recommended)
 
 The install script will help you through the setup, ensuring your shell is


### PR DESCRIPTION
Hidden by default to avoid messing up the readme look, also configured for 3 columns to limit the horizontal space taken