### PR TITLE
chore: schema cleanup

### DIFF
--- a/atuin-server-postgres/migrations/20240108124837_drop-some-defaults.sql
+++ b/atuin-server-postgres/migrations/20240108124837_drop-some-defaults.sql
@@ -1,0 +1,4 @@
+-- Add migration script here
+alter table history alter column user_id drop default;
+alter table sessions alter column user_id drop default;
+alter table total_history_count_user alter column user_id drop default;


### PR DESCRIPTION
The columns referred to in this PR, were for some reason created with defaults. When created years ago, they were `bigserial` not `bigint`.

The defaults were never actually used, as verified by

1. Checking the value of the sequences on the database
2. Checking the code

So we're safe to clean them up.