### PR TITLE
Add xonsh to auto import, respect $HISTFILE in xonsh import, and fix issue with up-arrow keybinding in xonsh

### DIFF
--- a/atuin/src/command/client/import.rs
+++ b/atuin/src/command/client/import.rs
@@ -60,20 +60,17 @@ impl Cmd {
                 }
 
                 // $XONSH_HISTORY_BACKEND isn't always set, but $XONSH_HISTORY_FILE is
-                match env::var("XONSH_HISTORY_FILE").as_deref() {
-                    Ok(p) if p.ends_with(".json") => {
-                        println!("Detected Xonsh",);
-                        return import::<Xonsh, DB>(db).await;
-                    }
-                    Ok(p) if p.ends_with(".sqlite") => {
-                        println!("Detected Xonsh (SQLite backend)");
-                        return import::<XonshSqlite, DB>(db).await;
-                    }
-                    _ => (),
-                }
-
+                let xonsh_histfile = env::var("XONSH_HISTORY_FILE")
+                    .unwrap_or_else(|_| String::from(""));
                 let shell = env::var("SHELL").unwrap_or_else(|_| String::from("NO_SHELL"));
-                if shell.ends_with("/zsh") {
+
+                if xonsh_histfile.ends_with(".json") {
+                    println!("Detected Xonsh",);
+                    import::<Xonsh, DB>(db).await
+                } else if xonsh_histfile.ends_with(".sqlite") {
+                    println!("Detected Xonsh (SQLite backend)");
+                    import::<XonshSqlite, DB>(db).await
+                } else if shell.ends_with("/zsh") {
                     if ZshHistDb::histpath().is_ok() {
                         println!(
                             "Detected Zsh-HistDb, using :{}",

--- a/atuin/src/command/client/import.rs
+++ b/atuin/src/command/client/import.rs
@@ -59,6 +59,19 @@ impl Cmd {
                     return Ok(());
                 }
 
+                // $XONSH_HISTORY_BACKEND isn't always set, but $XONSH_HISTORY_FILE is
+                match env::var("XONSH_HISTORY_FILE").as_deref() {
+                    Ok(p) if p.ends_with(".json") => {
+                        println!("Detected Xonsh",);
+                        return import::<Xonsh, DB>(db).await;
+                    }
+                    Ok(p) if p.ends_with(".sqlite") => {
+                        println!("Detected Xonsh (SQLite backend)");
+                        return import::<XonshSqlite, DB>(db).await;
+                    }
+                    _ => (),
+                }
+
                 let shell = env::var("SHELL").unwrap_or_else(|_| String::from("NO_SHELL"));
                 if shell.ends_with("/zsh") {
                     if ZshHistDb::histpath().is_ok() {


### PR DESCRIPTION
Hi! I'm back again with more Xonsh stuff. Turns out you can't get rid of me that easily! :smiling_imp:

This PR contains 3 somewhat-unrelated changes, which I bundled together because it seemed easier than splitting them into separate PRs and then trying to keep them all in sync with any changes. As always, though, happy to change the approach if it would be better otherwise! :) 

Summery of changes:
* Added Xonsh-detection to `atuin import auto`
* Fixed Xonsh importers to respect the presence of `$HISTFILE` in the env
* Fixed an issue with up-arrow keybinding clobbering Xonsh's built-in behavior when choosing items from autosuggest menu

## Detecting Xonsh in `atuin import auto`

The only weird thing about this is that Xonsh does not by default do anything to  `$SHELL` so we can't rely on that to know whether we are in Xonsh. Instead I'm looking at `$XONSH_HISTORY_FILE`, which should (if I understand correctly) always be set in an Xonsh session unless the user has specifically decided to unset it. Conveniently, we can also determine whether to use the JSON or SQLite importer by looking at the suffix of `$XONSH_HISTORY_FILE`.

## Rsepcting `$HISTFILE` in Xonsh importers

While working on updating the docs to describe the behavior of the Xonsh importers as discussed in my previous PR, I discovered the whole thing with `$HISTFILE`, which I hadn't been aware of. So I updated the Xonsh importers to respect that.

One note (which I will also include in the docs once this is all sorted out) `$HISTFILE` means something slightly different when Xonsh is running in its default JSON mode. In that case, because the history is stored in a bunch of different files rather than a single one, `$HISTFILE` should be set to the parent directory of those JSON files: by default, `~/.local/share/xonsh/history_json/`.

## Disabling the up-arrow binding in Xonsh when choosing an autocomplete suggestion

Much like in #1025, there's a situation in Xonsh when we don't want to be overriding the default behavior of the up-arrow. When you hit Tab and there are multiple possible completions for a command, Xonsh will bring up a menu that allows you to choose between them. You navigate this menu with the arrow keys, but unfortunately Atuin's up-arrow binding is still active when you're navigating this menu, so any time you hit Up you're dumped into an Atuin session that you probably weren't looking for. Fortunately Xonsh (actually the underlying `prompt_toolkit` instance) exposes enough of its state that we can detect when there's an active auto-complete and disable the binding in that case.

While I was at it I also slightly modified the Xonsh script to not even register its handlers if it was called with `--disable-up-arrow` or `--disable-ctrl-r`. I _think_ this is ever-so-slightly preferable because even if those handlers were always cancelled by the filter, that's still an extra check that the shell doesn't have to do.

## Checks
- [x] I am happy for maintainers to push small adjustments to this PR, to speed up the review cycle
- [x] I have checked that there are no existing pull requests for the same thing
