### PR TITLE
make atuin compile on non-win/mac/linux platforms

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -170,11 +170,11 @@ checksum = "c59bdb34bc650a32731b31bd8f0829cc15d24a708ee31559e0bb34f2bc320cba"
 
 [[package]]
 name = "atomic-write-file"
-version = "0.1.2"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edcdbedc2236483ab103a53415653d6b4442ea6141baf1ffa85df29635e88436"
+checksum = "a8204db279bf648d64fe845bd8840f78b39c8132ed4d6a4194c3b10d4b4cfb0b"
 dependencies = [
- "nix 0.27.1",
+ "nix 0.28.0",
  "rand",
 ]
 
@@ -576,6 +576,12 @@ name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "cfg_aliases"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd16c4719339c4530435d38e511904438d07cce7950afa3718a84ac36c10e89e"
 
 [[package]]
 name = "chacha20"
@@ -2100,12 +2106,13 @@ dependencies = [
 
 [[package]]
 name = "nix"
-version = "0.27.1"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2eb04e9c688eff1c89d72b407f168cf79bb9e867a9d3323ed6c01519eb9cc053"
+checksum = "ab2156c4fce2f8df6c499cc1c763e4394b7482525bf2a9701c9d79d215f519e4"
 dependencies = [
  "bitflags 2.4.2",
  "cfg-if",
+ "cfg_aliases",
  "libc",
 ]
 
@@ -4125,6 +4132,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
+name = "wasite"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8dad83b4f25e74f184f64c43b150b91efe7647395b42289f38e50566d82855b"
+
+[[package]]
 name = "wasm-bindgen"
 version = "0.2.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4267,11 +4280,12 @@ checksum = "5f20c57d8d7db6d3b86154206ae5d8fba62dd39573114de97c2cb0578251f8e1"
 
 [[package]]
 name = "whoami"
-version = "1.4.1"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22fc3756b8a9133049b26c7f61ab35416c130e8c09b660f5b3958b446f52cc50"
+checksum = "0fec781d48b41f8163426ed18e8fc2864c12937df9ce54c88ede7bd47270893e"
 dependencies = [
- "wasm-bindgen",
+ "redox_syscall",
+ "wasite",
  "web-sys",
 ]
 

--- a/atuin-client/src/api_client.rs
+++ b/atuin-client/src/api_client.rs
@@ -25,7 +25,7 @@ use semver::Version;
 use time::format_description::well_known::Rfc3339;
 use time::OffsetDateTime;
 
-use crate::{history::History, sync::hash_str};
+use crate::{history::History, sync::hash_str, utils::get_host_user};
 
 static APP_USER_AGENT: &str = concat!("atuin/", env!("CARGO_PKG_VERSION"),);
 
@@ -236,13 +236,7 @@ impl<'a> Client<'a> {
         history_ts: OffsetDateTime,
         host: Option<String>,
     ) -> Result<SyncHistoryResponse> {
-        let host = host.unwrap_or_else(|| {
-            hash_str(&format!(
-                "{}:{}",
-                env::var("ATUIN_HOST_NAME").unwrap_or_else(|_| whoami::hostname()),
-                env::var("ATUIN_HOST_USER").unwrap_or_else(|_| whoami::username())
-            ))
-        });
+        let host = host.unwrap_or_else(|| hash_str(&get_host_user()));
 
         let url = format!(
             "{}/sync/history?sync_ts={}&history_ts={}&host={}",

--- a/atuin-client/src/database.rs
+++ b/atuin-client/src/database.rs
@@ -21,7 +21,10 @@ use sqlx::{
 };
 use time::OffsetDateTime;
 
-use crate::history::{HistoryId, HistoryStats};
+use crate::{
+    history::{HistoryId, HistoryStats},
+    utils::get_host_user,
+};
 
 use super::{
     history::History,
@@ -55,11 +58,7 @@ pub fn current_context() -> Context {
         eprintln!("ERROR: Failed to find $ATUIN_SESSION in the environment. Check that you have correctly set up your shell.");
         std::process::exit(1);
     };
-    let hostname = format!(
-        "{}:{}",
-        env::var("ATUIN_HOST_NAME").unwrap_or_else(|_| whoami::hostname()),
-        env::var("ATUIN_HOST_USER").unwrap_or_else(|_| whoami::username())
-    );
+    let hostname = get_host_user();
     let cwd = utils::get_current_dir();
     let host_id = Settings::host_id().expect("failed to load host ID");
     let git_root = utils::in_git_repo(cwd.as_str());

--- a/atuin-client/src/history.rs
+++ b/atuin-client/src/history.rs
@@ -10,6 +10,7 @@ use atuin_common::utils::uuid_v7;
 use eyre::{bail, eyre, Result};
 use regex::RegexSet;
 
+use crate::utils::get_host_user;
 use crate::{secrets::SECRET_PATTERNS, settings::Settings};
 use time::OffsetDateTime;
 
@@ -106,13 +107,7 @@ impl History {
         let session = session
             .or_else(|| env::var("ATUIN_SESSION").ok())
             .unwrap_or_else(|| uuid_v7().as_simple().to_string());
-        let hostname = hostname.unwrap_or_else(|| {
-            format!(
-                "{}:{}",
-                env::var("ATUIN_HOST_NAME").unwrap_or_else(|_| whoami::hostname()),
-                env::var("ATUIN_HOST_USER").unwrap_or_else(|_| whoami::username())
-            )
-        });
+        let hostname = hostname.unwrap_or_else(get_host_user);
 
         Self {
             id: uuid_v7().as_simple().to_string().into(),

--- a/atuin-client/src/import/xonsh.rs
+++ b/atuin-client/src/import/xonsh.rs
@@ -12,6 +12,7 @@ use uuid::Uuid;
 
 use super::{get_histpath, Importer, Loader};
 use crate::history::History;
+use crate::utils::get_host_user;
 
 // Note: both HistoryFile and HistoryData have other keys present in the JSON, we don't
 // care about them so we leave them unspecified so as to avoid deserializing unnecessarily.
@@ -60,14 +61,6 @@ fn xonsh_hist_dir(xonsh_data_dir: Option<String>) -> Result<PathBuf> {
     }
 }
 
-fn get_hostname() -> String {
-    format!(
-        "{}:{}",
-        env::var("ATUIN_HOST_NAME").unwrap_or_else(|_| whoami::hostname()),
-        env::var("ATUIN_HOST_USER").unwrap_or_else(|_| whoami::username()),
-    )
-}
-
 fn load_sessions(hist_dir: &Path) -> Result<Vec<HistoryData>> {
     let mut sessions = vec![];
     for entry in fs::read_dir(hist_dir)? {
@@ -111,7 +104,7 @@ impl Importer for Xonsh {
         let xonsh_data_dir = env::var("XONSH_DATA_DIR").ok();
         let hist_dir = get_histpath(|| xonsh_hist_dir(xonsh_data_dir))?;
         let sessions = load_sessions(&hist_dir)?;
-        let hostname = get_hostname();
+        let hostname = get_host_user();
         Ok(Xonsh { sessions, hostname })
     }
 

--- a/atuin-client/src/import/xonsh_sqlite.rs
+++ b/atuin-client/src/import/xonsh_sqlite.rs
@@ -12,6 +12,7 @@ use uuid::Uuid;
 
 use super::{get_histpath, Importer, Loader};
 use crate::history::History;
+use crate::utils::get_host_user;
 
 #[derive(Debug, FromRow)]
 struct HistDbEntry {
@@ -79,14 +80,6 @@ fn xonsh_db_path(xonsh_data_dir: Option<String>) -> Result<PathBuf> {
     }
 }
 
-fn get_hostname() -> String {
-    format!(
-        "{}:{}",
-        env::var("ATUIN_HOST_NAME").unwrap_or_else(|_| whoami::hostname()),
-        env::var("ATUIN_HOST_USER").unwrap_or_else(|_| whoami::username()),
-    )
-}
-
 #[derive(Debug)]
 pub struct XonshSqlite {
     pool: SqlitePool,
@@ -109,7 +102,7 @@ impl Importer for XonshSqlite {
         })?;
 
         let pool = SqlitePool::connect(connection_str).await?;
-        let hostname = get_hostname();
+        let hostname = get_host_user();
         Ok(XonshSqlite { pool, hostname })
     }
 

--- a/atuin-client/src/import/zsh_histdb.rs
+++ b/atuin-client/src/import/zsh_histdb.rs
@@ -33,7 +33,6 @@
 //
 
 use std::collections::HashMap;
-use std::env;
 use std::path::{Path, PathBuf};
 
 use async_trait::async_trait;
@@ -46,6 +45,7 @@ use time::PrimitiveDateTime;
 use super::Importer;
 use crate::history::History;
 use crate::import::Loader;
+use crate::utils::{get_hostname, get_username};
 
 #[derive(sqlx::FromRow, Debug)]
 pub struct HistDbEntryCount {
@@ -62,14 +62,6 @@ pub struct HistDbEntry {
     pub duration: i64,
     pub exit_status: i64,
     pub session: i64,
-}
-
-fn get_hostname() -> String {
-    env::var("ATUIN_HOST_NAME").unwrap_or_else(|_| whoami::hostname())
-}
-
-fn get_username() -> String {
-    env::var("ATUIN_HOST_USER").unwrap_or_else(|_| whoami::username())
 }
 
 #[derive(Debug)]

--- a/atuin-client/src/lib.rs
+++ b/atuin-client/src/lib.rs
@@ -17,3 +17,5 @@ pub mod ordering;
 pub mod record;
 pub mod secrets;
 pub mod settings;
+
+mod utils;

--- a/atuin-client/src/utils.rs
+++ b/atuin-client/src/utils.rs
@@ -1,0 +1,14 @@
+pub(crate) fn get_hostname() -> String {
+    std::env::var("ATUIN_HOST_NAME").unwrap_or_else(|_| {
+        whoami::fallible::hostname().unwrap_or_else(|_| "unknown-host".to_string())
+    })
+}
+
+pub(crate) fn get_username() -> String {
+    std::env::var("ATUIN_HOST_USER").unwrap_or_else(|_| whoami::username())
+}
+
+/// Returns a pair of the hostname and username, separated by a colon.
+pub(crate) fn get_host_user() -> String {
+    format!("{}:{}", get_hostname(), get_username())
+}

--- a/atuin/Cargo.toml
+++ b/atuin/Cargo.toml
@@ -77,12 +77,13 @@ fuzzy-matcher = "0.3.7"
 colored = "2.0.4"
 ratatui = "0.25"
 tracing = "0.1"
-cli-clipboard = { version = "0.4.0", optional = true }
 uuid = { workspace = true }
 unicode-segmentation = "1.11.0"
 serde_yaml = "0.9.32"
 sysinfo = "0.30.5"
 
+[target.'cfg(any(target_os = "windows", target_os = "macos", target_os = "linux"))'.dependencies]
+cli-clipboard = { version = "0.4.0", optional = true }
 
 [dependencies.tracing-subscriber]
 version = "0.3"

--- a/atuin/src/command/client/search/interactive.rs
+++ b/atuin/src/command/client/search/interactive.rs
@@ -1074,10 +1074,18 @@ pub async fn history(
     }
 }
 
-#[cfg(feature = "clipboard")]
+// cli-clipboard only works on Windows, Mac, and Linux.
+
+#[cfg(all(
+    feature = "clipboard",
+    any(target_os = "windows", target_os = "macos", target_os = "linux")
+))]
 fn set_clipboard(s: String) {
     cli_clipboard::set_contents(s).unwrap();
 }
 
-#[cfg(not(feature = "clipboard"))]
+#[cfg(not(all(
+    feature = "clipboard",
+    any(target_os = "windows", target_os = "macos", target_os = "linux")
+)))]
 fn set_clipboard(_s: String) {}


### PR DESCRIPTION
Hi!

I've been trying to get atuin set up on the illumos machine I built for work @oxidecomputer, and I ran into a few issues which are fixed here:

1. The `clipboard` feature was only supported on Windows, Mac and Linux. I've added a platform gate for that.
2. The `atomic-write-file` crate needed an update to the version of `nix` -- that is included.
3. As part of this, I found a [security bug](https://rustsec.org/advisories/RUSTSEC-2024-0020.html) in the whoami crate. The bug has been fixed upstream and I've included it (it's required to prevent a crash that happens on illumos).

   whoami 1.5.0 deprecates the `hostname` function, which produced some fresh warnings. While fixing the warnings I also took the liberty of doing some code rearrangement, adding a few functions that wrap some common operations. I didn't really know where to put those functions, so I created a new `utils` module for it. If you have a better place to put them, I'm happy to change the PR.

With these issues fixed, I'm happy to say that atuin works fantastically on illumos with zsh!

Feel free to make any changes to this PR if you like before landing it, or to ask for review.

As a followup I'm also happy to set up a cross-compile build for atuin on illumos. It's a bit harder to run tests in CI for illumos at the moment, but I'm trying to get a project started up to make that happen in the future as well.

<!-- Thank you for making a PR! Bug fixes are always welcome, but if you're adding a new feature or changing an existing one, we'd really appreciate if you open an issue, post on the forum, or drop in on Discord -->

## Checks
- [x] I am happy for maintainers to push small adjustments to this PR, to speed up the review cycle
- [x] I have checked that there are no existing pull requests for the same thing
