### PR TITLE
feat: show preview auto

### DIFF
--- a/atuin-client/config.toml
+++ b/atuin-client/config.toml
@@ -73,6 +73,11 @@
 ## useful when the command is longer than the terminal width and is cut off
 # show_preview = false
 
+## enable or disable automatic preview. It shows a preview, if the command is
+## longer than the width of the terminal. It respects max_preview_height.
+## (default: true)
+# show_preview_auto = true
+
 ## what to do when the escape key is pressed when searching
 ## possible values: return-original, return-query
 # exit_mode = "return-original"

--- a/atuin-client/src/settings.rs
+++ b/atuin-client/src/settings.rs
@@ -352,6 +352,7 @@ pub struct Settings {
     pub inline_height: u16,
     pub invert: bool,
     pub show_preview: bool,
+    pub show_preview_auto: bool,
     pub max_preview_height: u16,
     pub show_help: bool,
     pub exit_mode: ExitMode,
@@ -591,6 +592,7 @@ impl Settings {
             .set_default("style", "auto")?
             .set_default("inline_height", 0)?
             .set_default("show_preview", false)?
+            .set_default("show_preview_auto", true)?
             .set_default("max_preview_height", 4)?
             .set_default("show_help", true)?
             .set_default("invert", false)?

--- a/atuin/src/command/client/search/interactive.rs
+++ b/atuin/src/command/client/search/interactive.rs
@@ -500,27 +500,41 @@ impl State {
         let invert = settings.invert;
         let border_size = if compact { 0 } else { 1 };
         let preview_width = f.size().width - 2;
-        let preview_height = if settings.show_preview && self.tab_index == 0 {
-            let longest_command = results
-                .iter()
-                .max_by(|h1, h2| h1.command.len().cmp(&h2.command.len()));
-            longest_command.map_or(0, |v| {
-                std::cmp::min(
-                    settings.max_preview_height,
-                    v.command
-                        .split('\n')
-                        .map(|line| {
-                            (line.len() as u16 + preview_width - 1 - border_size)
-                                / (preview_width - border_size)
-                        })
-                        .sum(),
-                )
-            }) + border_size * 2
-        } else if compact || self.tab_index == 1 {
-            0
-        } else {
-            1
-        };
+        let preview_height =
+            if settings.show_preview_auto && self.tab_index == 0 && !results.is_empty() {
+                let length_current_cmd =
+                    results[self.results_state.selected()].command.len() as u16;
+                // The '- 19' takes the characters before the command (duration and time) into account
+                if length_current_cmd > preview_width - 19 {
+                    std::cmp::min(
+                        settings.max_preview_height,
+                        (length_current_cmd + preview_width - 1 - border_size)
+                            / (preview_width - border_size),
+                    ) + border_size * 2
+                } else {
+                    1
+                }
+            } else if settings.show_preview && self.tab_index == 0 {
+                let longest_command = results
+                    .iter()
+                    .max_by(|h1, h2| h1.command.len().cmp(&h2.command.len()));
+                longest_command.map_or(0, |v| {
+                    std::cmp::min(
+                        settings.max_preview_height,
+                        v.command
+                            .split('\n')
+                            .map(|line| {
+                                (line.len() as u16 + preview_width - 1 - border_size)
+                                    / (preview_width - border_size)
+                            })
+                            .sum(),
+                    )
+                }) + border_size * 2
+            } else if compact || self.tab_index == 1 {
+                0
+            } else {
+                1
+            };
         let show_help = settings.show_help && (!compact || f.size().height > 1);
         let chunks = Layout::default()
             .direction(Direction::Vertical)


### PR DESCRIPTION
This change introduces a new config option `show_preview_auto = true|false` with `true` being the default.

I wanted to originally change the current boolean option `show_preview` with an option that takes also the value `auto`. But this would be a breaking change and should be done when the config/settings are updated to the new format. I am more than happy to create another PR then.

/ref [Show preview only if command longer than terminal width](https://forum.atuin.sh/t/show-preview-only-if-command-longer-than-terminal-width/212?u=tessus)

## Checks
- [x] I am happy for maintainers to push small adjustments to this PR, to speed up the review cycle
- [x] I have checked that there are no existing pull requests for the same thing
