### PR TITLE
feat: don't stop with invalid key

### DIFF
--- a/atuin-client/src/history/store.rs
+++ b/atuin-client/src/history/store.rs
@@ -164,7 +164,16 @@ impl HistoryStore {
         for record in records.into_iter() {
             let hist = match record.version.as_str() {
                 HISTORY_VERSION => {
-                    let decrypted = record.decrypt::<PASETO_V4>(&self.encryption_key)?;
+                    let decrypted = record.decrypt::<PASETO_V4>(&self.encryption_key);
+
+                    let decrypted = match decrypted {
+                        Ok(d) => d,
+                        Err(e) => {
+                            println!("failed to decrypt history: {e}");
+                            continue;
+                        }
+                    };
+
                     HistoryRecord::deserialize(&decrypted.data, HISTORY_VERSION)
                 }
                 version => bail!("unknown history version {version:?}"),

--- a/atuin-client/src/record/encryption.rs
+++ b/atuin-client/src/record/encryption.rs
@@ -128,6 +128,7 @@ impl PASETO_V4 {
         // For now though we will only support the one key and key rotation will
         // have to be a hard reset
         let current_kid = wrapping_key.to_id();
+
         ensure!(
             current_kid == kid,
             "attempting to decrypt with incorrect key. currently using {current_kid}, expecting {kid}"


### PR DESCRIPTION
An issue with the old sync was that if there was _one_ record encrypted with a different key, sync would stop. You'd need to delete your account and start from scratch. This sucked.

This change means we will carry on, and try to encrypt and build with as much of the history as we are able to decrypt.

This is possible because we can quite happily store data on disk that we cannot decrypt. The old store couldn't do this.

In future, we might consider a keyring containing multiple keys.