### PR TITLE
docs: remove activity graph docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,21 +121,6 @@ atuin sync
 
 Then restart your shell!
   
-### Opt-in to activity graph
-Alongside the hosted Atuin server, there is also a service which generates activity graphs for your shell history! These are inspired by the GitHub graph.
-  
-For example, here is mine:
-  
-![Activity Graph Example](docs/static/img/activity-graph-example.png)
-
-If you wish to get your own, after signing up for the sync server, run this
-  
-```
-curl https://api.atuin.sh/enable -d $(cat ~/.local/share/atuin/session)
-```
-  
-The response includes the URL to your graph. Feel free to share and/or embed this URL, the token is _not_ a secret, and simply prevents user enumeration. 
-  
 ## Offline only (no sync)
   
 ```


### PR DESCRIPTION
While Atuin is reliable and performs well under load, the activity graph service failed to scale so well. It was a Python service generating images for requests from a large series of data. For users with small amount of data this was fine, but for users with 100k+ lines of history it didn't respond well.

I'm going to be reworking it soon, but for now I'm taking it down rather than offer a less-than-optimal experience. It should be back soon :)