### PR TITLE
Update atuin.nu

### DIFF
--- a/atuin/src/shell/atuin.nu
+++ b/atuin/src/shell/atuin.nu
@@ -37,9 +37,9 @@ def _atuin_search_cmd [...flags: string] {
         ([
             `with-env { ATUIN_LOG: error, ATUIN_QUERY: (commandline) } {`,
                 (if $nu_version.0 <= 0 and $nu_version.1 <= 90 { 'commandline' } else { 'commandline edit' }),
-                `(run-external --redirect-stderr atuin search`,
+                (if $nu_version.1 >= 92 { '(run-external atuin search' } else { '(run-external --redirect-stderr atuin search' }),
                     ($flags | append [--interactive] | each {|e| $'"($e)"'}),
-                ` | complete | $in.stderr | str substring ..-1)`,
+                (if $nu_version.1 >= 92 { ' e>| str trim)' } else {' | complete | $in.stderr | str substring ..-1)'}),
             `}`,
         ] | flatten | str join ' '),
     ] | str join "\n"


### PR DESCRIPTION
Nushell will deprecate `--redirect-stderr` flag on upcoming release 0.92.0 due to this pr: https://github.com/nushell/nushell/pull/11934

This pr is going to make atuin compatible with new version

## Checks
- [X] I am happy for maintainers to push small adjustments to this PR, to speed up the review cycle
- [X] I have checked that there are no existing pull requests for the same thing
