### PR TITLE
style(bash): use consistent coding style

### DIFF
--- a/atuin/src/shell/atuin.bash
+++ b/atuin/src/shell/atuin.bash
@@ -20,11 +20,11 @@ __atuin_preexec() {
 __atuin_precmd() {
     local EXIT=$?
 
-    [[ -z $ATUIN_HISTORY_ID ]] && return
+    [[ ! $ATUIN_HISTORY_ID ]] && return
 
     local duration=""
     # shellcheck disable=SC2154,SC2309
-    if [[ -n ${BLE_ATTACHED-} && _ble_bash -ge 50000 && -n ${_ble_exec_time_ata-} ]]; then
+    if [[ ${BLE_ATTACHED-} && _ble_bash -ge 50000 && ${_ble_exec_time_ata-} ]]; then
         # We use the high-resolution duration based on EPOCHREALTIME (bash >=
         # 5.0) that is recorded by ble.sh. The shell variable
         # `_ble_exec_time_ata` contains the execution time in microseconds.
@@ -144,7 +144,7 @@ __atuin_history() {
     then
         HISTORY=${HISTORY#__atuin_accept__:}
 
-        if [[ -n ${BLE_ATTACHED-} ]]; then
+        if [[ ${BLE_ATTACHED-} ]]; then
             ble-edit/content/reset-and-check-dirty "$HISTORY"
             ble/widget/accept-line
         else
@@ -160,7 +160,7 @@ __atuin_history() {
 }
 
 # shellcheck disable=SC2154
-if [[ -n ${BLE_VERSION-} ]] && ((_ble_version >= 400)); then
+if [[ ${BLE_VERSION-} ]] && ((_ble_version >= 400)); then
     ble-import contrib/integration/bash-preexec
 
     # Define and register an autosuggestion source for ble.sh's auto-complete.

--- a/atuin/src/shell/atuin.bash
+++ b/atuin/src/shell/atuin.bash
@@ -14,11 +14,11 @@ __atuin_preexec() {
 
     local id
     id=$(atuin history start -- "$1")
-    export ATUIN_HISTORY_ID="${id}"
+    export ATUIN_HISTORY_ID=${id}
 }
 
 __atuin_precmd() {
-    local EXIT="$?"
+    local EXIT=$?
 
     [[ -z "${ATUIN_HISTORY_ID}" ]] && return
 
@@ -74,9 +74,9 @@ __atuin_accept_line() {
         if type -t "$__atuin_preexec_function" 1>/dev/null; then
             __atuin_set_ret_value "${__bp_last_ret_value:-}"
             "$__atuin_preexec_function" "$__atuin_command"
-            __atuin_preexec_function_ret_value="$?"
+            __atuin_preexec_function_ret_value=$?
             if [[ "$__atuin_preexec_function_ret_value" != 0 ]]; then
-                __atuin_preexec_ret_value="$__atuin_preexec_function_ret_value"
+                __atuin_preexec_ret_value=$__atuin_preexec_function_ret_value
             fi
         fi
     done
@@ -135,7 +135,7 @@ __atuin_history() {
         fi
     fi
 
-    HISTORY="$(ATUIN_SHELL_BASH=t ATUIN_LOG=error atuin search "$@" -i -- "${READLINE_LINE}" 3>&1 1>&2 2>&3)"
+    HISTORY=$(ATUIN_SHELL_BASH=t ATUIN_LOG=error atuin search "$@" -i -- "${READLINE_LINE}" 3>&1 1>&2 2>&3)
 
     # We do nothing when the search is canceled.
     [[ $HISTORY ]] || return 0

--- a/atuin/src/shell/atuin.bash
+++ b/atuin/src/shell/atuin.bash
@@ -20,11 +20,11 @@ __atuin_preexec() {
 __atuin_precmd() {
     local EXIT=$?
 
-    [[ -z "$ATUIN_HISTORY_ID" ]] && return
+    [[ -z $ATUIN_HISTORY_ID ]] && return
 
     local duration=""
     # shellcheck disable=SC2154,SC2309
-    if [[ -n "${BLE_ATTACHED-}" && _ble_bash -ge 50000 && -n "${_ble_exec_time_ata-}" ]]; then
+    if [[ -n ${BLE_ATTACHED-} && _ble_bash -ge 50000 && -n ${_ble_exec_time_ata-} ]]; then
         # We use the high-resolution duration based on EPOCHREALTIME (bash >=
         # 5.0) that is recorded by ble.sh. The shell variable
         # `_ble_exec_time_ata` contains the execution time in microseconds.
@@ -75,7 +75,7 @@ __atuin_accept_line() {
             __atuin_set_ret_value "${__bp_last_ret_value:-}"
             "$__atuin_preexec_function" "$__atuin_command"
             __atuin_preexec_function_ret_value=$?
-            if [[ "$__atuin_preexec_function_ret_value" != 0 ]]; then
+            if [[ $__atuin_preexec_function_ret_value != 0 ]]; then
                 __atuin_preexec_ret_value=$__atuin_preexec_function_ret_value
             fi
         fi
@@ -144,7 +144,7 @@ __atuin_history() {
     then
         HISTORY=${HISTORY#__atuin_accept__:}
 
-        if [[ -n "${BLE_ATTACHED-}" ]]; then
+        if [[ -n ${BLE_ATTACHED-} ]]; then
             ble-edit/content/reset-and-check-dirty "$HISTORY"
             ble/widget/accept-line
         else
@@ -160,7 +160,7 @@ __atuin_history() {
 }
 
 # shellcheck disable=SC2154
-if [[ -n "${BLE_VERSION-}" ]] && ((_ble_version >= 400)); then
+if [[ -n ${BLE_VERSION-} ]] && ((_ble_version >= 400)); then
     ble-import contrib/integration/bash-preexec
 
     # Define and register an autosuggestion source for ble.sh's auto-complete.

--- a/atuin/src/shell/atuin.bash
+++ b/atuin/src/shell/atuin.bash
@@ -25,10 +25,10 @@ __atuin_precmd() {
     local duration=""
     # shellcheck disable=SC2154,SC2309
     if [[ -n "${BLE_ATTACHED-}" && _ble_bash -ge 50000 && -n "${_ble_exec_time_ata-}" ]]; then
-      # We use the high-resolution duration based on EPOCHREALTIME (bash >=
-      # 5.0) that is recorded by ble.sh. The shell variable
-      # `_ble_exec_time_ata` contains the execution time in microseconds.
-      duration=${_ble_exec_time_ata}000
+        # We use the high-resolution duration based on EPOCHREALTIME (bash >=
+        # 5.0) that is recorded by ble.sh. The shell variable
+        # `_ble_exec_time_ata` contains the execution time in microseconds.
+        duration=${_ble_exec_time_ata}000
     fi
 
     (ATUIN_LOG=error atuin history end --exit "${EXIT}" ${duration:+--duration "$duration"} -- "${ATUIN_HISTORY_ID}" &) >/dev/null 2>&1
@@ -71,38 +71,39 @@ __atuin_accept_line() {
     local __atuin_preexec_function_ret_value
     local __atuin_preexec_ret_value=0
     for __atuin_preexec_function in "${preexec_functions[@]:-}"; do
-      if type -t "$__atuin_preexec_function" 1>/dev/null; then
-        __atuin_set_ret_value "${__bp_last_ret_value:-}"
-        "$__atuin_preexec_function" "$__atuin_command"
-        __atuin_preexec_function_ret_value="$?"
-        if [[ "$__atuin_preexec_function_ret_value" != 0 ]]; then
-          __atuin_preexec_ret_value="$__atuin_preexec_function_ret_value"
+        if type -t "$__atuin_preexec_function" 1>/dev/null; then
+            __atuin_set_ret_value "${__bp_last_ret_value:-}"
+            "$__atuin_preexec_function" "$__atuin_command"
+            __atuin_preexec_function_ret_value="$?"
+            if [[ "$__atuin_preexec_function_ret_value" != 0 ]]; then
+                __atuin_preexec_ret_value="$__atuin_preexec_function_ret_value"
+            fi
         fi
-      fi
     done
 
     # If extdebug is turned on and any preexec function returns non-zero
     # exit status, we do not run the user command.
     if ! { shopt -q extdebug && ((__atuin_preexec_ret_value)); }; then
-      # Juggle the terminal settings so that the command can be interacted with
-      local __atuin_stty_backup
-      __atuin_stty_backup=$(stty -g)
-      stty "$ATUIN_STTY"
+        # Juggle the terminal settings so that the command can be interacted
+        # with
+        local __atuin_stty_backup
+        __atuin_stty_backup=$(stty -g)
+        stty "$ATUIN_STTY"
 
-      # Execute the command.  Note: We need to record $? and $_ after the
-      # user command within the same call of "eval" because $_ is otherwise
-      # overwritten by the last argument of "eval".
-      __atuin_set_ret_value "${__bp_last_ret_value-}" "${__bp_last_argument_prev_command-}"
-      eval -- "$__atuin_command"$'\n__bp_last_ret_value=$? __bp_last_argument_prev_command=$_'
+        # Execute the command.  Note: We need to record $? and $_ after the
+        # user command within the same call of "eval" because $_ is otherwise
+        # overwritten by the last argument of "eval".
+        __atuin_set_ret_value "${__bp_last_ret_value-}" "${__bp_last_argument_prev_command-}"
+        eval -- "$__atuin_command"$'\n__bp_last_ret_value=$? __bp_last_argument_prev_command=$_'
 
-      stty "$__atuin_stty_backup"
+        stty "$__atuin_stty_backup"
     fi
 
     # Execute preprompt commands
     local __atuin_prompt_command
     for __atuin_prompt_command in "${PROMPT_COMMAND[@]}"; do
-      __atuin_set_ret_value "${__bp_last_ret_value-}" "${__bp_last_argument_prev_command-}"
-      eval -- "$__atuin_prompt_command"
+        __atuin_set_ret_value "${__bp_last_ret_value-}" "${__bp_last_argument_prev_command-}"
+        eval -- "$__atuin_prompt_command"
     done
     # Bash will redraw only the line with the prompt after we finish,
     # so to work for a multiline prompt we need to print it ourselves,
@@ -141,20 +142,20 @@ __atuin_history() {
 
     if [[ $HISTORY == __atuin_accept__:* ]]
     then
-      HISTORY=${HISTORY#__atuin_accept__:}
+        HISTORY=${HISTORY#__atuin_accept__:}
 
-      if [[ -n "${BLE_ATTACHED-}" ]]; then
-        ble-edit/content/reset-and-check-dirty "$HISTORY"
-        ble/widget/accept-line
-      else
-        __atuin_accept_line "$HISTORY"
-      fi
+        if [[ -n "${BLE_ATTACHED-}" ]]; then
+            ble-edit/content/reset-and-check-dirty "$HISTORY"
+            ble/widget/accept-line
+        else
+            __atuin_accept_line "$HISTORY"
+        fi
 
-      READLINE_LINE=""
-      READLINE_POINT=${#READLINE_LINE}
+        READLINE_LINE=""
+        READLINE_POINT=${#READLINE_LINE}
     else
-      READLINE_LINE=${HISTORY}
-      READLINE_POINT=${#READLINE_LINE}
+        READLINE_LINE=${HISTORY}
+        READLINE_POINT=${#READLINE_LINE}
     fi
 }
 

--- a/atuin/src/shell/atuin.bash
+++ b/atuin/src/shell/atuin.bash
@@ -140,8 +140,7 @@ __atuin_history() {
     # We do nothing when the search is canceled.
     [[ $HISTORY ]] || return 0
 
-    if [[ $HISTORY == __atuin_accept__:* ]]
-    then
+    if [[ $HISTORY == __atuin_accept__:* ]]; then
         HISTORY=${HISTORY#__atuin_accept__:}
 
         if [[ ${BLE_ATTACHED-} ]]; then

--- a/atuin/src/shell/atuin.bash
+++ b/atuin/src/shell/atuin.bash
@@ -14,13 +14,13 @@ __atuin_preexec() {
 
     local id
     id=$(atuin history start -- "$1")
-    export ATUIN_HISTORY_ID=${id}
+    export ATUIN_HISTORY_ID=$id
 }
 
 __atuin_precmd() {
     local EXIT=$?
 
-    [[ -z "${ATUIN_HISTORY_ID}" ]] && return
+    [[ -z "$ATUIN_HISTORY_ID" ]] && return
 
     local duration=""
     # shellcheck disable=SC2154,SC2309
@@ -31,7 +31,7 @@ __atuin_precmd() {
         duration=${_ble_exec_time_ata}000
     fi
 
-    (ATUIN_LOG=error atuin history end --exit "${EXIT}" ${duration:+--duration "$duration"} -- "${ATUIN_HISTORY_ID}" &) >/dev/null 2>&1
+    (ATUIN_LOG=error atuin history end --exit "$EXIT" ${duration:+--duration "$duration"} -- "$ATUIN_HISTORY_ID" &) >/dev/null 2>&1
     export ATUIN_HISTORY_ID=""
 }
 
@@ -135,7 +135,7 @@ __atuin_history() {
         fi
     fi
 
-    HISTORY=$(ATUIN_SHELL_BASH=t ATUIN_LOG=error atuin search "$@" -i -- "${READLINE_LINE}" 3>&1 1>&2 2>&3)
+    HISTORY=$(ATUIN_SHELL_BASH=t ATUIN_LOG=error atuin search "$@" -i -- "$READLINE_LINE" 3>&1 1>&2 2>&3)
 
     # We do nothing when the search is canceled.
     [[ $HISTORY ]] || return 0
@@ -154,7 +154,7 @@ __atuin_history() {
         READLINE_LINE=""
         READLINE_POINT=${#READLINE_LINE}
     else
-        READLINE_LINE=${HISTORY}
+        READLINE_LINE=$HISTORY
         READLINE_POINT=${#READLINE_LINE}
     fi
 }


### PR DESCRIPTION
This is just a cosmetic one. I originally planned to submit this after settling all the planned PRs, but some would overlap. I still have two planned PRs, but I'd like to submit this before those two.

Different coding styles and indentations are mixed in the current `atuin.bash`. In this PR, I try to normalize them. I separate the commits for each topic. These are more or less preferences, so if you would like the normalization the other way around, please specify it. I can adjust them (after the confirmation about the consequences if needed).

As usual, I left descriptions in commit messages.