### PR TITLE
fix(nushell): readd up-arrow keybinding, now with menu handling

### DIFF
--- a/atuin/src/command/client/init.rs
+++ b/atuin/src/command/client/init.rs
@@ -56,20 +56,23 @@ impl Cmd {
     )
 )";
             const BIND_UP_ARROW: &str = r"
-# The up arrow keybinding has surprising behavior in Nu, and is disabled by default.
-# See https://github.com/atuinsh/atuin/issues/1025 for details
-# $env.config = (
-#     $env.config | upsert keybindings (
-#         $env.config.keybindings
-#         | append {
-#             name: atuin
-#             modifier: none
-#             keycode: up
-#             mode: [emacs, vi_normal, vi_insert]
-#             event: { send: executehostcommand cmd: (_atuin_search_cmd '--shell-up-key-binding') }
-#         }
-#     )
-# )
+$env.config = (
+    $env.config | upsert keybindings (
+        $env.config.keybindings
+        | append {
+            name: atuin
+            modifier: none
+            keycode: up
+            mode: [emacs, vi_normal, vi_insert]
+            event: {
+                until: [
+                    {send: menuup}
+                    {send: executehostcommand cmd: (_atuin_search_cmd '--shell-up-key-binding') }
+                ]
+            }
+        }
+    )
+)
 ";
             if !self.disable_ctrl_r {
                 println!("{BIND_CTRL_R}");


### PR DESCRIPTION
<!-- Thank you for making a PR! Bug fixes are always welcome, but if you're adding a new feature or changing an existing one, we'd really appreciate if you open an issue, post on the forum, or drop in on Discord -->

Fixes #1025

This seems to work, see the nushell docs for `until`, and how it can account for the menu handling: https://www.nushell.sh/book/line_editor.html#until-type

## Checks
- [x] I am happy for maintainers to push small adjustments to this PR, to speed up the review cycle
- [x] I have checked that there are no existing pull requests for the same thing