### PR TITLE
Add timezone configuration option & CLI overrides

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -56,6 +56,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0942ffc6dcaadf03badf6e6a2d0228460359d5e34b57ccdc720b7382dfbd5ec5"
 
 [[package]]
+name = "android-tzdata"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e999941b234f3131b00bc13c22d06e8c5ff726d1b6318ac7eb276997bbb4fef0"
+
+[[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "anstream"
 version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -240,6 +255,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_regex",
+ "serde_with",
  "sha2",
  "shellexpand",
  "sql-builder",
@@ -569,6 +585,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "chrono"
+version = "0.4.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f13690e35a5e4ace198e7beea2895d29f3a9cc55015fcebe6336bd2010af9eb"
+dependencies = [
+ "android-tzdata",
+ "iana-time-zone",
+ "num-traits",
+ "serde",
+ "windows-targets 0.52.0",
+]
+
+[[package]]
 name = "cipher"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -861,6 +890,41 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
 dependencies = [
  "proc-macro2",
+ "quote",
+ "syn 2.0.48",
+]
+
+[[package]]
+name = "darling"
+version = "0.20.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0209d94da627ab5605dcccf08bb18afa5009cfbef48d8a8b7d7bdbc79be25c5e"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.20.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "177e3443818124b357d8e76f53be906d60937f0d3a90773a664fa63fa253e621"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn 2.0.48",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.20.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "836a9bbc7ad63342d6d6e7b815ccab164bc77a2d95d84bc3117a8c0d5c98e2d5"
+dependencies = [
+ "darling_core",
  "quote",
  "syn 2.0.48",
 ]
@@ -1568,6 +1632,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "iana-time-zone"
+version = "0.1.59"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6a67363e2aa4443928ce15e57ebae94fd8949958fd1223c4cfc0cd473ad7539"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "wasm-bindgen",
+ "windows-core",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
+]
+
+[[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
 name = "idna"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1591,6 +1684,7 @@ checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
 dependencies = [
  "autocfg",
  "hashbrown 0.12.3",
+ "serde",
 ]
 
 [[package]]
@@ -1601,6 +1695,7 @@ checksum = "d530e1a18b1cb4c484e6e34556a0d948706958449fca0cab753d649f2bce3d1f"
 dependencies = [
  "equivalent",
  "hashbrown 0.14.3",
+ "serde",
 ]
 
 [[package]]
@@ -2947,6 +3042,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_with"
+version = "3.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f5c9fdb6b00a489875b22efd4b78fe2b363b72265cc5f6eb2e2b9ee270e6140c"
+dependencies = [
+ "base64 0.21.7",
+ "chrono",
+ "hex",
+ "indexmap 1.9.3",
+ "indexmap 2.1.0",
+ "serde",
+ "serde_json",
+ "serde_with_macros",
+ "time",
+]
+
+[[package]]
+name = "serde_with_macros"
+version = "3.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbff351eb4b33600a2e138dfa0b10b65a238ea8ff8fb2387c422c5022a3e8298"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.48",
+]
+
+[[package]]
 name = "sha1"
 version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4087,6 +4211,15 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "windows-core"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
+dependencies = [
+ "windows-targets 0.52.0",
+]
 
 [[package]]
 name = "windows-sys"

--- a/atuin-client/Cargo.toml
+++ b/atuin-client/Cargo.toml
@@ -22,7 +22,7 @@ atuin-common = { path = "../atuin-common", version = "17.2.1" }
 
 log = { workspace = true }
 base64 = { workspace = true }
-time = { workspace = true }
+time = { workspace = true, features = ["macros", "formatting"] }
 clap = { workspace = true }
 eyre = { workspace = true }
 directories = { workspace = true }
@@ -53,6 +53,7 @@ thiserror = { workspace = true }
 futures = "0.3"
 crypto_secretbox = "0.1.1"
 generic-array = { version = "0.14", features = ["serde"] }
+serde_with = "3.5.1"
 
 # encryption
 rusty_paseto = { version = "0.6.0", default-features = false }

--- a/atuin-client/config.toml
+++ b/atuin-client/config.toml
@@ -16,6 +16,12 @@
 ## date format used, either "us" or "uk"
 # dialect = "us"
 
+## default timezone to use when displaying time
+## either "l", "local" to use the system's current local timezone, or an offset
+## from UTC in the format of "<+|->H[H][:M[M][:S[S]]]"
+## for example: "+9", "-05", "+03:30", "-01:23:45", etc.
+# timezone = "+0"
+
 ## enable or disable automatic sync
 # auto_sync = true
 

--- a/atuin-client/config.toml
+++ b/atuin-client/config.toml
@@ -20,7 +20,7 @@
 ## either "l", "local" to use the system's current local timezone, or an offset
 ## from UTC in the format of "<+|->H[H][:M[M][:S[S]]]"
 ## for example: "+9", "-05", "+03:30", "-01:23:45", etc.
-# timezone = "+0"
+# timezone = "local"
 
 ## enable or disable automatic sync
 # auto_sync = true

--- a/atuin-client/src/settings.rs
+++ b/atuin-client/src/settings.rs
@@ -529,7 +529,7 @@ impl Settings {
             .set_default("key_path", key_path.to_str())?
             .set_default("session_path", session_path.to_str())?
             .set_default("dialect", "us")?
-            .set_default("timezone", "+0")?
+            .set_default("timezone", "local")?
             .set_default("auto_sync", true)?
             .set_default("update_check", cfg!(feature = "check-update"))?
             .set_default("sync_address", "https://api.atuin.sh")?

--- a/atuin-client/src/settings.rs
+++ b/atuin-client/src/settings.rs
@@ -1,6 +1,7 @@
 use std::{
     collections::HashMap,
     convert::TryFrom,
+    fmt,
     io::prelude::*,
     path::{Path, PathBuf},
     str::FromStr,
@@ -11,13 +12,18 @@ use clap::ValueEnum;
 use config::{
     builder::DefaultState, Config, ConfigBuilder, Environment, File as ConfigFile, FileFormat,
 };
-use eyre::{eyre, Context, Result};
+use eyre::{bail, eyre, Context, Error, Result};
 use fs_err::{create_dir_all, File};
 use parse_duration::parse;
 use regex::RegexSet;
 use semver::Version;
 use serde::Deserialize;
-use time::{format_description::well_known::Rfc3339, OffsetDateTime};
+use serde_with::DeserializeFromStr;
+use time::{
+    format_description::{well_known::Rfc3339, FormatItem},
+    macros::format_description,
+    OffsetDateTime, UtcOffset,
+};
 use uuid::Uuid;
 
 pub const HISTORY_PAGE_SIZE: i64 = 100;
@@ -120,6 +126,46 @@ impl From<Dialect> for interim::Dialect {
             Dialect::Uk => interim::Dialect::Uk,
             Dialect::Us => interim::Dialect::Us,
         }
+    }
+}
+
+/// Type wrapper around `time::UtcOffset` to support a wider variety of timezone formats.
+///
+/// Note that the parsing of this struct needs to be done before starting any
+/// multithreaded runtime, otherwise it will fail on most Unix systems.
+///
+/// See: https://github.com/atuinsh/atuin/pull/1517#discussion_r1447516426
+#[derive(Clone, Copy, Debug, Eq, PartialEq, DeserializeFromStr)]
+pub struct Timezone(pub UtcOffset);
+impl fmt::Display for Timezone {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.0.fmt(f)
+    }
+}
+/// format: <+|-><hour>[:<minute>[:<second>]]
+static OFFSET_FMT: &[FormatItem<'_>] =
+    format_description!("[offset_hour sign:mandatory padding:none][optional [:[offset_minute padding:none][optional [:[offset_second padding:none]]]]]");
+impl FromStr for Timezone {
+    type Err = Error;
+
+    fn from_str(s: &str) -> Result<Self> {
+        // local timezone
+        if matches!(s.to_lowercase().as_str(), "l" | "local") {
+            let offset = UtcOffset::current_local_offset()?;
+            return Ok(Self(offset));
+        }
+
+        // offset from UTC
+        if let Ok(offset) = UtcOffset::parse(s, OFFSET_FMT) {
+            return Ok(Self(offset));
+        }
+
+        // IDEA: Currently named timezones are not supported, because the well-known crate
+        // for this is `chrono_tz`, which is not really interoperable with the datetime crate
+        // that we currently use - `time`. If ever we migrate to using `chrono`, this would
+        // be a good feature to add.
+
+        bail!(r#""{s}" is not a valid timezone spec"#)
     }
 }
 
@@ -251,6 +297,7 @@ pub struct Sync {
 #[derive(Clone, Debug, Deserialize)]
 pub struct Settings {
     pub dialect: Dialect,
+    pub timezone: Timezone,
     pub style: Style,
     pub auto_sync: bool,
     pub update_check: bool,
@@ -304,11 +351,6 @@ pub struct Settings {
     // config! Keep secrets and settings apart.
     #[serde(skip)]
     pub session_token: String,
-
-    // This is determined at startup and cached.
-    // This is due to non-threadsafe get-env limitations.
-    #[serde(skip)]
-    pub local_tz: Option<time::UtcOffset>,
 }
 
 impl Settings {
@@ -487,6 +529,7 @@ impl Settings {
             .set_default("key_path", key_path.to_str())?
             .set_default("session_path", session_path.to_str())?
             .set_default("dialect", "us")?
+            .set_default("timezone", "+0")?
             .set_default("auto_sync", true)?
             .set_default("update_check", cfg!(feature = "check-update"))?
             .set_default("sync_address", "https://api.atuin.sh")?
@@ -591,8 +634,6 @@ impl Settings {
             settings.session_token = String::from("not logged in");
         }
 
-        settings.local_tz = time::UtcOffset::current_local_offset().ok();
-
         Ok(settings)
     }
 
@@ -611,5 +652,44 @@ impl Default for Settings {
             .expect("Could not build config")
             .try_deserialize()
             .expect("Could not deserialize config")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::str::FromStr;
+
+    use eyre::Result;
+
+    use super::Timezone;
+
+    #[test]
+    fn can_parse_offset_timezone_spec() -> Result<()> {
+        assert_eq!(Timezone::from_str("+02")?.0.as_hms(), (2, 0, 0));
+        assert_eq!(Timezone::from_str("-04")?.0.as_hms(), (-4, 0, 0));
+        assert_eq!(Timezone::from_str("+05:30")?.0.as_hms(), (5, 30, 0));
+        assert_eq!(Timezone::from_str("-09:30")?.0.as_hms(), (-9, -30, 0));
+
+        // single digit hours are allowed
+        assert_eq!(Timezone::from_str("+2")?.0.as_hms(), (2, 0, 0));
+        assert_eq!(Timezone::from_str("-4")?.0.as_hms(), (-4, 0, 0));
+        assert_eq!(Timezone::from_str("+5:30")?.0.as_hms(), (5, 30, 0));
+        assert_eq!(Timezone::from_str("-9:30")?.0.as_hms(), (-9, -30, 0));
+
+        // fully qualified form
+        assert_eq!(Timezone::from_str("+09:30:00")?.0.as_hms(), (9, 30, 0));
+        assert_eq!(Timezone::from_str("-09:30:00")?.0.as_hms(), (-9, -30, 0));
+
+        // these offsets don't really exist but are supported anyway
+        assert_eq!(Timezone::from_str("+0:5")?.0.as_hms(), (0, 5, 0));
+        assert_eq!(Timezone::from_str("-0:5")?.0.as_hms(), (0, -5, 0));
+        assert_eq!(Timezone::from_str("+01:23:45")?.0.as_hms(), (1, 23, 45));
+        assert_eq!(Timezone::from_str("-01:23:45")?.0.as_hms(), (-1, -23, -45));
+
+        // require a leading sign for clarity
+        assert!(Timezone::from_str("5").is_err());
+        assert!(Timezone::from_str("10:30").is_err());
+
+        Ok(())
     }
 }

--- a/atuin/src/command/client/history.rs
+++ b/atuin/src/command/client/history.rs
@@ -161,7 +161,10 @@ impl FromStr for Timezone {
             return Ok(Self(offset));
         }
 
-        // IDEA: support named timezones; maybe use chrono_tz?
+        // IDEA: Currently named timezones are not supported, because the well-known crate
+        // for this is `chrono_tz`, which is not really interoperable with the datetime crate
+        // that we currently use - `time`. If ever we migrate to using `chrono`, this would
+        // be a good feature to add.
 
         bail!(r#""{}" is not a valid timezone spec"#, s)
     }

--- a/atuin/src/command/client/history.rs
+++ b/atuin/src/command/client/history.rs
@@ -521,18 +521,8 @@ mod tests {
     use std::str::FromStr;
 
     use eyre::Result;
-    use time::UtcOffset;
 
     use super::Timezone;
-
-    #[test]
-    fn can_parse_local_timezone_spec() -> Result<()> {
-        let local_tz = Timezone(UtcOffset::current_local_offset()?);
-
-        assert_eq!(Timezone::from_str("l")?, local_tz);
-        assert_eq!(Timezone::from_str("local")?, local_tz);
-        Ok(())
-    }
 
     #[test]
     fn can_parse_offset_timezone_spec() -> Result<()> {

--- a/atuin/src/command/client/history.rs
+++ b/atuin/src/command/client/history.rs
@@ -127,7 +127,7 @@ impl ListMode {
     }
 }
 
-/// Type wrapper around time::UtcOffset to support a wider variety of timezone formats.
+/// Type wrapper around `time::UtcOffset` to support a wider variety of timezone formats.
 #[derive(Clone, Copy, Debug)]
 pub struct Timezone(UtcOffset);
 
@@ -141,6 +141,11 @@ impl fmt::Display for Timezone {
         self.0.fmt(f)
     }
 }
+
+/// format: <+|-><hour>[:<minute>[:<second>]]
+static OFFSET_FMT: &[FormatItem<'_>] =
+    format_description!("[offset_hour sign:mandatory padding:none][optional [:[offset_minute padding:none][optional [:[offset_second padding:none]]]]]");
+
 impl FromStr for Timezone {
     type Err = Error;
 
@@ -152,10 +157,7 @@ impl FromStr for Timezone {
         }
 
         // offset from UTC
-        // format: <+|-><hour>[:<minute>[:<second>]]
-        static FMT: &[FormatItem<'_>] =
-            format_description!("[offset_hour sign:mandatory padding:none][optional [:[offset_minute padding:none][optional [:[offset_second padding:none]]]]]");
-        if let Ok(offset) = UtcOffset::parse(s, FMT) {
+        if let Ok(offset) = UtcOffset::parse(s, OFFSET_FMT) {
             return Ok(Self(offset));
         }
 

--- a/atuin/src/command/client/history.rs
+++ b/atuin/src/command/client/history.rs
@@ -74,8 +74,8 @@ pub enum Cmd {
         /// This option takes one of the following kinds of values:
         /// - the special value "local" (or "l") which refers to the system time zone
         /// - an offset from UTC (e.g. "+9", "-2:30")
-        #[arg(long)]
-        tz: Option<Timezone>,
+        #[arg(long, visible_alias = "tz")]
+        timezone: Option<Timezone>,
 
         /// Available variables: {command}, {directory}, {duration}, {user}, {host}, {exit} and {time}.
         /// Example: --format "{time} - [{duration}] - {directory}$\t{command}"
@@ -97,8 +97,8 @@ pub enum Cmd {
         /// This option takes one of the following kinds of values:
         /// - the special value "local" (or "l") which refers to the system time zone
         /// - an offset from UTC (e.g. "+9", "-2:30")
-        #[arg(long)]
-        tz: Option<Timezone>,
+        #[arg(long, visible_alias = "tz")]
+        timezone: Option<Timezone>,
 
         /// Available variables: {command}, {directory}, {duration}, {user}, {host} and {time}.
         /// Example: --format "{time} - [{duration}] - {directory}$\t{command}"
@@ -436,11 +436,11 @@ impl Cmd {
                 cmd_only,
                 print0,
                 reverse,
-                tz,
+                timezone,
                 format,
             } => {
                 let mode = ListMode::from_flags(human, cmd_only);
-                let tz = tz.unwrap_or(settings.timezone);
+                let tz = timezone.unwrap_or(settings.timezone);
                 Self::handle_list(
                     db, settings, context, session, cwd, mode, format, false, print0, reverse, tz,
                 )
@@ -450,12 +450,12 @@ impl Cmd {
             Self::Last {
                 human,
                 cmd_only,
-                tz,
+                timezone,
                 format,
             } => {
                 let last = db.last().await?;
                 let last = last.as_ref().map(std::slice::from_ref).unwrap_or_default();
-                let tz = tz.unwrap_or(settings.timezone);
+                let tz = timezone.unwrap_or(settings.timezone);
                 print_list(
                     last,
                     ListMode::from_flags(human, cmd_only),

--- a/atuin/src/command/client/search.rs
+++ b/atuin/src/command/client/search.rs
@@ -10,10 +10,10 @@ use atuin_client::{
     encryption,
     history::{store::HistoryStore, History},
     record::sqlite_store::SqliteStore,
-    settings::{FilterMode, KeymapMode, SearchMode, Settings},
+    settings::{FilterMode, KeymapMode, SearchMode, Settings, Timezone},
 };
 
-use super::history::{ListMode, Timezone};
+use super::history::ListMode;
 
 mod cursor;
 mod duration;
@@ -101,13 +101,13 @@ pub struct Cmd {
     #[arg(long, short)]
     reverse: bool,
 
-    /// Display the command time in another timezone other than UTC.
+    /// Display the command time in another timezone other than the configured default.
     ///
     /// This option takes one of the following kinds of values:
     /// - the special value "local" (or "l") which refers to the system time zone
     /// - an offset from UTC (e.g. "+9", "-2:30")
-    #[arg(long, default_value_t)]
-    tz: Timezone,
+    #[arg(long)]
+    tz: Option<Timezone>,
 
     /// Available variables: {command}, {directory}, {duration}, {user}, {host}, {time}, {exit} and
     /// {relativetime}.
@@ -228,13 +228,15 @@ impl Cmd {
                     None => Some(settings.history_format.as_str()),
                     _ => self.format.as_deref(),
                 };
+                let tz = self.tz.unwrap_or(settings.timezone);
+
                 super::history::print_list(
                     &entries,
                     ListMode::from_flags(self.human, self.cmd_only),
                     format,
                     false,
                     true,
-                    self.tz,
+                    tz,
                 );
             }
         };

--- a/atuin/src/command/client/search.rs
+++ b/atuin/src/command/client/search.rs
@@ -13,7 +13,7 @@ use atuin_client::{
     settings::{FilterMode, KeymapMode, SearchMode, Settings},
 };
 
-use super::history::ListMode;
+use super::history::{ListMode, Timezone};
 
 mod cursor;
 mod duration;
@@ -100,6 +100,14 @@ pub struct Cmd {
     /// Reverse the order of results, oldest first
     #[arg(long, short)]
     reverse: bool,
+
+    /// Display the command time in another timezone other than UTC.
+    ///
+    /// This option takes one of the following kinds of values:
+    /// - the special value "local" (or "l") which refers to the system time zone
+    /// - an offset from UTC (e.g. "+9", "-2:30")
+    #[arg(long, default_value_t)]
+    tz: Timezone,
 
     /// Available variables: {command}, {directory}, {duration}, {user}, {host}, {time}, {exit} and
     /// {relativetime}.
@@ -226,6 +234,7 @@ impl Cmd {
                     format,
                     false,
                     true,
+                    self.tz,
                 );
             }
         };

--- a/atuin/src/command/client/search.rs
+++ b/atuin/src/command/client/search.rs
@@ -106,8 +106,8 @@ pub struct Cmd {
     /// This option takes one of the following kinds of values:
     /// - the special value "local" (or "l") which refers to the system time zone
     /// - an offset from UTC (e.g. "+9", "-2:30")
-    #[arg(long)]
-    tz: Option<Timezone>,
+    #[arg(long, visible_alias = "tz")]
+    timezone: Option<Timezone>,
 
     /// Available variables: {command}, {directory}, {duration}, {user}, {host}, {time}, {exit} and
     /// {relativetime}.
@@ -228,7 +228,7 @@ impl Cmd {
                     None => Some(settings.history_format.as_str()),
                     _ => self.format.as_deref(),
                 };
-                let tz = self.tz.unwrap_or(settings.timezone);
+                let tz = self.timezone.unwrap_or(settings.timezone);
 
                 super::history::print_list(
                     &entries,

--- a/atuin/src/command/client/stats.rs
+++ b/atuin/src/command/client/stats.rs
@@ -86,8 +86,7 @@ impl Cmd {
             self.period.join(" ")
         };
 
-        let now = OffsetDateTime::now_utc();
-        let now = settings.local_tz.map_or(now, |local| now.to_offset(local));
+        let now = OffsetDateTime::now_utc().to_offset(settings.timezone.0);
         let last_night = now.replace_time(Time::MIDNIGHT);
 
         let history = if words.as_str() == "all" {


### PR DESCRIPTION
When reviewing history (usually for the purpose of filling out a work log), I often find it helpful if the timestamps are displayed in the local timezone. This PR adds this feature.

Currently, the `--tz` option either accepts an offset from UTC in the form of `<+|-><hour>[:<minute>[:<second>]]`, or the special value `l`/`local` to use the system's current timezones.

I also wanted to add support for named timezones using `chrono_tz`, but that seems to require pulling in `chrono` as well, which feels very redundant considering that we already depend on `time`. So I left that bit out for now.

## Unresolved questions

- [ ] <s>Are you (maintainers) willing to add `chrono` as a dependency for named timezone support? Or are there alternative, independent crates to `chrono_tz`?</s>
- [x] Do you think we need tests for this? I feel like it's borderline "too simple to warrant testing", but I would be happy to add them too if you so desire.