### PR TITLE
Stop control characters being printed to terminal

### DIFF
--- a/atuin/src/command/client/history.rs
+++ b/atuin/src/command/client/history.rs
@@ -5,7 +5,7 @@ use std::{
     time::Duration,
 };
 
-use atuin_common::utils;
+use atuin_common::utils::{self, Escapable as _};
 use clap::Subcommand;
 use eyre::{Context, Result};
 use runtime_format::{FormatKey, FormatKeyError, ParseSegment, ParsedFmt};
@@ -201,7 +201,7 @@ impl FormatKey for FmtHistory<'_> {
     #[allow(clippy::cast_sign_loss)]
     fn fmt(&self, key: &str, f: &mut fmt::Formatter<'_>) -> Result<(), FormatKeyError> {
         match key {
-            "command" => f.write_str(self.0.command.trim())?,
+            "command" => f.write_str(&self.0.command.trim().escape_control())?,
             "directory" => f.write_str(self.0.cwd.trim())?,
             "exit" => f.write_str(&self.0.exit.to_string())?,
             "duration" => {

--- a/atuin/src/command/client/search.rs
+++ b/atuin/src/command/client/search.rs
@@ -1,4 +1,4 @@
-use atuin_common::utils;
+use atuin_common::utils::{self, Escapable as _};
 use clap::Parser;
 use eyre::Result;
 
@@ -144,7 +144,7 @@ impl Cmd {
 
         if self.interactive {
             let item = interactive::history(&self.query, settings, db).await?;
-            eprintln!("{item}");
+            eprintln!("{}", item.escape_control());
         } else {
             let list_mode = ListMode::from_flags(self.human, self.cmd_only);
 

--- a/atuin/src/command/client/search/history_list.rs
+++ b/atuin/src/command/client/search/history_list.rs
@@ -1,6 +1,7 @@
 use std::time::Duration;
 
 use atuin_client::history::History;
+use atuin_common::utils::Escapable as _;
 use ratatui::{
     buffer::Buffer,
     layout::Rect,
@@ -168,7 +169,7 @@ impl DrawState<'_> {
             style = style.fg(Color::Red).add_modifier(Modifier::BOLD);
         }
 
-        for section in h.command.split_ascii_whitespace() {
+        for section in h.command.escape_control().split_ascii_whitespace() {
             self.x += 1;
             if self.x > self.list_area.width {
                 // Avoid attempting to draw a command section beyond the width

--- a/atuin/src/command/client/stats.rs
+++ b/atuin/src/command/client/stats.rs
@@ -1,5 +1,6 @@
 use std::collections::{HashMap, HashSet};
 
+use atuin_common::utils::Escapable as _;
 use clap::Parser;
 use crossterm::style::{Color, ResetColor, SetAttribute, SetForegroundColor};
 use eyre::{bail, Result};
@@ -66,7 +67,10 @@ fn compute_stats(settings: &Settings, history: &[History], count: usize) -> Resu
             print!(" ");
         }
 
-        println!("{ResetColor}] {gray}{count:num_pad$}{ResetColor} {bold}{command}{ResetColor}");
+        println!(
+            "{ResetColor}] {gray}{count:num_pad$}{ResetColor} {bold}{}{ResetColor}",
+            command.escape_control()
+        );
     }
     println!("Total commands:   {}", history.len());
     println!("Unique commands:  {unique}");


### PR DESCRIPTION
Detail of change is in the commit message but easiest steps to reproduce is to open a new terminal and run the following

```sh
echo one
echo '^[[31mtwo' # with `^[` entered as literal using ctrl-v + ctrl-[
echo three
atuin history list -s
```

With the previous behaviour, the control sequence would not be visible (and therefore not copyable) and everything after the second 'echo' would be red.

Running `atuin search -i --filter-mode session` afterwards would display the `echo two` command as `echo '[31mtwo'`. Selecting it would print `echo 'two'` without the control sequence and two onwards in red.