### PR TITLE
feat: reencrypt/rekey local store

### DIFF
--- a/atuin-client/src/record/sqlite_store.rs
+++ b/atuin-client/src/record/sqlite_store.rs
@@ -19,6 +19,7 @@ use atuin_common::record::{
 };
 use uuid::Uuid;
 
+use super::encryption::PASETO_V4;
 use super::store::Store;
 
 #[derive(Debug, Clone)]
@@ -105,6 +106,15 @@ impl SqliteStore {
                 content_encryption_key: row.get("cek"),
             },
         }
+    }
+
+    async fn load_all(&self) -> Result<Vec<Record<EncryptedData>>> {
+        let res = sqlx::query("select * from store ")
+            .map(Self::query_row)
+            .fetch_all(&self.pool)
+            .await?;
+
+        Ok(res)
     }
 }
 
@@ -250,6 +260,45 @@ impl Store for SqliteStore {
             .await?;
 
         Ok(res)
+    }
+
+    /// Reencrypt every single item in this store with a new key
+    /// Be careful - this may mess with sync.
+    async fn re_encrypt(&self, old_key: &[u8; 32], new_key: &[u8; 32]) -> Result<()> {
+        // Load all the records
+        // In memory like some of the other code here
+        // This will never be called in a hot loop, and only under the following circumstances
+        // 1. The user has logged into a new account, with a new key. They are unlikely to have a
+        //    lot of data
+        // 2. The user has encountered some sort of issue, and runs a maintenance command that
+        //    invokes this
+        let all = self.load_all().await?;
+
+        let re_encrypted = all
+            .into_iter()
+            .map(|record| record.re_encrypt::<PASETO_V4>(old_key, new_key))
+            .collect::<Result<Vec<_>>>()?;
+
+        // next up, we delete all the old data and reinsert the new stuff
+        // do it in one transaction, so if anything fails we rollback OK
+
+        let mut tx = self.pool.begin().await?;
+
+        let res = sqlx::query("delete from store").execute(&mut *tx).await?;
+
+        let rows = res.rows_affected();
+        debug!("deleted {rows} rows");
+
+        // don't call push_batch, as it will start its own transaction
+        // call the underlying save_raw
+
+        for record in re_encrypted {
+            Self::save_raw(&mut tx, &record).await?;
+        }
+
+        tx.commit().await?;
+
+        Ok(())
     }
 }
 

--- a/atuin-client/src/record/store.rs
+++ b/atuin-client/src/record/store.rs
@@ -28,6 +28,8 @@ pub trait Store {
     async fn last(&self, host: HostId, tag: &str) -> Result<Option<Record<EncryptedData>>>;
     async fn first(&self, host: HostId, tag: &str) -> Result<Option<Record<EncryptedData>>>;
 
+    async fn re_encrypt(&self, old_key: &[u8; 32], new_key: &[u8; 32]) -> Result<()>;
+
     /// Get the next `limit` records, after and including the given index
     async fn next(
         &self,

--- a/atuin/src/command/client.rs
+++ b/atuin/src/command/client.rs
@@ -95,7 +95,7 @@ impl Cmd {
             Self::Sync(sync) => sync.run(settings, &db, sqlite_store).await,
 
             #[cfg(feature = "sync")]
-            Self::Account(account) => account.run(settings).await,
+            Self::Account(account) => account.run(settings, sqlite_store).await,
 
             Self::Kv(kv) => kv.run(&settings, &sqlite_store).await,
 

--- a/atuin/src/command/client/account.rs
+++ b/atuin/src/command/client/account.rs
@@ -1,6 +1,7 @@
 use clap::{Args, Subcommand};
 use eyre::Result;
 
+use atuin_client::record::sqlite_store::SqliteStore;
 use atuin_client::settings::Settings;
 
 pub mod change_password;
@@ -33,9 +34,9 @@ pub enum Commands {
 }
 
 impl Cmd {
-    pub async fn run(self, settings: Settings) -> Result<()> {
+    pub async fn run(self, settings: Settings, store: SqliteStore) -> Result<()> {
         match self.command {
-            Commands::Login(l) => l.run(&settings).await,
+            Commands::Login(l) => l.run(&settings, &store).await,
             Commands::Register(r) => r.run(&settings).await,
             Commands::Logout => logout::run(&settings),
             Commands::Delete => delete::run(&settings).await,

--- a/atuin/src/command/client/account/login.rs
+++ b/atuin/src/command/client/account/login.rs
@@ -111,13 +111,19 @@ impl Cmd {
             // 2. if not, re-encrypt the local history and overwrite the key
             let current_key: [u8; 32] = load_key(settings)?.into();
 
+            let encoded = key.clone(); // gonna want to save it in a bit
             let new_key: [u8; 32] = decode_key(key)
                 .context("could not decode provided key - is not valid base64")?
                 .into();
 
             if new_key != current_key {
-                println!("Re-encrypting local store with new key");
+                println!("\nRe-encrypting local store with new key");
+
                 store.re_encrypt(&current_key, &new_key).await?;
+
+                println!("Writing new key");
+                let mut file = File::create(key_path).await?;
+                file.write_all(encoded.as_bytes()).await?;
             }
         }
 

--- a/atuin/src/command/client/sync.rs
+++ b/atuin/src/command/client/sync.rs
@@ -51,7 +51,7 @@ impl Cmd {
     ) -> Result<()> {
         match self {
             Self::Sync { force } => run(&settings, force, db, store).await,
-            Self::Login(l) => l.run(&settings).await,
+            Self::Login(l) => l.run(&settings, &store).await,
             Self::Logout => account::logout::run(&settings),
             Self::Register(r) => r.run(&settings).await,
             Self::Status => status::run(&settings, db).await,


### PR DESCRIPTION
When running a system for a while, without logging in, the local store is encrypted with a random key. Upon logging in, the user presents a _new_ key

In order to ensure that all records are encrypted with the same key, we need to reencrypt all local data. Do this automatically

TODO (this PR): add `atuin store rekey` to allow adding manually changing main key. either random or specified

TODO (another PR): allow force pushing records - wipe remote store, and push everything up
TODO (another PR): allow force pulling records - wipe local store, and assume all data from the remote

With these three things, we should be good for maintenance, debugging, and recovering from leaked keys

## Checks
- [ ] I am happy for maintainers to push small adjustments to this PR, to speed up the review cycle
- [ ] I have checked that there are no existing pull requests for the same thing
