### PR TITLE
fix(regex): disable regex error logs

### DIFF
--- a/atuin/src/command/client.rs
+++ b/atuin/src/command/client.rs
@@ -84,6 +84,7 @@ impl Cmd {
     async fn run_inner(self) -> Result<()> {
         Builder::new()
             .filter_level(log::LevelFilter::Off)
+            .filter_module("sqlx_sqlite::regexp", log::LevelFilter::Off)
             .parse_env("ATUIN_LOG")
             .init();
 


### PR DESCRIPTION
<!-- Thank you for making a PR! Bug fixes are always welcome, but if you're adding a new feature or changing an existing one, we'd really appreciate if you open an issue, post on the forum, or drop in on Discord -->

The sqlx regex crate will log errors automatically

See

https://github.com/launchbadge/sqlx/blob/27a49914ad5e0f21b8fb1f2a62db8d838724548f/sqlx-sqlite/src/regexp.rs#L124C13-L124C54

With this, we explicitly disable the logging for that module.

## Checks
- [ ] I am happy for maintainers to push small adjustments to this PR, to speed up the review cycle
- [ ] I have checked that there are no existing pull requests for the same thing
