### PR TITLE
ci: automatically update CONTRIBUTORS once a month

### DIFF
--- a/.github/workflows/update-contributors.yml
+++ b/.github/workflows/update-contributors.yml
@@ -1,0 +1,11 @@
+name: Update CONTRIBUTORS
+on:
+  schedule:
+    - cron: "0 0 1 * *"
+  workflow_dispatch:
+jobs:
+  update_contributors:
+    runs-on: ubuntu-latest
+    steps:
+      - name: update
+        uses: tessus/update-contributors-list@v1


### PR DESCRIPTION
The commit message says it all.

This action updates the CONTRIBUTORS file on the first day of the month. You can also run the workflow manually.

The list format and sort order is the same as the current one. Bots are excluded.

I didn't open an issue on the forum, because it's rather an infra/ci issue than an atuin feature request.

## Checks
- [x] I am happy for maintainers to push small adjustments to this PR, to speed up the review cycle
- [x] I have checked that there are no existing pull requests for the same thing
