### PR TITLE
fix(bash): avoid unexpected `atuin history start` for keybindings

### DIFF
--- a/atuin/src/shell/atuin.bash
+++ b/atuin/src/shell/atuin.bash
@@ -3,6 +3,14 @@ ATUIN_STTY=$(stty -g)
 export ATUIN_SESSION
 
 __atuin_preexec() {
+    if [[ ! ${BLE_ATTACHED-} ]]; then
+        # With bash-preexec, preexec may be called even for the command run by
+        # keybindings.  There is no general and robust way to detect the
+        # command for keybindings, but at least we want to exclude Atuin's
+        # keybindings.
+        [[ $BASH_COMMAND == '__atuin_history'* && $BASH_COMMAND != "$1" ]] && return 0
+    fi
+
     local id
     id=$(atuin history start -- "$1")
     export ATUIN_HISTORY_ID="${id}"


### PR DESCRIPTION
This fixes the second issue reported at https://github.com/atuinsh/atuin/issues/1003 by @gvlassis, i.e., the issue of "0s or wrong command duration".

The problem is that, with bash-preexec, the preexec hook may be called even for the commands executed by the keybindings.

* In particular, the preexec is called before the command `__atuin_history` is executed on pressing <kbd>C-r</kbd> and <kbd>up</kbd>.  In this case, `$1` passed to `__atuin_preexec` contains the last entry in the command history, so `atuin history start` is called for the last command.  As a result, pressing <kbd>C-r</kbd> and <kbd>up</kbd> clears the duration of the last command.  This causes the reported 0s duration.

* Furthermore, the precmd hook corresponding to the keybinding command will not be called, so the duration is only filled when the next user command starts.  This replaces the duration of the last command with the time interval between the last press of <kbd>C-r</kbd> or <kbd>up</kbd> and the start time of the next command.  This causes the reported wrong duration.

There is no general and robust way to distinguish the preexec invocation for keybindings from that for the user commands, but in this patch, we exclude the preexec invocation for Atuin's keybindings to <kbd>C-r</kbd> and <kbd>up</kbd> at least.