### PR TITLE
chore: add feature to allow always disable check update

### DIFF
--- a/atuin-client/Cargo.toml
+++ b/atuin-client/Cargo.toml
@@ -15,6 +15,7 @@ repository = { workspace = true }
 [features]
 default = ["sync"]
 sync = ["urlencoding", "reqwest", "sha2", "hex"]
+check-update = []
 
 [dependencies]
 atuin-common = { path = "../atuin-common", version = "17.2.1" }

--- a/atuin-client/src/api_client.rs
+++ b/atuin-client/src/api_client.rs
@@ -10,7 +10,7 @@ use reqwest::{
 
 use atuin_common::{
     api::{
-        AddHistoryRequest, CountResponse, DeleteHistoryRequest, ErrorResponse, IndexResponse,
+        AddHistoryRequest, CountResponse, DeleteHistoryRequest, ErrorResponse,
         LoginRequest, LoginResponse, RegisterResponse, StatusResponse, SyncHistoryResponse,
     },
     record::RecordStatus,
@@ -19,6 +19,7 @@ use atuin_common::{
     api::{ATUIN_CARGO_VERSION, ATUIN_HEADER_VERSION, ATUIN_VERSION},
     record::{EncryptedData, HostId, Record, RecordIdx},
 };
+
 use semver::Version;
 use time::format_description::well_known::Rfc3339;
 use time::OffsetDateTime;
@@ -97,7 +98,10 @@ pub async fn login(address: &str, req: LoginRequest) -> Result<LoginResponse> {
     Ok(session)
 }
 
+#[cfg(feature = "check-update")]
 pub async fn latest_version() -> Result<Version> {
+    use atuin_common::api::IndexResponse;
+
     let url = "https://api.atuin.sh";
     let client = reqwest::Client::new();
 

--- a/atuin-client/src/api_client.rs
+++ b/atuin-client/src/api_client.rs
@@ -10,8 +10,8 @@ use reqwest::{
 
 use atuin_common::{
     api::{
-        AddHistoryRequest, CountResponse, DeleteHistoryRequest, ErrorResponse,
-        LoginRequest, LoginResponse, RegisterResponse, StatusResponse, SyncHistoryResponse,
+        AddHistoryRequest, CountResponse, DeleteHistoryRequest, ErrorResponse, LoginRequest,
+        LoginResponse, RegisterResponse, StatusResponse, SyncHistoryResponse,
     },
     record::RecordStatus,
 };

--- a/atuin/Cargo.toml
+++ b/atuin/Cargo.toml
@@ -33,11 +33,12 @@ buildflags = ["--release"]
 atuin = { path = "/usr/bin/atuin" }
 
 [features]
-default = ["client", "sync", "server", "clipboard"]
+default = ["client", "sync", "server", "clipboard", "check-update"]
 client = ["atuin-client"]
 sync = ["atuin-client/sync"]
 server = ["atuin-server", "atuin-server-postgres", "tracing-subscriber"]
 clipboard = ["cli-clipboard"]
+check-update = ["atuin-client/check-update"]
 
 [dependencies]
 atuin-server-postgres = { path = "../atuin-server-postgres", version = "17.2.1", optional = true }


### PR DESCRIPTION
In the packaging rules of some Linux distributions, the software's self-update check needs to be permanently turned off

This commit will make it easier for these users to