### PR TITLE
feat(server): check PG version before running migrations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -351,6 +351,7 @@ dependencies = [
  "async-trait",
  "atuin-common",
  "atuin-server-database",
+ "eyre",
  "futures-util",
  "serde",
  "sqlx",

--- a/atuin-server-postgres/Cargo.toml
+++ b/atuin-server-postgres/Cargo.toml
@@ -13,6 +13,7 @@ repository = { workspace = true }
 atuin-common = { path = "../atuin-common", version = "18.0.1" }
 atuin-server-database = { path = "../atuin-server-database", version = "18.0.1" }
 
+eyre = { workspace = true }
 tracing = "0.1"
 time = { workspace = true }
 serde = { workspace = true }


### PR DESCRIPTION
To avoid more dupes of https://github.com/atuinsh/atuin/issues/1860, exit the server with a relevant error when PG is outdated.

This is pulling the `server_version_num` info (you can manually get it with a `SHOW server_version_num;` query). It's value is `major * 10000 + minor`, so 160002 for version 16.2. This could allow you to also check the minor version in the future if needed.

## Tested

```
docker run -e POSTGRES_PASSWORD=password -p 54322:5432 postgres:13

ATUIN_DB_URI=postgres://postgres:password@localhost:54322/postgres ./target/debug/atuin server start 
Error: failed to connect to db: PostgresSettings { db_uri: "postgres://postgres:password@localhost:54322/postgres" }

Caused by:
    Other(unsupported PostgreSQL version 13, minimum required is 14

    Location:
        atuin-server-postgres/src/lib.rs:61:39)

Location:
    /home/xavier/git/atuin/atuin-server/src/lib.rs:141:10
```

Server still starts fine with PG 15.

## Checks
- [x] I am happy for maintainers to push small adjustments to this PR, to speed up the review cycle
- [x] I have checked that there are no existing pull requests for the same thing

The generated errors are not pretty, feel free to change them.