### PR TITLE
feat: make store init idempotent

### DIFF
--- a/atuin/src/command/client/history.rs
+++ b/atuin/src/command/client/history.rs
@@ -379,6 +379,11 @@ impl Cmd {
         for i in history {
             println!("loaded {}", i.id);
 
+            if db.load(i.id.0.as_str()).await?.is_some() {
+                println!("skipping {} - already exists", i.id);
+                continue;
+            }
+
             if i.deleted_at.is_some() {
                 store.push(i.clone()).await?;
                 store.delete(i.id).await?;


### PR DESCRIPTION
This ensures that the user can run

```
atuin history init-store
```

a whole bunch of times, without getting duplicates in the store

Note that without this, nothing would break. You'd just end up with a much larger record store than necessary, which would be de-duped when built into a history database. Not ideal.