### PR TITLE
chore(release): prepare for release v18.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [18.0.2] - 2024-02-26
+
+### Bug Fixes
+
+- Rework #1509 to recover from the preexec failure ([#1729](https://github.com/atuinsh/atuin/issues/1729))
+
 ## [18.0.1] - 2024-02-12
 
 ### Bug Fixes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -180,7 +180,7 @@ dependencies = [
 
 [[package]]
 name = "atuin"
-version = "18.0.1"
+version = "18.0.2"
 dependencies = [
  "async-trait",
  "atuin-client",
@@ -224,7 +224,7 @@ dependencies = [
 
 [[package]]
 name = "atuin-client"
-version = "18.0.1"
+version = "18.0.2"
 dependencies = [
  "async-trait",
  "atuin-common",
@@ -273,7 +273,7 @@ dependencies = [
 
 [[package]]
 name = "atuin-common"
-version = "18.0.1"
+version = "18.0.2"
 dependencies = [
  "eyre",
  "lazy_static",
@@ -302,7 +302,7 @@ dependencies = [
 
 [[package]]
 name = "atuin-server"
-version = "18.0.1"
+version = "18.0.2"
 dependencies = [
  "argon2",
  "async-trait",
@@ -333,7 +333,7 @@ dependencies = [
 
 [[package]]
 name = "atuin-server-database"
-version = "18.0.1"
+version = "18.0.2"
 dependencies = [
  "async-trait",
  "atuin-common",
@@ -346,7 +346,7 @@ dependencies = [
 
 [[package]]
 name = "atuin-server-postgres"
-version = "18.0.1"
+version = "18.0.2"
 dependencies = [
  "async-trait",
  "atuin-common",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "18.0.1"
+version = "18.0.2"
 authors = ["Ellie Huxtable <ellie@elliehuxtable.com>"]
 rust-version = "1.67"
 license = "MIT"

--- a/atuin-client/Cargo.toml
+++ b/atuin-client/Cargo.toml
@@ -18,7 +18,7 @@ sync = ["urlencoding", "reqwest", "sha2", "hex"]
 check-update = []
 
 [dependencies]
-atuin-common = { path = "../atuin-common", version = "18.0.1" }
+atuin-common = { path = "../atuin-common", version = "18.0.2" }
 
 log = { workspace = true }
 base64 = { workspace = true }

--- a/atuin-server-database/Cargo.toml
+++ b/atuin-server-database/Cargo.toml
@@ -10,7 +10,7 @@ homepage = { workspace = true }
 repository = { workspace = true }
 
 [dependencies]
-atuin-common = { path = "../atuin-common", version = "18.0.1" }
+atuin-common = { path = "../atuin-common", version = "18.0.2" }
 
 tracing = "0.1"
 time = { workspace = true }

--- a/atuin-server-postgres/Cargo.toml
+++ b/atuin-server-postgres/Cargo.toml
@@ -10,8 +10,8 @@ homepage = { workspace = true }
 repository = { workspace = true }
 
 [dependencies]
-atuin-common = { path = "../atuin-common", version = "18.0.1" }
-atuin-server-database = { path = "../atuin-server-database", version = "18.0.1" }
+atuin-common = { path = "../atuin-common", version = "18.0.2" }
+atuin-server-database = { path = "../atuin-server-database", version = "18.0.2" }
 
 tracing = "0.1"
 time = { workspace = true }

--- a/atuin-server/Cargo.toml
+++ b/atuin-server/Cargo.toml
@@ -11,8 +11,8 @@ homepage = { workspace = true }
 repository = { workspace = true }
 
 [dependencies]
-atuin-common = { path = "../atuin-common", version = "18.0.1" }
-atuin-server-database = { path = "../atuin-server-database", version = "18.0.1" }
+atuin-common = { path = "../atuin-common", version = "18.0.2" }
+atuin-server-database = { path = "../atuin-server-database", version = "18.0.2" }
 
 tracing = "0.1"
 time = { workspace = true }

--- a/atuin/Cargo.toml
+++ b/atuin/Cargo.toml
@@ -41,10 +41,10 @@ clipboard = ["cli-clipboard"]
 check-update = ["atuin-client/check-update"]
 
 [dependencies]
-atuin-server-postgres = { path = "../atuin-server-postgres", version = "18.0.1", optional = true }
-atuin-server = { path = "../atuin-server", version = "18.0.1", optional = true }
-atuin-client = { path = "../atuin-client", version = "18.0.1", optional = true, default-features = false }
-atuin-common = { path = "../atuin-common", version = "18.0.1" }
+atuin-server-postgres = { path = "../atuin-server-postgres", version = "18.0.2", optional = true }
+atuin-server = { path = "../atuin-server", version = "18.0.2", optional = true }
+atuin-client = { path = "../atuin-client", version = "18.0.2", optional = true, default-features = false }
+atuin-common = { path = "../atuin-common", version = "18.0.2" }
 atuin-config = { path = "../atuin-config", version = "0.1.0" }
 
 log = { workspace = true }


### PR DESCRIPTION
I backported a fix + released v18.0.2, but also need to ensure `main` is up to date with the latest version.

I didn't want to release everything on `main`, just the fix. Hence this :)

## Checks
- [ ] I am happy for maintainers to push small adjustments to this PR, to speed up the review cycle
- [ ] I have checked that there are no existing pull requests for the same thing
