### PR TITLE
fix: missing characters in preview

### DIFF
--- a/atuin/src/command/client/search/interactive.rs
+++ b/atuin/src/command/client/search/interactive.rs
@@ -639,6 +639,11 @@ impl State {
         let input = self.build_input(style);
         f.render_widget(input, input_chunk);
 
+        let preview_width = if compact {
+            preview_width
+        } else {
+            preview_width - 2
+        };
         let preview =
             self.build_preview(results, compact, preview_width, preview_chunk.width.into());
         f.render_widget(preview, preview_chunk);


### PR DESCRIPTION
fixes #1792

Padding did not help. The only way was to decrease the width by 2 in non-compact mode.

## Checks
- [x] I am happy for maintainers to push small adjustments to this PR, to speed up the review cycle
- [x] I have checked that there are no existing pull requests for the same thing
