### PR TITLE
chore: make clipboard dep optional as a feature

### DIFF
--- a/atuin/Cargo.toml
+++ b/atuin/Cargo.toml
@@ -33,10 +33,11 @@ buildflags = ["--release"]
 atuin = { path = "/usr/bin/atuin" }
 
 [features]
-default = ["client", "sync", "server"]
+default = ["client", "sync", "server", "clipboard"]
 client = ["atuin-client"]
 sync = ["atuin-client/sync"]
 server = ["atuin-server", "atuin-server-postgres", "tracing-subscriber"]
+clipboard = ["cli-clipboard"]
 
 [dependencies]
 atuin-server-postgres = { path = "../atuin-server-postgres", version = "17.2.1", optional = true }
@@ -73,7 +74,7 @@ fuzzy-matcher = "0.3.7"
 colored = "2.0.4"
 ratatui = "0.25"
 tracing = "0.1"
-cli-clipboard = "0.4.0"
+cli-clipboard = { version = "0.4.0", optional = true }
 
 
 [dependencies.tracing-subscriber]

--- a/atuin/src/command/client/search/interactive.rs
+++ b/atuin/src/command/client/search/interactive.rs
@@ -940,7 +940,7 @@ pub async fn history(
         InputAction::ReturnOriginal => Ok(String::new()),
         InputAction::Copy(index) => {
             let cmd = results.swap_remove(index).command;
-            cli_clipboard::set_contents(cmd).unwrap();
+            set_clipboard(cmd);
             Ok(String::new())
         }
         InputAction::ReturnQuery | InputAction::Accept(_) => {
@@ -954,3 +954,11 @@ pub async fn history(
         }
     }
 }
+
+#[cfg(feature = "clipboard")]
+fn set_clipboard(s: String) {
+    cli_clipboard::set_contents(s).unwrap();
+}
+
+#[cfg(not(feature = "clipboard"))]
+fn set_clipboard(_s: String) {}


### PR DESCRIPTION
The cli-clipboard crate doesn't compile on systems other than Windows, Linux and MacOS, e.g. on Android it fails to compile.