### PR TITLE
feat: add automatic history store init

### DIFF
--- a/atuin-client/src/history/store.rs
+++ b/atuin-client/src/history/store.rs
@@ -5,7 +5,7 @@ use indicatif::{ProgressBar, ProgressState, ProgressStyle};
 use rmp::decode::Bytes;
 
 use crate::{
-    database::{self, Database},
+    database::{current_context, Database},
     record::{encryption::PASETO_V4, sqlite_store::SqliteStore, store::Store},
 };
 use atuin_common::record::{DecryptedData, Host, HostId, Record, RecordId, RecordIdx};
@@ -287,7 +287,7 @@ impl HistoryStore {
         Ok(ret)
     }
 
-    pub async fn init_store(&self, context: database::Context, db: &impl Database) -> Result<()> {
+    pub async fn init_store(&self, db: &impl Database) -> Result<()> {
         let pb = ProgressBar::new_spinner();
         pb.set_style(
             ProgressStyle::with_template("{spinner:.blue} {msg}")
@@ -300,6 +300,8 @@ impl HistoryStore {
         pb.enable_steady_tick(Duration::from_millis(500));
 
         pb.set_message("Fetching history from old database");
+
+        let context = current_context();
         let history = db.list(&[], &context, None, false, true).await?;
 
         pb.set_message("Fetching history already in store");

--- a/atuin/src/command/client/history.rs
+++ b/atuin/src/command/client/history.rs
@@ -475,11 +475,6 @@ impl Cmd {
         Ok(())
     }
 
-    async fn init_store(&self, db: &impl Database, history_store: HistoryStore) -> Result<()> {
-        let context = current_context();
-        history_store.init_store(context, db).await
-    }
-
     pub async fn run(
         self,
         settings: &Settings,
@@ -542,7 +537,7 @@ impl Cmd {
                 Ok(())
             }
 
-            Self::InitStore => self.init_store(db, history_store).await,
+            Self::InitStore => history_store.init_store(db).await,
 
             Self::Prune { dry_run } => {
                 Self::handle_prune(db, settings, store, context, dry_run).await

--- a/atuin/src/command/client/sync.rs
+++ b/atuin/src/command/client/sync.rs
@@ -99,11 +99,13 @@ async fn run(
 
         #[allow(clippy::cast_sign_loss)]
         if history_length as u64 > store_history_length {
-            println!("History DB is longer than history record store");
-            println!("This happens when you used Atuin pre-record-store");
-            println!("Run atuin history init-store to correct this");
+            println!(
+                "{history_length} in history index, but {store_history_length} in history store"
+            );
+            println!("Running automatic history store init...");
 
-            println!("\n");
+            // Internally we use the global filter mode, so this context is ignored.
+            history_store.init_store(db).await?;
         }
     } else {
         atuin_client::sync::sync(settings, force, db).await?;


### PR DESCRIPTION
This means that users do not have to run `init-store` manually any longer. With the performance improvements lately, it is also unlikely to take much time to init a store.

## Checks
- [ ] I am happy for maintainers to push small adjustments to this PR, to speed up the review cycle
- [ ] I have checked that there are no existing pull requests for the same thing
