### PR TITLE
fix(tz): attempt to fix timezone reading

### DIFF
--- a/atuin-client/src/settings.rs
+++ b/atuin-client/src/settings.rs
@@ -151,7 +151,11 @@ impl FromStr for Timezone {
     fn from_str(s: &str) -> Result<Self> {
         // local timezone
         if matches!(s.to_lowercase().as_str(), "l" | "local") {
-            let offset = UtcOffset::current_local_offset()?;
+            // There have been some timezone issues, related to errors fetching it on some
+            // platforms
+            // Rather than fail to start, fallback to UTC. The user should still be able to specify
+            // their timezone manually in the config file.
+            let offset = UtcOffset::current_local_offset().unwrap_or(UtcOffset::UTC);
             return Ok(Self(offset));
         }
 

--- a/atuin/src/command/client.rs
+++ b/atuin/src/command/client.rs
@@ -74,14 +74,15 @@ impl Cmd {
             .build()
             .unwrap();
 
-        let res = runtime.block_on(self.run_inner());
+        let settings = Settings::new().wrap_err("could not load client settings")?;
+        let res = runtime.block_on(self.run_inner(settings));
 
         runtime.shutdown_timeout(std::time::Duration::from_millis(50));
 
         res
     }
 
-    async fn run_inner(self) -> Result<()> {
+    async fn run_inner(self, mut settings: Settings) -> Result<()> {
         Builder::new()
             .filter_level(log::LevelFilter::Off)
             .filter_module("sqlx_sqlite::regexp", log::LevelFilter::Off)
@@ -89,8 +90,6 @@ impl Cmd {
             .init();
 
         tracing::trace!(command = ?self, "client command");
-
-        let mut settings = Settings::new().wrap_err("could not load client settings")?;
 
         let db_path = PathBuf::from(settings.db_path.as_str());
         let record_store_path = PathBuf::from(settings.record_store_path.as_str());


### PR DESCRIPTION
<!-- Thank you for making a PR! Bug fixes are always welcome, but if you're adding a new feature or changing an existing one, we'd really appreciate if you open an issue, post on the forum, or drop in on Discord -->

Read settings earlier on, to reduced risk of being in a multithreaded env
 
if we fail to read the timezone, fallback to UTC. This is only used for display, as we always stored UTC anyway. The user can still specify a different tz if they wish

## Checks
- [ ] I am happy for maintainers to push small adjustments to this PR, to speed up the review cycle
- [ ] I have checked that there are no existing pull requests for the same thing
