### PR TITLE
feat(zsh): update widget names

### DIFF
--- a/atuin/src/command/init.rs
+++ b/atuin/src/command/init.rs
@@ -32,17 +32,17 @@ impl Cmd {
         println!("{base}");
 
         if std::env::var("ATUIN_NOBIND").is_err() {
-            const BIND_CTRL_R: &str = r"bindkey -M emacs '^r' _atuin_search_widget
-bindkey -M viins '^r' _atuin_search_viins_widget
-bindkey -M vicmd '/' _atuin_search_widget";
+            const BIND_CTRL_R: &str = r"bindkey -M emacs '^r' atuin-search
+bindkey -M viins '^r' atuin-search-viins
+bindkey -M vicmd '/' atuin-search";
 
-            const BIND_UP_ARROW: &str = r"bindkey -M emacs '^[[A' _atuin_up_search_widget
-bindkey -M vicmd '^[[A' _atuin_up_search_vicmd_widget
-bindkey -M viins '^[[A' _atuin_up_search_viins_widget
-bindkey -M emacs '^[OA' _atuin_up_search_widget
-bindkey -M vicmd '^[OA' _atuin_up_search_vicmd_widget
-bindkey -M viins '^[OA' _atuin_up_search_viins_widget
-bindkey -M vicmd 'k' _atuin_up_search_vicmd_widget";
+            const BIND_UP_ARROW: &str = r"bindkey -M emacs '^[[A' atuin-up-search
+bindkey -M vicmd '^[[A' atuin-up-search-vicmd
+bindkey -M viins '^[[A' atuin-up-search-viins
+bindkey -M emacs '^[OA' atuin-up-search
+bindkey -M vicmd '^[OA' atuin-up-search-vicmd
+bindkey -M viins '^[OA' atuin-up-search-viins
+bindkey -M vicmd 'k' atuin-up-search-vicmd";
 
             if !self.disable_ctrl_r {
                 println!("{BIND_CTRL_R}");

--- a/atuin/src/shell/atuin.zsh
+++ b/atuin/src/shell/atuin.zsh
@@ -96,9 +96,13 @@ _atuin_up_search_viins() {
 add-zsh-hook preexec _atuin_preexec
 add-zsh-hook precmd _atuin_precmd
 
+zle -N atuin-search _atuin_search
+zle -N atuin-search-vicmd _atuin_search_vicmd
+zle -N atuin-search-viins _atuin_search_viins
+zle -N atuin-up-search _atuin_up_search
+zle -N atuin-up-search-vicmd _atuin_up_search_vicmd
+zle -N atuin-up-search-viins _atuin_up_search_viins
+
+# These are compatibility widget names for "atuin <= 17.2.1" users.
 zle -N _atuin_search_widget _atuin_search
-zle -N _atuin_search_vicmd_widget _atuin_search_vicmd
-zle -N _atuin_search_viins_widget _atuin_search_viins
 zle -N _atuin_up_search_widget _atuin_up_search
-zle -N _atuin_up_search_vicmd_widget _atuin_up_search_vicmd
-zle -N _atuin_up_search_viins_widget _atuin_up_search_viins

--- a/docs/ru/key-binding_ru.md
+++ b/docs/ru/key-binding_ru.md
@@ -15,17 +15,17 @@ eval "$(atuin init zsh)"
 
 # zsh
 
-Autin устанавливает виджет ZLE "\_atuin_search_widget"
+Autin устанавливает виджет ZLE "atuin-search"
 
 ```
 export ATUIN_NOBIND="true"
 eval "$(atuin init zsh)"
 
-bindkey '^r' _atuin_search_widget
+bindkey '^r' atuin-search
 
 # зависит от режима терминала
-bindkey '^[[A' _atuin_search_widget
-bindkey '^[OA' _atuin_search_widget
+bindkey '^[[A' atuin-search
+bindkey '^[OA' atuin-search
 ```
 
 # bash

--- a/docs/zh-CN/key-binding.md
+++ b/docs/zh-CN/key-binding.md
@@ -13,17 +13,17 @@ eval "$(atuin init zsh)"
 
 # zsh
 
-Atuin 定义了 ZLE 部件 "\_atuin_search_widget"
+Atuin 定义了 ZLE 部件 "atuin-search"
 
 ```
 export ATUIN_NOBIND="true"
 eval "$(atuin init zsh)"
 
-bindkey '^r' _atuin_search_widget
+bindkey '^r' atuin-search
 
 # 取决于终端模式
-bindkey '^[[A' _atuin_search_widget
-bindkey '^[OA' _atuin_search_widget
+bindkey '^[[A' atuin-search
+bindkey '^[OA' atuin-search
 ```
 
 # bash


### PR DESCRIPTION
This is another suggestion. See the commit message.

For more contexts, the following is the list of how the other zsh frameworks name their widgets:

- https://github.com/jeffreytse/zsh-vi-mode ... `zvm_*`
- https://github.com/babarot/zsh-vimode-visual ... `vi-visual-*`
- https://github.com/junegunn/fzf/blob/master/shell/key-bindings.zsh ... `fzf-*-widget`
- https://github.com/ohmyzsh/ohmyzsh/
  - `plugins/{fuck,history-substring-search,man,per-directory-history,sudo,shrink-path}` ... `<PLUGIN>-*` (where `<PLUGIN>` is the name of the plugin)
  - `plugins/{npm,percol}` ... `<PLUGIN>_*`
  - `plugins/git-escape-magic` ... `<PLUGIN>.*`
  - `plugins/{globalias,copybuffer,fancy-ctrl-z}` ... `<PLUGIN>` (These define a single widget that has the same name as the plugin)
  - `plugins/zsh-navigation-tools` ... `znt-*-widget`
  - `plugins/zsh-interactive-cd` ... `zic-*`
  - `plugins/jump` ... `_mark_expansion`
  - `plugins/dircycle` ... `insert-cycled*`
  - `plugins/safe-paste` ... `_bracketed_paste_*`
  - `plugins/dirhistory` ... `dirhistory_zle_dirhistory_*`

Also, it should be noted that ZLE also prepares the special widget names `zle-*` for the users to customize the behavior. The most popular namespacing seems to be `<ProjectName>-*`.