### PR TITLE
RFC/WIP: make common "before editing" keys accept selection

### DIFF
--- a/atuin/src/shell/atuin.bash
+++ b/atuin/src/shell/atuin.bash
@@ -244,6 +244,9 @@ __atuin_history() {
 
         READLINE_LINE=""
         READLINE_POINT=${#READLINE_LINE}
+    elif [[ $__atuin_output = __atuin_home__:* ]]; then
+        READLINE_LINE=${__atuin_output#__atuin_home__:}
+        READLINE_POINT=0
     else
         READLINE_LINE=$__atuin_output
         READLINE_POINT=${#READLINE_LINE}


### PR DESCRIPTION
Looking for old commands through ctrl-r I might often accept the command as is, but using the up key I'll almost always want to edit it.

When editing a command, I'll almost always want to move the cursor (home or left key) or try to delete something (backspace); this patch is just something to get a feeling of how that'd be and confirm that'd be useful as a feature (could be an option, or wait for #193)

However just custom key bindings isn't enough: when exiting through the home key you'd want to go to the begining of the line. This is easy enough to do the same way we're doing the enter_accept code: just pass some position argument with the command back for shells to parse (only implemented bash in this poc)

I'd be tempted to be greedy and also want to emulate stuff like alt-left/^W etc but that'd require computing the exact position and passing an exact position to handle in each shells instead of the beginning of line token I've used here, so that'll wait for more feedback -- I'm also still in a 'trying atuin out' phase so I might just drop this all tomorrow for all I know -- feel free to give this low priority and only consider it a source of idea for a few weeks if you want to make sure I'll finish it.

so:
 - what do you think of having such a feature?
 - how do you want to go about differentiating this from editing the search query? honestly I don't think I'll ever edit the search query in up mode, but in ctrl-r mode I might miss the backspace key..

(aaaand I just saw the PR template comment saying you prefer discussing in issues or forum, happy to open an issue and move discussion there if you prefer, but as far as I'm concerned a poc PR and an issue are the same thing and this gives something concrete to describe what I'm trying to do -- I'm obviously not intending for this to be merged in this form)