### PR TITLE
fix(client): no panic on empty inspector

### DIFF
--- a/atuin/src/command/client/search/interactive.rs
+++ b/atuin/src/command/client/search/interactive.rs
@@ -581,7 +581,7 @@ impl State {
 
             1 => {
                 if results.is_empty() {
-                    let message = Paragraph::new("Nothing to inspect. :-(")
+                    let message = Paragraph::new("Nothing to inspect")
                         .block(
                             Block::new()
                                 .title(

--- a/atuin/src/command/client/search/interactive.rs
+++ b/atuin/src/command/client/search/interactive.rs
@@ -580,14 +580,7 @@ impl State {
             }
 
             1 => {
-                if !results.is_empty() {
-                    super::inspector::draw(
-                        f,
-                        results_list_chunk,
-                        &results[self.results_state.selected()],
-                        &stats.expect("Drawing inspector, but no stats"),
-                    );
-                } else {
+                if results.is_empty() {
                     let message = Paragraph::new("Nothing to inspect. :-(")
                         .block(
                             Block::new()
@@ -599,6 +592,13 @@ impl State {
                         )
                         .alignment(Alignment::Center);
                     f.render_widget(message, results_list_chunk);
+                } else {
+                    super::inspector::draw(
+                        f,
+                        results_list_chunk,
+                        &results[self.results_state.selected()],
+                        &stats.expect("Drawing inspector, but no stats"),
+                    );
                 }
 
                 // HACK: I'm following up with abstracting this into the UI container, with a


### PR DESCRIPTION
atuin no longer panics, if the inspector is invoked from an empty search window.

<img width="1047" alt="image" src="https://github.com/atuinsh/atuin/assets/223439/7ba9ff2e-7014-478a-a2cf-445c2ce8cf39">


fixes #1713

## Checks
- [x] I am happy for maintainers to push small adjustments to this PR, to speed up the review cycle
- [x] I have checked that there are no existing pull requests for the same thing
