### PR TITLE
fix(bash): work around custom IFS

### DIFF
--- a/atuin/src/shell/atuin.bash
+++ b/atuin/src/shell/atuin.bash
@@ -113,8 +113,7 @@ __atuin_accept_line() {
 }
 
 __atuin_history() {
-    # shellcheck disable=SC2048,SC2086
-    HISTORY="$(ATUIN_SHELL_BASH=t ATUIN_LOG=error atuin search $* -i -- "${READLINE_LINE}" 3>&1 1>&2 2>&3)"
+    HISTORY="$(ATUIN_SHELL_BASH=t ATUIN_LOG=error atuin search "$@" -i -- "${READLINE_LINE}" 3>&1 1>&2 2>&3)"
 
     # We do nothing when the search is canceled.
     [[ $HISTORY ]] || return 0


### PR DESCRIPTION
When the user sets a custom value of `IFS`, the up keybinding may fail because the option `--shell-up-key-binding` passed to `__atuin_history` is broken by the word splitting of the shell.  For example, when the user sets `IFS=-`, `atuin` called from `__atuin_history` receives `shell up key binding <content>` as the search string.

```bash
$ IFS=-
$ echo [up] # <-- this does not work as expected
```

Note that the problem only happens with the plain Bash without ble.sh. The problem does not arise within ble.sh because ble.sh separates the user environment and the line-editor environment by saving/restoring the shell settings.  The keybindings are processed in the line-editor environment in ble.sh, so the custom `IFS` set by the user does not affect it.

In this patch, we properly quote the arguments to the `atuin` command.