### PR TITLE
feat: add env syncing support for nushell

### DIFF
--- a/crates/atuin-dotfiles/src/shell.rs
+++ b/crates/atuin-dotfiles/src/shell.rs
@@ -10,6 +10,7 @@ pub mod bash;
 pub mod fish;
 pub mod xonsh;
 pub mod zsh;
+pub mod nu;
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 pub struct Alias {

--- a/crates/atuin-dotfiles/src/shell/nu.rs
+++ b/crates/atuin-dotfiles/src/shell/nu.rs
@@ -1,0 +1,7 @@
+pub async fn var_config() -> String {
+    // Because nushell won't autoupdate, we just parse the output of `atuin dotfiles var list` in
+    // nushell and load the env vars that way
+
+    // we should only do this if the dotfiles are enabled
+    String::from(r#"atuin dotfiles var list | lines | parse "export {name}={value}" | reduce -f {} {|it, acc| $acc | upsert $it.name $it.value} | load-env"#)
+}

--- a/crates/atuin/src/command/client/init/nu.rs
+++ b/crates/atuin/src/command/client/init/nu.rs
@@ -1,0 +1,55 @@
+use eyre::Result;
+
+const BIND_CTRL_R: &str = r"$env.config = (
+    $env.config | upsert keybindings (
+        $env.config.keybindings
+        | append {
+            name: atuin
+            modifier: control
+            keycode: char_r
+            mode: [emacs, vi_normal, vi_insert]
+            event: { send: executehostcommand cmd: (_atuin_search_cmd) }
+        }
+    )
+)";
+const BIND_UP_ARROW: &str = r"
+$env.config = (
+    $env.config | upsert keybindings (
+        $env.config.keybindings
+        | append {
+            name: atuin
+            modifier: none
+            keycode: up
+            mode: [emacs, vi_normal, vi_insert]
+            event: {
+                until: [
+                    {send: menuup}
+                    {send: executehostcommand cmd: (_atuin_search_cmd '--shell-up-key-binding') }
+                ]
+            }
+        }
+    )
+)
+";
+
+pub fn init_static(disable_up_arrow: bool, disable_ctrl_r: bool) {
+    let full = include_str!("../../../shell/atuin.nu");
+    println!("{full}");
+
+    if !disable_ctrl_r && std::env::var("ATUIN_NOBIND").is_err() {
+        println!("{BIND_CTRL_R}");
+    }
+    if !disable_up_arrow && std::env::var("ATUIN_NOBIND").is_err() {
+        println!("{BIND_UP_ARROW}");
+    }
+}
+
+pub async fn init(disable_up_arrow: bool, disable_ctrl_r: bool) -> Result<()> {
+    init_static(disable_up_arrow, disable_ctrl_r);
+
+    let vars = atuin_dotfiles::shell::nu::var_config().await;
+
+    println!("{vars}");
+
+    Ok(())
+}


### PR DESCRIPTION
Adds support for env syncing for nushell, it auto updates because it just parses `autin dotfiles var list` at runtime.

## Checks
- [x] I am happy for maintainers to push small adjustments to this PR, to speed up the review cycle
- [x] I have checked that there are no existing pull requests for the same thing
