### PR TITLE
perf(dotfiles): cache aliases and read straight from file

### DIFF
--- a/atuin-client/src/record/sync.rs
+++ b/atuin-client/src/record/sync.rs
@@ -1,11 +1,11 @@
 // do a sync :O
 use std::{cmp::Ordering, fmt::Write};
 
-use eyre::Result;
+use eyre::{Context, Result};
 use thiserror::Error;
 
-use super::store::Store;
-use crate::{api_client::Client, settings::Settings};
+use super::{sqlite_store::SqliteStore, store::Store};
+use crate::{api_client::Client, history::store::HistoryStore, settings::Settings};
 
 use atuin_common::record::{Diff, HostId, RecordId, RecordIdx, RecordStatus};
 use indicatif::{ProgressBar, ProgressState, ProgressStyle};

--- a/atuin-client/src/record/sync.rs
+++ b/atuin-client/src/record/sync.rs
@@ -1,10 +1,10 @@
 // do a sync :O
 use std::{cmp::Ordering, fmt::Write};
 
-use eyre::{Result};
+use eyre::Result;
 use thiserror::Error;
 
-use super::{store::Store};
+use super::store::Store;
 use crate::{api_client::Client, settings::Settings};
 
 use atuin_common::record::{Diff, HostId, RecordId, RecordIdx, RecordStatus};

--- a/atuin-client/src/record/sync.rs
+++ b/atuin-client/src/record/sync.rs
@@ -1,11 +1,11 @@
 // do a sync :O
 use std::{cmp::Ordering, fmt::Write};
 
-use eyre::{Context, Result};
+use eyre::{Result};
 use thiserror::Error;
 
-use super::{sqlite_store::SqliteStore, store::Store};
-use crate::{api_client::Client, history::store::HistoryStore, settings::Settings};
+use super::{store::Store};
+use crate::{api_client::Client, settings::Settings};
 
 use atuin_common::record::{Diff, HostId, RecordId, RecordIdx, RecordStatus};
 use indicatif::{ProgressBar, ProgressState, ProgressStyle};

--- a/atuin-common/src/utils.rs
+++ b/atuin-common/src/utils.rs
@@ -75,6 +75,14 @@ pub fn data_dir() -> PathBuf {
     data_dir.join("atuin")
 }
 
+pub fn dotfiles_cache_dir() -> PathBuf {
+    // In most cases, this will be  ~/.local/share/atuin/dotfiles/cache
+    let data_dir = std::env::var("XDG_DATA_HOME")
+        .map_or_else(|_| home_dir().join(".local").join("share"), PathBuf::from);
+
+    data_dir.join("atuin").join("dotfiles").join("cache")
+}
+
 pub fn get_current_dir() -> String {
     // Prefer PWD environment variable over cwd if available to better support symbolic links
     match env::var("PWD") {

--- a/atuin-dotfiles/src/shell/bash.rs
+++ b/atuin-dotfiles/src/shell/bash.rs
@@ -4,15 +4,15 @@ use crate::store::AliasStore;
 
 async fn cached_aliases(path: PathBuf, store: &AliasStore) -> String {
     match tokio::fs::read_to_string(path).await {
-        Ok(aliases) => return aliases,
+        Ok(aliases) => aliases,
         Err(r) => {
             // we failed to read the file for some reason, but the file does exist
             // fallback to generating new aliases on the fly
-            let aliases = store.posix().await.unwrap_or_else(|e| {
-                format!("echo 'Atuin: failed to read and generate aliases: \n{r}\n{e}'",)
-            });
+            
 
-            return aliases;
+            store.posix().await.unwrap_or_else(|e| {
+                format!("echo 'Atuin: failed to read and generate aliases: \n{r}\n{e}'",)
+            })
         }
     }
 }

--- a/atuin-dotfiles/src/shell/bash.rs
+++ b/atuin-dotfiles/src/shell/bash.rs
@@ -1,12 +1,40 @@
-use super::Alias;
+use std::path::PathBuf;
 
-// Configuration for bash
-pub fn build(aliases: &[Alias]) -> String {
-    let mut config = String::new();
+use crate::store::AliasStore;
 
-    for alias in aliases {
-        config.push_str(&format!("alias {}='{}'\n", alias.name, alias.value));
+async fn cached_aliases(path: PathBuf, store: &AliasStore) -> String {
+    match tokio::fs::read_to_string(path).await {
+        Ok(aliases) => return aliases,
+        Err(r) => {
+            // we failed to read the file for some reason, but the file does exist
+            // fallback to generating new aliases on the fly
+            let aliases = store.posix().await.unwrap_or_else(|e| {
+                format!("echo 'Atuin: failed to read and generate aliases: \n{r}\n{e}'",)
+            });
+
+            return aliases;
+        }
+    }
+}
+
+/// Return bash dotfile config
+///
+/// Do not return an error. We should not prevent the shell from starting.
+///
+/// In the worst case, Atuin should not function but the shell should start correctly.
+///
+/// While currently this only returns aliases, it will be extended to also return other synced dotfiles
+pub async fn config(store: &AliasStore) -> String {
+    // First try to read the cached config
+    let aliases = atuin_common::utils::dotfiles_cache_dir().join("aliases.bash");
+
+    if aliases.exists() {
+        return cached_aliases(aliases, store).await;
     }
 
-    config
+    if let Err(e) = store.build().await {
+        return format!("echo 'Atuin: failed to generate aliases: {}'", e);
+    }
+
+    cached_aliases(aliases, store).await
 }

--- a/atuin-dotfiles/src/shell/bash.rs
+++ b/atuin-dotfiles/src/shell/bash.rs
@@ -8,7 +8,6 @@ async fn cached_aliases(path: PathBuf, store: &AliasStore) -> String {
         Err(r) => {
             // we failed to read the file for some reason, but the file does exist
             // fallback to generating new aliases on the fly
-            
 
             store.posix().await.unwrap_or_else(|e| {
                 format!("echo 'Atuin: failed to read and generate aliases: \n{r}\n{e}'",)

--- a/atuin-dotfiles/src/shell/fish.rs
+++ b/atuin-dotfiles/src/shell/fish.rs
@@ -9,7 +9,6 @@ async fn cached_aliases(path: PathBuf, store: &AliasStore) -> String {
         Err(r) => {
             // we failed to read the file for some reason, but the file does exist
             // fallback to generating new aliases on the fly
-            
 
             store.posix().await.unwrap_or_else(|e| {
                 format!("echo 'Atuin: failed to read and generate aliases: \n{r}\n{e}'",)

--- a/atuin-dotfiles/src/shell/fish.rs
+++ b/atuin-dotfiles/src/shell/fish.rs
@@ -5,15 +5,15 @@ use crate::store::AliasStore;
 
 async fn cached_aliases(path: PathBuf, store: &AliasStore) -> String {
     match tokio::fs::read_to_string(path).await {
-        Ok(aliases) => return aliases,
+        Ok(aliases) => aliases,
         Err(r) => {
             // we failed to read the file for some reason, but the file does exist
             // fallback to generating new aliases on the fly
-            let aliases = store.posix().await.unwrap_or_else(|e| {
-                format!("echo 'Atuin: failed to read and generate aliases: \n{r}\n{e}'",)
-            });
+            
 
-            return aliases;
+            store.posix().await.unwrap_or_else(|e| {
+                format!("echo 'Atuin: failed to read and generate aliases: \n{r}\n{e}'",)
+            })
         }
     }
 }

--- a/atuin-dotfiles/src/shell/fish.rs
+++ b/atuin-dotfiles/src/shell/fish.rs
@@ -1,12 +1,41 @@
-use super::Alias;
-
 // Configuration for fish
-pub fn build(aliases: &[Alias]) -> String {
-    let mut config = String::new();
+use std::path::PathBuf;
 
-    for alias in aliases {
-        config.push_str(&format!("alias {}='{}'\n", alias.name, alias.value));
+use crate::store::AliasStore;
+
+async fn cached_aliases(path: PathBuf, store: &AliasStore) -> String {
+    match tokio::fs::read_to_string(path).await {
+        Ok(aliases) => return aliases,
+        Err(r) => {
+            // we failed to read the file for some reason, but the file does exist
+            // fallback to generating new aliases on the fly
+            let aliases = store.posix().await.unwrap_or_else(|e| {
+                format!("echo 'Atuin: failed to read and generate aliases: \n{r}\n{e}'",)
+            });
+
+            return aliases;
+        }
+    }
+}
+
+/// Return fish dotfile config
+///
+/// Do not return an error. We should not prevent the shell from starting.
+///
+/// In the worst case, Atuin should not function but the shell should start correctly.
+///
+/// While currently this only returns aliases, it will be extended to also return other synced dotfiles
+pub async fn config(store: &AliasStore) -> String {
+    // First try to read the cached config
+    let aliases = atuin_common::utils::dotfiles_cache_dir().join("aliases.fish");
+
+    if aliases.exists() {
+        return cached_aliases(aliases, store).await;
     }
 
-    config
+    if let Err(e) = store.build().await {
+        return format!("echo 'Atuin: failed to generate aliases: {}'", e);
+    }
+
+    cached_aliases(aliases, store).await
 }

--- a/atuin-dotfiles/src/shell/xonsh.rs
+++ b/atuin-dotfiles/src/shell/xonsh.rs
@@ -8,7 +8,6 @@ async fn cached_aliases(path: PathBuf, store: &AliasStore) -> String {
         Err(r) => {
             // we failed to read the file for some reason, but the file does exist
             // fallback to generating new aliases on the fly
-            
 
             store.xonsh().await.unwrap_or_else(|e| {
                 format!("echo 'Atuin: failed to read and generate aliases: \n{r}\n{e}'",)

--- a/atuin-dotfiles/src/shell/xonsh.rs
+++ b/atuin-dotfiles/src/shell/xonsh.rs
@@ -1,12 +1,40 @@
-use super::Alias;
+use std::path::PathBuf;
 
-// Configuration for xonsh
-pub fn build(aliases: &[Alias]) -> String {
-    let mut config = String::new();
+use crate::store::AliasStore;
 
-    for alias in aliases {
-        config.push_str(&format!("aliases['{}'] ='{}'\n", alias.name, alias.value));
+async fn cached_aliases(path: PathBuf, store: &AliasStore) -> String {
+    match tokio::fs::read_to_string(path).await {
+        Ok(aliases) => return aliases,
+        Err(r) => {
+            // we failed to read the file for some reason, but the file does exist
+            // fallback to generating new aliases on the fly
+            let aliases = store.xonsh().await.unwrap_or_else(|e| {
+                format!("echo 'Atuin: failed to read and generate aliases: \n{r}\n{e}'",)
+            });
+
+            return aliases;
+        }
+    }
+}
+
+/// Return xonsh dotfile config
+///
+/// Do not return an error. We should not prevent the shell from starting.
+///
+/// In the worst case, Atuin should not function but the shell should start correctly.
+///
+/// While currently this only returns aliases, it will be extended to also return other synced dotfiles
+pub async fn config(store: &AliasStore) -> String {
+    // First try to read the cached config
+    let aliases = atuin_common::utils::dotfiles_cache_dir().join("aliases.xsh");
+
+    if aliases.exists() {
+        return cached_aliases(aliases, store).await;
     }
 
-    config
+    if let Err(e) = store.build().await {
+        return format!("echo 'Atuin: failed to generate aliases: {}'", e);
+    }
+
+    cached_aliases(aliases, store).await
 }

--- a/atuin-dotfiles/src/shell/xonsh.rs
+++ b/atuin-dotfiles/src/shell/xonsh.rs
@@ -4,15 +4,15 @@ use crate::store::AliasStore;
 
 async fn cached_aliases(path: PathBuf, store: &AliasStore) -> String {
     match tokio::fs::read_to_string(path).await {
-        Ok(aliases) => return aliases,
+        Ok(aliases) => aliases,
         Err(r) => {
             // we failed to read the file for some reason, but the file does exist
             // fallback to generating new aliases on the fly
-            let aliases = store.xonsh().await.unwrap_or_else(|e| {
-                format!("echo 'Atuin: failed to read and generate aliases: \n{r}\n{e}'",)
-            });
+            
 
-            return aliases;
+            store.xonsh().await.unwrap_or_else(|e| {
+                format!("echo 'Atuin: failed to read and generate aliases: \n{r}\n{e}'",)
+            })
         }
     }
 }

--- a/atuin-dotfiles/src/shell/zsh.rs
+++ b/atuin-dotfiles/src/shell/zsh.rs
@@ -8,7 +8,7 @@ async fn cached_aliases(path: PathBuf, store: &AliasStore) -> String {
         Err(r) => {
             // we failed to read the file for some reason, but the file does exist
             // fallback to generating new aliases on the fly
-            let aliases = store.zsh().await.unwrap_or_else(|e| {
+            let aliases = store.posix().await.unwrap_or_else(|e| {
                 format!("echo 'Atuin: failed to read and generate aliases: \n{r}\n{e}'",)
             });
 

--- a/atuin-dotfiles/src/shell/zsh.rs
+++ b/atuin-dotfiles/src/shell/zsh.rs
@@ -1,12 +1,40 @@
-use super::Alias;
+use std::path::PathBuf;
 
-// Configuration for zsh
-pub fn build(aliases: &[Alias]) -> String {
-    let mut config = String::new();
+use crate::store::AliasStore;
 
-    for alias in aliases {
-        config.push_str(&format!("alias {}='{}'\n", alias.name, alias.value));
+async fn cached_aliases(path: PathBuf, store: &AliasStore) -> String {
+    match tokio::fs::read_to_string(path).await {
+        Ok(aliases) => return aliases,
+        Err(r) => {
+            // we failed to read the file for some reason, but the file does exist
+            // fallback to generating new aliases on the fly
+            let aliases = store.zsh().await.unwrap_or_else(|e| {
+                format!("echo 'Atuin: failed to read and generate aliases: \n{r}\n{e}'",)
+            });
+
+            return aliases;
+        }
+    }
+}
+
+/// Return zsh dotfile config
+///
+/// Do not return an error. We should not prevent the shell from starting.
+///
+/// In the worst case, Atuin should not function but the shell should start correctly.
+///
+/// While currently this only returns aliases, it will be extended to also return other synced dotfiles
+pub async fn config(store: &AliasStore) -> String {
+    // First try to read the cached config
+    let aliases = atuin_common::utils::dotfiles_cache_dir().join("aliases.zsh");
+
+    if aliases.exists() {
+        return cached_aliases(aliases, store).await;
     }
 
-    config
+    if let Err(e) = store.build().await {
+        return format!("echo 'Atuin: failed to generate aliases: {}'", e);
+    }
+
+    cached_aliases(aliases, store).await
 }

--- a/atuin-dotfiles/src/shell/zsh.rs
+++ b/atuin-dotfiles/src/shell/zsh.rs
@@ -4,15 +4,15 @@ use crate::store::AliasStore;
 
 async fn cached_aliases(path: PathBuf, store: &AliasStore) -> String {
     match tokio::fs::read_to_string(path).await {
-        Ok(aliases) => return aliases,
+        Ok(aliases) => aliases,
         Err(r) => {
             // we failed to read the file for some reason, but the file does exist
             // fallback to generating new aliases on the fly
-            let aliases = store.posix().await.unwrap_or_else(|e| {
-                format!("echo 'Atuin: failed to read and generate aliases: \n{r}\n{e}'",)
-            });
+            
 
-            return aliases;
+            store.posix().await.unwrap_or_else(|e| {
+                format!("echo 'Atuin: failed to read and generate aliases: \n{r}\n{e}'",)
+            })
         }
     }
 }

--- a/atuin-dotfiles/src/shell/zsh.rs
+++ b/atuin-dotfiles/src/shell/zsh.rs
@@ -8,7 +8,6 @@ async fn cached_aliases(path: PathBuf, store: &AliasStore) -> String {
         Err(r) => {
             // we failed to read the file for some reason, but the file does exist
             // fallback to generating new aliases on the fly
-            
 
             store.posix().await.unwrap_or_else(|e| {
                 format!("echo 'Atuin: failed to read and generate aliases: \n{r}\n{e}'",)

--- a/atuin-dotfiles/src/store.rs
+++ b/atuin-dotfiles/src/store.rs
@@ -1,5 +1,5 @@
 use std::collections::BTreeMap;
-use std::path::PathBuf;
+
 
 use atuin_client::record::sqlite_store::SqliteStore;
 // Sync aliases

--- a/atuin-dotfiles/src/store.rs
+++ b/atuin-dotfiles/src/store.rs
@@ -1,6 +1,5 @@
 use std::collections::BTreeMap;
 
-
 use atuin_client::record::sqlite_store::SqliteStore;
 // Sync aliases
 // This will be noticeable similar to the kv store, though I expect the two shall diverge

--- a/atuin/src/command/client/history.rs
+++ b/atuin/src/command/client/history.rs
@@ -365,7 +365,7 @@ impl Cmd {
                     let (_, downloaded) = record::sync::sync(settings, &store).await?;
                     Settings::save_sync_time()?;
 
-                    history_store.incremental_build(db, &downloaded).await?;
+                    crate::sync::build(settings, &store, db, Some(&downloaded)).await?;
                 } else {
                     debug!("running periodic background sync");
                     sync::sync(settings, false, db).await?;

--- a/atuin/src/command/client/init/bash.rs
+++ b/atuin/src/command/client/init/bash.rs
@@ -18,8 +18,7 @@ pub fn init_static(disable_up_arrow: bool, disable_ctrl_r: bool) {
 pub async fn init(store: AliasStore, disable_up_arrow: bool, disable_ctrl_r: bool) -> Result<()> {
     init_static(disable_up_arrow, disable_ctrl_r);
 
-    let aliases = store.aliases().await?;
-    let aliases = atuin_dotfiles::shell::bash::build(&aliases[..]);
+    let aliases = atuin_dotfiles::shell::bash::config(&store).await;
 
     println!("{aliases}");
 

--- a/atuin/src/command/client/init/fish.rs
+++ b/atuin/src/command/client/init/fish.rs
@@ -37,8 +37,7 @@ bind -M insert \e\[A _atuin_bind_up";
 pub async fn init(store: AliasStore, disable_up_arrow: bool, disable_ctrl_r: bool) -> Result<()> {
     init_static(disable_up_arrow, disable_ctrl_r);
 
-    let aliases = store.aliases().await?;
-    let aliases = atuin_dotfiles::shell::fish::build(&aliases[..]);
+    let aliases = atuin_dotfiles::shell::fish::config(&store).await;
 
     println!("{aliases}");
 

--- a/atuin/src/command/client/init/xonsh.rs
+++ b/atuin/src/command/client/init/xonsh.rs
@@ -23,8 +23,7 @@ pub fn init_static(disable_up_arrow: bool, disable_ctrl_r: bool) {
 pub async fn init(store: AliasStore, disable_up_arrow: bool, disable_ctrl_r: bool) -> Result<()> {
     init_static(disable_up_arrow, disable_ctrl_r);
 
-    let aliases = store.aliases().await?;
-    let aliases = atuin_dotfiles::shell::xonsh::build(&aliases[..]);
+    let aliases = atuin_dotfiles::shell::xonsh::config(&store).await;
 
     println!("{aliases}");
 

--- a/atuin/src/command/client/init/zsh.rs
+++ b/atuin/src/command/client/init/zsh.rs
@@ -31,8 +31,7 @@ bindkey -M vicmd 'k' atuin-up-search-vicmd";
 pub async fn init(store: AliasStore, disable_up_arrow: bool, disable_ctrl_r: bool) -> Result<()> {
     init_static(disable_up_arrow, disable_ctrl_r);
 
-    let aliases = store.aliases().await?;
-    let aliases = atuin_dotfiles::shell::zsh::build(&aliases[..]);
+    let aliases = atuin_dotfiles::shell::zsh::config(&store).await;
 
     println!("{aliases}");
 

--- a/atuin/src/command/client/store/pull.rs
+++ b/atuin/src/command/client/store/pull.rs
@@ -1,3 +1,4 @@
+use atuin_dotfiles::store::AliasStore;
 use clap::Args;
 use eyre::{Result, WrapErr};
 
@@ -73,13 +74,7 @@ impl Pull {
 
         println!("Downloaded {} records", downloaded.len());
 
-        let encryption_key: [u8; 32] = encryption::load_key(settings)
-            .context("could not load encryption key")?
-            .into();
-
-        let host_id = Settings::host_id().expect("failed to get host_id");
-        let history_store = HistoryStore::new(store.clone(), host_id, encryption_key);
-        history_store.incremental_build(db, &downloaded).await?;
+        crate::sync::build(settings, &store, db, Some(&downloaded)).await?;
 
         Ok(())
     }

--- a/atuin/src/command/client/store/pull.rs
+++ b/atuin/src/command/client/store/pull.rs
@@ -1,6 +1,5 @@
-
 use clap::Args;
-use eyre::{Result};
+use eyre::Result;
 
 use atuin_client::{
     database::Database,

--- a/atuin/src/command/client/store/pull.rs
+++ b/atuin/src/command/client/store/pull.rs
@@ -1,11 +1,9 @@
-use atuin_dotfiles::store::AliasStore;
+
 use clap::Args;
-use eyre::{Result, WrapErr};
+use eyre::{Result};
 
 use atuin_client::{
     database::Database,
-    encryption,
-    history::store::HistoryStore,
     record::store::Store,
     record::sync::Operation,
     record::{sqlite_store::SqliteStore, sync},

--- a/atuin/src/command/client/sync.rs
+++ b/atuin/src/command/client/sync.rs
@@ -90,7 +90,7 @@ async fn run(
 
         let (uploaded, downloaded) = sync::sync(settings, &store).await?;
 
-        history_store.incremental_build(db, &downloaded).await?;
+        crate::sync::build(settings, &store, db, Some(&downloaded)).await?;
 
         println!("{uploaded}/{} up/down to record store", downloaded.len());
 
@@ -113,7 +113,7 @@ async fn run(
             // we'll want to run sync once more, as there will now be stuff to upload
             let (uploaded, downloaded) = sync::sync(settings, &store).await?;
 
-            history_store.incremental_build(db, &downloaded).await?;
+            crate::sync::build(settings, &store, db, Some(&downloaded)).await?;
 
             println!("{uploaded}/{} up/down to record store", downloaded.len());
         }

--- a/atuin/src/main.rs
+++ b/atuin/src/main.rs
@@ -7,6 +7,7 @@ use eyre::Result;
 use command::AtuinCmd;
 
 mod command;
+mod sync;
 
 const VERSION: &str = env!("CARGO_PKG_VERSION");
 const SHA: &str = env!("GIT_HASH");

--- a/atuin/src/main.rs
+++ b/atuin/src/main.rs
@@ -7,6 +7,8 @@ use eyre::Result;
 use command::AtuinCmd;
 
 mod command;
+
+#[cfg(feature = "sync")]
 mod sync;
 
 const VERSION: &str = env!("CARGO_PKG_VERSION");

--- a/atuin/src/sync.rs
+++ b/atuin/src/sync.rs
@@ -25,7 +25,7 @@ pub async fn build(
 
     let host_id = Settings::host_id().expect("failed to get host_id");
 
-    let downloaded = downloaded.unwrap_or_else(|| &[]);
+    let downloaded = downloaded.unwrap_or(&[]);
 
     let history_store = HistoryStore::new(store.clone(), host_id, encryption_key);
     let alias_store = AliasStore::new(store.clone(), host_id, encryption_key);

--- a/atuin/src/sync.rs
+++ b/atuin/src/sync.rs
@@ -1,0 +1,37 @@
+use atuin_dotfiles::store::AliasStore;
+use eyre::{Context, Result};
+
+use atuin_client::{
+    database::Database, history::store::HistoryStore, record::sqlite_store::SqliteStore,
+    settings::Settings,
+};
+use atuin_common::record::RecordId;
+
+/// This is the only crate that ties together all other crates.
+/// Therefore, it's the only crate where functions tying together all stores can live
+
+/// Rebuild all stores after a sync
+/// Note: for history, this only does an _incremental_ sync. Hence the need to specify downloaded
+/// records.
+pub async fn build(
+    settings: &Settings,
+    store: &SqliteStore,
+    db: &dyn Database,
+    downloaded: Option<&[RecordId]>,
+) -> Result<()> {
+    let encryption_key: [u8; 32] = atuin_client::encryption::load_key(settings)
+        .context("could not load encryption key")?
+        .into();
+
+    let host_id = Settings::host_id().expect("failed to get host_id");
+
+    let downloaded = downloaded.unwrap_or_else(|| &[]);
+
+    let history_store = HistoryStore::new(store.clone(), host_id, encryption_key);
+    let alias_store = AliasStore::new(store.clone(), host_id, encryption_key);
+
+    history_store.incremental_build(db, downloaded).await?;
+    alias_store.build().await?;
+
+    Ok(())
+}


### PR DESCRIPTION
Previously, we'd rebuild all aliases from sqlite every single time the shell started. This is... ok? 

But not great.

With more aliases, we get slower shell starts. On a new-ish macbook pro this isn't too bad, but I imagine it gets worse with older hardware, and especially spinning rust.

This PR builds aliases into cached files every time they are mutated - either locally, or from sync. From there, starting a new shell is pretty much just reading and printing a file.

I've also neatened up the store "building" code a bit

I'd like to follow up with removing the async runtime from the init path if possible, as that is adding overhead and isn't needed to read the cached file. If the cache doesn't exist, we can start tokio and build it.

There's some obvious duplication here that could be cleaned up. I decided that I'd rather leave it as-is, so that future dotfiles have a nice path to follow. While aliases are the same for posix shells, not everything will be

## Checks
- [ ] I am happy for maintainers to push small adjustments to this PR, to speed up the review cycle
- [ ] I have checked that there are no existing pull requests for the same thing
