### PR TITLE
Guard against ancient versions of bash (3.2) where Atuin does not work.

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,5 +1,10 @@
 #! /usr/bin/env bash
 
+if [[ "${BASH_VERSION%%.*}" -eq 3 ]]; then
+    echo "Atuin has limited support for Bash 3.2. The Atuin config enter_accept cannot be turned off." >&2
+    echo "To turn off enter_accept, please upgrade your version of bash (possibly via homebrew or ports)" >&2
+fi
+
 set -euo pipefail
 
 cat << EOF


### PR DESCRIPTION
Hi.

<!-- Thank you for making a PR! Bug fixes are always welcome, but if you're adding a new feature or changing an existing one, we'd really appreciate if you open an issue, post on the forum, or drop in on Discord -->

## Checks
- [✔️ ] I am happy for maintainers to push small adjustments to this PR, to speed up the review cycle
- [✔️ ] I have checked that there are no existing pull requests for the same thing
  * I searched issues for "bash 3.2" and got nothing relevant.

I'm on OS X, version `Sonoma 14.2.1 (23C71)`, which ships an ancient version of bash (3.2).

Atuin doesn't work under bash 3.2. it runs when I hit "up", but then when I hit enter, the command doesn't get put into the line to be run if I hit enter a second time.

Of course, the first thing to do with that is to upgrade to a recent version of bash using homebrew.

Unfortunately, that doesn't always take fully, resulting in bash 3.2 getting run... sometimes.

This adds a guard to install.sh, erroring out, saying that Atuin doesn't work in bash 3.2.