### PR TITLE
Enable multiple command stats to be shown using unicode_segmentation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -217,6 +217,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "tracing-tree",
+ "unicode-segmentation",
  "unicode-width",
  "uuid",
  "whoami",
@@ -3937,9 +3938,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-segmentation"
-version = "1.10.1"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1dd624098567895118886609431a7c3b8f516e41d30e0643f03d94592a147e36"
+checksum = "d4c87d22b6e3f4a18d4d40ef354e97c90fcb14dd91d7dc0aa9d8a1172ebf7202"
 
 [[package]]
 name = "unicode-width"

--- a/atuin/Cargo.toml
+++ b/atuin/Cargo.toml
@@ -78,6 +78,7 @@ ratatui = "0.25"
 tracing = "0.1"
 cli-clipboard = { version = "0.4.0", optional = true }
 uuid = { workspace = true }
+unicode-segmentation = "1.11.0"
 
 
 [dependencies.tracing-subscriber]

--- a/atuin/src/command/client/stats.rs
+++ b/atuin/src/command/client/stats.rs
@@ -32,22 +32,22 @@ fn split_at_pipe(command: &str) -> Vec<&str> {
     let mut result = vec![];
     let mut quoted = false;
     let mut start = 0;
-    let mut graphemes = UnicodeSegmentation::grapheme_indices(command, true).peekable();
+    let mut graphemes = UnicodeSegmentation::grapheme_indices(command, true);
 
     while let Some((i, c)) = graphemes.next() {
         let current = i;
         match c {
             "\"" => {
                 if command[start..current] != *"\"" {
-                    quoted = !quoted
+                    quoted = !quoted;
                 }
             }
             "'" => {
                 if command[start..current] != *"'" {
-                    quoted = !quoted
+                    quoted = !quoted;
                 }
             }
-            "\\" => if let Some(_) = graphemes.next() {},
+            "\\" => if graphemes.next().is_some() {},
             "|" => {
                 if !quoted {
                     if command[start..].starts_with('|') {
@@ -67,7 +67,12 @@ fn split_at_pipe(command: &str) -> Vec<&str> {
     result
 }
 
-fn compute_stats(settings: &Settings, history: &[History], count: usize, ngram_size: usize) -> (usize, usize) {
+fn compute_stats(
+    settings: &Settings,
+    history: &[History],
+    count: usize,
+    ngram_size: usize,
+) -> (usize, usize) {
     let mut commands = HashSet::<&str>::with_capacity(history.len());
     let mut total_unignored = 0;
     let mut prefixes = HashMap::<Vec<&str>, usize>::with_capacity(history.len());
@@ -145,7 +150,7 @@ fn compute_stats(settings: &Settings, history: &[History], count: usize, ngram_s
         let formatted_command = command
             .iter()
             .zip(column_widths.iter())
-            .map(|(cmd, width)| format!("{:width$}", cmd))
+            .map(|(cmd, width)| format!("{cmd:width$}"))
             .collect::<Vec<_>>()
             .join(" | ");
 

--- a/atuin/src/command/client/stats.rs
+++ b/atuin/src/command/client/stats.rs
@@ -419,4 +419,12 @@ mod tests {
             ["foo ", " bar baz \\| quux"]
         );
     }
+
+    #[test]
+    fn emoji() {
+        assert_eq!(
+            split_at_pipe("git commit -m \"🚀\""),
+            ["git commit -m \"🚀\""]
+        );
+    }
 }

--- a/atuin/src/command/client/stats.rs
+++ b/atuin/src/command/client/stats.rs
@@ -11,6 +11,7 @@ use atuin_client::{
     settings::Settings,
 };
 use time::{Duration, OffsetDateTime, Time};
+use unicode_segmentation::UnicodeSegmentation;
 
 #[derive(Parser, Debug)]
 #[command(infer_subcommands = true)]
@@ -31,22 +32,23 @@ fn split_at_pipe(command: &str) -> Vec<&str> {
     let mut result = vec![];
     let mut quoted = false;
     let mut start = 0;
-    let mut chars = command.chars().enumerate().peekable();
-    while let Some((i, c)) = chars.next() {
+    let mut graphemes = UnicodeSegmentation::grapheme_indices(command, true).peekable();
+
+    while let Some((i, c)) = graphemes.next() {
         let current = i;
         match c {
-            '"' => {
+            "\"" => {
                 if command[start..current] != *"\"" {
                     quoted = !quoted
                 }
             }
-            '\'' => {
+            "'" => {
                 if command[start..current] != *"'" {
                     quoted = !quoted
                 }
             }
-            '\\' => if let Some(_) = chars.next() {},
-            '|' => {
+            "\\" => if let Some(_) = graphemes.next() {},
+            "|" => {
                 if !quoted {
                     if command[start..].starts_with('|') {
                         start += 1;

--- a/atuin/src/command/client/stats.rs
+++ b/atuin/src/command/client/stats.rs
@@ -1,6 +1,5 @@
 use std::collections::{HashMap, HashSet};
 
-use atuin_common::utils::Escapable as _;
 use clap::Parser;
 use crossterm::style::{Color, ResetColor, SetAttribute, SetForegroundColor};
 use eyre::Result;
@@ -22,12 +21,54 @@ pub struct Cmd {
     /// How many top commands to list
     #[arg(long, short, default_value = "10")]
     count: usize,
+
+    /// The number of consecutive commands to consider
+    #[arg(long, short, default_value = "1")]
+    ngram_size: usize,
 }
 
-fn compute_stats(settings: &Settings, history: &[History], count: usize) -> (usize, usize) {
+fn split_at_pipe(command: &str) -> Vec<&str> {
+    let mut result = vec![];
+    let mut quoted = false;
+    let mut start = 0;
+    let mut chars = command.chars().enumerate().peekable();
+    while let Some((i, c)) = chars.next() {
+        let current = i;
+        match c {
+            '"' => {
+                if command[start..current] != *"\"" {
+                    quoted = !quoted
+                }
+            }
+            '\'' => {
+                if command[start..current] != *"'" {
+                    quoted = !quoted
+                }
+            }
+            '\\' => if let Some(_) = chars.next() {},
+            '|' => {
+                if !quoted {
+                    if command[start..].starts_with('|') {
+                        start += 1;
+                    }
+                    result.push(&command[start..current]);
+                    start = current;
+                }
+            }
+            _ => {}
+        }
+    }
+    if command[start..].starts_with('|') {
+        start += 1;
+    }
+    result.push(&command[start..]);
+    result
+}
+
+fn compute_stats(settings: &Settings, history: &[History], count: usize, ngram_size: usize) -> (usize, usize) {
     let mut commands = HashSet::<&str>::with_capacity(history.len());
-    let mut prefixes = HashMap::<&str, usize>::with_capacity(history.len());
     let mut total_unignored = 0;
+    let mut prefixes = HashMap::<Vec<&str>, usize>::with_capacity(history.len());
     for i in history {
         // just in case it somehow has a leading tab or space or something (legacy atuin didn't ignore space prefixes)
         let command = i.command.trim();
@@ -39,7 +80,21 @@ fn compute_stats(settings: &Settings, history: &[History], count: usize) -> (usi
 
         total_unignored += 1;
         commands.insert(command);
-        *prefixes.entry(prefix).or_default() += 1;
+
+        split_at_pipe(i.command.trim())
+            .iter()
+            .map(|l| {
+                let command = l.trim();
+                commands.insert(command);
+                command
+            })
+            .collect::<Vec<_>>()
+            .windows(ngram_size)
+            .for_each(|w| {
+                *prefixes
+                    .entry(w.iter().map(|c| interesting_command(settings, c)).collect())
+                    .or_default() += 1;
+            });
     }
 
     let unique = commands.len();
@@ -53,6 +108,17 @@ fn compute_stats(settings: &Settings, history: &[History], count: usize) -> (usi
 
     let max = top.iter().map(|x| x.1).max().unwrap();
     let num_pad = max.ilog10() as usize + 1;
+
+    // Find the length of the longest command name for each column
+    let column_widths = top
+        .iter()
+        .map(|(commands, _)| commands.iter().map(|c| c.len()).collect::<Vec<usize>>())
+        .fold(vec![0; ngram_size], |acc, item| {
+            acc.iter()
+                .zip(item.iter())
+                .map(|(a, i)| *std::cmp::max(a, i))
+                .collect()
+        });
 
     for (command, count) in top {
         let gray = SetForegroundColor(Color::Grey);
@@ -74,10 +140,14 @@ fn compute_stats(settings: &Settings, history: &[History], count: usize) -> (usi
             print!(" ");
         }
 
-        println!(
-            "{ResetColor}] {gray}{count:num_pad$}{ResetColor} {bold}{}{ResetColor}",
-            command.escape_control()
-        );
+        let formatted_command = command
+            .iter()
+            .zip(column_widths.iter())
+            .map(|(cmd, width)| format!("{:width$}", cmd))
+            .collect::<Vec<_>>()
+            .join(" | ");
+
+        println!("{ResetColor}] {gray}{count:num_pad$}{ResetColor} {bold}{formatted_command}{ResetColor}");
     }
     println!("Total commands:   {total_unignored}");
     println!("Unique commands:  {unique}");
@@ -120,7 +190,7 @@ impl Cmd {
             let end = start + Duration::days(1);
             db.range(start, end).await?
         };
-        compute_stats(settings, &history, self.count);
+        compute_stats(settings, &history, self.count, self.ngram_size);
         Ok(())
     }
 }
@@ -189,7 +259,7 @@ mod tests {
     use time::OffsetDateTime;
 
     use super::compute_stats;
-    use super::interesting_command;
+    use super::{interesting_command, split_at_pipe};
 
     #[test]
     fn ignored_commands() {
@@ -209,7 +279,7 @@ mod tests {
                 .into(),
         ];
 
-        let (total, unique) = compute_stats(&settings, &history, 10);
+        let (total, unique) = compute_stats(&settings, &history, 10, 1);
         assert_eq!(total, 1);
         assert_eq!(unique, 1);
     }
@@ -310,6 +380,43 @@ mod tests {
         assert_eq!(
             interesting_command(&settings, "sudo test cargo build foo bar"),
             "cargo build foo"
+        );
+    }
+
+    #[test]
+    fn split_simple() {
+        assert_eq!(split_at_pipe("fd | rg"), ["fd ", " rg"]);
+    }
+
+    #[test]
+    fn split_multi() {
+        assert_eq!(
+            split_at_pipe("kubectl | jq | rg"),
+            ["kubectl ", " jq ", " rg"]
+        );
+    }
+
+    #[test]
+    fn split_simple_quoted() {
+        assert_eq!(
+            split_at_pipe("foo | bar 'baz {} | quux' | xyzzy"),
+            ["foo ", " bar 'baz {} | quux' ", " xyzzy"]
+        );
+    }
+
+    #[test]
+    fn split_multi_quoted() {
+        assert_eq!(
+            split_at_pipe("foo | bar 'baz \"{}\" | quux' | xyzzy"),
+            ["foo ", " bar 'baz \"{}\" | quux' ", " xyzzy"]
+        );
+    }
+
+    #[test]
+    fn escaped_pipes() {
+        assert_eq!(
+            split_at_pipe("foo | bar baz \\| quux"),
+            ["foo ", " bar baz \\| quux"]
         );
     }
 }


### PR DESCRIPTION
This addresses feedback in #1054

Closes #1054

## Checks
- [x] I am happy for maintainers to push small adjustments to this PR, to speed up the review cycle
- [x] I have checked that there are no existing pull requests for the same thing (other PR found as noted)
