### PR TITLE
fix(windows): disables unix specific stuff for windows

### DIFF
--- a/atuin/src/command/mod.rs
+++ b/atuin/src/command/mod.rs
@@ -2,7 +2,7 @@ use clap::{CommandFactory, Subcommand};
 use clap_complete::{generate, generate_to, Shell};
 use eyre::Result;
 
-#[cfg(not(target_family = "windows"))]
+#[cfg(not(windows))]
 use rustix::{fs::Mode, process::umask};
 
 #[cfg(feature = "client")]
@@ -49,8 +49,7 @@ pub enum AtuinCmd {
 
 impl AtuinCmd {
     pub fn run(self) -> Result<()> {
-
-        #[cfg(not(target_family = "windows"))]
+        #[cfg(not(windows))]
         {
             // set umask before we potentially open/create files
             // or in other words, 077. Do not allow any access to any other user

--- a/atuin/src/command/mod.rs
+++ b/atuin/src/command/mod.rs
@@ -2,6 +2,7 @@ use clap::{CommandFactory, Subcommand};
 use clap_complete::{generate, generate_to, Shell};
 use eyre::Result;
 
+#[cfg(not(target_family = "windows"))]
 use rustix::{fs::Mode, process::umask};
 
 #[cfg(feature = "client")]
@@ -48,10 +49,14 @@ pub enum AtuinCmd {
 
 impl AtuinCmd {
     pub fn run(self) -> Result<()> {
-        // set umask before we potentially open/create files
-        // or in other words, 077. Do not allow any access to any other user
-        let mode = Mode::RWXG | Mode::RWXO;
-        umask(mode);
+
+        #[cfg(not(target_family = "windows"))]
+        {
+            // set umask before we potentially open/create files
+            // or in other words, 077. Do not allow any access to any other user
+            let mode = Mode::RWXG | Mode::RWXO;
+            umask(mode);
+        }
 
         match self {
             #[cfg(feature = "client")]


### PR DESCRIPTION
Windows automatically doesn't allow other users to access other's files (unless they are a admin). So a replacement for windows isn't needed.