### PR TITLE
feat: make store init idempotent

### DIFF
--- a/atuin-client/src/history/store.rs
+++ b/atuin-client/src/history/store.rs
@@ -1,3 +1,5 @@
+use std::collections::HashSet;
+
 use eyre::{bail, eyre, Result};
 use rmp::decode::Bytes;
 
@@ -229,6 +231,20 @@ impl HistoryStore {
         }
 
         Ok(())
+    }
+
+    /// Get a list of history IDs that exist in the store
+    /// Note: This currently involves loading all history into memory. This is not going to be a
+    /// large amount in absolute terms, but do not all it in a hot loop.
+    pub async fn history_ids(&self) -> Result<HashSet<HistoryId>> {
+        let history = self.history().await?;
+
+        let ret = HashSet::from_iter(history.iter().map(|h| match h {
+            HistoryRecord::Create(h) => h.id.clone(),
+            HistoryRecord::Delete(id) => id.clone(),
+        }));
+
+        Ok(ret)
     }
 }
 

--- a/atuin/src/command/client/history.rs
+++ b/atuin/src/command/client/history.rs
@@ -374,10 +374,19 @@ impl Cmd {
     ) -> Result<()> {
         println!("Importing all history.db data into records.db");
 
+        println!("Fetching history from old database");
         let history = db.list(&[], &context, None, false, true).await?;
+
+        println!("Fetching history already in store");
+        let store_ids = store.history_ids().await?;
 
         for i in history {
             println!("loaded {}", i.id);
+
+            if store_ids.contains(&i.id) {
+                println!("skipping {} - already exists", i.id);
+                continue;
+            }
 
             if i.deleted_at.is_some() {
                 store.push(i.clone()).await?;


### PR DESCRIPTION
Make the history store init idempotent

This ensures the user cannot import the same data from the database multiple times

Useful for the case where the user toggles the record store sync on/off, and to ensure accidents don't lead to store bloat.