### PR TITLE
fix(ui): don't preserve for empty space

### DIFF
--- a/atuin/src/command/client/search/history_list.rs
+++ b/atuin/src/command/client/search/history_list.rs
@@ -109,7 +109,7 @@ impl<'a> HistoryList<'a> {
     fn get_items_bounds(&self, selected: usize, offset: usize, height: usize) -> (usize, usize) {
         let offset = offset.min(self.history.len().saturating_sub(1));
 
-        let max_scroll_space = height.min(10);
+        let max_scroll_space = height.min(10).min(self.history.len() - selected);
         if offset + height < selected + max_scroll_space {
             let end = selected + max_scroll_space;
             (end - height, end)


### PR DESCRIPTION
For the following situation:
```
$ atuin search -i --inline-height 15
 [     HOST     ] query
  > 1m    19d ago item 1
  1 0s    1mo ago item 2
  2 0s    1mo ago item 3
  3 0s    1mo ago item 4
  4 0s    1mo ago item 5
  5 0s    1mo ago item 6







 Atuin v17.2.1 [...]
```
Scrolling to item 6 results:
```
 [     HOST     ] query
    0s    1mo ago item 3
    0s    1mo ago item 4
    0s    1mo ago item 5
  > 0s    1mo ago item 6










 Atuin v17.2.1 [...]
```
With this patch it becomes:
```
 [     HOST     ] query
    1m    19d ago item 1
    0s    1mo ago item 2
    0s    1mo ago item 3
    0s    1mo ago item 4
    0s    1mo ago item 5
  > 0s    1mo ago item 6







 Atuin v17.2.1 [...]
```
<!-- Thank you for making a PR! Bug fixes are always welcome, but if you're adding a new feature or changing an existing one, we'd really appreciate if you open an issue, post on the forum, or drop in on Discord -->

## Checks
- [x] I am happy for maintainers to push small adjustments to this PR, to speed up the review cycle
- [x] I have checked that there are no existing pull requests for the same thing
