### PR TITLE
Set ATUIN_ variables for development in devshell

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -30,6 +30,20 @@
             rustfmt
           ];
         RUST_SRC_PATH = "${pkgs.rustPlatform.rustLibSrc}";
+
+        shellHook = ''
+          echo >&2 "Setting development database path"
+          export ATUIN_DB_PATH="/tmp/atuin_dev.db"
+          export ATUIN_RECORD_STORE_PATH="/tmp/atuin_records.db"
+
+          if [ -e "''${ATUIN_DB_PATH}" ]; then
+            echo >&2 "''${ATUIN_DB_PATH} already exists, you might want to double-check that"
+          fi
+
+          if [ -e "''${ATUIN_RECORD_STORE_PATH}" ]; then
+            echo >&2 "''${ATUIN_RECORD_STORE_PATH} already exists, you might want to double-check that"
+          fi
+        '';
       });
     })
     // {


### PR DESCRIPTION
I accidentially broke my atuin database by executing `atuin` from the PR I was working on without setting these variables and had to manually roll back my local database.

That shouldn't happen, so we set the database and record store path in the devshell to something that does not overwrite our normal databases. We also warn if these files already exist, because when entering the devshell, a user might want to start from a clean slate here.


## Checks
- [x] I am happy for maintainers to push small adjustments to this PR, to speed up the review cycle
- [ ] I have checked that there are no existing pull requests for the same thing
