### PR TITLE
fix(tests): add Settings::utc() for utc settings

### DIFF
--- a/atuin-client/src/history.rs
+++ b/atuin-client/src/history.rs
@@ -362,7 +362,7 @@ mod tests {
         let settings = Settings {
             cwd_filter: RegexSet::new(["^/supasecret"]).unwrap(),
             history_filter: RegexSet::new(["^psql"]).unwrap(),
-            ..Settings::default()
+            ..Settings::utc()
         };
 
         let normal_command: History = History::capture()
@@ -411,7 +411,7 @@ mod tests {
     fn disable_secrets() {
         let settings = Settings {
             secrets_filter: false,
-            ..Settings::default()
+            ..Settings::utc()
         };
 
         let stripe_key: History = History::capture()

--- a/atuin-client/src/settings.rs
+++ b/atuin-client/src/settings.rs
@@ -155,6 +155,11 @@ impl FromStr for Timezone {
             return Ok(Self(offset));
         }
 
+        if matches!(s.to_lowercase().as_str(), "0" | "utc") {
+            let offset = UtcOffset::UTC;
+            return Ok(Self(offset));
+        }
+
         // offset from UTC
         if let Ok(offset) = UtcOffset::parse(s, OFFSET_FMT) {
             return Ok(Self(offset));
@@ -355,6 +360,17 @@ pub struct Settings {
 }
 
 impl Settings {
+    pub fn utc() -> Self {
+        Self::builder()
+            .expect("Could not build default")
+            .set_override("timezone", "0")
+            .expect("failed to override timezone with UTC")
+            .build()
+            .expect("Could not build config")
+            .try_deserialize()
+            .expect("Could not deserialize config")
+    }
+
     fn save_to_data_dir(filename: &str, value: &str) -> Result<()> {
         let data_dir = atuin_common::utils::data_dir();
         let data_dir = data_dir.as_path();

--- a/atuin/src/command/client/stats.rs
+++ b/atuin/src/command/client/stats.rs
@@ -182,7 +182,7 @@ mod tests {
 
     #[test]
     fn interesting_commands() {
-        let settings = Settings::default();
+        let settings = Settings::utc();
 
         assert_eq!(interesting_command(&settings, "cargo"), "cargo");
         assert_eq!(
@@ -199,7 +199,7 @@ mod tests {
     // Test with spaces in the common_prefix
     #[test]
     fn interesting_commands_spaces() {
-        let mut settings = Settings::default();
+        let mut settings = Settings::utc();
         settings.stats.common_prefix.push("sudo test".to_string());
 
         assert_eq!(interesting_command(&settings, "sudo test"), "sudo test");
@@ -224,7 +224,7 @@ mod tests {
     // Test with spaces in the common_subcommand
     #[test]
     fn interesting_commands_spaces_subcommand() {
-        let mut settings = Settings::default();
+        let mut settings = Settings::utc();
         settings
             .stats
             .common_subcommands
@@ -254,7 +254,7 @@ mod tests {
     // Test with spaces in the common_prefix and common_subcommand
     #[test]
     fn interesting_commands_spaces_both() {
-        let mut settings = Settings::default();
+        let mut settings = Settings::utc();
         settings.stats.common_prefix.push("sudo test".to_string());
         settings
             .stats


### PR DESCRIPTION
Means we don't try and load timezones in tests, as this fails due to multiple threads.

Also allow specifying '0' or 'utc' as a timezone

<!-- Thank you for making a PR! Bug fixes are always welcome, but if you're adding a new feature or changing an existing one, we'd really appreciate if you open an issue, post on the forum, or drop in on Discord -->

## Checks
- [ ] I am happy for maintainers to push small adjustments to this PR, to speed up the review cycle
- [ ] I have checked that there are no existing pull requests for the same thing
