### PR TITLE
feat(search): process [C-h] and [C-?] as representations of backspace

### DIFF
--- a/atuin/src/command/client/search/interactive.rs
+++ b/atuin/src/command/client/search/interactive.rs
@@ -379,6 +379,21 @@ impl State {
             KeyCode::Backspace => {
                 self.search.input.back();
             }
+            KeyCode::Char('h' | '?') if ctrl => {
+                // Depending on the terminal, [Backspace] can be transmitted as
+                // \x08 or \x7F.  Also, [Ctrl+Backspace] can be transmitted as
+                // \x08 or \x7F or \x1F.  On the other hand, [Ctrl+h] and
+                // [Ctrl+?] are also transmitted as \x08 or \x7F by the
+                // terminals.
+                //
+                // The crossterm library translates \x08 and \x7F to C-h and
+                // Backspace, respectively.  With the extended keyboard
+                // protocol enabled, crossterm can faithfully translate
+                // [Ctrl+h] and [Ctrl+?] to C-h and C-?.  There is no perfect
+                // solution, but we treat C-h and C-? the same as backspace to
+                // suppress quirks as much as possible.
+                self.search.input.back();
+            }
             KeyCode::Delete if ctrl => self
                 .search
                 .input


### PR DESCRIPTION
Fixes #1753

As discussed in #1753, I think this should ideally be fixed in `crossterm`, but there are general limitations by the terminal protocols and the support by the terminals in the market. I here instead suggest solving this at Atuin's side. The description is found in the commit message and also in a code comment.

## Checks
- [x] I am happy for maintainers to push small adjustments to this PR, to speed up the review cycle
- [x] I have checked that there are no existing pull requests for the same thing
