### PR TITLE
Add atuin stats --filter-mode

### DIFF
--- a/crates/atuin-client/src/database.rs
+++ b/crates/atuin-client/src/database.rs
@@ -194,6 +194,7 @@ pub trait Database: Send + Sync + 'static {
         max: Option<usize>,
         unique: bool,
         include_deleted: bool,
+        range: Option<(OffsetDateTime, OffsetDateTime)>,
     ) -> Result<Vec<History>>;
     async fn range(&self, from: OffsetDateTime, to: OffsetDateTime) -> Result<Vec<History>>;
 
@@ -455,6 +456,7 @@ impl Database for Sqlite {
         max: Option<usize>,
         unique: bool,
         include_deleted: bool,
+        range: Option<(OffsetDateTime, OffsetDateTime)>,
     ) -> Result<Vec<History>> {
         debug!("listing history");
 
@@ -495,6 +497,13 @@ impl Database for Sqlite {
 
         if let Some(max) = max {
             query.limit(max);
+        }
+
+        // Inclusive on both ends, matching `range()`. `stats` relies on this to count a
+        // command recorded exactly on a period boundary (e.g. at midnight).
+        if let Some((from, to)) = range {
+            query.and_where_ge("timestamp", from.unix_timestamp_nanos() as i64);
+            query.and_where_le("timestamp", to.unix_timestamp_nanos() as i64);
         }
 
         let query = query.sql().expect("bug in list query. please report");
@@ -1251,6 +1260,52 @@ mod test {
         captured
     }
 
+    // `stats --filter-mode` scopes over a period by handing `list` an inclusive
+    // `(from, to)` range. The bounds must be inclusive on both ends so a command
+    // recorded exactly on a period boundary (e.g. at midnight) is still counted.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_list_range_is_inclusive() {
+        let db = Sqlite::new("sqlite::memory:", test_local_timeout())
+            .await
+            .unwrap();
+        let context = Context {
+            hostname: "booop".to_string(),
+            session: "beep boop".to_string(),
+            cwd: "/home/ellie".to_string(),
+            host_id: "test-host".to_string(),
+            git_root: None,
+        };
+
+        // One item at a fixed instant, one at `now` (far outside the window below).
+        let at = OffsetDateTime::from_unix_timestamp(1_708_330_400).unwrap();
+        let mut past: History = History::capture()
+            .timestamp(at)
+            .command("ls /home/ellie")
+            .cwd("/home/ellie")
+            .build()
+            .into();
+        past.session = "beep boop".to_string();
+        past.hostname = "booop".to_string();
+        db.save(&past).await.unwrap();
+        save_history_item(&db, "ls /home/frank").await;
+
+        // No range -> everything.
+        let all = db
+            .list(&[], &context, None, false, false, None)
+            .await
+            .unwrap();
+        assert_eq!(all.len(), 2);
+
+        // A zero-width window on the item's exact timestamp matches it, because the
+        // bounds are inclusive (`timestamp >= from AND timestamp <= to`).
+        let hits = db
+            .list(&[], &context, None, false, false, Some((at, at)))
+            .await
+            .unwrap();
+        assert_eq!(hits.len(), 1);
+        assert_eq!(hits[0].command, "ls /home/ellie");
+    }
+
     #[tokio::test(flavor = "multi_thread")]
     async fn test_load_active_returns_only_requested_rows() {
         let db = Sqlite::new("sqlite::memory:", test_local_timeout())
@@ -1672,6 +1727,7 @@ mod test {
                 None,
                 false,
                 false,
+                None,
             )
             .await
             .unwrap();

--- a/crates/atuin-client/src/history/store.rs
+++ b/crates/atuin-client/src/history/store.rs
@@ -374,7 +374,7 @@ impl HistoryStore {
         pb.set_message("Fetching history from old database");
 
         let context = current_context().await?;
-        let history = db.list(&[], &context, None, false, true).await?;
+        let history = db.list(&[], &context, None, false, true, None).await?;
 
         pb.set_message("Fetching history already in store");
         let store_ids = self.history_ids().await?;

--- a/crates/atuin/src/command/client/history.rs
+++ b/crates/atuin/src/command/client/history.rs
@@ -951,7 +951,7 @@ impl Cmd {
         };
 
         let history = db
-            .list(&filters, &context, None, false, include_deleted)
+            .list(&filters, &context, None, false, include_deleted, None)
             .await?;
 
         print_list(
@@ -979,7 +979,7 @@ impl Cmd {
         // Grab all executed commands and filter them using History::should_save.
         // We could iterate or paginate here if memory usage becomes an issue.
         let matches: Vec<History> = db
-            .list(&[Global], &context, None, false, false)
+            .list(&[Global], &context, None, false, false, None)
             .await?
             .into_iter()
             .filter(|h| !h.should_save(settings))

--- a/crates/atuin/src/command/client/scripts.rs
+++ b/crates/atuin/src/command/client/scripts.rs
@@ -235,7 +235,7 @@ impl Cmd {
             let filters = [settings.default_filter_mode(context.git_root.is_some())];
 
             let mut history = history_db
-                .list(&filters, &context, Some(count), false, false)
+                .list(&filters, &context, Some(count), false, false, None)
                 .await?;
 
             // Reverse to get chronological order

--- a/crates/atuin/src/command/client/stats.rs
+++ b/crates/atuin/src/command/client/stats.rs
@@ -5,7 +5,7 @@ use time::{Duration, OffsetDateTime, Time};
 
 use atuin_client::{
     database::{Database, current_context},
-    settings::Settings,
+    settings::{FilterMode, Settings},
     theme::Theme,
 };
 
@@ -36,6 +36,10 @@ pub struct Cmd {
     /// The number of consecutive commands to consider
     #[arg(long, short, default_value = "1", value_parser = parse_ngram_size)]
     ngram_size: usize,
+
+    /// Filter commands by scope [global, host, session, directory, workspace]
+    #[arg(long = "filter-mode")]
+    filter_mode: Option<FilterMode>,
 }
 
 impl Cmd {
@@ -47,32 +51,40 @@ impl Cmd {
             self.period.join(" ")
         };
 
+        // A single filter mode, or none. `list` takes a slice so it can OR several,
+        // but stats only ever scopes to one at a time.
+        let filter = self.filter_mode.map(|f| vec![f]).unwrap_or_default();
+
         let now = OffsetDateTime::now_utc().to_offset(settings.timezone.0);
         let last_night = now.replace_time(Time::MIDNIGHT);
 
-        let history = if words.as_str() == "all" {
-            db.list(&[], &context, None, false, false).await?
+        let range = if words.as_str() == "all" {
+            None
         } else if words.trim() == "today" {
             let start = last_night;
             let end = start + Duration::days(1);
-            db.range(start, end).await?
+            Some((start, end))
         } else if words.trim() == "month" {
             let end = last_night;
             let start = end - Duration::days(31);
-            db.range(start, end).await?
+            Some((start, end))
         } else if words.trim() == "week" {
             let end = last_night;
             let start = end - Duration::days(7);
-            db.range(start, end).await?
+            Some((start, end))
         } else if words.trim() == "year" {
             let end = last_night;
             let start = end - Duration::days(365);
-            db.range(start, end).await?
+            Some((start, end))
         } else {
             let start = parse_date_string(&words, now, settings.dialect.into())?;
             let end = start + Duration::days(1);
-            db.range(start, end).await?
+            Some((start, end))
         };
+
+        let history = db
+            .list(filter.as_slice(), &context, None, false, false, range)
+            .await?;
 
         let stats = compute(settings, &history, self.count, self.ngram_size);
 


### PR DESCRIPTION
This adds `atuin stats --filter-mode` which takes the same options as `atuin search --filter-mode`.  It allows filtering `atuin stats` output.

To accomplish this `Database::list()` now has an optional range argument and adds a WHERE clause matching `Database::range()`.

Full output:

```
❯ cargo run --bin atuin -- stats
[▮▮▮▮▮▮▮▮▮▮] 4334 cargo nextest
[▮▮▮▮▮▮▮   ] 3275 git status
[▮▮▮▮▮     ] 2190 cargo run
[▮▮▮▮▮     ] 2190 git diff
[▮▮▮▮      ] 2083 git commit
[▮▮▮▮      ] 1823 c
[▮▮▮       ] 1645 cargo b
[▮▮▮       ] 1482 git switch
[▮▮▮       ] 1406 nvim
[▮▮▮       ] 1386 ls
Total commands:   49595
Unique commands:  14105
```

Workspace output:

```
❯ cargo run --bin atuin -- stats --filter-mode workspace
[▮▮▮▮▮▮▮▮▮▮] 35 cargo nextest
[▮▮▮▮▮▮▮▮▮ ] 33 cargo run
[▮▮▮       ] 12 ssh
[▮▮        ] 10 git diff
[▮▮        ]  7 git push
[▮         ]  6 git commit
[▮         ]  6 nvim
[▮         ]  5 date
[▮         ]  5 cargo b
[▮         ]  5 git switch
Total commands:   166
Unique commands:  64
```

Workspace with date filter:

```
❯ cargo run --bin atuin -- stats --filter-mode workspace today
[▮▮▮▮▮▮▮▮▮▮] 31 cargo nextest
[▮▮▮       ] 12 cargo run
[▮         ]  5 date
[▮         ]  5 RUST_LOG=debug
[▮         ]  4 git diff
[          ]  2 git commit
[          ]  1 git push
[          ]  1 git status
[          ]  1 rm
Total commands:   62
Unique commands:  18
```

## Checks
- [x] I am happy for maintainers to push small adjustments to this PR, to speed up the review cycle
- [x] I have checked that there are no existing pull requests for the same thing
