### PR TITLE
feat(client): add config option keys.scroll_exits

### DIFF
--- a/atuin-client/config.toml
+++ b/atuin-client/config.toml
@@ -174,3 +174,7 @@ enter_accept = true
 
 ## Set commands that will be completely ignored from stats
 #ignored_commands = ["cd", "ls", "vi"]
+
+[keys]
+# Defaults to true. If disabled, using the up/down key won't exit the TUI when scrolled past the first/last entry.
+# scroll_exits = false

--- a/atuin-client/src/settings.rs
+++ b/atuin-client/src/settings.rs
@@ -306,6 +306,11 @@ pub struct Sync {
     pub records: bool,
 }
 
+#[derive(Clone, Debug, Deserialize, Default)]
+pub struct Keys {
+    pub scroll_exits: bool,
+}
+
 #[derive(Clone, Debug, Deserialize)]
 pub struct Settings {
     pub dialect: Dialect,
@@ -359,6 +364,9 @@ pub struct Settings {
 
     #[serde(default)]
     pub sync: Sync,
+
+    #[serde(default)]
+    pub keys: Keys,
 
     // This is automatically loaded when settings is created. Do not set in
     // config! Keep secrets and settings apart.
@@ -588,6 +596,7 @@ impl Settings {
             // New users will get the new default, that is more similar to what they are used to.
             .set_default("enter_accept", false)?
             .set_default("sync.records", false)?
+            .set_default("keys.scroll_exits", true)?
             .set_default("keymap_mode", "emacs")?
             .set_default("keymap_mode_shell", "auto")?
             .set_default("keymap_cursor", HashMap::<String, String>::new())?

--- a/atuin/src/command/client/search/interactive.rs
+++ b/atuin/src/command/client/search/interactive.rs
@@ -225,7 +225,7 @@ impl State {
         is_down: bool,
     ) -> InputAction {
         if is_down {
-            if enable_exit && self.results_state.selected() == 0 && settings.keys.scroll_exits {
+            if settings.keys.scroll_exits && enable_exit && self.results_state.selected() == 0 {
                 return Self::handle_key_exit(settings);
             }
             self.scroll_down(1);

--- a/atuin/src/command/client/search/interactive.rs
+++ b/atuin/src/command/client/search/interactive.rs
@@ -225,7 +225,7 @@ impl State {
         is_down: bool,
     ) -> InputAction {
         if is_down {
-            if enable_exit && self.results_state.selected() == 0 {
+            if enable_exit && self.results_state.selected() == 0 && settings.keys.scroll_exits {
                 return Self::handle_key_exit(settings);
             }
             self.scroll_down(1);


### PR DESCRIPTION
If the config option is set the `false`, using the up/down key won't exit the TUI when scrolled past the first/last entry.

Example:

```
[keys]
scroll_exits = false
```

The default is `true`, which is the current behavior.

/ref https://forum.atuin.sh/t/add-option-to-stop-down-arrow-exiting-search/94

fixes #922

<!-- Thank you for making a PR! Bug fixes are always welcome, but if you're adding a new feature or changing an existing one, we'd really appreciate if you open an issue, post on the forum, or drop in on Discord -->

## Checks
- [x] I am happy for maintainers to push small adjustments to this PR, to speed up the review cycle
- [x] I have checked that there are no existing pull requests for the same thing
