### PR TITLE
fix(history): dedupe was removing history

### DIFF
--- a/atuin-client/src/database.rs
+++ b/atuin-client/src/database.rs
@@ -306,10 +306,7 @@ impl Database for Sqlite {
         }
 
         if unique {
-            query.and_where_eq(
-                "timestamp",
-                "(select max(timestamp) from history where h.command = history.command)",
-            );
+            query.group_by("command").having("max(timestamp)");
         }
 
         if let Some(max) = max {


### PR DESCRIPTION
Related: https://forum.atuin.sh/t/search-ignoring-commands/74/5?u=ellie

When a user ran a duplicated command, but in another session, it was removed by filters. This is because the subquery that was once used did not have the same filters applied as the main query.

Instead of messing with subqueries, `group by` instead. This aligns with the search() function