### PR TITLE
fix(search): fix invisible tab title in light background

### DIFF
--- a/atuin/src/command/client/search/interactive.rs
+++ b/atuin/src/command/client/search/interactive.rs
@@ -469,7 +469,7 @@ impl State {
             .block(Block::default().borders(Borders::NONE))
             .select(self.tab_index)
             .style(Style::default())
-            .highlight_style(Style::default().bold().on_black());
+            .highlight_style(Style::default().bold().white().on_black());
 
         f.render_widget(tabs, tabs_chunk);
 


### PR DESCRIPTION
In the current `main` branch, I cannot read the selected tab title because the background and foreground colors are the same in terminals with the light background. Here is an example (where the red part is drawn by me):

![atuin-pr16-2](https://github.com/atuinsh/atuin/assets/8982192/8ad26dca-7b71-4a2e-95b1-f2b165d4c451)

This patch specifies the foreground color explicitly. After the fix, it looks as follows:

![atuin-pr16-1](https://github.com/atuinsh/atuin/assets/8982192/afdc8930-e790-4994-9e67-e081802c6dc5)
