### PR TITLE
feat: adds info command to show env vars and config files

### DIFF
--- a/atuin/src/command/client.rs
+++ b/atuin/src/command/client.rs
@@ -22,6 +22,7 @@ mod kv;
 mod search;
 mod stats;
 mod store;
+mod info;
 
 #[derive(Subcommand, Debug)]
 #[command(infer_subcommands = true)]
@@ -58,6 +59,10 @@ pub enum Cmd {
 
     #[command()]
     Init(init::Cmd),
+
+    /// Information about dotfiles locations and ENV vars
+    #[command()]
+    Info,
 
     #[command()]
     Doctor,
@@ -116,6 +121,8 @@ impl Cmd {
             Self::Dotfiles(dotfiles) => dotfiles.run(&settings, sqlite_store).await,
 
             Self::Init(init) => init.run(&settings).await,
+
+            Self::Info => info::run(&settings),
 
             Self::Doctor => doctor::run(&settings),
 

--- a/atuin/src/command/client.rs
+++ b/atuin/src/command/client.rs
@@ -17,12 +17,12 @@ mod doctor;
 mod dotfiles;
 mod history;
 mod import;
+mod info;
 mod init;
 mod kv;
 mod search;
 mod stats;
 mod store;
-mod info;
 
 #[derive(Subcommand, Debug)]
 #[command(infer_subcommands = true)]
@@ -122,7 +122,10 @@ impl Cmd {
 
             Self::Init(init) => init.run(&settings).await,
 
-            Self::Info => info::run(&settings),
+            Self::Info => {
+                info::run(&settings);
+                Ok(())
+            }
 
             Self::Doctor => doctor::run(&settings),
 

--- a/atuin/src/command/client/info.rs
+++ b/atuin/src/command/client/info.rs
@@ -3,7 +3,7 @@ use eyre::Result;
 
 use crate::VERSION;
 
-pub fn run(settings: &Settings) -> Result<()> {
+pub fn run(settings: &Settings) {
     let config = atuin_common::utils::config_dir();
     let mut config_file = config.clone();
     config_file.push("config.toml");
@@ -32,6 +32,4 @@ pub fn run(settings: &Settings) -> Result<()> {
     let print_out = format!("{config_paths}\n\n{env_vars}\n\n{general_info}");
 
     println!("{print_out}");
-
-    Ok(())
 }

--- a/atuin/src/command/client/info.rs
+++ b/atuin/src/command/client/info.rs
@@ -1,0 +1,37 @@
+use atuin_client::settings::Settings;
+use eyre::Result;
+
+use crate::VERSION;
+
+pub fn run(settings: &Settings) -> Result<()> {
+    let config = atuin_common::utils::config_dir();
+    let mut config_file = config.clone();
+    config_file.push("config.toml");
+    let mut sever_config = config;
+    sever_config.push("server.toml");
+
+    let config_paths = format!(
+        "Config files:\nclient config: {:?}\nserver config: {:?}\nclient db path: {:?}\nkey path: {:?}\nsession path: {:?}",
+        config_file.to_string_lossy(),
+        sever_config.to_string_lossy(),
+        settings.db_path,
+        settings.key_path,
+        settings.session_path
+    );
+
+    let env_vars = format!(
+        "Env Vars:\nATUIN_CONFIG_DIR = {:?}",
+        std::env::var("ATUIN_CONFIG_DIR").unwrap_or_else(|_| "None".into())
+    );
+
+    let general_info = format!(
+        "Version info:\nversion: {}",
+        VERSION,
+    );
+
+    let print_out = format!("{config_paths}\n\n{env_vars}\n\n{general_info}");
+
+    println!("{print_out}");
+
+    Ok(())
+}

--- a/atuin/src/command/client/info.rs
+++ b/atuin/src/command/client/info.rs
@@ -1,5 +1,4 @@
 use atuin_client::settings::Settings;
-use eyre::Result;
 
 use crate::VERSION;
 
@@ -24,10 +23,7 @@ pub fn run(settings: &Settings) {
         std::env::var("ATUIN_CONFIG_DIR").unwrap_or_else(|_| "None".into())
     );
 
-    let general_info = format!(
-        "Version info:\nversion: {}",
-        VERSION,
-    );
+    let general_info = format!("Version info:\nversion: {VERSION}");
 
     let print_out = format!("{config_paths}\n\n{env_vars}\n\n{general_info}");
 


### PR DESCRIPTION
Fixes #1542 
Adds `atuin info` that prints config locations and version information (see below). This could be a sub command, but IDK what command it would fall under. Possible a new command like `atuin config` that would reset the config (just an idea)?
```
Config files:
client config: ~/.config/atuin/config.toml"
server config: "~/.config/atuin/server.toml"
client db path: "~/share/atuin/history.db"
key path: "~/.local/share/atuin/key"
session path: "~/.local/share/atuin/session"

Env Vars:
ATUIN_CONFIG_DIR = "None"

Version info:
version: 18.0.2
```

## Checks
- [x] I am happy for maintainers to push small adjustments to this PR, to speed up the review cycle
- [x] I have checked that there are no existing pull requests for the same thing
