### PR TITLE
feat: support syncing aliases

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -185,6 +185,7 @@ dependencies = [
  "async-trait",
  "atuin-client",
  "atuin-common",
+ "atuin-config",
  "atuin-server",
  "atuin-server-postgres",
  "base64 0.21.7",
@@ -284,6 +285,19 @@ dependencies = [
  "time",
  "typed-builder",
  "uuid",
+]
+
+[[package]]
+name = "atuin-config"
+version = "0.1.0"
+dependencies = [
+ "atuin-client",
+ "atuin-common",
+ "crypto_secretbox",
+ "eyre",
+ "rand",
+ "rmp",
+ "tokio",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,8 @@ members = [
   "atuin-server",
   "atuin-server-postgres",
   "atuin-server-database",
-  "atuin-common",
+  "atuin-common", 
+  "atuin-config",
 ]
 
 resolver = "2"

--- a/atuin-config/Cargo.toml
+++ b/atuin-config/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+name = "atuin-config"
+edition = "2021"
+version = "0.1.0" # intentionally not the same as the rest
+
+authors.workspace = true
+rust-version.workspace = true
+license.workspace = true
+homepage.workspace = true
+repository.workspace = true
+readme.workspace = true
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+atuin-common = { path = "../atuin-common", version = "18.0.1" }
+atuin-client = { path = "../atuin-client", version = "18.0.1" }
+
+eyre = { workspace = true }
+tokio = { workspace = true }
+rmp = { version = "0.8.11" }
+rand = { workspace = true }
+crypto_secretbox = "0.1.1"

--- a/atuin-config/src/lib.rs
+++ b/atuin-config/src/lib.rs
@@ -1,0 +1,2 @@
+pub mod shell;
+pub mod store;

--- a/atuin-config/src/shell.rs
+++ b/atuin-config/src/shell.rs
@@ -1,0 +1,7 @@
+pub mod zsh;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Alias {
+    pub name: String,
+    pub value: String,
+}

--- a/atuin-config/src/shell.rs
+++ b/atuin-config/src/shell.rs
@@ -1,3 +1,6 @@
+pub mod bash;
+pub mod fish;
+pub mod xonsh;
 pub mod zsh;
 
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/atuin-config/src/shell/bash.rs
+++ b/atuin-config/src/shell/bash.rs
@@ -1,0 +1,12 @@
+use super::Alias;
+
+// Configuration for bash
+pub fn build(aliases: &[Alias]) -> String {
+    let mut config = String::new();
+
+    for alias in aliases {
+        config.push_str(&format!("alias {}='{}'\n", alias.name, alias.value));
+    }
+
+    config
+}

--- a/atuin-config/src/shell/fish.rs
+++ b/atuin-config/src/shell/fish.rs
@@ -1,0 +1,12 @@
+use super::Alias;
+
+// Configuration for fish
+pub fn build(aliases: &[Alias]) -> String {
+    let mut config = String::new();
+
+    for alias in aliases {
+        config.push_str(&format!("alias {}='{}'\n", alias.name, alias.value));
+    }
+
+    config
+}

--- a/atuin-config/src/shell/xonsh.rs
+++ b/atuin-config/src/shell/xonsh.rs
@@ -1,0 +1,12 @@
+use super::Alias;
+
+// Configuration for xonsh
+pub fn build(aliases: &[Alias]) -> String {
+    let mut config = String::new();
+
+    for alias in aliases {
+        config.push_str(&format!("aliases['{}'] ='{}'\n", alias.name, alias.value));
+    }
+
+    config
+}

--- a/atuin-config/src/shell/zsh.rs
+++ b/atuin-config/src/shell/zsh.rs
@@ -1,0 +1,12 @@
+use super::Alias;
+
+// Configuration for zsh
+pub fn build(aliases: &[Alias]) -> String {
+    let mut config = String::new();
+
+    for alias in aliases {
+        config.push_str(&format!("alias {}='{}'\n", alias.name, alias.value));
+    }
+
+    config
+}

--- a/atuin-config/src/store.rs
+++ b/atuin-config/src/store.rs
@@ -1,0 +1,280 @@
+use std::collections::BTreeMap;
+
+use atuin_client::record::sqlite_store::SqliteStore;
+// Sync aliases
+// This will be noticeable similar to the kv store, though I expect the two shall diverge
+// While we will support a range of shell config, I'd rather have a larger number of small records
+// + stores, rather than one mega config store.
+use atuin_common::record::{DecryptedData, Host, HostId};
+use eyre::{bail, ensure, eyre, Result};
+
+use atuin_client::record::encryption::PASETO_V4;
+use atuin_client::record::store::Store;
+
+use crate::shell::Alias;
+
+const CONFIG_SHELL_ALIAS_VERSION: &str = "v0";
+const CONFIG_SHELL_ALIAS_TAG: &str = "config-shell-alias";
+const CONFIG_SHELL_ALIAS_FIELD_MAX_LEN: usize = 20000; // 20kb max total len, way more than should be needed.
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum AliasRecord {
+    Create(Alias),  // create a full record
+    Delete(String), // delete by name
+}
+
+impl AliasRecord {
+    pub fn serialize(&self) -> Result<DecryptedData> {
+        use rmp::encode;
+
+        let mut output = vec![];
+
+        match self {
+            AliasRecord::Create(alias) => {
+                encode::write_u8(&mut output, 0)?; // create
+                encode::write_array_len(&mut output, 2)?; // 2 fields
+
+                encode::write_str(&mut output, alias.name.as_str())?;
+                encode::write_str(&mut output, alias.value.as_str())?;
+            }
+            AliasRecord::Delete(name) => {
+                encode::write_u8(&mut output, 1)?; // delete
+                encode::write_array_len(&mut output, 1)?; // 1 field
+
+                encode::write_str(&mut output, name.as_str())?;
+            }
+        }
+
+        Ok(DecryptedData(output))
+    }
+
+    pub fn deserialize(data: &DecryptedData, version: &str) -> Result<Self> {
+        use rmp::decode;
+
+        fn error_report<E: std::fmt::Debug>(err: E) -> eyre::Report {
+            eyre!("{err:?}")
+        }
+
+        match version {
+            CONFIG_SHELL_ALIAS_VERSION => {
+                let mut bytes = decode::Bytes::new(&data.0);
+
+                let record_type = decode::read_u8(&mut bytes).map_err(error_report)?;
+
+                match record_type {
+                    // create
+                    0 => {
+                        let nfields = decode::read_array_len(&mut bytes).map_err(error_report)?;
+                        ensure!(
+                            nfields == 2,
+                            "too many entries in v0 shell alias create record"
+                        );
+
+                        let bytes = bytes.remaining_slice();
+
+                        let (key, bytes) =
+                            decode::read_str_from_slice(bytes).map_err(error_report)?;
+                        let (value, bytes) =
+                            decode::read_str_from_slice(bytes).map_err(error_report)?;
+
+                        if !bytes.is_empty() {
+                            bail!("trailing bytes in encoded shell alias record. malformed")
+                        }
+
+                        Ok(AliasRecord::Create(Alias {
+                            name: key.to_owned(),
+                            value: value.to_owned(),
+                        }))
+                    }
+
+                    // delete
+                    1 => {
+                        let nfields = decode::read_array_len(&mut bytes).map_err(error_report)?;
+                        ensure!(
+                            nfields == 1,
+                            "too many entries in v0 shell alias delete record"
+                        );
+
+                        let bytes = bytes.remaining_slice();
+
+                        let (key, bytes) =
+                            decode::read_str_from_slice(bytes).map_err(error_report)?;
+
+                        if !bytes.is_empty() {
+                            bail!("trailing bytes in encoded shell alias record. malformed")
+                        }
+
+                        Ok(AliasRecord::Delete(key.to_owned()))
+                    }
+
+                    n => {
+                        bail!("unknown AliasRecord type {n}")
+                    }
+                }
+            }
+            _ => {
+                bail!("unknown version {version:?}")
+            }
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct AliasStore {
+    pub store: SqliteStore,
+    pub host_id: HostId,
+    pub encryption_key: [u8; 32],
+}
+
+impl AliasStore {
+    // will want to init the actual kv store when that is done
+    pub fn new(store: SqliteStore, host_id: HostId, encryption_key: [u8; 32]) -> AliasStore {
+        AliasStore {
+            store,
+            host_id,
+            encryption_key,
+        }
+    }
+
+    pub async fn set(&self, name: &str, value: &str) -> Result<()> {
+        if name.len() + value.len() > CONFIG_SHELL_ALIAS_FIELD_MAX_LEN {
+            return Err(eyre!(
+                "alias record too large: max len {} bytes",
+                CONFIG_SHELL_ALIAS_FIELD_MAX_LEN
+            ));
+        }
+
+        let record = AliasRecord::Create(Alias {
+            name: name.to_string(),
+            value: value.to_string(),
+        });
+
+        let bytes = record.serialize()?;
+
+        let idx = self
+            .store
+            .last(self.host_id, CONFIG_SHELL_ALIAS_TAG)
+            .await?
+            .map_or(0, |entry| entry.idx + 1);
+
+        let record = atuin_common::record::Record::builder()
+            .host(Host::new(self.host_id))
+            .version(CONFIG_SHELL_ALIAS_VERSION.to_string())
+            .tag(CONFIG_SHELL_ALIAS_TAG.to_string())
+            .idx(idx)
+            .data(bytes)
+            .build();
+
+        self.store
+            .push(&record.encrypt::<PASETO_V4>(&self.encryption_key))
+            .await?;
+
+        Ok(())
+    }
+
+    pub async fn aliases(&self) -> Result<Vec<Alias>> {
+        let mut build = BTreeMap::new();
+
+        // this is sorted, oldest to newest
+        let tagged = self.store.all_tagged(CONFIG_SHELL_ALIAS_TAG).await?;
+
+        for record in tagged {
+            let version = record.version.clone();
+
+            let decrypted = match version.as_str() {
+                CONFIG_SHELL_ALIAS_VERSION => record.decrypt::<PASETO_V4>(&self.encryption_key)?,
+                version => bail!("unknown version {version:?}"),
+            };
+
+            let ar = AliasRecord::deserialize(&decrypted.data, version.as_str())?;
+
+            match ar {
+                AliasRecord::Create(a) => {
+                    build.insert(a.name.clone(), a);
+                }
+                AliasRecord::Delete(d) => {
+                    build.remove(&d);
+                }
+            }
+        }
+
+        Ok(build.into_values().collect())
+    }
+}
+
+#[cfg(test)]
+pub(crate) fn test_sqlite_store_timeout() -> f64 {
+    std::env::var("ATUIN_TEST_SQLITE_STORE_TIMEOUT")
+        .ok()
+        .and_then(|x| x.parse().ok())
+        .unwrap_or(0.1)
+}
+
+#[cfg(test)]
+mod tests {
+    use rand::rngs::OsRng;
+
+    use atuin_client::record::sqlite_store::SqliteStore;
+
+    use crate::shell::Alias;
+
+    use super::{test_sqlite_store_timeout, AliasRecord, AliasStore, CONFIG_SHELL_ALIAS_VERSION};
+    use crypto_secretbox::{KeyInit, XSalsa20Poly1305};
+
+    #[test]
+    fn encode_decode() {
+        let record = Alias {
+            name: "k".to_owned(),
+            value: "kubectl".to_owned(),
+        };
+        let record = AliasRecord::Create(record);
+
+        let snapshot = [204, 0, 146, 161, 107, 167, 107, 117, 98, 101, 99, 116, 108];
+
+        let encoded = record.serialize().unwrap();
+        let decoded = AliasRecord::deserialize(&encoded, CONFIG_SHELL_ALIAS_VERSION).unwrap();
+
+        assert_eq!(encoded.0, &snapshot);
+        assert_eq!(decoded, record);
+    }
+
+    #[tokio::test]
+    async fn build_aliases() {
+        let mut store = SqliteStore::new(":memory:", test_sqlite_store_timeout())
+            .await
+            .unwrap();
+        let key: [u8; 32] = XSalsa20Poly1305::generate_key(&mut OsRng).into();
+        let host_id = atuin_common::record::HostId(atuin_common::utils::uuid_v7());
+
+        let alias = AliasStore::new(store, host_id, key);
+
+        alias.set("k", "kubectl").await.unwrap();
+
+        alias.set("gp", "git push").await.unwrap();
+
+        let mut aliases = alias.aliases().await.unwrap();
+
+        aliases.sort_by_key(|a| match a.clone() {
+            AliasRecord::Create(a) => a.name,
+            AliasRecord::Delete(n) => n,
+        });
+
+        assert_eq!(aliases.len(), 2);
+
+        assert_eq!(
+            aliases[0],
+            AliasRecord::Create(Alias {
+                name: String::from("gp"),
+                value: String::from("git push")
+            })
+        );
+
+        assert_eq!(
+            aliases[1],
+            AliasRecord::Create(Alias {
+                name: String::from("k"),
+                value: String::from("kubectl")
+            })
+        );
+    }
+}

--- a/atuin-config/src/store.rs
+++ b/atuin-config/src/store.rs
@@ -240,7 +240,7 @@ mod tests {
 
     #[tokio::test]
     async fn build_aliases() {
-        let mut store = SqliteStore::new(":memory:", test_sqlite_store_timeout())
+        let store = SqliteStore::new(":memory:", test_sqlite_store_timeout())
             .await
             .unwrap();
         let key: [u8; 32] = XSalsa20Poly1305::generate_key(&mut OsRng).into();
@@ -254,27 +254,24 @@ mod tests {
 
         let mut aliases = alias.aliases().await.unwrap();
 
-        aliases.sort_by_key(|a| match a.clone() {
-            AliasRecord::Create(a) => a.name,
-            AliasRecord::Delete(n) => n,
-        });
+        aliases.sort_by_key(|a| a.name.clone());
 
         assert_eq!(aliases.len(), 2);
 
         assert_eq!(
             aliases[0],
-            AliasRecord::Create(Alias {
+            Alias {
                 name: String::from("gp"),
                 value: String::from("git push")
-            })
+            }
         );
 
         assert_eq!(
             aliases[1],
-            AliasRecord::Create(Alias {
+            Alias {
                 name: String::from("k"),
                 value: String::from("kubectl")
-            })
+            }
         );
     }
 }

--- a/atuin/Cargo.toml
+++ b/atuin/Cargo.toml
@@ -45,6 +45,7 @@ atuin-server-postgres = { path = "../atuin-server-postgres", version = "18.0.1",
 atuin-server = { path = "../atuin-server", version = "18.0.1", optional = true }
 atuin-client = { path = "../atuin-client", version = "18.0.1", optional = true, default-features = false }
 atuin-common = { path = "../atuin-common", version = "18.0.1" }
+atuin-config = { path = "../atuin-config", version = "0.1.0" }
 
 log = { workspace = true }
 env_logger = "0.10.0"

--- a/atuin/src/command/client.rs
+++ b/atuin/src/command/client.rs
@@ -13,8 +13,10 @@ mod sync;
 mod account;
 
 mod config;
+mod default_config;
 mod history;
 mod import;
+mod init;
 mod kv;
 mod search;
 mod stats;
@@ -49,6 +51,12 @@ pub enum Cmd {
 
     #[command(subcommand)]
     Store(store::Cmd),
+
+    #[command(subcommand)]
+    Config(config::Cmd),
+
+    #[command()]
+    Init(init::Cmd),
 
     /// Print example configuration
     #[command()]
@@ -101,8 +109,12 @@ impl Cmd {
 
             Self::Store(store) => store.run(&settings, &db, sqlite_store).await,
 
+            Self::Config(config) => config.run(&settings, sqlite_store).await,
+
+            Self::Init(init) => init.run(&settings).await,
+
             Self::DefaultConfig => {
-                config::run();
+                default_config::run();
                 Ok(())
             }
         }

--- a/atuin/src/command/client/config.rs
+++ b/atuin/src/command/client/config.rs
@@ -1,29 +1,7 @@
-use std::{
-    fmt::{self, Display},
-    io::{self, IsTerminal, Write},
-    time::Duration,
-};
-
-use atuin_common::utils::{self, Escapable as _};
 use clap::Subcommand;
-use eyre::{Context, Result};
-use runtime_format::{FormatKey, FormatKeyError, ParseSegment, ParsedFmt};
+use eyre::Result;
 
-use atuin_client::{
-    database::{current_context, Database},
-    encryption,
-    history::{store::HistoryStore, History},
-    record::sqlite_store::SqliteStore,
-    settings::{
-        FilterMode::{Directory, Global, Session},
-        Settings, Timezone,
-    },
-};
-
-use log::{debug, warn};
-use time::{macros::format_description, OffsetDateTime};
-
-use super::search::format_duration_into;
+use atuin_client::{record::sqlite_store::SqliteStore, settings::Settings};
 
 mod alias;
 

--- a/atuin/src/command/client/config.rs
+++ b/atuin/src/command/client/config.rs
@@ -1,5 +1,43 @@
-use atuin_client::settings::Settings;
+use std::{
+    fmt::{self, Display},
+    io::{self, IsTerminal, Write},
+    time::Duration,
+};
 
-pub fn run() {
-    println!("{}", Settings::example_config());
+use atuin_common::utils::{self, Escapable as _};
+use clap::Subcommand;
+use eyre::{Context, Result};
+use runtime_format::{FormatKey, FormatKeyError, ParseSegment, ParsedFmt};
+
+use atuin_client::{
+    database::{current_context, Database},
+    encryption,
+    history::{store::HistoryStore, History},
+    record::sqlite_store::SqliteStore,
+    settings::{
+        FilterMode::{Directory, Global, Session},
+        Settings, Timezone,
+    },
+};
+
+use log::{debug, warn};
+use time::{macros::format_description, OffsetDateTime};
+
+use super::search::format_duration_into;
+
+mod alias;
+
+#[derive(Subcommand, Debug)]
+#[command(infer_subcommands = true)]
+pub enum Cmd {
+    #[command(subcommand)]
+    Alias(alias::Cmd),
+}
+
+impl Cmd {
+    pub async fn run(self, settings: &Settings, store: SqliteStore) -> Result<()> {
+        match self {
+            Self::Alias(cmd) => cmd.run(settings, store).await,
+        }
+    }
 }

--- a/atuin/src/command/client/config/alias.rs
+++ b/atuin/src/command/client/config/alias.rs
@@ -1,27 +1,7 @@
-use std::{
-    fmt::{self, Display},
-    io::{self, IsTerminal, Write},
-    time::Duration,
-};
-
-use atuin_common::utils::{self, Escapable as _};
 use clap::Subcommand;
 use eyre::{Context, Result};
-use runtime_format::{FormatKey, FormatKeyError, ParseSegment, ParsedFmt};
 
-use atuin_client::{
-    database::{current_context, Database},
-    encryption,
-    history::{store::HistoryStore, History},
-    record::sqlite_store::SqliteStore,
-    settings::{
-        FilterMode::{Directory, Global, Session},
-        Settings, Timezone,
-    },
-};
-
-use log::{debug, warn};
-use time::{macros::format_description, OffsetDateTime};
+use atuin_client::{encryption, record::sqlite_store::SqliteStore, settings::Settings};
 
 use atuin_config::store::AliasStore;
 

--- a/atuin/src/command/client/config/alias.rs
+++ b/atuin/src/command/client/config/alias.rs
@@ -1,0 +1,62 @@
+use std::{
+    fmt::{self, Display},
+    io::{self, IsTerminal, Write},
+    time::Duration,
+};
+
+use atuin_common::utils::{self, Escapable as _};
+use clap::Subcommand;
+use eyre::{Context, Result};
+use runtime_format::{FormatKey, FormatKeyError, ParseSegment, ParsedFmt};
+
+use atuin_client::{
+    database::{current_context, Database},
+    encryption,
+    history::{store::HistoryStore, History},
+    record::sqlite_store::SqliteStore,
+    settings::{
+        FilterMode::{Directory, Global, Session},
+        Settings, Timezone,
+    },
+};
+
+use log::{debug, warn};
+use time::{macros::format_description, OffsetDateTime};
+
+use atuin_config::store::AliasStore;
+
+#[derive(Subcommand, Debug)]
+#[command(infer_subcommands = true)]
+pub enum Cmd {
+    Set { name: String, value: String },
+}
+
+impl Cmd {
+    async fn set(
+        &self,
+        _settings: &Settings,
+        store: AliasStore,
+        name: String,
+        value: String,
+    ) -> Result<()> {
+        store.set(&name, &value).await?;
+
+        Ok(())
+    }
+
+    pub async fn run(&self, settings: &Settings, store: SqliteStore) -> Result<()> {
+        let encryption_key: [u8; 32] = encryption::load_key(settings)
+            .context("could not load encryption key")?
+            .into();
+        let host_id = Settings::host_id().expect("failed to get host_id");
+
+        let alias_store = AliasStore::new(store, host_id, encryption_key);
+
+        match self {
+            Self::Set { name, value } => {
+                self.set(settings, alias_store, name.clone(), value.clone())
+                    .await
+            }
+        }
+    }
+}

--- a/atuin/src/command/client/config/alias.rs
+++ b/atuin/src/command/client/config/alias.rs
@@ -9,6 +9,7 @@ use atuin_config::store::AliasStore;
 #[command(infer_subcommands = true)]
 pub enum Cmd {
     Set { name: String, value: String },
+    Delete { name: String },
 }
 
 impl Cmd {
@@ -20,6 +21,12 @@ impl Cmd {
         value: String,
     ) -> Result<()> {
         store.set(&name, &value).await?;
+
+        Ok(())
+    }
+
+    async fn delete(&self, _settings: &Settings, store: AliasStore, name: String) -> Result<()> {
+        store.delete(&name).await?;
 
         Ok(())
     }
@@ -37,6 +44,8 @@ impl Cmd {
                 self.set(settings, alias_store, name.clone(), value.clone())
                     .await
             }
+
+            Self::Delete { name } => self.delete(settings, alias_store, name.clone()).await,
         }
     }
 }

--- a/atuin/src/command/client/config/alias.rs
+++ b/atuin/src/command/client/config/alias.rs
@@ -15,7 +15,6 @@ pub enum Cmd {
 impl Cmd {
     async fn set(
         &self,
-        _settings: &Settings,
         store: AliasStore,
         name: String,
         value: String,
@@ -25,7 +24,11 @@ impl Cmd {
         Ok(())
     }
 
-    async fn delete(&self, _settings: &Settings, store: AliasStore, name: String) -> Result<()> {
+    async fn delete(
+        &self,
+        store: AliasStore,
+        name: String,
+    ) -> Result<()> {
         store.delete(&name).await?;
 
         Ok(())
@@ -41,11 +44,14 @@ impl Cmd {
 
         match self {
             Self::Set { name, value } => {
-                self.set(settings, alias_store, name.clone(), value.clone())
+                self.set(alias_store, name.clone(), value.clone())
                     .await
             }
 
-            Self::Delete { name } => self.delete(settings, alias_store, name.clone()).await,
+            Self::Delete{ name } => {
+                self.delete(alias_store, name.clone())
+                    .await
+            }
         }
     }
 }

--- a/atuin/src/command/client/config/alias.rs
+++ b/atuin/src/command/client/config/alias.rs
@@ -13,22 +13,13 @@ pub enum Cmd {
 }
 
 impl Cmd {
-    async fn set(
-        &self,
-        store: AliasStore,
-        name: String,
-        value: String,
-    ) -> Result<()> {
+    async fn set(&self, store: AliasStore, name: String, value: String) -> Result<()> {
         store.set(&name, &value).await?;
 
         Ok(())
     }
 
-    async fn delete(
-        &self,
-        store: AliasStore,
-        name: String,
-    ) -> Result<()> {
+    async fn delete(&self, store: AliasStore, name: String) -> Result<()> {
         store.delete(&name).await?;
 
         Ok(())
@@ -43,15 +34,9 @@ impl Cmd {
         let alias_store = AliasStore::new(store, host_id, encryption_key);
 
         match self {
-            Self::Set { name, value } => {
-                self.set(alias_store, name.clone(), value.clone())
-                    .await
-            }
+            Self::Set { name, value } => self.set(alias_store, name.clone(), value.clone()).await,
 
-            Self::Delete{ name } => {
-                self.delete(alias_store, name.clone())
-                    .await
-            }
+            Self::Delete { name } => self.delete(alias_store, name.clone()).await,
         }
     }
 }

--- a/atuin/src/command/client/default_config.rs
+++ b/atuin/src/command/client/default_config.rs
@@ -1,0 +1,5 @@
+use atuin_client::settings::Settings;
+
+pub fn run() {
+    println!("{}", Settings::example_config());
+}

--- a/atuin/src/command/client/init.rs
+++ b/atuin/src/command/client/init.rs
@@ -144,7 +144,7 @@ bind -M insert \e\[A _atuin_bind_up";
         let record_store_path = PathBuf::from(settings.record_store_path.as_str());
         let sqlite_store = SqliteStore::new(record_store_path, settings.local_timeout).await?;
 
-        let encryption_key: [u8; 32] = encryption::load_key(&settings)
+        let encryption_key: [u8; 32] = encryption::load_key(settings)
             .context("could not load encryption key")?
             .into();
         let host_id = Settings::host_id().expect("failed to get host_id");
@@ -153,7 +153,7 @@ bind -M insert \e\[A _atuin_bind_up";
 
         match self.shell {
             Shell::Zsh => {
-                zsh::init(alias_store, self.disable_up_arrow, self.disable_ctrl_r).await?
+                zsh::init(alias_store, self.disable_up_arrow, self.disable_ctrl_r).await?;
             }
             Shell::Bash => self.init_bash(),
             Shell::Fish => self.init_fish(),

--- a/atuin/src/command/client/init.rs
+++ b/atuin/src/command/client/init.rs
@@ -99,11 +99,11 @@ impl Cmd {
                 bash::init(alias_store, self.disable_up_arrow, self.disable_ctrl_r).await?;
             }
             Shell::Fish => {
-                fish::init(alias_store, self.disable_up_arrow, self.disable_ctrl_r).await?
+                fish::init(alias_store, self.disable_up_arrow, self.disable_ctrl_r).await?;
             }
             Shell::Nu => self.init_nu(),
             Shell::Xonsh => {
-                xonsh::init(alias_store, self.disable_up_arrow, self.disable_ctrl_r).await?
+                xonsh::init(alias_store, self.disable_up_arrow, self.disable_ctrl_r).await?;
             }
         }
 

--- a/atuin/src/command/client/init.rs
+++ b/atuin/src/command/client/init.rs
@@ -5,6 +5,9 @@ use atuin_config::store::AliasStore;
 use clap::{Parser, ValueEnum};
 use eyre::{Result, WrapErr};
 
+mod bash;
+mod fish;
+mod xonsh;
 mod zsh;
 
 #[derive(Parser, Debug)]
@@ -35,51 +38,6 @@ pub enum Shell {
 }
 
 impl Cmd {
-    fn init_bash(&self) {
-        let base = include_str!("../../shell/atuin.bash");
-        let (bind_ctrl_r, bind_up_arrow) = if std::env::var("ATUIN_NOBIND").is_ok() {
-            (false, false)
-        } else {
-            (!self.disable_ctrl_r, !self.disable_up_arrow)
-        };
-
-        println!("__atuin_bind_ctrl_r={bind_ctrl_r}");
-        println!("__atuin_bind_up_arrow={bind_up_arrow}");
-        println!("{base}");
-    }
-
-    fn init_fish(&self) {
-        let full = include_str!("../../shell/atuin.fish");
-        println!("{full}");
-
-        if std::env::var("ATUIN_NOBIND").is_err() {
-            const BIND_CTRL_R: &str = r"bind \cr _atuin_search";
-            const BIND_UP_ARROW: &str = r"bind -k up _atuin_bind_up
-bind \eOA _atuin_bind_up
-bind \e\[A _atuin_bind_up";
-            const BIND_CTRL_R_INS: &str = r"bind -M insert \cr _atuin_search";
-            const BIND_UP_ARROW_INS: &str = r"bind -M insert -k up _atuin_bind_up
-bind -M insert \eOA _atuin_bind_up
-bind -M insert \e\[A _atuin_bind_up";
-
-            if !self.disable_ctrl_r {
-                println!("{BIND_CTRL_R}");
-            }
-            if !self.disable_up_arrow {
-                println!("{BIND_UP_ARROW}");
-            }
-
-            println!("if bind -M insert > /dev/null 2>&1");
-            if !self.disable_ctrl_r {
-                println!("{BIND_CTRL_R_INS}");
-            }
-            if !self.disable_up_arrow {
-                println!("{BIND_UP_ARROW_INS}");
-            }
-            println!("end");
-        }
-    }
-
     fn init_nu(&self) {
         let full = include_str!("../../shell/atuin.nu");
         println!("{full}");
@@ -122,24 +80,6 @@ bind -M insert \e\[A _atuin_bind_up";
         }
     }
 
-    fn init_xonsh(&self) {
-        let base = include_str!("../../shell/atuin.xsh");
-        let (bind_ctrl_r, bind_up_arrow) = if std::env::var("ATUIN_NOBIND").is_ok() {
-            (false, false)
-        } else {
-            (!self.disable_ctrl_r, !self.disable_up_arrow)
-        };
-        println!(
-            "_ATUIN_BIND_CTRL_R={}",
-            if bind_ctrl_r { "True" } else { "False" }
-        );
-        println!(
-            "_ATUIN_BIND_UP_ARROW={}",
-            if bind_up_arrow { "True" } else { "False" }
-        );
-        println!("{base}");
-    }
-
     pub async fn run(self, settings: &Settings) -> Result<()> {
         let record_store_path = PathBuf::from(settings.record_store_path.as_str());
         let sqlite_store = SqliteStore::new(record_store_path, settings.local_timeout).await?;
@@ -155,10 +95,16 @@ bind -M insert \e\[A _atuin_bind_up";
             Shell::Zsh => {
                 zsh::init(alias_store, self.disable_up_arrow, self.disable_ctrl_r).await?;
             }
-            Shell::Bash => self.init_bash(),
-            Shell::Fish => self.init_fish(),
+            Shell::Bash => {
+                bash::init(alias_store, self.disable_up_arrow, self.disable_ctrl_r).await?;
+            }
+            Shell::Fish => {
+                fish::init(alias_store, self.disable_up_arrow, self.disable_ctrl_r).await?
+            }
             Shell::Nu => self.init_nu(),
-            Shell::Xonsh => self.init_xonsh(),
+            Shell::Xonsh => {
+                xonsh::init(alias_store, self.disable_up_arrow, self.disable_ctrl_r).await?
+            }
         }
 
         Ok(())

--- a/atuin/src/command/client/init/bash.rs
+++ b/atuin/src/command/client/init/bash.rs
@@ -1,0 +1,23 @@
+use atuin_config::store::AliasStore;
+use eyre::Result;
+
+pub async fn init(store: AliasStore, disable_up_arrow: bool, disable_ctrl_r: bool) -> Result<()> {
+    let base = include_str!("../../../shell/atuin.bash");
+
+    let aliases = store.aliases().await?;
+
+    let aliases = atuin_config::shell::bash::build(&aliases[..]);
+
+    let (bind_ctrl_r, bind_up_arrow) = if std::env::var("ATUIN_NOBIND").is_ok() {
+        (false, false)
+    } else {
+        (!disable_ctrl_r, !disable_up_arrow)
+    };
+
+    println!("__atuin_bind_ctrl_r={bind_ctrl_r}");
+    println!("__atuin_bind_up_arrow={bind_up_arrow}");
+    println!("{base}");
+    println!("{aliases}");
+
+    Ok(())
+}

--- a/atuin/src/command/client/init/fish.rs
+++ b/atuin/src/command/client/init/fish.rs
@@ -1,0 +1,42 @@
+use atuin_config::store::AliasStore;
+use eyre::Result;
+
+pub async fn init(store: AliasStore, disable_up_arrow: bool, disable_ctrl_r: bool) -> Result<()> {
+    let base = include_str!("../../../shell/atuin.zsh");
+
+    println!("{base}");
+
+    if std::env::var("ATUIN_NOBIND").is_err() {
+        const BIND_CTRL_R: &str = r"bind \cr _atuin_search";
+        const BIND_UP_ARROW: &str = r"bind -k up _atuin_bind_up
+bind \eOA _atuin_bind_up
+bind \e\[A _atuin_bind_up";
+        const BIND_CTRL_R_INS: &str = r"bind -M insert \cr _atuin_search";
+        const BIND_UP_ARROW_INS: &str = r"bind -M insert -k up _atuin_bind_up
+bind -M insert \eOA _atuin_bind_up
+bind -M insert \e\[A _atuin_bind_up";
+
+        if !disable_ctrl_r {
+            println!("{BIND_CTRL_R}");
+        }
+        if !disable_up_arrow {
+            println!("{BIND_UP_ARROW}");
+        }
+
+        println!("if bind -M insert > /dev/null 2>&1");
+        if !disable_ctrl_r {
+            println!("{BIND_CTRL_R_INS}");
+        }
+        if !disable_up_arrow {
+            println!("{BIND_UP_ARROW_INS}");
+        }
+        println!("end");
+    }
+
+    let aliases = store.aliases().await?;
+    let aliases = atuin_config::shell::fish::build(&aliases[..]);
+
+    println!("{aliases}");
+
+    Ok(())
+}

--- a/atuin/src/command/client/init/xonsh.rs
+++ b/atuin/src/command/client/init/xonsh.rs
@@ -1,0 +1,28 @@
+use atuin_config::store::AliasStore;
+use eyre::Result;
+
+pub async fn init(store: AliasStore, disable_up_arrow: bool, disable_ctrl_r: bool) -> Result<()> {
+    let base = include_str!("../../../shell/atuin.xsh");
+
+    let (bind_ctrl_r, bind_up_arrow) = if std::env::var("ATUIN_NOBIND").is_ok() {
+        (false, false)
+    } else {
+        (!disable_ctrl_r, !disable_up_arrow)
+    };
+    println!(
+        "_ATUIN_BIND_CTRL_R={}",
+        if bind_ctrl_r { "True" } else { "False" }
+    );
+    println!(
+        "_ATUIN_BIND_UP_ARROW={}",
+        if bind_up_arrow { "True" } else { "False" }
+    );
+    println!("{base}");
+
+    let aliases = store.aliases().await?;
+    let aliases = atuin_config::shell::fish::build(&aliases[..]);
+
+    println!("{aliases}");
+
+    Ok(())
+}

--- a/atuin/src/command/client/init/xonsh.rs
+++ b/atuin/src/command/client/init/xonsh.rs
@@ -20,7 +20,7 @@ pub async fn init(store: AliasStore, disable_up_arrow: bool, disable_ctrl_r: boo
     println!("{base}");
 
     let aliases = store.aliases().await?;
-    let aliases = atuin_config::shell::fish::build(&aliases[..]);
+    let aliases = atuin_config::shell::xonsh::build(&aliases[..]);
 
     println!("{aliases}");
 

--- a/atuin/src/command/client/init/zsh.rs
+++ b/atuin/src/command/client/init/zsh.rs
@@ -1,0 +1,36 @@
+use atuin_config::store::AliasStore;
+use eyre::Result;
+
+pub async fn init(store: AliasStore, disable_up_arrow: bool, disable_ctrl_r: bool) -> Result<()> {
+    let base = include_str!("../../../shell/atuin.zsh");
+
+    println!("{base}");
+
+    if std::env::var("ATUIN_NOBIND").is_err() {
+        const BIND_CTRL_R: &str = r"bindkey -M emacs '^r' atuin-search
+bindkey -M viins '^r' atuin-search-viins
+bindkey -M vicmd '/' atuin-search";
+
+        const BIND_UP_ARROW: &str = r"bindkey -M emacs '^[[A' atuin-up-search
+bindkey -M vicmd '^[[A' atuin-up-search-vicmd
+bindkey -M viins '^[[A' atuin-up-search-viins
+bindkey -M emacs '^[OA' atuin-up-search
+bindkey -M vicmd '^[OA' atuin-up-search-vicmd
+bindkey -M viins '^[OA' atuin-up-search-viins
+bindkey -M vicmd 'k' atuin-up-search-vicmd";
+
+        if !disable_ctrl_r {
+            println!("{BIND_CTRL_R}");
+        }
+        if !disable_up_arrow {
+            println!("{BIND_UP_ARROW}");
+        }
+    }
+
+    let aliases = store.aliases().await?;
+    let aliases = atuin_config::shell::zsh::build(&aliases[..]);
+
+    println!("{aliases}");
+
+    Ok(())
+}

--- a/atuin/src/command/mod.rs
+++ b/atuin/src/command/mod.rs
@@ -11,8 +11,6 @@ mod client;
 #[cfg(feature = "server")]
 mod server;
 
-mod init;
-
 mod contributors;
 
 #[derive(Subcommand)]
@@ -26,9 +24,6 @@ pub enum AtuinCmd {
     #[cfg(feature = "server")]
     #[command(subcommand)]
     Server(server::Cmd),
-
-    /// Output shell setup
-    Init(init::Cmd),
 
     /// Generate a UUID
     Uuid,
@@ -65,10 +60,6 @@ impl AtuinCmd {
             Self::Server(server) => server.run(),
             Self::Contributors => {
                 contributors::run();
-                Ok(())
-            }
-            Self::Init(init) => {
-                init.run();
                 Ok(())
             }
             Self::Uuid => {


### PR DESCRIPTION
```
atuin config alias set k kubectl
```

to set an alias. in this example, alias k -> kubectl

```
atuin config alias delete k
```

to delete an alias, in this example deleting the one we just set.

Aliases will be copied across shells, and across machines. All that's needed is a shell reload (in the future maybe let's remove that too)

<!-- Thank you for making a PR! Bug fixes are always welcome, but if you're adding a new feature or changing an existing one, we'd really appreciate if you open an issue, post on the forum, or drop in on Discord -->

## Checks
- [ ] I am happy for maintainers to push small adjustments to this PR, to speed up the review cycle
- [ ] I have checked that there are no existing pull requests for the same thing
