### PR TITLE
fix(dotfiles): unquote aliases before quoting

### DIFF
--- a/crates/atuin-common/src/utils.rs
+++ b/crates/atuin-common/src/utils.rs
@@ -2,6 +2,8 @@ use std::borrow::Cow;
 use std::env;
 use std::path::PathBuf;
 
+use eyre::{eyre, Result};
+
 use rand::RngCore;
 use uuid::Uuid;
 
@@ -142,6 +144,30 @@ pub trait Escapable: AsRef<str> {
             buf.into()
         }
     }
+}
+
+pub fn unquote(s: &str) -> Result<String> {
+    if s.chars().count() < 2 {
+        return Err(eyre!("not enough chars"));
+    }
+
+    let quote = s.chars().next().unwrap();
+
+    // not quoted, do nothing
+    if quote != '"' && quote != '\'' && quote != '`' {
+        return Ok(s.to_string());
+    }
+
+    if s.chars().last().unwrap() != quote {
+        return Err(eyre!("unexpected eof, quotes do not match"));
+    }
+
+    // removes quote characters
+    // the sanity checks performed above ensure that the quotes will be ASCII and this will not
+    // panic
+    let s = &s[1..s.len() - 1];
+
+    Ok(s.to_string())
 }
 
 impl<T: AsRef<str>> Escapable for T {}

--- a/crates/atuin-dotfiles/src/store.rs
+++ b/crates/atuin-dotfiles/src/store.rs
@@ -6,6 +6,7 @@ use atuin_client::record::sqlite_store::SqliteStore;
 // While we will support a range of shell config, I'd rather have a larger number of small records
 // + stores, rather than one mega config store.
 use atuin_common::record::{DecryptedData, Host, HostId};
+use atuin_common::utils::unquote;
 use eyre::{bail, ensure, eyre, Result};
 
 use atuin_client::record::encryption::PASETO_V4;
@@ -142,7 +143,11 @@ impl AliasStore {
         let mut config = String::new();
 
         for alias in aliases {
-            config.push_str(&format!("alias {}='{}'\n", alias.name, alias.value));
+            // If it's quoted, remove the quotes. If it's not quoted, do nothing.
+            let value = unquote(alias.value.as_str()).unwrap_or(alias.value.clone());
+
+            // we're about to quote it ourselves anyway!
+            config.push_str(&format!("alias {}='{}'\n", alias.name, value));
         }
 
         Ok(config)
@@ -171,7 +176,7 @@ impl AliasStore {
         // All the same contents, maybe optimize in the future or perhaps there will be quirks
         // per-shell
         // I'd prefer separation atm
-        let zsh = dir.join("aliases.zsh");
+        let zsh = dir.join("aliases.zsh-boop");
         let bash = dir.join("aliases.bash");
         let fish = dir.join("aliases.fish");
         let xsh = dir.join("aliases.xsh");


### PR DESCRIPTION
We want to quote all aliases when setting config. Aliases in the store may be quoted, but may also be unquoted.

First normalise to unquoted, then quote.

## Checks
- [ ] I am happy for maintainers to push small adjustments to this PR, to speed up the review cycle
- [ ] I have checked that there are no existing pull requests for the same thing
