### PR TITLE
feat(dotfiles): add enable setting to dotfiles, disable by default

### DIFF
--- a/atuin-client/src/settings.rs
+++ b/atuin-client/src/settings.rs
@@ -33,6 +33,8 @@ pub const LATEST_VERSION_FILENAME: &str = "latest_version";
 pub const HOST_ID_FILENAME: &str = "host_id";
 static EXAMPLE_CONFIG: &str = include_str!("../config.toml");
 
+mod dotfiles;
+
 #[derive(Clone, Debug, Deserialize, Copy, ValueEnum, PartialEq)]
 pub enum SearchMode {
     #[serde(rename = "prefix")]
@@ -392,6 +394,9 @@ pub struct Settings {
 
     #[serde(default)]
     pub keys: Keys,
+
+    #[serde(default)]
+    pub dotfiles: dotfiles::Settings,
 
     // This is automatically loaded when settings is created. Do not set in
     // config! Keep secrets and settings apart.

--- a/atuin-client/src/settings/dotfiles.rs
+++ b/atuin-client/src/settings/dotfiles.rs
@@ -1,0 +1,6 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Serialize, Deserialize, Clone, Default)]
+pub struct Settings {
+    pub enabled: bool,
+}

--- a/atuin/src/command/client/dotfiles/alias.rs
+++ b/atuin/src/command/client/dotfiles/alias.rs
@@ -54,6 +54,12 @@ impl Cmd {
     }
 
     pub async fn run(&self, settings: &Settings, store: SqliteStore) -> Result<()> {
+        if !settings.dotfiles.enabled {
+            eprintln!("Dotfiles are not enabled. Add\n\n[dotfiles]\nenabled = true\n\nto your configuration file to enable them.\n");
+            eprintln!("The default configuration file is located at ~/.config/atuin/config.toml.");
+            return Ok(());
+        }
+
         let encryption_key: [u8; 32] = encryption::load_key(settings)
             .context("could not load encryption key")?
             .into();

--- a/atuin/src/command/client/init/bash.rs
+++ b/atuin/src/command/client/init/bash.rs
@@ -1,12 +1,8 @@
 use atuin_dotfiles::store::AliasStore;
 use eyre::Result;
 
-pub async fn init(store: AliasStore, disable_up_arrow: bool, disable_ctrl_r: bool) -> Result<()> {
+pub fn init_static(disable_up_arrow: bool, disable_ctrl_r: bool) {
     let base = include_str!("../../../shell/atuin.bash");
-
-    let aliases = store.aliases().await?;
-
-    let aliases = atuin_dotfiles::shell::bash::build(&aliases[..]);
 
     let (bind_ctrl_r, bind_up_arrow) = if std::env::var("ATUIN_NOBIND").is_ok() {
         (false, false)
@@ -17,6 +13,14 @@ pub async fn init(store: AliasStore, disable_up_arrow: bool, disable_ctrl_r: boo
     println!("__atuin_bind_ctrl_r={bind_ctrl_r}");
     println!("__atuin_bind_up_arrow={bind_up_arrow}");
     println!("{base}");
+}
+
+pub async fn init(store: AliasStore, disable_up_arrow: bool, disable_ctrl_r: bool) -> Result<()> {
+    init_static(disable_up_arrow, disable_ctrl_r);
+
+    let aliases = store.aliases().await?;
+    let aliases = atuin_dotfiles::shell::bash::build(&aliases[..]);
+
     println!("{aliases}");
 
     Ok(())

--- a/atuin/src/command/client/init/fish.rs
+++ b/atuin/src/command/client/init/fish.rs
@@ -1,7 +1,7 @@
 use atuin_dotfiles::store::AliasStore;
 use eyre::Result;
 
-pub async fn init(store: AliasStore, disable_up_arrow: bool, disable_ctrl_r: bool) -> Result<()> {
+pub fn init_static(disable_up_arrow: bool, disable_ctrl_r: bool) {
     let base = include_str!("../../../shell/atuin.fish");
 
     println!("{base}");
@@ -32,6 +32,10 @@ bind -M insert \e\[A _atuin_bind_up";
         }
         println!("end");
     }
+}
+
+pub async fn init(store: AliasStore, disable_up_arrow: bool, disable_ctrl_r: bool) -> Result<()> {
+    init_static(disable_up_arrow, disable_ctrl_r);
 
     let aliases = store.aliases().await?;
     let aliases = atuin_dotfiles::shell::fish::build(&aliases[..]);

--- a/atuin/src/command/client/init/xonsh.rs
+++ b/atuin/src/command/client/init/xonsh.rs
@@ -1,7 +1,7 @@
 use atuin_dotfiles::store::AliasStore;
 use eyre::Result;
 
-pub async fn init(store: AliasStore, disable_up_arrow: bool, disable_ctrl_r: bool) -> Result<()> {
+pub fn init_static(disable_up_arrow: bool, disable_ctrl_r: bool) {
     let base = include_str!("../../../shell/atuin.xsh");
 
     let (bind_ctrl_r, bind_up_arrow) = if std::env::var("ATUIN_NOBIND").is_ok() {
@@ -18,6 +18,10 @@ pub async fn init(store: AliasStore, disable_up_arrow: bool, disable_ctrl_r: boo
         if bind_up_arrow { "True" } else { "False" }
     );
     println!("{base}");
+}
+
+pub async fn init(store: AliasStore, disable_up_arrow: bool, disable_ctrl_r: bool) -> Result<()> {
+    init_static(disable_up_arrow, disable_ctrl_r);
 
     let aliases = store.aliases().await?;
     let aliases = atuin_dotfiles::shell::xonsh::build(&aliases[..]);

--- a/atuin/src/command/client/init/zsh.rs
+++ b/atuin/src/command/client/init/zsh.rs
@@ -1,7 +1,7 @@
 use atuin_dotfiles::store::AliasStore;
 use eyre::Result;
 
-pub async fn init(store: AliasStore, disable_up_arrow: bool, disable_ctrl_r: bool) -> Result<()> {
+pub fn init_static(disable_up_arrow: bool, disable_ctrl_r: bool) {
     let base = include_str!("../../../shell/atuin.zsh");
 
     println!("{base}");
@@ -26,6 +26,10 @@ bindkey -M vicmd 'k' atuin-up-search-vicmd";
             println!("{BIND_UP_ARROW}");
         }
     }
+}
+
+pub async fn init(store: AliasStore, disable_up_arrow: bool, disable_ctrl_r: bool) -> Result<()> {
+    init_static(disable_up_arrow, disable_ctrl_r);
 
     let aliases = store.aliases().await?;
     let aliases = atuin_dotfiles::shell::zsh::build(&aliases[..]);


### PR DESCRIPTION
<!-- Thank you for making a PR! Bug fixes are always welcome, but if you're adding a new feature or changing an existing one, we'd really appreciate if you open an issue, post on the forum, or drop in on Discord -->

While it only costs a few ms, dotfiles is not yet as optimised as it should be. Running the whole store build _is_ fast, but could be faster. I don't want to add the cost to all users, only those using dotfiles.

With a few hundred aliases set, building the alias list takes me around 20ms. Imo init should only be "read a prebuilt list", with no compute required.

## Checks
- [ ] I am happy for maintainers to push small adjustments to this PR, to speed up the review cycle
- [ ] I have checked that there are no existing pull requests for the same thing
