### PR TITLE
Update atuin.nu

### DIFF
--- a/atuin/src/shell/atuin.nu
+++ b/atuin/src/shell/atuin.nu
@@ -31,7 +31,7 @@ def _atuin_search_cmd [...flags: string] {
     [
         $ATUIN_KEYBINDING_TOKEN,
         ([
-            `commandline (ATUIN_LOG=error run-external --redirect-stderr atuin search`,
+            `commandline edit -r (ATUIN_LOG=error run-external --redirect-stderr atuin search`,
             ($flags | append [--interactive, --] | each {|e| $'"($e)"'}),
             `(commandline) | complete | $in.stderr | str substring ..-1)`,
         ] | flatten | str join ' '),


### PR DESCRIPTION
Reflect to nushell pr: https://github.com/nushell/nushell/pull/11877
Since commandline with positional argument will be deprecated on nushell 0.91.0 version, and it uses `commandline edit -r` instead.

## Checks
- [X] I am happy for maintainers to push small adjustments to this PR, to speed up the review cycle
- [X] I have checked that there are no existing pull requests for the same thing

I don't think we need to merge it until nushell 0.91.0 is coming out.  Just create a pr for reminding