### PR TITLE
feat(shell)!: bind the Atuin search to "/" in vi-normal mode

### DIFF
--- a/atuin/src/command/init.rs
+++ b/atuin/src/command/init.rs
@@ -33,8 +33,8 @@ impl Cmd {
 
         if std::env::var("ATUIN_NOBIND").is_err() {
             const BIND_CTRL_R: &str = r"bindkey -M emacs '^r' _atuin_search_widget
-bindkey -M vicmd '^r' _atuin_search_vicmd_widget
-bindkey -M viins '^r' _atuin_search_viins_widget";
+bindkey -M viins '^r' _atuin_search_viins_widget
+bindkey -M vicmd '/' _atuin_search_widget";
 
             const BIND_UP_ARROW: &str = r"bindkey -M emacs '^[[A' _atuin_up_search_widget
 bindkey -M vicmd '^[[A' _atuin_up_search_vicmd_widget

--- a/atuin/src/shell/atuin.bash
+++ b/atuin/src/shell/atuin.bash
@@ -244,6 +244,7 @@ if [[ $__atuin_bind_ctrl_r == true ]]; then
     # the vi_nmap keymap in ble.sh.
     bind -m emacs -x '"\C-r": __atuin_history --keymap-mode=emacs'
     bind -m vi-insert -x '"\C-r": __atuin_history --keymap-mode=vim-insert'
+    bind -m vi-command -x '"/": __atuin_history --keymap-mode=emacs'
 fi
 
 # shellcheck disable=SC2154


### PR DESCRIPTION
This is a suggestion for the keybinding to <kbd>/</kbd> motivated by @Nemo157's comments https://github.com/atuinsh/atuin/pull/1553#issuecomment-1892022291 and https://github.com/atuinsh/atuin/pull/1570#issuecomment-1892163553.

Also, I suggest removing keybinding to <kbd>C-r</kbd> in the `vicmd` keymap of Zsh since it overwrites the existing widget (redo) which is not a search. Since this involves removal of a keybinding, I think we need to discuss it carefully.

See also the commit message.