### PR TITLE
fix: never overwrite the key

### DIFF
--- a/atuin-client/src/encryption.rs
+++ b/atuin-client/src/encryption.rs
@@ -32,6 +32,11 @@ pub struct EncryptedHistory {
 
 pub fn new_key(settings: &Settings) -> Result<Key> {
     let path = settings.key_path.as_str();
+    let path = PathBuf::from(path);
+
+    if path.exists() {
+        bail!("key already exists! cannot overwrite");
+    }
 
     let key = XSalsa20Poly1305::generate_key(&mut OsRng);
     let encoded = encode_key(&key)?;


### PR DESCRIPTION
Now that local history is stored encrypted, new_key should not overwrite an existing one. This may be frustrating, but will remove the risk of Atuin generating a new key and the user losing their old one.

<!-- Thank you for making a PR! Bug fixes are always welcome, but if you're adding a new feature or changing an existing one, we'd really appreciate if you open an issue, post on the forum, or drop in on Discord -->

## Checks
- [ ] I am happy for maintainers to push small adjustments to this PR, to speed up the review cycle
- [ ] I have checked that there are no existing pull requests for the same thing
