### PR TITLE
feat(nushell): add nushell completion generation

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -154,7 +154,7 @@ jobs:
         esac;
 
         # Shell completions
-        for sh in 'bash' 'fish' 'zsh'; do
+        for sh in 'bash' 'fish' 'zsh' 'nushell'; do
           $QEMU_PREFIX "${{ steps.strip.outputs.BIN_PATH }}" gen-completions -s $sh -o "${ARCHIVE_DIR}/completions"
         done
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -191,6 +191,7 @@ dependencies = [
  "base64 0.21.7",
  "clap",
  "clap_complete",
+ "clap_complete_nushell",
  "cli-clipboard",
  "colored",
  "crossterm",
@@ -659,6 +660,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "885e4d7d5af40bfb99ae6f9433e292feac98d452dcb3ec3d25dfe7552b77da8c"
 dependencies = [
  "clap",
+]
+
+[[package]]
+name = "clap_complete_nushell"
+version = "4.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80d0e48e026ce7df2040239117d25e4e79714907420c70294a5ce4b6bbe6a7b6"
+dependencies = [
+ "clap",
+ "clap_complete",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ time = { version = "0.3", features = [
   "macros",
   "local-offset",
 ] }
-clap = { version = "4.0.18", features = ["derive"] }
+clap = { version = "4.5.1", features = ["derive"] }
 config = { version = "0.13", default-features = false, features = ["toml"] }
 directories = "5.0.1"
 eyre = "0.6"

--- a/atuin/Cargo.toml
+++ b/atuin/Cargo.toml
@@ -63,7 +63,8 @@ async-trait = { workspace = true }
 interim = { workspace = true }
 base64 = { workspace = true }
 clap = { workspace = true }
-clap_complete = "4.0.3"
+clap_complete = "4.5.1"
+clap_complete_nushell = "4.5.1"
 fs-err = { workspace = true }
 whoami = { workspace = true }
 rpassword = "7.0"

--- a/atuin/src/command/gen_completions.rs
+++ b/atuin/src/command/gen_completions.rs
@@ -1,0 +1,84 @@
+use clap::{CommandFactory, Parser, ValueEnum};
+use clap_complete::{generate, generate_to, Generator, Shell};
+use clap_complete_nushell::Nushell;
+use eyre::Result;
+
+// clap put nushell completions into a seperate package due to the maintainers
+// being a little less commited to support them.
+// This means we have to do a tiny bit of legwork to combine these completions
+// into one command.
+#[derive(Debug, Clone, ValueEnum)]
+#[value(rename_all = "lower")]
+pub enum GenShell {
+    Bash,
+    Elvish,
+    Fish,
+    Nushell,
+    PowerShell,
+    Zsh,
+}
+
+impl Generator for GenShell {
+    fn file_name(&self, name: &str) -> String {
+        match self {
+            // clap_complete
+            Self::Bash => Shell::Bash.file_name(name),
+            Self::Elvish => Shell::Elvish.file_name(name),
+            Self::Fish => Shell::Fish.file_name(name),
+            Self::PowerShell => Shell::PowerShell.file_name(name),
+            Self::Zsh => Shell::Zsh.file_name(name),
+
+            // clap_complete_nushell
+            Self::Nushell => Nushell.file_name(name),
+        }
+    }
+
+    fn generate(&self, cmd: &clap::Command, buf: &mut dyn std::io::prelude::Write) {
+        match self {
+            // clap_complete
+            Self::Bash => Shell::Bash.generate(cmd, buf),
+            Self::Elvish => Shell::Elvish.generate(cmd, buf),
+            Self::Fish => Shell::Fish.generate(cmd, buf),
+            Self::PowerShell => Shell::PowerShell.generate(cmd, buf),
+            Self::Zsh => Shell::Zsh.generate(cmd, buf),
+
+            // clap_complete_nushell
+            Self::Nushell => Nushell.generate(cmd, buf),
+        }
+    }
+}
+
+#[derive(Debug, Parser)]
+pub struct Cmd {
+    /// Set the shell for generating completions
+    #[arg(long, short)]
+    shell: GenShell,
+
+    /// Set the output directory
+    #[arg(long, short)]
+    out_dir: Option<String>,
+}
+
+impl Cmd {
+    pub fn run(self) -> Result<()> {
+        let Cmd { shell, out_dir } = self;
+
+        let mut cli = crate::Atuin::command();
+
+        match out_dir {
+            Some(out_dir) => {
+                generate_to(shell, &mut cli, env!("CARGO_PKG_NAME"), &out_dir)?;
+            }
+            None => {
+                generate(
+                    shell,
+                    &mut cli,
+                    env!("CARGO_PKG_NAME"),
+                    &mut std::io::stdout(),
+                );
+            }
+        }
+
+        Ok(())
+    }
+}

--- a/atuin/src/command/mod.rs
+++ b/atuin/src/command/mod.rs
@@ -1,5 +1,4 @@
-use clap::{CommandFactory, Subcommand};
-use clap_complete::{generate, generate_to, Shell};
+use clap::Subcommand;
 use eyre::Result;
 
 #[cfg(not(windows))]
@@ -12,6 +11,8 @@ mod client;
 mod server;
 
 mod contributors;
+
+mod gen_completions;
 
 #[derive(Subcommand)]
 #[command(infer_subcommands = true)]
@@ -31,15 +32,7 @@ pub enum AtuinCmd {
     Contributors,
 
     /// Generate shell completions
-    GenCompletions {
-        /// Set the shell for generating completions
-        #[arg(long, short)]
-        shell: Shell,
-
-        /// Set the output directory
-        #[arg(long, short)]
-        out_dir: Option<String>,
-    },
+    GenCompletions(gen_completions::Cmd),
 }
 
 impl AtuinCmd {
@@ -66,25 +59,7 @@ impl AtuinCmd {
                 println!("{}", atuin_common::utils::uuid_v7().as_simple());
                 Ok(())
             }
-            Self::GenCompletions { shell, out_dir } => {
-                let mut cli = crate::Atuin::command();
-
-                match out_dir {
-                    Some(out_dir) => {
-                        generate_to(shell, &mut cli, env!("CARGO_PKG_NAME"), &out_dir)?;
-                    }
-                    None => {
-                        generate(
-                            shell,
-                            &mut cli,
-                            env!("CARGO_PKG_NAME"),
-                            &mut std::io::stdout(),
-                        );
-                    }
-                }
-
-                Ok(())
-            }
+            Self::GenCompletions(gen_completions) => gen_completions.run(),
         }
     }
 }


### PR DESCRIPTION
<!-- Thank you for making a PR! Bug fixes are always welcome, but if you're adding a new feature or changing an existing one, we'd really appreciate if you open an issue, post on the forum, or drop in on Discord -->

As mentioned on Discord, I noticed that clap offers completion generation for nushell in a separate crate. I went ahead and implemented these for the existing gen-completions command.

Some extensive implementation notes:
- When installing the new dependency, I also updated the clap and clap_complete versions in the manifests. I thought it couldn't hurt to have the whole group up to date when installing a new part. Looking at the lock file changes, I believe it had these versions already installed anyway.
- I moved the gen-completions code into a new module, similar to the other commands. With the extra impl it took up quite a bit of space in `mod.rs` otherwise.
- After trying out a few variants of composing the two crates into one command, I landed on defining an enum ourselves and adding some repetitive glue code. It was the most ergonomic version I could come up with, but I'm happy for alternative suggestions
- **Question:** I'm not sure if the nushell generations are wanted in the release tarball? I just noticed it when searching for mentions of completions.
- Another bit of code for the completions that I wasn't sure about was in `atuin.nix`. But the function used there, `installShellCompletion`, seems to only support bash fish and zsh in this way, so I didn't touch it (also I have next to no experience with nix, so I wouldn't want to break anything).
- I tested the generated completions using the latest nushell version, `0.90.1`, and everything worked well for me. 
- I'm gonna have a look at preparing a corresponding docs update PR tomorrow, or latest on the weekend, at least to update the list of supported shells for completion generation. 


## Checks
- [x] I am happy for maintainers to push small adjustments to this PR, to speed up the review cycle
- [x] I have checked that there are no existing pull requests for the same thing
