### PR TITLE
feat: automatically init history store when record sync is enabled

### DIFF
--- a/atuin-client/src/record/store.rs
+++ b/atuin-client/src/record/store.rs
@@ -21,7 +21,9 @@ pub trait Store {
     ) -> Result<()>;
 
     async fn get(&self, id: RecordId) -> Result<Record<EncryptedData>>;
+
     async fn len(&self, host: HostId, tag: &str) -> Result<u64>;
+    async fn len_tag(&self, tag: &str) -> Result<u64>;
 
     async fn last(&self, host: HostId, tag: &str) -> Result<Option<Record<EncryptedData>>>;
     async fn first(&self, host: HostId, tag: &str) -> Result<Option<Record<EncryptedData>>>;

--- a/atuin/src/command/client/account/delete.rs
+++ b/atuin/src/command/client/account/delete.rs
@@ -5,7 +5,6 @@ use std::path::PathBuf;
 
 pub async fn run(settings: &Settings) -> Result<()> {
     let session_path = settings.session_path.as_str();
-    let key_path = settings.key_path.as_str();
 
     if !PathBuf::from(session_path).exists() {
         bail!("You are not logged in");
@@ -23,10 +22,6 @@ pub async fn run(settings: &Settings) -> Result<()> {
     // Fixes stale session+key when account is deleted via CLI.
     if PathBuf::from(session_path).exists() {
         remove_file(PathBuf::from(session_path))?;
-    }
-
-    if PathBuf::from(key_path).exists() {
-        remove_file(PathBuf::from(key_path))?;
     }
 
     println!("Your account is deleted");

--- a/atuin/src/command/client/account/register.rs
+++ b/atuin/src/command/client/account/register.rs
@@ -50,7 +50,11 @@ pub async fn run(
     file.write_all(session.session.as_bytes()).await?;
 
     // Create a new key, and save it to disk
-    let _key = atuin_client::encryption::new_key(settings)?;
+    // If using the record store, the user will already have a key.
+    // Records are stored encrypted on disk
+    if !settings.sync.records {
+        let _key = atuin_client::encryption::new_key(settings)?;
+    }
 
     Ok(())
 }

--- a/atuin/src/command/client/account/register.rs
+++ b/atuin/src/command/client/account/register.rs
@@ -49,12 +49,7 @@ pub async fn run(
     let mut file = File::create(path).await?;
     file.write_all(session.session.as_bytes()).await?;
 
-    // Create a new key, and save it to disk
-    // If using the record store, the user will already have a key.
-    // Records are stored encrypted on disk
-    if !settings.sync.records {
-        let _key = atuin_client::encryption::new_key(settings)?;
-    }
+    let _key = atuin_client::encryption::load_key(settings)?;
 
     Ok(())
 }

--- a/atuin/src/command/client/history.rs
+++ b/atuin/src/command/client/history.rs
@@ -88,10 +88,6 @@ pub enum Cmd {
         #[arg(long, short)]
         format: Option<String>,
     },
-
-    /// Import all old history.db data into the record store. Do not run more than once, and do not
-    /// run unless you know what you're doing (or the docs ask you to)
-    InitStore,
 }
 
 #[derive(Clone, Copy, Debug)]
@@ -368,14 +364,6 @@ impl Cmd {
         Ok(())
     }
 
-    async fn init_store(
-        context: atuin_client::database::Context,
-        db: &impl Database,
-        store: HistoryStore,
-    ) -> Result<()> {
-        store.init_store(context, db).await
-    }
-
     pub async fn run(
         self,
         settings: &Settings,
@@ -429,8 +417,6 @@ impl Cmd {
 
                 Ok(())
             }
-
-            Self::InitStore => Self::init_store(context, db, history_store).await,
         }
     }
 }

--- a/atuin/src/command/client/history.rs
+++ b/atuin/src/command/client/history.rs
@@ -321,10 +321,7 @@ impl Cmd {
             #[cfg(feature = "sync")]
             {
                 if settings.sync.records {
-                    let (diff, _) = record::sync::diff(settings, &store).await?;
-                    let operations = record::sync::operations(diff, &store).await?;
-                    let (_, downloaded) =
-                        record::sync::sync_remote(operations, &store, settings).await?;
+                    let (_, downloaded) = record::sync::sync(settings, &store).await?;
 
                     history_store.incremental_build(db, &downloaded).await?;
                 } else {

--- a/atuin/src/command/client/history.rs
+++ b/atuin/src/command/client/history.rs
@@ -373,31 +373,7 @@ impl Cmd {
         db: &impl Database,
         store: HistoryStore,
     ) -> Result<()> {
-        println!("Importing all history.db data into records.db");
-
-        println!("Fetching history from old database");
-        let history = db.list(&[], &context, None, false, true).await?;
-
-        println!("Fetching history already in store");
-        let store_ids = store.history_ids().await?;
-
-        for i in history {
-            println!("loaded {}", i.id);
-
-            if store_ids.contains(&i.id) {
-                println!("skipping {} - already exists", i.id);
-                continue;
-            }
-
-            if i.deleted_at.is_some() {
-                store.push(i.clone()).await?;
-                store.delete(i.id).await?;
-            } else {
-                store.push(i).await?;
-            }
-        }
-
-        Ok(())
+        store.init_store(context, db).await
     }
 
     pub async fn run(

--- a/atuin/src/command/client/sync.rs
+++ b/atuin/src/command/client/sync.rs
@@ -90,6 +90,7 @@ async fn run(
         let history_length = db.history_count(true).await?;
         let store_history_length = store.len_tag("history").await?;
 
+        #[allow(clippy::cast_sign_loss)]
         if history_length as u64 > store_history_length {
             println!("History DB is longer than history record store");
             println!("This happens when you used Atuin pre-record-store");

--- a/atuin/src/command/client/sync.rs
+++ b/atuin/src/command/client/sync.rs
@@ -80,8 +80,6 @@ async fn run(
     store: SqliteStore,
 ) -> Result<()> {
     if settings.sync.records {
-        let (uploaded, downloaded) = sync::sync(settings, &store).await?;
-
         let encryption_key: [u8; 32] = encryption::load_key(settings)
             .context("could not load encryption key")?
             .into();
@@ -98,7 +96,11 @@ async fn run(
 
             let context = current_context();
             history_store.init_store(context, db).await?;
+
+            println!("");
         }
+
+        let (uploaded, downloaded) = sync::sync(settings, &store).await?;
 
         history_store.incremental_build(db, &downloaded).await?;
 

--- a/atuin/src/command/client/sync.rs
+++ b/atuin/src/command/client/sync.rs
@@ -80,9 +80,7 @@ async fn run(
     store: SqliteStore,
 ) -> Result<()> {
     if settings.sync.records {
-        let (diff, _) = sync::diff(settings, &store).await?;
-        let operations = sync::operations(diff, &store).await?;
-        let (uploaded, downloaded) = sync::sync_remote(operations, &store, settings).await?;
+        let (uploaded, downloaded) = sync::sync(settings, &store).await?;
 
         let encryption_key: [u8; 32] = encryption::load_key(settings)
             .context("could not load encryption key")?

--- a/atuin/src/command/client/sync.rs
+++ b/atuin/src/command/client/sync.rs
@@ -97,7 +97,7 @@ async fn run(
             let context = current_context();
             history_store.init_store(context, db).await?;
 
-            println!("");
+            println!("\n");
         }
 
         let (uploaded, downloaded) = sync::sync(settings, &store).await?;


### PR DESCRIPTION
Automatically import history from the old DB when record sync is enabled.

This means that users only need to add

```
[sync]
records = true
```

to use the new system.

I've tested this on systems that already have record sync enabled + have already init-d the records. As well as those that used the old sync, and then enabled record sync.
