### PR TITLE
nushell: use version.(major|minor|patch) if available

### DIFF
--- a/crates/atuin/src/shell/atuin.nu
+++ b/crates/atuin/src/shell/atuin.nu
@@ -31,7 +31,17 @@ let _atuin_pre_prompt = {||
 }
 
 def _atuin_search_cmd [...flags: string] {
-    let nu_version = ($env.NU_VERSION | split row '.' | each { || into int })
+    let nu_version = do {
+        let version = version
+        let major = $version.major?
+        if $major != null {
+            # These members are only available in versions > 0.92.2
+            [$major $version.minor $version.patch]
+        } else {
+            # So fall back to the slower parsing when they're missing
+            $version.version | split row '.' | into int
+        }
+    }
     [
         $ATUIN_KEYBINDING_TOKEN,
         ([


### PR DESCRIPTION
<!-- Thank you for making a PR! Bug fixes are always welcome, but if you're adding a new feature or changing an existing one, we'd really appreciate if you open an issue, post on the forum, or drop in on Discord -->

I added `(version).major` and others like it in https://github.com/nushell/nushell/issues/12561 to make atuin's life easier regarding version parsing.

At the moment we obviously have to keep the support for older versions but in a year (or more?) we will be able to reasonably just use the new members I think and make that part of the script much cleaner 🤞 

## Checks
- [x] I am happy for maintainers to push small adjustments to this PR, to speed up the review cycle
- [x] I have checked that there are no existing pull requests for the same thing