### PR TITLE
docs: fix `Destination file already exists` in Nushell

### DIFF
--- a/README.md
+++ b/README.md
@@ -313,7 +313,7 @@ Run in *Nushell*:
 
 ```
 mkdir ~/.local/share/atuin/
-atuin init nu | save ~/.local/share/atuin/init.nu
+atuin init nu | save -f ~/.local/share/atuin/init.nu
 ```
 
 Add to `config.nu`:


### PR DESCRIPTION
It is a common practice to use `-f` in Nushell configurations to avoid `Destination file already exists` error.


```nushell
🦄 nu
Error:   × Destination file already exists
    ╭─[/home/user/.config/nushell/env.nu:20:1]
 20 │ starship init nu | save -f ~/.cache/starship/init.nu
 21 │ atuin init nu | save ~/.local/share/atuin/init.nu
    ·                      ──────────────┬─────────────
    ·                                    ╰── Destination file '/home/user/.local/share/atuin/init.nu' already exists
 22 │
    ╰────
  help: you can use -f, --force to force overwriting the destination
```

