### PR TITLE
feat: Add 'a', 'A', 'h', and 'l' bindings to vim-normal mode

### DIFF
--- a/atuin/src/command/client/search/interactive.rs
+++ b/atuin/src/command/client/search/interactive.rs
@@ -264,6 +264,26 @@ impl State {
                 KeyCode::Char('k') if !ctrl => {
                     return self.handle_search_up(settings, true);
                 }
+                KeyCode::Char('h') if !ctrl => {
+                    self.search.input.left();
+                    return InputAction::Continue;
+                }
+                KeyCode::Char('l') if !ctrl => {
+                    self.search.input.right();
+                    return InputAction::Continue;
+                }
+                KeyCode::Char('a') if !ctrl => {
+                    self.search.input.right();
+                    self.set_keymap_cursor(settings, "vim_insert");
+                    self.keymap_mode = KeymapMode::VimInsert;
+                    return InputAction::Continue;
+                }
+                KeyCode::Char('A') if !ctrl => {
+                    self.search.input.end();
+                    self.set_keymap_cursor(settings, "vim_insert");
+                    self.keymap_mode = KeymapMode::VimInsert;
+                    return InputAction::Continue;
+                }
                 KeyCode::Char('i') if !ctrl => {
                     self.set_keymap_cursor(settings, "vim_insert");
                     self.keymap_mode = KeymapMode::VimInsert;


### PR DESCRIPTION
The current 'i' binding to switch to insert mode is entirely unintuitive since what I almost always want to do is append to the current query. The fact that the cursor extends past the current input (which vim doesn't do with default settings) adds to the problem. The 'a' key is what I would reach for, but 'A' makes a lot of sense too so I added that.

The 'h' and 'l' bindings for moving the cursor also help makes things a bit more usable.

## Checks
- [x] I am happy for maintainers to push small adjustments to this PR, to speed up the review cycle
- [x] I have checked that there are no existing pull requests for the same thing
