### PR TITLE
feat: prevents stderr from going to the screen when syncing nushell

### DIFF
--- a/atuin/src/shell/atuin.nu
+++ b/atuin/src/shell/atuin.nu
@@ -24,7 +24,7 @@ let _atuin_pre_prompt = {||
         return
     }
     with-env { ATUIN_LOG: error } {
-        do { atuin history end $'--exit=($last_exit)' -- $env.ATUIN_HISTORY_ID | null } | null
+        do { atuin history end $'--exit=($last_exit)' -- $env.ATUIN_HISTORY_ID } | complete
 
     }
     hide-env ATUIN_HISTORY_ID


### PR DESCRIPTION
I have no idea why this works, but it does! The problem was that when atuin was syncing after a command, it would print the progress bar, this fixes it!

## Checks
- [x] I am happy for maintainers to push small adjustments to this PR, to speed up the review cycle
- [x] I have checked that there are no existing pull requests for the same thing
