### PR TITLE
feat(nix): add update action

### DIFF
--- a/.github/workflows/update-nix-deps.yml
+++ b/.github/workflows/update-nix-deps.yml
@@ -1,0 +1,20 @@
+name: Update Nix Deps
+on:
+  workflow_dispatch: # allows manual triggering
+  schedule:
+    - cron: '0 0 1 * *' # runs monthly on the first day of the month at 00:00
+
+jobs:
+  lockfile:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+      - name: Install Nix
+        uses: DeterminateSystems/nix-installer-action@main
+      - name: Update flake.lock
+        uses: DeterminateSystems/update-flake-lock@main
+        with:
+          pr-title: "chore(deps): update flake.lock"
+          pr-labels: |
+            dependencies


### PR DESCRIPTION
<!-- Thank you for making a PR! Bug fixes are always welcome, but if you're adding a new feature or changing an existing one, we'd really appreciate if you open an issue, post on the forum, or drop in on Discord -->
Adds a github action that will update the Nix dependencies once a month, and can also be triggered manually.

I ran this in my fork, and confirmed it works as expected. See https://github.com/arcuru/atuin/actions/workflows/update-nix-deps.yml and https://github.com/arcuru/atuin/pull/56

## Checks
- [x] I am happy for maintainers to push small adjustments to this PR, to speed up the review cycle
- [x] I have checked that there are no existing pull requests for the same thing
