### PR TITLE
Fix: Check for format errors when printing history

### DIFF
--- a/atuin/src/command/client/history.rs
+++ b/atuin/src/command/client/history.rs
@@ -152,7 +152,12 @@ pub fn print_list(
     for h in iterator {
         let fh = FmtHistory(h, CmdFormat::for_output(&w));
         let args = parsed_fmt.with_args(&fh);
-        check_for_write_errors(write!(w, "{args}{entry_terminator}"));
+        let write = write!(w, "{args}{entry_terminator}");
+        if let Err(err) = args.status() {
+            eprintln!("ERROR: history output failed with: {err}");
+            std::process::exit(1);
+        }
+        check_for_write_errors(write);
         if flush_each_line {
             check_for_write_errors(w.flush());
         }


### PR DESCRIPTION
Improve the errors reported when a format string is not valid, eg

    atuin search cargo --format '{invalid}'

gives

    history output failed with: The requested key "invalid" is unknown

instead of

    history output failed with: formatter error

Was the runtime-format library forked/written for use in atuin - it looks like
the timelines match? How feasible would it be either vendor the parts atuin
needs or refactor it so that the API exposes errors in a more conventional way?
I notice the repo doesn't have issues enabled or I'd raise it there.
