### PR TITLE
fix(bash): work around bash < 4 and introduce initialization guards

### DIFF
--- a/README.md
+++ b/README.md
@@ -265,6 +265,8 @@ antigen bundle atuinsh/atuin@main
 
 ### bash
 
+Atuin works in `bash >= 3.1`, but we recommend to use Atuin with the recent versions of `bash >= 5`.
+
 #### [ble.sh](https://github.com/akinomyoga/ble.sh)
 
 Atuin works best in bash when using [ble.sh](https://github.com/akinomyoga/ble.sh) >= 0.4.
@@ -297,6 +299,8 @@ echo 'eval "$(atuin init bash)"' >> ~/.bashrc
 **PLEASE NOTE**
 
 bash-preexec currently has an issue where it will stop honoring `ignorespace`. While Atuin will ignore commands prefixed with whitespace, they may still end up in your bash history. Please check your configuration! All other shells do not have this issue.
+
+To use Atuin in `bash < 4` with bash-preexec, the option `enter_accept` needs to be turned on (which is so by default).
 
 ### fish
 

--- a/atuin/src/shell/atuin.bash
+++ b/atuin/src/shell/atuin.bash
@@ -1,3 +1,6 @@
+# Enable only in interactive shells
+[[ $- == *i* ]] || return 0
+
 ATUIN_SESSION=$(atuin uuid)
 ATUIN_STTY=$(stty -g)
 export ATUIN_SESSION

--- a/atuin/src/shell/atuin.bash
+++ b/atuin/src/shell/atuin.bash
@@ -1,6 +1,12 @@
 # Enable only in interactive shells
 [[ $- == *i* ]] || return 0
 
+# Require bash >= 3.1
+if ((BASH_VERSINFO[0] < 3 || BASH_VERSINFO[0] == 3 && BASH_VERSINFO[1] < 1)); then
+    [[ -t 2 ]] && printf 'atuin: requires bash >= 3.1 for the integration.\n' >&2
+    return 0
+fi
+
 ATUIN_SESSION=$(atuin uuid)
 ATUIN_STTY=$(stty -g)
 export ATUIN_SESSION

--- a/atuin/src/shell/atuin.bash
+++ b/atuin/src/shell/atuin.bash
@@ -163,6 +163,12 @@ __atuin_history() {
         fi
     fi
 
+    # READLINE_LINE and READLINE_POINT are only supported by bash >= 4.0 or
+    # ble.sh.  When it is not supported, we localize them to suppress strange
+    # behaviors.
+    [[ ${BLE_ATTACHED-} ]] || ((BASH_VERSINFO[0] >= 4)) ||
+        local READLINE_LINE="" READLINE_POINT=0
+
     local __atuin_output
     __atuin_output=$(ATUIN_SHELL_BASH=t ATUIN_LOG=error atuin search "$@" -i -- "$READLINE_LINE" 3>&1 1>&2 2>&3)
 

--- a/atuin/src/shell/atuin.bash
+++ b/atuin/src/shell/atuin.bash
@@ -1,3 +1,7 @@
+# Include guard
+[[ ${__atuin_initialized-} == true ]] && return 0
+__atuin_initialized=true
+
 # Enable only in interactive shells
 [[ $- == *i* ]] || return 0
 


### PR DESCRIPTION
### (First commit) Check interactive shell.

In a typical configuration of `.bashrc`, in an interactive session (where `$-` contains the letter `i`), it returns at the beginning of `~/.bashrc`. However, a different configuration is possible. In such a case, `eval "$(atuin init bash)"` can be called from non-interactive shells, and causes error messages related to the keybindings, i.e., the uses of the `bind` command in non-interactive shells causes warning messages. We can have a check also at the beginning of `atuin.bash`.

### (Second commit) Check the Bash version
The requirement on the Bash version does not seem to be clarified anywhere, so I suggest explicitly specifying it to be bash >= 3.1.  This is the same as that of bash-preexec.

- As far as I tested it in Bash 3.1 and 3.2 with bash-preexec, it doesn't work perfectly, but it still works in not a too bad way with `enter_accept`. In Bash 3.1 & 3.2, there is no way to obtain the content of the current command line because `READLINE_LINE` and `READLINE_POINT` are only introduced in bash >= 4. This forces Atuin to always start with the full history for the search (without filtering by the current command-line content), but it still works with `enter_accept`. Also, there is no way to clear up the current command-line content after `enter_accept`. This behavior might feel a bit strange, but it's still acceptable.
- Without `enter_accept`, there is no robust way to insert the suggestion in the command line. I here suggest just noting that in README. Alternatively, we could still insert the suggestion by doing a hack similar to what is done by [`fzf-keybindings.bash` L110](https://github.com/junegunn/fzf/blob/e4d0f7acd516d8f5869d3a2210fbf552743a129a/shell/key-bindings.bash#L110). Although this can be broken by various conditions, if would like to introduce, this one I can consider the possibility of implementing it.
- Note: this does not happen with ble.sh. ble.sh implements `READLINE_LINE` and `READLINE_POINT` also for Bash 3.

### (Third commit) Work around missing READLINE_LINE in Bash 3 w/ bash-preexec

However, in bash < 4, there is still possibly a strange behavior caused by the remaining `READLINE_LINE` from the previous call of `atuin`. To prevent it, I suggest localizing `READLINE_LINE` and `READLINE_POINT` in bash < 4 without ble.sh. I also left some descriptions in the commit message.

### (Fourth commit) Avoid double initialization

See the commit message. As another option, we may add our hooks into `preexec_functions` and `precmd_functions` only when there are no existing ones. This enables the reloading of Atuin's settings in the same shell session after updating Atuin. If you'd like it this way, I can adjust the PR.
