### PR TITLE
Update install.sh to support KDE Neon

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -103,7 +103,7 @@ __atuin_install_linux(){
 	case "$OS" in
 		"arch" | "manjarolinux" | "endeavouros")
 			__atuin_install_arch;;
-		"ubuntu" | "ubuntuwsl" | "debian" | "linuxmint" | "parrot" | "kali" | "elementary" | "pop")
+		"ubuntu" | "ubuntuwsl" | "debian" | "linuxmint" | "parrot" | "kali" | "elementary" | "pop" | "neon")
 			__atuin_install_ubuntu;;
 		*)
 			# TODO: download a binary or smth


### PR DESCRIPTION
KDE Neon is based on Ubuntu 22.04, but the OS List for Ubuntu-based distros does not have the string "neon".  This commit adds it.

<!-- Thank you for making a PR! Bug fixes are always welcome, but if you're adding a new feature or changing an existing one, we'd really appreciate if you open an issue, post on the forum, or drop in on Discord -->

## Checks
- [x] I am happy for maintainers to push small adjustments to this PR, to speed up the review cycle
- [x] I have checked that there are no existing pull requests for the same thing
