### PR TITLE
Revert "fix(bash): avoid unexpected `atuin history start` for keybindings"

### DIFF
--- a/atuin/src/shell/atuin.bash
+++ b/atuin/src/shell/atuin.bash
@@ -17,14 +17,6 @@ export ATUIN_SESSION
 ATUIN_HISTORY_ID=""
 
 __atuin_preexec() {
-    if [[ ! ${BLE_ATTACHED-} ]]; then
-        # With bash-preexec, preexec may be called even for the command run by
-        # keybindings.  There is no general and robust way to detect the
-        # command for keybindings, but at least we want to exclude Atuin's
-        # keybindings.
-        [[ $BASH_COMMAND == '__atuin_history'* && $BASH_COMMAND != "$1" ]] && return 0
-    fi
-
     local id
     id=$(atuin history start -- "$1")
     export ATUIN_HISTORY_ID=$id


### PR DESCRIPTION
Reverts atuinsh/atuin#1509

cc @akinomyoga 

Looks like this is causing some of the "bash not recording commands" issues, from what I've managed to replicate. I'd rather take inaccurate timings vs missed commands :/ 