### PR TITLE
fix: reorder the exit of enhanced keyboard mode

### DIFF
--- a/atuin/src/command/client/search/interactive.rs
+++ b/atuin/src/command/client/search/interactive.rs
@@ -794,6 +794,9 @@ impl Stdout {
 
 impl Drop for Stdout {
     fn drop(&mut self) {
+        #[cfg(not(target_os = "windows"))]
+        execute!(self.stdout, PopKeyboardEnhancementFlags).unwrap();
+
         if !self.inline_mode {
             execute!(self.stdout, terminal::LeaveAlternateScreen).unwrap();
         }
@@ -803,9 +806,6 @@ impl Drop for Stdout {
             event::DisableBracketedPaste,
         )
         .unwrap();
-
-        #[cfg(not(target_os = "windows"))]
-        execute!(self.stdout, PopKeyboardEnhancementFlags).unwrap();
 
         terminal::disable_raw_mode().unwrap();
     }


### PR DESCRIPTION
The `Stdout::new` function first enters an alternate screen then later enables enhanced keyboard mode.

In `Drop`, we need to do this in the opposite order: disable enhanced keyboard mode then exit alternate mode.

Fixes #1693

<!-- Thank you for making a PR! Bug fixes are always welcome, but if you're adding a new feature or changing an existing one, we'd really appreciate if you open an issue, post on the forum, or drop in on Discord -->

## Checks
- [x] I am happy for maintainers to push small adjustments to this PR, to speed up the review cycle
- [x] I have checked that there are no existing pull requests for the same thing
