### PR TITLE
fix(doctor): detect preexec plugin using env ATUIN_PREEXEC_BACKEND 

### DIFF
--- a/atuin/src/command/client/doctor.rs
+++ b/atuin/src/command/client/doctor.rs
@@ -19,12 +19,12 @@ struct ShellInfo {
 
 impl ShellInfo {
     // HACK ALERT!
-    // Many of the env vars we need to detect are not exported :(
-    // So, we're going to run `env` in a subshell and parse the output
-    // There's a chance this won't work, so it should not be fatal.
+    // Many of the shell vars we need to detect are not exported :(
+    // So, we're going to run a interactive session and directly check the
+    // variable.  There's a chance this won't work, so it should not be fatal.
     //
-    // Every shell we support handles `shell -c 'command'`
-    fn env_exists(shell: &str, var: &str) -> bool {
+    // Every shell we support handles `shell -ic 'command'`
+    fn shellvar_exists(shell: &str, var: &str) -> bool {
         let cmd = Command::new(shell)
             .args([
                 "-ic",
@@ -41,7 +41,7 @@ impl ShellInfo {
 
     pub fn plugins(shell: &str) -> Vec<String> {
         // consider a different detection approach if there are plugins
-        // that don't set env vars
+        // that don't set shell vars
 
         let map = HashMap::from([
             ("ATUIN_SESSION", "atuin"),
@@ -50,8 +50,8 @@ impl ShellInfo {
         ]);
 
         map.into_iter()
-            .filter_map(|(env, plugin)| {
-                if ShellInfo::env_exists(shell, env) {
+            .filter_map(|(shellvar, plugin)| {
+                if ShellInfo::shellvar_exists(shell, shellvar) {
                     return Some(plugin.to_string());
                 }
 

--- a/atuin/src/shell/atuin.bash
+++ b/atuin/src/shell/atuin.bash
@@ -271,6 +271,11 @@ if [[ ${BLE_VERSION-} ]] && ((_ble_version >= 400)); then
     }
     ble/util/import/eval-after-load core-complete '
         ble/array#unshift _ble_complete_auto_source atuin-history'
+
+    # @env BLE_SESSION_ID: `atuin doctor` references the environment variable
+    # BLE_SESSION_ID.  We explicitly export the variable because it was not
+    # exported in older versions of ble.sh.
+    [[ ${BLE_SESSION_ID-} ]] && export BLE_SESSION_ID
 fi
 precmd_functions+=(__atuin_precmd)
 preexec_functions+=(__atuin_preexec)


### PR DESCRIPTION
Partial fix for #1849 

This is *one possible approach* to solve #1849. Depending on what we want to specifically detect, we might need adjustments. For the implementation details, please see the commit message and changes. There is an extra commit 68a5d5aa that fixes the function names and code comments for the current approach using `shell -ic command` and shell variables.

## Discussion

I added a new environment variable `ATUIN_PREEXEC_BACKEND` in `atuin/src/shell/atuin.bash` to detect if any preexec backend is correctly set up for Atuin in the Bash session that executed `atuin doctor`. However, one might want to check the default shell setup but not the setup in the caller session. Currently, the shell name is determined by the shell that executed `atuin doctor`. In that sense, it would be natural to extract the setup of the session that executed `atuin doctor`. However, the existing code seems to try to extract the setup of the user's default setup of the shell.

Another possibility is to prepare another section for the preexec backend than the `plugin` section. Or, we may include the preexec-backend information in the plugin string of `atuin`, such as `atuin (preexec: blesh-0.4.0)` or `atuin (preexec: bash-preexec)`.

## Checks
- [x] I am happy for maintainers to push small adjustments to this PR, to speed up the review cycle
- [x] I have checked that there are no existing pull requests for the same thing
