### PR TITLE
feat: add 'ctrl-a a' to jump to beginning of line

### DIFF
--- a/atuin/src/command/client/search/interactive.rs
+++ b/atuin/src/command/client/search/interactive.rs
@@ -295,6 +295,10 @@ impl State {
                 KeyCode::Char('d') => {
                     return InputAction::Delete(self.results_state.selected());
                 }
+                KeyCode::Char('a') => {
+                    self.search.input.start();
+                    return InputAction::Continue;
+                }
                 _ => {}
             }
         }


### PR DESCRIPTION
The `ctrl-a` shortcut (to jump to the beginning of the line) was replaced by the prefix.

tmux handles it in a way so that if `ctrl-a` is the prefix, `ctrl-a a` will jump to the beginning of the line.
This change implements the same machanism in atuin.

## Checks
- [x] I am happy for maintainers to push small adjustments to this PR, to speed up the review cycle
- [x] I have checked that there are no existing pull requests for the same thing

P.S.: I didn't open an issue, because it is a follow-up to #1875
