### PR TITLE
feat: add `CTRL+[` binding as `<Esc>` alias

### DIFF
--- a/atuin/src/command/client/search/interactive.rs
+++ b/atuin/src/command/client/search/interactive.rs
@@ -189,11 +189,15 @@ impl State {
         }
 
         let ctrl = input.modifiers.contains(KeyModifiers::CONTROL);
+        let esc_allow_exit = !(self.tab_index == 0 && self.keymap_mode == KeymapMode::VimInsert);
 
         // core input handling, common for all tabs
         match input.code {
             KeyCode::Char('c' | 'g') if ctrl => return InputAction::ReturnOriginal,
-            KeyCode::Esc if !(self.tab_index == 0 && self.keymap_mode == KeymapMode::VimInsert) => {
+            KeyCode::Esc if esc_allow_exit => {
+                return Self::handle_key_exit(settings);
+            }
+            KeyCode::Char('[') if ctrl && esc_allow_exit => {
                 return Self::handle_key_exit(settings);
             }
             KeyCode::Tab => {
@@ -320,7 +324,7 @@ impl State {
                 _ => {}
             },
             KeymapMode::VimInsert => {
-                if input.code == KeyCode::Esc {
+                if input.code == KeyCode::Esc || (ctrl && input.code == KeyCode::Char('[')) {
                     self.set_keymap_cursor(settings, "vim_normal");
                     self.keymap_mode = KeymapMode::VimNormal;
                     return InputAction::Continue;


### PR DESCRIPTION
in Vim/Neovim there is alias for `<Esc>` mapping -- `<C-[>`. it is useful if your `<Esc>` key is hard to hit on your keyboard.

for reference:

- https://vimhelp.org/insert.txt.html#i_CTRL-%5B
- https://neovim.io/doc/user/insert.html#i_CTRL-%5B

<!-- Thank you for making a PR! Bug fixes are always welcome, but if you're adding a new feature or changing an existing one, we'd really appreciate if you open an issue, post on the forum, or drop in on Discord -->

## Checks
- [x] I am happy for maintainers to push small adjustments to this PR, to speed up the review cycle
- [x] I have checked that there are no existing pull requests for the same thing
