### PR TITLE
feat(search): process Ctrl+m for kitty keyboard protocol

### DIFF
--- a/atuin/src/command/client/search/interactive.rs
+++ b/atuin/src/command/client/search/interactive.rs
@@ -243,6 +243,13 @@ impl State {
         self.handle_search_scroll_one_line(settings, enable_exit, !settings.invert)
     }
 
+    fn handle_search_accept(&mut self, settings: &Settings) -> InputAction {
+        if settings.enter_accept {
+            self.accept = true;
+        }
+        InputAction::Accept(self.results_state.selected())
+    }
+
     #[allow(clippy::too_many_lines)]
     #[allow(clippy::cognitive_complexity)]
     fn handle_search_input(&mut self, settings: &Settings, input: &KeyEvent) -> InputAction {
@@ -305,13 +312,8 @@ impl State {
         }
 
         match input.code {
-            KeyCode::Enter => {
-                if settings.enter_accept {
-                    self.accept = true;
-                }
-
-                return InputAction::Accept(self.results_state.selected());
-            }
+            KeyCode::Enter => return self.handle_search_accept(settings),
+            KeyCode::Char('m') if ctrl => return self.handle_search_accept(settings),
             KeyCode::Char('y') if ctrl => {
                 return InputAction::Copy(self.results_state.selected());
             }


### PR DESCRIPTION
Fixes https://github.com/atuinsh/atuin/issues/1719

The background is explained in the commit mesasge.

I know there is tension between the readline bindings and Atuin's specific bindings for the available key-sequence space, but I think <kbd>C-m</kbd> cannot be used for Atuin's feature anyway because it can only be used with the terminals with an extended keyboard protocol.

<!-- Thank you for making a PR! Bug fixes are always welcome, but if you're adding a new feature or changing an existing one, we'd really appreciate if you open an issue, post on the forum, or drop in on Discord -->

## Checks
- [x] I am happy for maintainers to push small adjustments to this PR, to speed up the review cycle
- [x] I have checked that there are no existing pull requests for the same thing
