### PR TITLE
refer to image with multi-arch support

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3.5'
 services:
   atuin:
     restart: always
-    image: ghcr.io/atuinsh/atuin:main
+    image: ghcr.io/atuinsh/atuin:latest
     command: server start
     volumes:
       - "./config:/config"

--- a/docs/docs/self-hosting/docker.md
+++ b/docs/docs/self-hosting/docker.md
@@ -25,7 +25,7 @@ version: '3.5'
 services:
   atuin:
     restart: always
-    image: ghcr.io/atuinsh/atuin:main
+    image: ghcr.io/atuinsh/atuin:latest
     command: server start
     volumes:
       - "./config:/config"

--- a/docs/docs/self-hosting/k8s.md
+++ b/docs/docs/self-hosting/k8s.md
@@ -55,7 +55,7 @@ spec:
               value: "8888"
             - name: ATUIN_OPEN_REGISTRATION
               value: "true"
-          image: ghcr.io/atuinsh/atuin:main
+          image: ghcr.io/atuinsh/atuin:latest
           name: atuin
           ports:
             - containerPort: 8888

--- a/docs/zh-CN/k8s.md
+++ b/docs/zh-CN/k8s.md
@@ -56,7 +56,7 @@ spec:
               value: "8888"
             - name: ATUIN_OPEN_REGISTRATION
               value: "true"
-          image: ghcr.io/atuinsh/atuin:main
+          image: ghcr.io/atuinsh/atuin:latest
           name: atuin
           ports:
             - containerPort: 8888

--- a/k8s/atuin.yaml
+++ b/k8s/atuin.yaml
@@ -30,7 +30,7 @@ spec:
               value: "8888"
             - name: ATUIN_OPEN_REGISTRATION
               value: "true"
-          image: ghcr.io/atuinsh/atuin:main
+          image: ghcr.io/atuinsh/atuin:latest
           name: atuin
           ports:
             - containerPort: 8888


### PR DESCRIPTION
The docker compose / k8s files all refer to an image without ARM support:
```
➜ docker pull ghcr.io/atuinsh/atuin:main
main: Pulling from atuinsh/atuin
no matching manifest for linux/arm64/v8 in the manifest list entries
```

This change refers to the image with ARM support, to enable usage on Linux arm64 and to improve performance on Apple Silicon machines.