### PR TITLE
chore: add some more debug logs

### DIFF
--- a/crates/atuin-server/src/handlers/v0/record.rs
+++ b/crates/atuin-server/src/handlers/v0/record.rs
@@ -70,6 +70,8 @@ pub async fn index<DB: Database>(
         }
     };
 
+    tracing::debug!(user = user.username, "record index request");
+
     Ok(Json(record_index))
 }
 


### PR DESCRIPTION
P99 is usually <100ms which is excellent, but occasionally has big spikes to 1000ms. This is only on the record index.

I don't want this to get out of hand. I've ran a few test queries and they all complete very fast, and are purely index scans.

Hopefully this helps figure out if it's a specific user with tonnes of stores or something? Otherwise there could be something up with my db.

I should probably also figure out some proper log levels or tracing lol.

<!-- Thank you for making a PR! Bug fixes are always welcome, but if you're adding a new feature or changing an existing one, we'd really appreciate if you open an issue, post on the forum, or drop in on Discord -->

## Checks
- [ ] I am happy for maintainers to push small adjustments to this PR, to speed up the review cycle
- [ ] I have checked that there are no existing pull requests for the same thing
