### PR TITLE
feat: Add '/', '?', and 'I' bindings to vim-normal mode

### DIFF
--- a/atuin/src/command/client/search/interactive.rs
+++ b/atuin/src/command/client/search/interactive.rs
@@ -265,6 +265,18 @@ impl State {
         // First handle keymap specific keybindings.
         match self.keymap_mode {
             KeymapMode::VimNormal => match input.code {
+                KeyCode::Char('/') if !ctrl => {
+                    self.search.input.clear();
+                    self.set_keymap_cursor(settings, "vim_insert");
+                    self.keymap_mode = KeymapMode::VimInsert;
+                    return InputAction::Continue;
+                }
+                KeyCode::Char('?') if !ctrl => {
+                    self.search.input.clear();
+                    self.set_keymap_cursor(settings, "vim_insert");
+                    self.keymap_mode = KeymapMode::VimInsert;
+                    return InputAction::Continue;
+                }
                 KeyCode::Char('j') if !ctrl => {
                     return self.handle_search_down(settings, true);
                 }
@@ -292,6 +304,12 @@ impl State {
                     return InputAction::Continue;
                 }
                 KeyCode::Char('i') if !ctrl => {
+                    self.set_keymap_cursor(settings, "vim_insert");
+                    self.keymap_mode = KeymapMode::VimInsert;
+                    return InputAction::Continue;
+                }
+                KeyCode::Char('I') if !ctrl => {
+                    self.search.input.start();
                     self.set_keymap_cursor(settings, "vim_insert");
                     self.keymap_mode = KeymapMode::VimInsert;
                     return InputAction::Continue;


### PR DESCRIPTION
Add 'I' binding to vim-normal mode (a la 'A' introduced in #1697) to jump into vim-insert mode at the beginning of the search input.

Also add '/' and '?' bindings to vim-normal mode to clear the search input and jump into vim-insert mode. This mimics the UX in e.g. `set -o vi` (bash) or `bindkey -v` (zsh) mode when you are using 'k' and 'j' to browse history lines and can type '/' or '?' to start a new search. (In a perfect world it would target the search in the forward or backward range starting at your current position in the history, but this is a reasonable first step.)

## Checks
- [x] I am happy for maintainers to push small adjustments to this PR, to speed up the review cycle
- [x] I have checked that there are no existing pull requests for the same thing
