### PR TITLE
fix(bash): strip control chars generated by `\[\]` in PS1 with bash-preexec

### DIFF
--- a/atuin/src/shell/atuin.bash
+++ b/atuin/src/shell/atuin.bash
@@ -88,10 +88,15 @@ if ((BASH_VERSINFO[0] >= 5 || BASH_VERSINFO[0] == 4 && BASH_VERSINFO[1] >= 4)); 
         # characters before outputting it to the terminal.  We here strip these
         # characters following Bash's behavior.
         __atuin_prompt=${__atuin_prompt//[$'\001\002']}
+
+        # Count the number of newlines contained in $__atuin_prompt
+        __atuin_prompt_offset=${__atuin_prompt//[!$'\n']}
+        __atuin_prompt_offset=${#__atuin_prompt_offset}
     }
 else
     __atuin_evaluate_prompt() {
         __atuin_prompt='$ '
+        __atuin_prompt_offset=0
     }
 fi
 
@@ -99,10 +104,8 @@ __atuin_accept_line() {
     local __atuin_command=$1
 
     # Reprint the prompt, accounting for multiple lines
-    local __atuin_prompt
+    local __atuin_prompt __atuin_prompt_offset
     __atuin_evaluate_prompt
-    local __atuin_prompt_offset
-    __atuin_prompt_offset=$(printf '%s' "$__atuin_prompt" | wc -l)
     if ((__atuin_prompt_offset > 0)); then
         tput cuu "$__atuin_prompt_offset"
     fi


### PR DESCRIPTION
Fixes https://github.com/atuinsh/atuin/issues/1617

This contains an extra commit dc2afa7, which counts the newlines in the prompt result using Bash's built-in features. The previous implementations used the external command `wc` with the command substitution, which involves 3 forks and 1 exec so is slow. We can count newlines by first removing all the characters except for the newlines and then counting the number of remaining characters.
