### PR TITLE
feat: add metrics counter for records downloaded

### DIFF
--- a/atuin-server/src/handlers/v0/record.rs
+++ b/atuin-server/src/handlers/v0/record.rs
@@ -107,5 +107,7 @@ pub async fn next<DB: Database>(
         }
     };
 
+    counter!("atuin_record_downloaded", records.len() as u64);
+
     Ok(Json(records))
 }


### PR DESCRIPTION
We have uploaded, so this follows. Now that it's (in `main`) used for sync, I'd like to monitor properly while testing

To watch for: reasonably similar upload/download when used across machines, rather than the higher values we saw for the old sync