### PR TITLE
set durability for sqlite to recommended settings

### DIFF
--- a/atuin-client/src/database.rs
+++ b/atuin-client/src/database.rs
@@ -14,7 +14,10 @@ use rand::{distributions::Alphanumeric, Rng};
 use regex::Regex;
 use sql_builder::{esc, quote, SqlBuilder, SqlName};
 use sqlx::{
-    sqlite::{SqliteConnectOptions, SqliteJournalMode, SqlitePool, SqlitePoolOptions, SqliteRow},
+    sqlite::{
+        SqliteConnectOptions, SqliteJournalMode, SqlitePool, SqlitePoolOptions, SqliteRow,
+        SqliteSynchronous,
+    },
     Result, Row,
 };
 use time::OffsetDateTime;
@@ -137,6 +140,8 @@ impl Sqlite {
 
         let opts = SqliteConnectOptions::from_str(path.as_os_str().to_str().unwrap())?
             .journal_mode(SqliteJournalMode::Wal)
+            .optimize_on_close(true, None)
+            .synchronous(SqliteSynchronous::Normal)
             .create_if_missing(true);
 
         let pool = SqlitePoolOptions::new()


### PR DESCRIPTION
On my ZFS system, commands were being blocked by history insertion due to `FULL` durability being enabled by default in SQLx for the WAL, sometimes for over a second, but at least half the time there was at least 500ms before the command was run. According to the [documentation](https://www.sqlite.org/pragma.html#pragma_synchronous), `NORMAL` is recommended.

With this change, my terminal commands are no longer being blocked.

## Checks
- [x ] I am happy for maintainers to push small adjustments to this PR, to speed up the review cycle
- [ x] I have checked that there are no existing pull requests for the same thing
