### PR TITLE
chore(ci): use github m1 for release builds

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -30,7 +30,7 @@ jobs:
           - { os: ubuntu-20.04 , target: x86_64-unknown-linux-gnu    }
           - { os: ubuntu-20.04 , target: aarch64-unknown-linux-gnu    }
           - { os: macos-12     , target: x86_64-apple-darwin         }
-          - { os: self-hosted     , target: aarch64-apple-darwin         }
+          - { os: macos-14     , target: aarch64-apple-darwin         }
     steps:
     - name: Check for release
       id: is-release

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -42,7 +42,7 @@ jobs:
       run: cargo build --all --locked --release && strip target/release/atuin
 
   unit-test:
-    runs-on: [self-hosted, ARM64, macOS]
+    runs-on: ubuntu-latest
 
     steps:
     - uses: actions/checkout@v3


### PR DESCRIPTION
I can now use this instead of the mac under my desk!

No more CI approvals required 🥳 

## Checks
- [ ] I am happy for maintainers to push small adjustments to this PR, to speed up the review cycle
- [ ] I have checked that there are no existing pull requests for the same thing
