### PR TITLE
fix: report alternate keys so shift still works

### DIFF
--- a/atuin/src/command/client/search/interactive.rs
+++ b/atuin/src/command/client/search/interactive.rs
@@ -722,6 +722,7 @@ impl Stdout {
             PushKeyboardEnhancementFlags(
                 KeyboardEnhancementFlags::DISAMBIGUATE_ESCAPE_CODES
                     | KeyboardEnhancementFlags::REPORT_ALL_KEYS_AS_ESCAPE_CODES
+                    | KeyboardEnhancementFlags::REPORT_ALTERNATE_KEYS
             ),
         )?;
 


### PR DESCRIPTION
Kitty terminal was sending `shift-a` as `shift` + `a` and not `A`, and we have no special handling of shift, so atuin was only acknowledging lowercase `a`.

https://sw.kovidgoyal.net/kitty/keyboard-protocol/#report-alternate-keys fixes it for me, although I don't know if this has any other side-effects