### PR TITLE
Escape control characters in command preview

### DIFF
--- a/atuin/src/command/client/search/interactive.rs
+++ b/atuin/src/command/client/search/interactive.rs
@@ -3,7 +3,7 @@ use std::{
     time::Duration,
 };
 
-use atuin_common::utils;
+use atuin_common::utils::{self, Escapable as _};
 use crossterm::{
     cursor::SetCursorStyle,
     event::{
@@ -678,7 +678,7 @@ impl State {
                         .map(|(i, _)| i)
                         .chain(Some(line.len()))
                         .tuple_windows()
-                        .map(|(a, b)| &line[a..b])
+                        .map(|(a, b)| (&line[a..b]).escape_control().to_string())
                 })
                 .join("\n")
         };


### PR DESCRIPTION
This was missed in the initial change to escape control characters.