### PR TITLE
Use existing db querying for history list

### DIFF
--- a/atuin/src/command/client/search/engines.rs
+++ b/atuin/src/command/client/search/engines.rs
@@ -35,7 +35,7 @@ pub trait SearchEngine: Send + Sync + 'static {
     async fn query(&mut self, state: &SearchState, db: &mut dyn Database) -> Result<Vec<History>> {
         if state.input.as_str().is_empty() {
             Ok(db
-                .list(state.filter_mode, &state.context, Some(200), true, false)
+                .list(&[state.filter_mode], &state.context, Some(200), true, false)
                 .await?
                 .into_iter()
                 .collect::<Vec<_>>())

--- a/atuin/src/command/client/stats.rs
+++ b/atuin/src/command/client/stats.rs
@@ -9,7 +9,7 @@ use interim::parse_date_string;
 use atuin_client::{
     database::{current_context, Database},
     history::History,
-    settings::{FilterMode, Settings},
+    settings::Settings,
 };
 use time::{Duration, OffsetDateTime, Time};
 
@@ -92,8 +92,7 @@ impl Cmd {
         let last_night = now.replace_time(Time::MIDNIGHT);
 
         let history = if words.as_str() == "all" {
-            db.list(FilterMode::Global, &context, None, false, false)
-                .await?
+            db.list(&[], &context, None, false, false).await?
         } else if words.trim() == "today" {
             let start = last_night;
             let end = start + Duration::days(1);


### PR DESCRIPTION
When printing the history list with either the session or cwd filter
enabled, use to same query method as without either to ensure that the
other options (hide deleted entries etc) are respected.
