### PR TITLE
feat: add progress bars to sync and store init

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -237,6 +237,7 @@ dependencies = [
  "futures",
  "generic-array",
  "hex",
+ "indicatif",
  "interim",
  "itertools",
  "lazy_static",

--- a/atuin-client/Cargo.toml
+++ b/atuin-client/Cargo.toml
@@ -67,6 +67,7 @@ urlencoding = { version = "2.1.0", optional = true }
 reqwest = { workspace = true, optional = true }
 hex = { version = "0.4", optional = true }
 sha2 = { version = "0.10", optional = true }
+indicatif = "0.17.7"
 
 [dev-dependencies]
 tokio = { version = "1", features = ["full"] }


### PR DESCRIPTION
Replace lots of logging with some progress bars. This looks much nicer

I'd like to move it out of the atuin-client crate and into the atuin crate. But first, I want to decouple a lot of the record moving, so it can wait until that's done.

<!-- Thank you for making a PR! Bug fixes are always welcome, but if you're adding a new feature or changing an existing one, we'd really appreciate if you open an issue, post on the forum, or drop in on Discord -->

## Checks
- [ ] I am happy for maintainers to push small adjustments to this PR, to speed up the review cycle
- [ ] I have checked that there are no existing pull requests for the same thing
