### PR TITLE
fix: Skip padding time if it will overflow the allowed prefix length

### DIFF
--- a/atuin/src/command/client/search/history_list.rs
+++ b/atuin/src/command/client/search/history_list.rs
@@ -164,10 +164,10 @@ impl DrawState<'_> {
         let time = format_duration(since.try_into().unwrap_or_default());
 
         // pad the time a little bit before we write. this aligns things nicely
-        self.draw(
-            &SPACES[..((PREFIX_LENGTH - self.x) as usize - 4 - time.len())],
-            Style::default(),
-        );
+        // skip padding if for some reason it is already too long to align nicely
+        let padding =
+            usize::from(PREFIX_LENGTH).saturating_sub(usize::from(self.x) + 4 + time.len());
+        self.draw(&SPACES[..padding], Style::default());
 
         self.draw(&time, style);
         self.draw(" ago", style);


### PR DESCRIPTION
Fixes issue from https://github.com/atuinsh/atuin/pull/1574#discussion_r1467552000 (though, I wasn't able to reproduce, the failure implies that `PREFIX_LENGTH` is inadequate for some situations, and the previous implementation would have been overwriting the already printed duration).