### PR TITLE
refactor(bash): refactor and localize `HISTORY => __atuin_output`

### DIFF
--- a/atuin/src/shell/atuin.bash
+++ b/atuin/src/shell/atuin.bash
@@ -135,25 +135,26 @@ __atuin_history() {
         fi
     fi
 
-    HISTORY=$(ATUIN_SHELL_BASH=t ATUIN_LOG=error atuin search "$@" -i -- "$READLINE_LINE" 3>&1 1>&2 2>&3)
+    local __atuin_output
+    __atuin_output=$(ATUIN_SHELL_BASH=t ATUIN_LOG=error atuin search "$@" -i -- "$READLINE_LINE" 3>&1 1>&2 2>&3)
 
     # We do nothing when the search is canceled.
-    [[ $HISTORY ]] || return 0
+    [[ $__atuin_output ]] || return 0
 
-    if [[ $HISTORY == __atuin_accept__:* ]]; then
-        HISTORY=${HISTORY#__atuin_accept__:}
+    if [[ $__atuin_output == __atuin_accept__:* ]]; then
+        __atuin_output=${__atuin_output#__atuin_accept__:}
 
         if [[ ${BLE_ATTACHED-} ]]; then
-            ble-edit/content/reset-and-check-dirty "$HISTORY"
+            ble-edit/content/reset-and-check-dirty "$__atuin_output"
             ble/widget/accept-line
         else
-            __atuin_accept_line "$HISTORY"
+            __atuin_accept_line "$__atuin_output"
         fi
 
         READLINE_LINE=""
         READLINE_POINT=${#READLINE_LINE}
     else
-        READLINE_LINE=$HISTORY
+        READLINE_LINE=$__atuin_output
         READLINE_POINT=${#READLINE_LINE}
     fi
 }

--- a/atuin/src/shell/atuin.zsh
+++ b/atuin/src/shell/atuin.zsh
@@ -54,6 +54,7 @@ _atuin_search() {
 
     # swap stderr and stdout, so that the tui stuff works
     # TODO: not this
+    local output
     # shellcheck disable=SC2048
     output=$(ATUIN_SHELL_ZSH=t ATUIN_LOG=error atuin search $* -i -- $BUFFER 3>&1 1>&2 2>&3)
 


### PR DESCRIPTION
This is relatively trivial. I do not see the global variable `HISTORY` set by `__atuin_history` being documented. Also, the variable names are different for different shells (e.g. `output` in zsh, and `ATUIN_H` in fish), so this doesn't seem to be a part of the public interface of Atuin's integration. I'd suggest localizing those variables. Note that `ATUIN_H` in fish seems to be already local. I'm not sure how this is processed for the Nu shell integration, but I guess it would be processed without creating a variable.

I also localize `output` set by the Zsh integration. Even if we expose it on purpose, the variable name choice doesn't seem nice to avoid conflicts with the users' variables.
