### PR TITLE
fix(bash): fix and improve the keybinding to `up`

### DIFF
--- a/atuin/src/command/init.rs
+++ b/atuin/src/command/init.rs
@@ -58,9 +58,18 @@ bindkey -M vicmd 'k' _atuin_up_search_widget";
         println!("{base}");
 
         if std::env::var("ATUIN_NOBIND").is_err() {
-            const BIND_CTRL_R: &str = r#"bind -x '"\C-r": __atuin_history'"#;
-            const BIND_UP_ARROW: &str = r#"bind -x '"\e[A": __atuin_history --shell-up-key-binding'
-bind -x '"\eOA": __atuin_history --shell-up-key-binding'"#;
+            // Note: We do not overwrite [C-r] in the vi-command keymap for
+            // Bash because we do not want to overwrite "redo", which is
+            // already bound to [C-r] in the vi_nmap keymap in ble.sh.
+            const BIND_CTRL_R: &str = r#"bind -m emacs -x '"\C-r": __atuin_history'
+bind -m vi-insert -x '"\C-r": __atuin_history'"#;
+            const BIND_UP_ARROW: &str = r#"bind -m emacs -x '"\e[A": __atuin_history --shell-up-key-binding'
+bind -m emacs -x '"\eOA": __atuin_history --shell-up-key-binding'
+bind -m vi-insert -x '"\e[A": __atuin_history --shell-up-key-binding'
+bind -m vi-insert -x '"\eOA": __atuin_history --shell-up-key-binding'
+bind -m vi-command -x '"\e[A": __atuin_history --shell-up-key-binding'
+bind -m vi-command -x '"\eOA": __atuin_history --shell-up-key-binding'
+bind -m vi-command -x '"k": __atuin_history --shell-up-key-binding'"#;
             if !self.disable_ctrl_r {
                 println!("{BIND_CTRL_R}");
             }

--- a/atuin/src/command/init.rs
+++ b/atuin/src/command/init.rs
@@ -55,46 +55,15 @@ bindkey -M vicmd 'k' _atuin_up_search_widget";
 
     fn init_bash(&self) {
         let base = include_str!("../shell/atuin.bash");
-        println!("{base}");
+        let (bind_ctrl_r, bind_up_arrow) = if !std::env::var("ATUIN_NOBIND").is_err() {
+            (false, false)
+        } else {
+            (!self.disable_ctrl_r, !self.disable_up_arrow)
+        };
 
-        if std::env::var("ATUIN_NOBIND").is_err() {
-            // Note: We do not overwrite [C-r] in the vi-command keymap for
-            // Bash because we do not want to overwrite "redo", which is
-            // already bound to [C-r] in the vi_nmap keymap in ble.sh.
-            const BIND_CTRL_R: &str = r#"bind -m emacs -x '"\C-r": __atuin_history'
-bind -m vi-insert -x '"\C-r": __atuin_history'"#;
-            const BIND_UP_ARROW: &str = r#"if ((BASH_VERSINFO[0] > 4 || BASH_VERSINFO[0] == 4 && BASH_VERSINFO[1] >= 3)); then
-    bind -m emacs -x '"\e[A": __atuin_history --shell-up-key-binding'
-    bind -m emacs -x '"\eOA": __atuin_history --shell-up-key-binding'
-    bind -m vi-insert -x '"\e[A": __atuin_history --shell-up-key-binding'
-    bind -m vi-insert -x '"\eOA": __atuin_history --shell-up-key-binding'
-    bind -m vi-command -x '"\e[A": __atuin_history --shell-up-key-binding'
-    bind -m vi-command -x '"\eOA": __atuin_history --shell-up-key-binding'
-    bind -m vi-command -x '"k": __atuin_history --shell-up-key-binding'
-else
-    # In bash < 4.3, "bind -x" cannot bind a shell command to a keyseq having
-    # more than two bytes.  To work around this, we first translate the keyseqs
-    # to the two-byte sequence \C-x\C-p (which is not used by default) using
-    # string macros and run the shell command through the keybinding to
-    # \C-x\C-p.
-    bind -m emacs -x '"\C-x\C-p": __atuin_history --shell-up-key-binding'
-    bind -m emacs '"\e[A": "\C-x\C-p"'
-    bind -m emacs '"\eOA": "\C-x\C-p"'
-    bind -m vi-insert -x '"\C-x\C-p": __atuin_history --shell-up-key-binding'
-    bind -m vi-insert -x '"\e[A": "\C-x\C-p"'
-    bind -m vi-insert -x '"\eOA": "\C-x\C-p"'
-    bind -m vi-command -x '"\C-x\C-p": __atuin_history --shell-up-key-binding'
-    bind -m vi-command -x '"\e[A": "\C-x\C-p"'
-    bind -m vi-command -x '"\eOA": "\C-x\C-p"'
-    bind -m vi-command -x '"k": "\C-x\C-p"'
-fi"#;
-            if !self.disable_ctrl_r {
-                println!("{BIND_CTRL_R}");
-            }
-            if !self.disable_up_arrow {
-                println!("{BIND_UP_ARROW}");
-            }
-        }
+        println!("__atuin_bind_ctrl_r={bind_ctrl_r}");
+        println!("__atuin_bind_up_arrow={bind_up_arrow}");
+        println!("{base}");
     }
 
     fn init_fish(&self) {

--- a/atuin/src/command/init.rs
+++ b/atuin/src/command/init.rs
@@ -55,7 +55,7 @@ bindkey -M vicmd 'k' _atuin_up_search_widget";
 
     fn init_bash(&self) {
         let base = include_str!("../shell/atuin.bash");
-        let (bind_ctrl_r, bind_up_arrow) = if !std::env::var("ATUIN_NOBIND").is_err() {
+        let (bind_ctrl_r, bind_up_arrow) = if std::env::var("ATUIN_NOBIND").is_ok() {
             (false, false)
         } else {
             (!self.disable_ctrl_r, !self.disable_up_arrow)

--- a/atuin/src/command/init.rs
+++ b/atuin/src/command/init.rs
@@ -63,13 +63,31 @@ bindkey -M vicmd 'k' _atuin_up_search_widget";
             // already bound to [C-r] in the vi_nmap keymap in ble.sh.
             const BIND_CTRL_R: &str = r#"bind -m emacs -x '"\C-r": __atuin_history'
 bind -m vi-insert -x '"\C-r": __atuin_history'"#;
-            const BIND_UP_ARROW: &str = r#"bind -m emacs -x '"\e[A": __atuin_history --shell-up-key-binding'
-bind -m emacs -x '"\eOA": __atuin_history --shell-up-key-binding'
-bind -m vi-insert -x '"\e[A": __atuin_history --shell-up-key-binding'
-bind -m vi-insert -x '"\eOA": __atuin_history --shell-up-key-binding'
-bind -m vi-command -x '"\e[A": __atuin_history --shell-up-key-binding'
-bind -m vi-command -x '"\eOA": __atuin_history --shell-up-key-binding'
-bind -m vi-command -x '"k": __atuin_history --shell-up-key-binding'"#;
+            const BIND_UP_ARROW: &str = r#"if ((BASH_VERSINFO[0] > 4 || BASH_VERSINFO[0] == 4 && BASH_VERSINFO[1] >= 3)); then
+    bind -m emacs -x '"\e[A": __atuin_history --shell-up-key-binding'
+    bind -m emacs -x '"\eOA": __atuin_history --shell-up-key-binding'
+    bind -m vi-insert -x '"\e[A": __atuin_history --shell-up-key-binding'
+    bind -m vi-insert -x '"\eOA": __atuin_history --shell-up-key-binding'
+    bind -m vi-command -x '"\e[A": __atuin_history --shell-up-key-binding'
+    bind -m vi-command -x '"\eOA": __atuin_history --shell-up-key-binding'
+    bind -m vi-command -x '"k": __atuin_history --shell-up-key-binding'
+else
+    # In bash < 4.3, "bind -x" cannot bind a shell command to a keyseq having
+    # more than two bytes.  To work around this, we first translate the keyseqs
+    # to the two-byte sequence \C-x\C-p (which is not used by default) using
+    # string macros and run the shell command through the keybinding to
+    # \C-x\C-p.
+    bind -m emacs -x '"\C-x\C-p": __atuin_history --shell-up-key-binding'
+    bind -m emacs '"\e[A": "\C-x\C-p"'
+    bind -m emacs '"\eOA": "\C-x\C-p"'
+    bind -m vi-insert -x '"\C-x\C-p": __atuin_history --shell-up-key-binding'
+    bind -m vi-insert -x '"\e[A": "\C-x\C-p"'
+    bind -m vi-insert -x '"\eOA": "\C-x\C-p"'
+    bind -m vi-command -x '"\C-x\C-p": __atuin_history --shell-up-key-binding'
+    bind -m vi-command -x '"\e[A": "\C-x\C-p"'
+    bind -m vi-command -x '"\eOA": "\C-x\C-p"'
+    bind -m vi-command -x '"k": "\C-x\C-p"'
+fi"#;
             if !self.disable_ctrl_r {
                 println!("{BIND_CTRL_R}");
             }

--- a/atuin/src/shell/atuin.bash
+++ b/atuin/src/shell/atuin.bash
@@ -181,3 +181,41 @@ if [[ -n "${BLE_VERSION-}" ]] && ((_ble_version >= 400)); then
 fi
 precmd_functions+=(__atuin_precmd)
 preexec_functions+=(__atuin_preexec)
+
+# shellcheck disable=SC2154
+if [[ $__atuin_bind_ctrl_r == true ]]; then
+    # Note: We do not overwrite [C-r] in the vi-command keymap for Bash because
+    # we do not want to overwrite "redo", which is already bound to [C-r] in
+    # the vi_nmap keymap in ble.sh.
+    bind -m emacs -x '"\C-r": __atuin_history'
+    bind -m vi-insert -x '"\C-r": __atuin_history'
+fi
+
+# shellcheck disable=SC2154
+if [[ $__atuin_bind_up_arrow == true ]]; then
+    if ((BASH_VERSINFO[0] > 4 || BASH_VERSINFO[0] == 4 && BASH_VERSINFO[1] >= 3)); then
+        bind -m emacs -x '"\e[A": __atuin_history --shell-up-key-binding'
+        bind -m emacs -x '"\eOA": __atuin_history --shell-up-key-binding'
+        bind -m vi-insert -x '"\e[A": __atuin_history --shell-up-key-binding'
+        bind -m vi-insert -x '"\eOA": __atuin_history --shell-up-key-binding'
+        bind -m vi-command -x '"\e[A": __atuin_history --shell-up-key-binding'
+        bind -m vi-command -x '"\eOA": __atuin_history --shell-up-key-binding'
+        bind -m vi-command -x '"k": __atuin_history --shell-up-key-binding'
+    else
+        # In bash < 4.3, "bind -x" cannot bind a shell command to a keyseq
+        # having more than two bytes.  To work around this, we first translate
+        # the keyseqs to the two-byte sequence \C-x\C-p (which is not used by
+        # default) using string macros and run the shell command through the
+        # keybinding to \C-x\C-p.
+        bind -m emacs -x '"\C-x\C-p": __atuin_history --shell-up-key-binding'
+        bind -m emacs '"\e[A": "\C-x\C-p"'
+        bind -m emacs '"\eOA": "\C-x\C-p"'
+        bind -m vi-insert -x '"\C-x\C-p": __atuin_history --shell-up-key-binding'
+        bind -m vi-insert -x '"\e[A": "\C-x\C-p"'
+        bind -m vi-insert -x '"\eOA": "\C-x\C-p"'
+        bind -m vi-command -x '"\C-x\C-p": __atuin_history --shell-up-key-binding'
+        bind -m vi-command -x '"\e[A": "\C-x\C-p"'
+        bind -m vi-command -x '"\eOA": "\C-x\C-p"'
+        bind -m vi-command -x '"k": "\C-x\C-p"'
+    fi
+fi


### PR DESCRIPTION
This PR includes three different fixes related to the keybinding to <kbd>up</kbd> in Bash. The descriptions are found in commit messages and in code comments.
