### PR TITLE
Add PHP package manager "composer" to list of default common subcommands

### DIFF
--- a/atuin-client/src/settings.rs
+++ b/atuin-client/src/settings.rs
@@ -280,7 +280,7 @@ impl Stats {
     }
 
     fn common_subcommands_default() -> Vec<String> {
-        vec!["cargo", "go", "git", "npm", "yarn", "pnpm", "kubectl"]
+        vec!["cargo", "go", "git", "npm", "yarn", "pnpm", "kubectl", "composer"]
             .into_iter()
             .map(String::from)
             .collect()

--- a/atuin-client/src/settings.rs
+++ b/atuin-client/src/settings.rs
@@ -280,10 +280,12 @@ impl Stats {
     }
 
     fn common_subcommands_default() -> Vec<String> {
-        vec!["cargo", "go", "git", "npm", "yarn", "pnpm", "kubectl", "composer"]
-            .into_iter()
-            .map(String::from)
-            .collect()
+        vec![
+            "cargo", "composer", "git", "go", "kubectl", "npm", "pnpm", "yarn",
+        ]
+        .into_iter()
+        .map(String::from)
+        .collect()
     }
 
     fn ignored_commands_default() -> Vec<String> {


### PR DESCRIPTION
Composer is the de facto standard dependency manager for PHP, similar to NPM for node. This PR updates the `common_subcommands_default` so that composer is included by default like similar tools for node.

## Checks
- [x] I am happy for maintainers to push small adjustments to this PR, to speed up the review cycle
- [x] I have checked that there are no existing pull requests for the same thing
