### PR TITLE
feat: add store push

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -202,6 +202,7 @@ dependencies = [
  "tracing-subscriber",
  "tracing-tree",
  "unicode-width",
+ "uuid",
  "whoami",
 ]
 

--- a/atuin-client/src/record/mod.rs
+++ b/atuin-client/src/record/mod.rs
@@ -1,5 +1,6 @@
 pub mod encryption;
 pub mod sqlite_store;
 pub mod store;
+
 #[cfg(feature = "sync")]
 pub mod sync;

--- a/atuin/Cargo.toml
+++ b/atuin/Cargo.toml
@@ -76,6 +76,7 @@ colored = "2.0.4"
 ratatui = "0.25"
 tracing = "0.1"
 cli-clipboard = { version = "0.4.0", optional = true }
+uuid = { workspace = true }
 
 
 [dependencies.tracing-subscriber]

--- a/atuin/src/command/client/history.rs
+++ b/atuin/src/command/client/history.rs
@@ -13,7 +13,7 @@ use atuin_client::{
     database::{current_context, Database},
     encryption,
     history::{store::HistoryStore, History},
-    record::{self, sqlite_store::SqliteStore},
+    record::sqlite_store::SqliteStore,
     settings::{
         FilterMode::{Directory, Global, Session},
         Settings,
@@ -21,7 +21,8 @@ use atuin_client::{
 };
 
 #[cfg(feature = "sync")]
-use atuin_client::sync;
+use atuin_client::{record, sync};
+
 use log::{debug, warn};
 use time::{macros::format_description, OffsetDateTime};
 
@@ -282,6 +283,7 @@ impl Cmd {
         Ok(())
     }
 
+    #[allow(unused_variables)]
     async fn handle_end(
         db: &impl Database,
         store: SqliteStore,

--- a/atuin/src/command/client/store.rs
+++ b/atuin/src/command/client/store.rs
@@ -1,10 +1,8 @@
-use clap::{Args, Subcommand};
-use eyre::{bail, Result};
+use clap::Subcommand;
+use eyre::Result;
 
 use atuin_client::{
     database::Database,
-    encryption,
-    history::store::HistoryStore,
     record::{sqlite_store::SqliteStore, store::Store},
     settings::Settings,
 };

--- a/atuin/src/command/client/store.rs
+++ b/atuin/src/command/client/store.rs
@@ -8,7 +8,9 @@ use atuin_client::{
 };
 use time::OffsetDateTime;
 
+#[cfg(feature = "sync")]
 mod push;
+
 mod rebuild;
 
 #[derive(Subcommand, Debug)]
@@ -16,6 +18,8 @@ mod rebuild;
 pub enum Cmd {
     Status,
     Rebuild(rebuild::Rebuild),
+
+    #[cfg(feature = "sync")]
     Push(push::Push),
 }
 
@@ -29,6 +33,8 @@ impl Cmd {
         match self {
             Self::Status => self.status(store).await,
             Self::Rebuild(rebuild) => rebuild.run(settings, store, database).await,
+
+            #[cfg(feature = "sync")]
             Self::Push(push) => push.run(settings, store).await,
         }
     }

--- a/atuin/src/command/client/store.rs
+++ b/atuin/src/command/client/store.rs
@@ -10,56 +10,15 @@ use atuin_client::{
 };
 use time::OffsetDateTime;
 
-#[derive(Args, Debug)]
-pub struct Rebuild {
-    pub tag: String,
-}
-
-impl Rebuild {
-    pub async fn run(
-        &self,
-        settings: &Settings,
-        store: SqliteStore,
-        database: &dyn Database,
-    ) -> Result<()> {
-        // keep it as a string and not an enum atm
-        // would be super cool to build this dynamically in the future
-        // eg register handles for rebuilding various tags without having to make this part of the
-        // binary big
-        match self.tag.as_str() {
-            "history" => {
-                self.rebuild_history(settings, store.clone(), database)
-                    .await?;
-            }
-
-            tag => bail!("unknown tag: {tag}"),
-        }
-
-        Ok(())
-    }
-
-    async fn rebuild_history(
-        &self,
-        settings: &Settings,
-        store: SqliteStore,
-        database: &dyn Database,
-    ) -> Result<()> {
-        let encryption_key: [u8; 32] = encryption::load_key(settings)?.into();
-
-        let host_id = Settings::host_id().expect("failed to get host_id");
-        let history_store = HistoryStore::new(store, host_id, encryption_key);
-
-        history_store.build(database).await?;
-
-        Ok(())
-    }
-}
+mod push;
+mod rebuild;
 
 #[derive(Subcommand, Debug)]
 #[command(infer_subcommands = true)]
 pub enum Cmd {
     Status,
-    Rebuild(Rebuild),
+    Rebuild(rebuild::Rebuild),
+    Push(push::Push),
 }
 
 impl Cmd {
@@ -72,6 +31,7 @@ impl Cmd {
         match self {
             Self::Status => self.status(store).await,
             Self::Rebuild(rebuild) => rebuild.run(settings, store, database).await,
+            Self::Push(push) => push.run(settings, store).await,
         }
     }
 

--- a/atuin/src/command/client/store/push.rs
+++ b/atuin/src/command/client/store/push.rs
@@ -14,15 +14,18 @@ use atuin_client::{
 
 #[derive(Args, Debug)]
 pub struct Push {
+    /// The tag to push (eg, 'history'). Defaults to all tags
     #[arg(long, short)]
     pub tag: Option<String>,
 
+    /// The host to push, in the form of a UUID host ID. Defaults to the current host.
     #[arg(long)]
     pub host: Option<Uuid>,
 }
 
 impl Push {
     pub async fn run(&self, settings: &Settings, store: SqliteStore) -> Result<()> {
+        let host_id = Settings::host_id().expect("failed to get host_id");
         // We can actually just use the existing diff/etc to push
         // 1. Diff
         // 2. Get operations
@@ -45,6 +48,10 @@ impl Push {
                 Operation::Upload { host, tag, .. } => {
                     if let Some(h) = self.host {
                         if HostId(h) != *host {
+                            return false;
+                        }
+                    } else {
+                        if *host != host_id {
                             return false;
                         }
                     }

--- a/atuin/src/command/client/store/push.rs
+++ b/atuin/src/command/client/store/push.rs
@@ -1,0 +1,69 @@
+use atuin_common::record::HostId;
+use clap::Args;
+use eyre::{bail, Context, Result};
+use uuid::Uuid;
+
+use atuin_client::{
+    database::Database,
+    encryption,
+    history::store::HistoryStore,
+    record::{sqlite_store::SqliteStore, sync},
+    record::{store::Store, sync::Operation},
+    settings::Settings,
+};
+
+#[derive(Args, Debug)]
+pub struct Push {
+    #[arg(long, short)]
+    pub tag: Option<String>,
+
+    #[arg(long)]
+    pub host: Option<Uuid>,
+}
+
+impl Push {
+    pub async fn run(&self, settings: &Settings, store: SqliteStore) -> Result<()> {
+        // We can actually just use the existing diff/etc to push
+        // 1. Diff
+        // 2. Get operations
+        // 3. Filter operations by
+        //  a) are they an upload op?
+        //  b) are they for the host/tag we are pushing here?
+        let (diff, _) = sync::diff(settings, &store).await?;
+        let operations = sync::operations(diff, &store).await?;
+
+        let operations = operations
+            .into_iter()
+            .filter(|op| match op {
+                // No noops thx
+                Operation::Noop { .. } => false,
+
+                // this is a push, so no downloads either
+                Operation::Download { .. } => false,
+
+                // push, so yes plz to uploads!
+                Operation::Upload { host, tag, .. } => {
+                    if let Some(h) = self.host {
+                        if HostId(h) != *host {
+                            return false;
+                        }
+                    }
+
+                    if let Some(t) = self.tag.clone() {
+                        if t != *tag {
+                            return false;
+                        }
+                    }
+
+                    true
+                }
+            })
+            .collect();
+
+        let (uploaded, _) = sync::sync_remote(operations, &store, settings).await?;
+
+        println!("Uploaded {} records", uploaded);
+
+        Ok(())
+    }
+}

--- a/atuin/src/command/client/store/rebuild.rs
+++ b/atuin/src/command/client/store/rebuild.rs
@@ -1,0 +1,52 @@
+use clap::Args;
+use eyre::{bail, Result};
+
+use atuin_client::{
+    database::Database, encryption, history::store::HistoryStore,
+    record::sqlite_store::SqliteStore, settings::Settings,
+};
+
+#[derive(Args, Debug)]
+pub struct Rebuild {
+    pub tag: String,
+}
+
+impl Rebuild {
+    pub async fn run(
+        &self,
+        settings: &Settings,
+        store: SqliteStore,
+        database: &dyn Database,
+    ) -> Result<()> {
+        // keep it as a string and not an enum atm
+        // would be super cool to build this dynamically in the future
+        // eg register handles for rebuilding various tags without having to make this part of the
+        // binary big
+        match self.tag.as_str() {
+            "history" => {
+                self.rebuild_history(settings, store.clone(), database)
+                    .await?;
+            }
+
+            tag => bail!("unknown tag: {tag}"),
+        }
+
+        Ok(())
+    }
+
+    async fn rebuild_history(
+        &self,
+        settings: &Settings,
+        store: SqliteStore,
+        database: &dyn Database,
+    ) -> Result<()> {
+        let encryption_key: [u8; 32] = encryption::load_key(settings)?.into();
+
+        let host_id = Settings::host_id().expect("failed to get host_id");
+        let history_store = HistoryStore::new(store, host_id, encryption_key);
+
+        history_store.build(database).await?;
+
+        Ok(())
+    }
+}

--- a/atuin/tests/common/mod.rs
+++ b/atuin/tests/common/mod.rs
@@ -1,11 +1,10 @@
 use std::{env, time::Duration};
 
 use atuin_client::api_client;
-use atuin_common::{api::AddHistoryRequest, utils::uuid_v7};
+use atuin_common::utils::uuid_v7;
 use atuin_server::{launch_with_tcp_listener, Settings as ServerSettings};
 use atuin_server_postgres::{Postgres, PostgresSettings};
 use futures_util::TryFutureExt;
-use time::OffsetDateTime;
 use tokio::{net::TcpListener, sync::oneshot, task::JoinHandle};
 use tracing::{dispatcher, Dispatch};
 use tracing_subscriber::{layer::SubscriberExt, EnvFilter};
@@ -80,6 +79,7 @@ pub async fn register_inner<'a>(
     api_client::Client::new(address, &registration_response.session, 5, 30).unwrap()
 }
 
+#[allow(dead_code)]
 pub async fn login(address: &str, username: String, password: String) -> api_client::Client<'_> {
     // registration works
     let login_respose = api_client::login(
@@ -92,6 +92,7 @@ pub async fn login(address: &str, username: String, password: String) -> api_cli
     api_client::Client::new(address, &login_respose.session, 5, 30).unwrap()
 }
 
+#[allow(dead_code)]
 pub async fn register(address: &str) -> api_client::Client<'_> {
     let username = uuid_v7().as_simple().to_string();
     let password = uuid_v7().as_simple().to_string();

--- a/atuin/tests/sync.rs
+++ b/atuin/tests/sync.rs
@@ -1,14 +1,5 @@
-use std::{env, time::Duration};
-
-use atuin_client::api_client;
 use atuin_common::{api::AddHistoryRequest, utils::uuid_v7};
-use atuin_server::{launch_with_tcp_listener, Settings as ServerSettings};
-use atuin_server_postgres::{Postgres, PostgresSettings};
-use futures_util::TryFutureExt;
 use time::OffsetDateTime;
-use tokio::{net::TcpListener, sync::oneshot, task::JoinHandle};
-use tracing::{dispatcher, Dispatch};
-use tracing_subscriber::{layer::SubscriberExt, EnvFilter};
 
 mod common;
 

--- a/atuin/tests/users.rs
+++ b/atuin/tests/users.rs
@@ -1,14 +1,4 @@
-use std::{env, time::Duration};
-
-use atuin_client::api_client;
-use atuin_common::{api::AddHistoryRequest, utils::uuid_v7};
-use atuin_server::{launch_with_tcp_listener, Settings as ServerSettings};
-use atuin_server_postgres::{Postgres, PostgresSettings};
-use futures_util::TryFutureExt;
-use time::OffsetDateTime;
-use tokio::{net::TcpListener, sync::oneshot, task::JoinHandle};
-use tracing::{dispatcher, Dispatch};
-use tracing_subscriber::{layer::SubscriberExt, EnvFilter};
+use atuin_common::utils::uuid_v7;
 
 mod common;
 


### PR DESCRIPTION
This allows the user to _push_ records from the current host, without full syncing.

Coming next:

1. Push, along with `--force`/`--rewrite`. This will allow a host to overwrite the remote store. If you would like to change an encryption key, this is more or less the only way to do so. Think of it like `git push --force`
2. Pull
