### PR TITLE
fix(bash/preexec): erase prompt last line before Bash renders on it

### DIFF
--- a/atuin/src/shell/atuin.bash
+++ b/atuin/src/shell/atuin.bash
@@ -106,10 +106,16 @@ __atuin_accept_line() {
     # Reprint the prompt, accounting for multiple lines
     local __atuin_prompt __atuin_prompt_offset
     __atuin_evaluate_prompt
+    local __atuin_clear_prompt
+    __atuin_clear_prompt=$'\r'$(tput el)
     if ((__atuin_prompt_offset > 0)); then
-        tput cuu "$__atuin_prompt_offset"
+        __atuin_clear_prompt+=$(
+            tput cuu "$__atuin_prompt_offset"
+            tput dl "$__atuin_prompt_offset"
+            tput il "$__atuin_prompt_offset"
+        )
     fi
-    printf '%s\n' "$__atuin_prompt$__atuin_command"
+    printf '%s\n' "$__atuin_clear_prompt$__atuin_prompt$__atuin_command"
 
     # Add it to the bash history
     history -s "$__atuin_command"

--- a/atuin/src/shell/atuin.bash
+++ b/atuin/src/shell/atuin.bash
@@ -158,7 +158,7 @@ __atuin_accept_line() {
     # so to work for a multiline prompt we need to print it ourselves,
     # then go to the beginning of the last line.
     __atuin_evaluate_prompt
-    printf '%s\r' "$__atuin_prompt"
+    printf '%s\r%s' "$__atuin_prompt" "$(tput el)"
 }
 
 __atuin_history() {


### PR DESCRIPTION
Fixes #1668

The descriptions are found in commit messages.

## Checks
- [x] I am happy for maintainers to push small adjustments to this PR, to speed up the review cycle
- [x] I have checked that there are no existing pull requests for the same thing
