### PR TITLE
fix(sync): record size limiter

### DIFF
--- a/atuin-server/src/handlers/v0/record.rs
+++ b/atuin-server/src/handlers/v0/record.rs
@@ -27,11 +27,11 @@ pub async fn post<DB: Database>(
 
     counter!("atuin_record_uploaded", records.len() as u64);
 
-    let too_big = records
+    let keep = records
         .iter()
-        .any(|r| r.data.data.len() >= settings.max_record_size || settings.max_record_size == 0);
+        .all(|r| r.data.data.len() <= settings.max_record_size || settings.max_record_size == 0);
 
-    if too_big {
+    if !keep {
         counter!("atuin_record_too_large", 1);
 
         return Err(


### PR DESCRIPTION
Settings the record size limit to 0 had issues. Inverting the condition works better.

<!-- Thank you for making a PR! Bug fixes are always welcome, but if you're adding a new feature or changing an existing one, we'd really appreciate if you open an issue, post on the forum, or drop in on Discord -->

## Checks
- [ ] I am happy for maintainers to push small adjustments to this PR, to speed up the review cycle
- [ ] I have checked that there are no existing pull requests for the same thing
