### PR TITLE
fix(import/zsh-histdb): missing or wrong fields

### DIFF
--- a/atuin-client/src/import/zsh_histdb.rs
+++ b/atuin-client/src/import/zsh_histdb.rs
@@ -63,6 +63,10 @@ pub struct HistDbEntry {
 
 impl From<HistDbEntry> for History {
     fn from(histdb_item: HistDbEntry) -> Self {
+        let hostname = String::from_utf8(histdb_item.host)
+            .unwrap_or_else(|_e| String::from(""))
+            .trim_end()
+            .to_string();
         let imported = History::import()
             .timestamp(histdb_item.start_time.assume_utc())
             .command(
@@ -79,13 +83,8 @@ impl From<HistDbEntry> for History {
             )
             .duration(histdb_item.duration)
             .exit(histdb_item.exit_status)
-            .session(histdb_item.session.to_string())
-            .hostname(
-                String::from_utf8(histdb_item.host)
-                    .unwrap_or_else(|_e| String::from(""))
-                    .trim_end()
-                    .to_string(),
-            );
+            .session(format!("{}:{}", hostname, histdb_item.session))
+            .hostname(hostname);
 
         imported.build().into()
     }

--- a/atuin-client/src/import/zsh_histdb.rs
+++ b/atuin-client/src/import/zsh_histdb.rs
@@ -168,7 +168,7 @@ impl Importer for ZshHistDb {
                 .timestamp(entry.start_time.assume_utc())
                 .command(command)
                 .cwd(cwd)
-                .duration(entry.duration)
+                .duration(entry.duration * 1_000_000_000)
                 .exit(entry.exit_status)
                 .session(session.as_simple().to_string())
                 .hostname(hostname)


### PR DESCRIPTION
<!-- Thank you for making a PR! Bug fixes are always welcome, but if you're adding a new feature or changing an existing one, we'd really appreciate if you open an issue, post on the forum, or drop in on Discord -->

This PR do two things:
1. Imports `exit_status` and `session` columns from zsh-histdb
2. Converts `duration` to nanoseconds for importing

## Checks
- [x] I am happy for maintainers to push small adjustments to this PR, to speed up the review cycle
- [x] I have checked that there are no existing pull requests for the same thing
