### PR TITLE
fix(sync): save sync time when it starts, not ends

### DIFF
--- a/atuin-client/src/sync.rs
+++ b/atuin-client/src/sync.rs
@@ -196,6 +196,8 @@ pub async fn sync(settings: &Settings, force: bool, db: &(impl Database + Send))
         settings.network_timeout,
     )?;
 
+    Settings::save_sync_time()?;
+
     let key = load_key(settings)?; // encryption key
 
     sync_upload(&key, force, &client, db).await?;
@@ -203,8 +205,6 @@ pub async fn sync(settings: &Settings, force: bool, db: &(impl Database + Send))
     let download = sync_download(&key, force, &client, db).await?;
 
     debug!("sync downloaded {}", download.0);
-
-    Settings::save_sync_time()?;
 
     Ok(())
 }


### PR DESCRIPTION
Imagine the scenario where a sync fails. The function touched here will never save the sync time.

That means that external to this function, the sync never happened. The next command will try and start one immediately.

The happy scenario is that this succeeds. The unhappy scenario is that this fails. Fails, and isn't saved, so we try again...

Should add proper backoff but this is a good start.