### PR TITLE
feat: sync v2 default for new installs

### DIFF
--- a/atuin-client/config.toml
+++ b/atuin-client/config.toml
@@ -197,3 +197,9 @@ enter_accept = true
 [keys]
 # Defaults to true. If disabled, using the up/down key won't exit the TUI when scrolled past the first/last entry.
 # scroll_exits = false
+
+[sync]
+# Enable sync v2 by default
+# This ensures that sync v2 is enabled for new installs only
+# In a later release it will become the default across the board
+records = true


### PR DESCRIPTION
Enable sync v2 by default for new installs

Later, I will change the default for all existing installs. 

## Checks
- [ ] I am happy for maintainers to push small adjustments to this PR, to speed up the review cycle
- [ ] I have checked that there are no existing pull requests for the same thing
