### PR TITLE
Nushell: check if command history is disabled

### DIFF
--- a/atuin/src/shell/atuin.nu
+++ b/atuin/src/shell/atuin.nu
@@ -6,6 +6,9 @@ hide-env -i ATUIN_HISTORY_ID
 let ATUIN_KEYBINDING_TOKEN = $"# (random uuid)"
 
 let _atuin_pre_execution = {||
+    if ($nu | get -i history-enabled) == false {
+        return
+    }
     let cmd = (commandline)
     if ($cmd | is-empty) {
         return


### PR DESCRIPTION
Somewhat recently in Nushell, we added a [CLI option](https://github.com/nushell/nushell/pull/11550) to disable command history. This is very similar to fish's private mode. Like in #577, this PR skips `atuin history start` if history is disabled.

## Checks
- [x] I am happy for maintainers to push small adjustments to this PR, to speed up the review cycle
- [x] I have checked that there are no existing pull requests for the same thing
