### PR TITLE
Clarify operation result for working with aliases

### DIFF
--- a/atuin/src/command/client/config/alias.rs
+++ b/atuin/src/command/client/config/alias.rs
@@ -19,10 +19,10 @@ impl Cmd {
         let found: Vec<Alias> = aliases.into_iter().filter(|a| a.name == name).collect();
 
         if found.is_empty() {
-            println!("Aliasing {name}={value}");
+            println!("Aliasing '{name}={value}'.");
         } else {
             println!(
-                "Overwriting alias {name}={} with {name}={value}",
+                "Overwriting alias '{name}={}' with '{name}={value}'.",
                 found[0].value
             );
         }
@@ -43,16 +43,13 @@ impl Cmd {
     }
 
     async fn delete(&self, store: AliasStore, name: String) -> Result<()> {
-        let aliases = store.aliases().await?;
-        let found = aliases.into_iter().any(|a| a.name == name);
-
-        if !found {
-            eprintln!("Alias not found - \"{name}\" - could not delete");
-            return Ok(());
-        }
-
-        store.delete(&name).await?;
-
+        let mut aliases = store.aliases().await?.into_iter();
+        if let Some(alias) = aliases.find(|alias| alias.name == name) {
+            println!("Deleting '{name}={}'.", alias.value);
+            store.delete(&name).await?;
+        } else {
+            eprintln!("Cannot delete '{name}': Alias not set.");
+        };
         Ok(())
     }
 


### PR DESCRIPTION
This PR tries to clarify the info messages when working with aliases. No functional changes were made.

The delete message mentions which alias with which value was deleted so that the user can confirm that this is indeed the alias they wanted to remove. If not, they can reset it again. In case of an error, the error message format of `rm` is followed: `problem: reason` (`rm: cannot remove 'file': No such file or directory`).

The set alias message clearly separates the beginning and end of alias `name=value` from the normal text. Otherwise, one needs to parse the `name=value with name=value2` where `with` blends in with the end of the `value`.
```
$ atuin config alias set m "make run"
# Change this:
Overwriting alias m=make with m=make run
# to this:
Overwriting alias 'm=make' with 'm="make run"'.
```

If the changes are not to your liking, feel free to modify or close the PR.

## Checks
- [x] I am happy for maintainers to push small adjustments to this PR, to speed up the review cycle
- [x] I have checked that there are no existing pull requests for the same thing
