### PR TITLE
fix(nix): set meta.mainProgram in the package

### DIFF
--- a/atuin.nix
+++ b/atuin.nix
@@ -1,7 +1,7 @@
 # Atuin package definition
 #
 # This file will be similar to the package definition in nixpkgs:
-#     https://github.com/NixOS/nixpkgs/blob/master/pkgs/tools/misc/atuin/default.nix
+#     https://github.com/NixOS/nixpkgs/blob/master/pkgs/by-name/at/atuin/package.nix
 #
 # Helpful documentation: https://github.com/NixOS/nixpkgs/blob/master/doc/languages-frameworks/rust.section.md
 {

--- a/atuin.nix
+++ b/atuin.nix
@@ -42,5 +42,6 @@ rustPlatform.buildRustPackage {
     description = "Replacement for a shell history which records additional commands context with optional encrypted synchronization between machines";
     homepage = "https://github.com/atuinsh/atuin";
     license = licenses.mit;
+    mainProgram = "atuin";
   };
 }


### PR DESCRIPTION
<!-- Thank you for making a PR! Bug fixes are always welcome, but if you're adding a new feature or changing an existing one, we'd really appreciate if you open an issue, post on the forum, or drop in on Discord -->
Small change, as nixpkgs is starting to require meta.mainProgram to be set for the package. I also updated the link to the nixpkgs package after some refactoring in that repo broke the link. They don't intend to move it again.

## Checks
- [x] I am happy for maintainers to push small adjustments to this PR, to speed up the review cycle
- [x] I have checked that there are no existing pull requests for the same thing
