### PR TITLE
fix: disable musl deb building

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -178,7 +178,7 @@ jobs:
     - name: Create Debian package
       id: debian-package
       shell: bash
-      if: startsWith(matrix.job.os, 'ubuntu')
+      if: startsWith(matrix.job.os, 'ubuntu') && endsWith(matrix.job.target, 'gnu')
       run: |
         cargo install cargo-deb
         cargo deb --deb-revision="" -p atuin


### PR DESCRIPTION
It never worked, and broke release building. I don't think we need musl debs, but if so ensure they don't break install scripts

Resolve #1500