### PR TITLE
fix(shell): fix incorrect timing of child shells

### DIFF
--- a/atuin/src/shell/atuin.bash
+++ b/atuin/src/shell/atuin.bash
@@ -1,6 +1,7 @@
 ATUIN_SESSION=$(atuin uuid)
 ATUIN_STTY=$(stty -g)
 export ATUIN_SESSION
+ATUIN_HISTORY_ID=""
 
 __atuin_preexec() {
     local id

--- a/atuin/src/shell/atuin.fish
+++ b/atuin/src/shell/atuin.fish
@@ -1,4 +1,5 @@
 set -gx ATUIN_SESSION (atuin uuid)
+set --erase ATUIN_HISTORY_ID
 
 function _atuin_preexec --on-event fish_preexec
     if not test -n "$fish_private_mode"

--- a/atuin/src/shell/atuin.nu
+++ b/atuin/src/shell/atuin.nu
@@ -1,5 +1,6 @@
 # Source this in your ~/.config/nushell/config.nu
 $env.ATUIN_SESSION = (atuin uuid)
+hide-env -i ATUIN_HISTORY_ID
 
 # Magic token to make sure we don't record commands run by keybindings
 let ATUIN_KEYBINDING_TOKEN = $"# (random uuid)"

--- a/atuin/src/shell/atuin.zsh
+++ b/atuin/src/shell/atuin.zsh
@@ -25,6 +25,7 @@ else
 fi
 
 export ATUIN_SESSION=$(atuin uuid)
+ATUIN_HISTORY_ID=""
 
 _atuin_preexec() {
     local id


### PR DESCRIPTION
When a child shell session is started from another shell session (let us call this parent session hereafter), the environment variable `ATUIN_HISTORY_ID` set by the *parent* session causes Atuin's precmd hook of the *child* session to be unexpectedly performed before the first call of Atuin's preexec hook.

For example, let us consider the case to run `bash` inside the terminal to start a new session.

```bash
[parent]$ bash
# 1. [atuin history start] is called for "bash" by the preexec in the parent session.
# 2. The command "bash" is run.
# 3. [atuin history end] is called for "bash" by the precmd in the child session (This is the UNEXPECTED one).
[child]$ echo some-commands
[child]$ exit
# 4. the preexec hook for "exit" is called in the child session
# 5. The command "exit" is run, and the child session is terminated.
# 6. [atuin history end] is called for "bash" by the precmd in the parent session. (This is the EXPECTED one but has no effect because of 3)
```

In this patch, we clear `ATUIN_HISTORY_ID` (possibly set by the parent session) on the startup of the session. The variable `ATUIN_HISTORY_ID` doesn't seem to be an environment variable in the fish integration, but we clear it also in the fish integration for consistency.

### Possible drawback

With this solution, when the user runs `source .bashrc` (or `eval "$(atuin init bash)"`) in the command line, the `ATUIN_HSITORY_ID` for `source .bashrc` is lost and the timing for that command is not recorded. However, the same happens for the `exit` command. In the sense that `source .bashrc` terminates the existing `ATUIN_SESSION` (and creates another), it is similar to `exit`. For this reason, we might not need to care about it more than `exit`.

### Other possible solutions

However, another possible option would be not to make `ATUIN_HISTORY_ID` the environment variable from the beginning. As far as I search in the codebase, there does not seem to be a code that reads the environment variable `ATUIN_HISTORY_ID` from other processes. So I do not see the necessity to make the variable an environment variable.

Or, with the current `main`, we are effectively measuring the startup time of the child shell. Maybe we can keep the current code if this is the intended one, but then, this seems inconsistent: In this way, only the startup times of the child sessions are measured, but the startup time of the parent session (the login shell started by the terminal) is not measured. Also, this does not work in the current integration with the fish shell because ATUIN_HISTORY_ID doesn't seem to be an environment variable in the fish integration.

### Review request

In this patch, I touch the integrations with all the shells, but I'm only familiar with Bash. If possible, I'd like reviews from the contributors to the integrations with the other shells: @ellie (for zsh, etc.), @conradludgate (for fish, etc.), @stevenxxiu (for nu), and @sophiajt (for env in nu)
