### PR TITLE
chore: disable nix tests

### DIFF
--- a/atuin.nix
+++ b/atuin.nix
@@ -36,12 +36,7 @@ rustPlatform.buildRustPackage {
       --zsh <($out/bin/atuin gen-completions -s zsh)
   '';
 
-  # Additional flags passed to the cargo test binary, see `cargo test -- --help`
-  checkFlags = [
-    # Sync tests require a postgres server
-    "--skip=sync"
-    "--skip=registration"
-  ];
+  doCheck = false;
 
   meta = with lib; {
     description = "Replacement for a shell history which records additional commands context with optional encrypted synchronization between machines";


### PR DESCRIPTION
For a few reasons

1. This step is really, really slow. I don't think there's sufficient value in a slow CI step to keep it
2. Whenever we add an integration test it needs to be added to the ignore list. I want to keep friction on adding such tests as low as is possible.
3. We already run tests in a bunch of places, so I don't think this is needed

Ref: #1123

<!-- Thank you for making a PR! Bug fixes are always welcome, but if you're adding a new feature or changing an existing one, we'd really appreciate if you open an issue, post on the forum, or drop in on Discord -->

## Checks
- [ ] I am happy for maintainers to push small adjustments to this PR, to speed up the review cycle
- [ ] I have checked that there are no existing pull requests for the same thing
