### PR TITLE
add 'ignored_commands' option to stats

### DIFF
--- a/atuin-client/config.toml
+++ b/atuin-client/config.toml
@@ -171,3 +171,6 @@ enter_accept = true
 
 ## Set commands that should be totally stripped and ignored from stats
 #common_prefix = ["sudo"]
+
+## Set commands that will be completely ignored from stats
+#ignored_commands = ["cd", "ls", "vi"]

--- a/atuin-client/src/settings.rs
+++ b/atuin-client/src/settings.rs
@@ -270,6 +270,8 @@ pub struct Stats {
     pub common_prefix: Vec<String>, // sudo, etc. commands we want to strip off
     #[serde(default = "Stats::common_subcommands_default")]
     pub common_subcommands: Vec<String>, // kubectl, commands we should consider subcommands for
+    #[serde(default = "Stats::ignored_commands_default")]
+    pub ignored_commands: Vec<String>, // cd, ls, etc. commands we want to completely hide from stats
 }
 
 impl Stats {
@@ -283,6 +285,10 @@ impl Stats {
             .map(String::from)
             .collect()
     }
+
+    fn ignored_commands_default() -> Vec<String> {
+        vec![]
+    }
 }
 
 impl Default for Stats {
@@ -290,6 +296,7 @@ impl Default for Stats {
         Self {
             common_prefix: Self::common_prefix_default(),
             common_subcommands: Self::common_subcommands_default(),
+            ignored_commands: Self::ignored_commands_default(),
         }
     }
 }


### PR DESCRIPTION
This resolves #1714.

I add a `ignored_commands` option to `stats` so that common commands that you don't want showing up in stats can be skipped.  

- I am unsure what the default for this option should be: I left it empty so as to keep it consistent with existing behaviour.  Happy to change that if you want.
- I added a test for this, which required updating the return signature for `compute_stats` -- I think in the long run the way to test this is by splitting out `compute_stats` from the function that prints the results, but I thought that might be too much for this PR.  Happy to take a stab at this if you disagree.

Output on my machine, using `ignored_commands = ["cd", "vi", "ls"]`:

(before)
```
> target/release/atuin stats
[▮▮▮▮▮▮▮▮▮▮] 903 cd
[▮▮▮▮▮▮▮▮▮ ] 874 vi
[▮▮▮▮▮▮    ] 619 ls
[▮▮        ] 199 kcgp
[▮         ] 166 git stat
[▮         ] 159 kcl
[▮         ] 141 kcapp
[▮         ] 131 kcrm
[▮         ] 131 git co
[▮         ] 119 kcg
Total commands:   6747
Unique commands:  1933
```

(after)
```
> target/release/atuin stats
[▮▮▮▮▮▮▮▮▮▮] 199 kcgp
[▮▮▮▮▮▮▮▮  ] 166 git stat
[▮▮▮▮▮▮▮   ] 159 kcl
[▮▮▮▮▮▮▮   ] 141 kcapp
[▮▮▮▮▮▮    ] 131 git co
[▮▮▮▮▮▮    ] 131 kcrm
[▮▮▮▮▮     ] 119 kcg
[▮▮▮▮▮     ] 110 kns
[▮▮▮▮▮     ] 109 git amend
[▮▮▮▮▮     ] 107 rm
Total commands:   4352
Unique commands:  1457
```

## Checks
- [x] I am happy for maintainers to push small adjustments to this PR, to speed up the review cycle
- [x] I have checked that there are no existing pull requests for the same thing
