### PR TITLE
Fix fish integration on older fishes

### DIFF
--- a/atuin/src/shell/atuin.fish
+++ b/atuin/src/shell/atuin.fish
@@ -19,11 +19,14 @@ function _atuin_postexec --on-event fish_postexec
 end
 
 function _atuin_search
-    set -l ATUIN_H (ATUIN_SHELL_FISH=t ATUIN_LOG=error atuin search $argv -i -- (commandline -b) 3>&1 1>&2 2>&3)
+    # In fish 3.4 and above we can use `"$(some command)"` to keep multiple lines separate;
+    # but to support fish 3.3 we need to use `(some command | string collect)`.
+    # https://fishshell.com/docs/current/relnotes.html#id24 (fish 3.4 "Notable improvements and fixes")
+    set -l ATUIN_H (ATUIN_SHELL_FISH=t ATUIN_LOG=error atuin search $argv -i -- (commandline -b) 3>&1 1>&2 2>&3 | string collect)
 
     if test -n "$ATUIN_H"
         if string match --quiet '__atuin_accept__:*' "$ATUIN_H"
-          set -l ATUIN_HIST (string replace "__atuin_accept__:" "" -- "$ATUIN_H")
+          set -l ATUIN_HIST (string replace "__atuin_accept__:" "" -- "$ATUIN_H" | string collect)
           commandline -r "$ATUIN_HIST"
           commandline -f repaint
           commandline -f execute

--- a/atuin/src/shell/atuin.fish
+++ b/atuin/src/shell/atuin.fish
@@ -19,11 +19,11 @@ function _atuin_postexec --on-event fish_postexec
 end
 
 function _atuin_search
-    set -l ATUIN_H "$(ATUIN_SHELL_FISH=t ATUIN_LOG=error atuin search $argv -i -- (commandline -b) 3>&1 1>&2 2>&3)"
+    set -l ATUIN_H (ATUIN_SHELL_FISH=t ATUIN_LOG=error atuin search $argv -i -- (commandline -b) 3>&1 1>&2 2>&3)
 
     if test -n "$ATUIN_H"
         if string match --quiet '__atuin_accept__:*' "$ATUIN_H"
-          set -l ATUIN_HIST "$(string replace "__atuin_accept__:" "" -- "$ATUIN_H")"
+          set -l ATUIN_HIST (string replace "__atuin_accept__:" "" -- "$ATUIN_H")
           commandline -r "$ATUIN_HIST"
           commandline -f repaint
           commandline -f execute


### PR DESCRIPTION
- On fish 3.3 the bash-style `$(...)` doesn't work, we should use `(...)`
- Also quoting `"(moo)"` on older fishes gives a literal `moo`
- The result of a `(subcommand)` is a single token, so no need to quote it, anyway

Tested by making the change, executing `cargo run -- init fish > atuin.fish` and then copying and source that script on a system with fish 3.3, as well as 3.6 and observing both still work.

Fixes #1562.