### PR TITLE
add ctrl-k shortcut

### DIFF
--- a/atuin/src/command/client/search/cursor.rs
+++ b/atuin/src/command/client/search/cursor.rs
@@ -191,6 +191,10 @@ impl Cursor {
         }
     }
 
+    pub fn truncate(&mut self) {
+        self.source.truncate(self.index);
+    }
+
     pub fn clear(&mut self) {
         self.source.clear();
         self.index = 0;

--- a/atuin/src/command/client/search/interactive.rs
+++ b/atuin/src/command/client/search/interactive.rs
@@ -380,6 +380,7 @@ impl State {
                 }
             }
             KeyCode::Char('u') if ctrl => self.search.input.clear(),
+            KeyCode::Char('k') if ctrl => self.search.input.truncate(),
             KeyCode::Char('r') if ctrl => {
                 let filter_modes = if settings.workspaces && self.search.context.git_root.is_some()
                 {


### PR DESCRIPTION
fixes  #1715

Adds the control-k (k for unalive) shortcut which is hardwired into my brain.  I do humbly suggest that rustyline or some other readline equivalent be used for cursor handling to prevent reimplementing every shortcut from scratch tho.


## Checks
- [x] I am happy for maintainers to push small adjustments to this PR, to speed up the review cycle
- [x] I have checked that there are no existing pull requests for the same thing
