### PR TITLE
fix(bash): do not use "return" to cancel initialization

### DIFF
--- a/atuin/src/shell/atuin.bash
+++ b/atuin/src/shell/atuin.bash
@@ -1,15 +1,16 @@
 # Include guard
-[[ ${__atuin_initialized-} == true ]] && return 0
-__atuin_initialized=true
-
-# Enable only in interactive shells
-[[ $- == *i* ]] || return 0
-
-# Require bash >= 3.1
-if ((BASH_VERSINFO[0] < 3 || BASH_VERSINFO[0] == 3 && BASH_VERSINFO[1] < 1)); then
+if [[ ${__atuin_initialized-} == true ]]; then
+    false
+elif [[ $- != *i* ]]; then
+    # Enable only in interactive shells
+    false
+elif ((BASH_VERSINFO[0] < 3 || BASH_VERSINFO[0] == 3 && BASH_VERSINFO[1] < 1)); then
+    # Require bash >= 3.1
     [[ -t 2 ]] && printf 'atuin: requires bash >= 3.1 for the integration.\n' >&2
-    return 0
-fi
+    false
+else # (include guard) beginning of main content
+#------------------------------------------------------------------------------
+__atuin_initialized=true
 
 ATUIN_SESSION=$(atuin uuid)
 ATUIN_STTY=$(stty -g)
@@ -318,3 +319,6 @@ if [[ $__atuin_bind_up_arrow == true ]]; then
         bind -m vi-command -x '"k": "\C-x\C-p"'
     fi
 fi
+
+#------------------------------------------------------------------------------
+fi # (include guard) end of main content


### PR DESCRIPTION
In #1533, I used `return 0` for the "include guards" of Atuin's initialization. However, I noticed that it would unexpectedly cancel the entire processing of `~/.bashrc` because it is evaluated by `eval`. This is my fault. In this PR, I suggest enclosing the entire content of the integration code within a `if`-statement.

### Estimation on the impact

I expect the impact of `return 0` would not be so big since the problem only happens when (i) `~/.bashrc` is sourced twice in an interactive session, (ii) `eval "$(atuin init bash)"` is performed outside the interactive sessions, or (iii) it is performed in a very old version of Bash for which Atuin's doesn't offer the support. For case (ii), with a typical `.bashrc` starting with `case $- in *i*) ;; *) return ;; esac` (or equivalent), `eval "$(atuin init bash)"` is usually performed only in interactive sessions. For case (iii), Atuin's initialization anyway produces an error message, so the setup is technically wrong. If the user use mixed versions of Bash, the user is supposed to check the Bash version at the caller side in `~/.bashrc` before evaluating `eval "$(atuin init bash)"`.

<!-- Thank you for making a PR! Bug fixes are always welcome, but if you're adding a new feature or changing an existing one, we'd really appreciate if you open an issue, post on the forum, or drop in on Discord -->

## Checks
- [x] I am happy for maintainers to push small adjustments to this PR, to speed up the review cycle
- [x] I have checked that there are no existing pull requests for the same thing
