### PR TITLE
feat(stats): add linux sysadmin commands to common_subcommands

### DIFF
--- a/atuin-client/config.toml
+++ b/atuin-client/config.toml
@@ -161,12 +161,22 @@ enter_accept = true
 ## Set commands where we should consider the subcommand for statistics. Eg, kubectl get vs just kubectl
 # common_subcommands = [
 #   "cargo",
+#   "composer",
+#   "dnf",
+#   "docker",
 #   "git",
 #   "go",
+#   "ip",
 #   "kubectl",
-#   "npm",
 #   "nix",
+#   "nmcli",
+#   "npm",
+#   "pecl",
 #   "pnpm",
+#   "podman",
+#   "port",
+#   "systemctl",
+#   "tmux",
 #   "yarn",
 # ]
 

--- a/atuin-client/config.toml
+++ b/atuin-client/config.toml
@@ -160,6 +160,7 @@ enter_accept = true
 [stats]
 ## Set commands where we should consider the subcommand for statistics. Eg, kubectl get vs just kubectl
 # common_subcommands = [
+#   "apt",
 #   "cargo",
 #   "composer",
 #   "dnf",

--- a/atuin-client/src/settings.rs
+++ b/atuin-client/src/settings.rs
@@ -281,7 +281,24 @@ impl Stats {
 
     fn common_subcommands_default() -> Vec<String> {
         vec![
-            "cargo", "composer", "go", "git", "kubectl", "nix", "npm", "pnpm", "yarn",
+            "cargo",
+            "composer",
+            "dnf",
+            "docker",
+            "git",
+            "go",
+            "ip",
+            "kubectl",
+            "nix",
+            "nmcli",
+            "npm",
+            "pecl",
+            "pnpm",
+            "podman",
+            "port",
+            "systemctl",
+            "tmux",
+            "yarn",
         ]
         .into_iter()
         .map(String::from)

--- a/atuin-client/src/settings.rs
+++ b/atuin-client/src/settings.rs
@@ -281,6 +281,7 @@ impl Stats {
 
     fn common_subcommands_default() -> Vec<String> {
         vec![
+            "apt",
             "cargo",
             "composer",
             "dnf",


### PR DESCRIPTION
I've been using atuin on my Linux box for some time now and I have noticed that a few commands that are used rather often are not in the list of common_subcommands.
This change adds these commands to the list.

see also https://github.com/atuinsh/docs/pull/38

<!-- Thank you for making a PR! Bug fixes are always welcome, but if you're adding a new feature or changing an existing one, we'd really appreciate if you open an issue, post on the forum, or drop in on Discord -->

## Checks
- [x] I am happy for maintainers to push small adjustments to this PR, to speed up the review cycle
- [x] I have checked that there are no existing pull requests for the same thing
