### PR TITLE
Set the synchronous option for the records DB connection to "normal".

### DIFF
--- a/atuin-client/src/record/sqlite_store.rs
+++ b/atuin-client/src/record/sqlite_store.rs
@@ -10,7 +10,10 @@ use eyre::{eyre, Result};
 use fs_err as fs;
 
 use sqlx::{
-    sqlite::{SqliteConnectOptions, SqliteJournalMode, SqlitePool, SqlitePoolOptions, SqliteRow},
+    sqlite::{
+        SqliteConnectOptions, SqliteJournalMode, SqlitePool, SqlitePoolOptions, SqliteRow,
+        SqliteSynchronous,
+    },
     Row,
 };
 
@@ -42,6 +45,7 @@ impl SqliteStore {
 
         let opts = SqliteConnectOptions::from_str(path.as_os_str().to_str().unwrap())?
             .journal_mode(SqliteJournalMode::Wal)
+            .synchronous(SqliteSynchronous::Normal)
             .foreign_keys(true)
             .create_if_missing(true);
 


### PR DESCRIPTION
Just like #1667, when connecting to a DB using WAL mode for journaling, the recommended setting for synchronizing the data is "NORMAL", while the SQLx default is "FULL", which causes hangs on ZFS systems.

Without this change, the hangs are not as long or frequent as before #1667, but are still present. With this change, there are no hanging commands.

<!-- Thank you for making a PR! Bug fixes are always welcome, but if you're adding a new feature or changing an existing one, we'd really appreciate if you open an issue, post on the forum, or drop in on Discord -->

## Checks
- [x] I am happy for maintainers to push small adjustments to this PR, to speed up the review cycle
- [x] I have checked that there are no existing pull requests for the same thing
