### PR TITLE
Print literal control characters to non terminals

### DIFF
--- a/atuin/src/command/client/search.rs
+++ b/atuin/src/command/client/search.rs
@@ -1,3 +1,5 @@
+use std::io::{stderr, IsTerminal as _};
+
 use atuin_common::utils::{self, Escapable as _};
 use clap::Parser;
 use eyre::Result;
@@ -167,7 +169,11 @@ impl Cmd {
 
         if self.interactive {
             let item = interactive::history(&self.query, settings, db, &history_store).await?;
-            eprintln!("{}", item.escape_control());
+            if stderr().is_terminal() {
+                eprintln!("{}", item.escape_control());
+            } else {
+                eprintln!("{}", item);
+            }
         } else {
             let list_mode = ListMode::from_flags(self.human, self.cmd_only);
 

--- a/atuin/src/command/client/search.rs
+++ b/atuin/src/command/client/search.rs
@@ -172,7 +172,7 @@ impl Cmd {
             if stderr().is_terminal() {
                 eprintln!("{}", item.escape_control());
             } else {
-                eprintln!("{}", item);
+                eprintln!("{item}");
             }
         } else {
             let list_mode = ListMode::from_flags(self.human, self.cmd_only);


### PR DESCRIPTION
Previous 'fix' to prevent control sequences being interpreted when they
shouldn't have been also prevented them being used when they should have
been. This checks if the output is to a terminal (where control
sequences shouldn't be interpreted) before escaping control characters.
