### PR TITLE
refactor: preview_auto to use enum and different option

### DIFF
--- a/crates/atuin-client/config.toml
+++ b/crates/atuin-client/config.toml
@@ -71,12 +71,7 @@
 
 ## enable or disable showing a preview of the selected command
 ## useful when the command is longer than the terminal width and is cut off
-# show_preview = false
-
-## enable or disable automatic preview. It shows a preview, if the command is
-## longer than the width of the terminal. It respects max_preview_height.
-## (default: true)
-# show_preview_auto = true
+# show_preview = true
 
 ## what to do when the escape key is pressed when searching
 ## possible values: return-original, return-query
@@ -208,3 +203,10 @@ enter_accept = true
 # This ensures that sync v2 is enabled for new installs only
 # In a later release it will become the default across the board
 records = true
+
+[preview]
+## which preview strategy to use to calculate the preview height (respects max_preview_height).
+## possible values: auto, static
+## auto: length of the selected command.
+## static: length of the longest command stored in the history.
+# strategy = auto

--- a/crates/atuin-client/src/settings.rs
+++ b/crates/atuin-client/src/settings.rs
@@ -350,7 +350,7 @@ impl Default for Preview {
     }
 }
 
-// The preview hight strategy also takes max_preview_height into account.
+// The preview height strategy also takes max_preview_height into account.
 #[derive(Clone, Debug, Deserialize, Copy, PartialEq, Eq, ValueEnum, Serialize)]
 pub enum PreviewStrategy {
     // Preview height is calculated for the length of the selected command.

--- a/crates/atuin-client/src/settings.rs
+++ b/crates/atuin-client/src/settings.rs
@@ -338,6 +338,31 @@ pub struct Keys {
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct Preview {
+    pub strategy: PreviewStrategy,
+}
+
+impl Default for Preview {
+    fn default() -> Self {
+        Self {
+            strategy: PreviewStrategy::Auto,
+        }
+    }
+}
+
+// The preview hight strategy also takes max_preview_height into account.
+#[derive(Clone, Debug, Deserialize, Copy, PartialEq, Eq, ValueEnum, Serialize)]
+pub enum PreviewStrategy {
+    // Preview height is calculated for the length of the selected command.
+    #[serde(rename = "auto")]
+    Auto,
+
+    // Preview height is calculated for the length of the longest command stored in the history.
+    #[serde(rename = "static")]
+    Static,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Settings {
     pub dialect: Dialect,
     pub timezone: Timezone,
@@ -358,7 +383,6 @@ pub struct Settings {
     pub inline_height: u16,
     pub invert: bool,
     pub show_preview: bool,
-    pub show_preview_auto: bool,
     pub max_preview_height: u16,
     pub show_help: bool,
     pub show_tabs: bool,
@@ -397,6 +421,9 @@ pub struct Settings {
 
     #[serde(default)]
     pub keys: Keys,
+
+    #[serde(default)]
+    pub preview: Preview,
 
     #[serde(default)]
     pub dotfiles: dotfiles::Settings,
@@ -615,8 +642,7 @@ impl Settings {
             .set_default("filter_mode", "global")?
             .set_default("style", "auto")?
             .set_default("inline_height", 0)?
-            .set_default("show_preview", false)?
-            .set_default("show_preview_auto", true)?
+            .set_default("show_preview", true)?
             .set_default("max_preview_height", 4)?
             .set_default("show_help", true)?
             .set_default("show_tabs", true)?

--- a/crates/atuin/src/command/client/search/interactive.rs
+++ b/crates/atuin/src/command/client/search/interactive.rs
@@ -22,7 +22,9 @@ use unicode_width::UnicodeWidthStr;
 use atuin_client::{
     database::{current_context, Database},
     history::{store::HistoryStore, History, HistoryStats},
-    settings::{CursorStyle, ExitMode, FilterMode, KeymapMode, SearchMode, Settings},
+    settings::{
+        CursorStyle, ExitMode, FilterMode, KeymapMode, PreviewStrategy, SearchMode, Settings,
+    },
 };
 
 use super::{
@@ -544,7 +546,11 @@ impl State {
         border_size: u16,
         preview_width: u16,
     ) -> u16 {
-        if settings.show_preview_auto && tab_index == 0 && !results.is_empty() {
+        if settings.show_preview
+            && settings.preview.strategy == PreviewStrategy::Auto
+            && tab_index == 0
+            && !results.is_empty()
+        {
             let length_current_cmd = results[selected].command.len() as u16;
             // The '- 19' takes the characters before the command (duration and time) into account
             if length_current_cmd > preview_width - 19 {
@@ -556,7 +562,10 @@ impl State {
             } else {
                 1
             }
-        } else if settings.show_preview && !settings.show_preview_auto && tab_index == 0 {
+        } else if settings.show_preview
+            && settings.preview.strategy == PreviewStrategy::Static
+            && tab_index == 0
+        {
             let longest_command = results
                 .iter()
                 .max_by(|h1, h2| h1.command.len().cmp(&h2.command.len()));
@@ -1179,25 +1188,33 @@ fn set_clipboard(_s: String) {}
 #[cfg(test)]
 mod tests {
     use atuin_client::history::History;
-    use atuin_client::settings::Settings;
+    use atuin_client::settings::{Preview, PreviewStrategy, Settings};
 
     use super::State;
 
     #[test]
     fn calc_preview_height_test() {
         let settings_preview_auto = Settings {
-            show_preview_auto: true,
+            preview: Preview {
+                strategy: PreviewStrategy::Auto,
+            },
+            show_preview: true,
             ..Settings::utc()
         };
 
         let settings_preview_auto_h2 = Settings {
-            show_preview_auto: true,
+            preview: Preview {
+                strategy: PreviewStrategy::Auto,
+            },
+            show_preview: true,
             max_preview_height: 2,
             ..Settings::utc()
         };
 
         let settings_preview_h4 = Settings {
-            show_preview_auto: false,
+            preview: Preview {
+                strategy: PreviewStrategy::Static,
+            },
             show_preview: true,
             max_preview_height: 4,
             ..Settings::utc()


### PR DESCRIPTION
This is a follow-up PR to #1804. It implements an enum and adds a new table `[preview]` (should be used for `max_preview_height` and `show_preview` when the new settings are implemented, although the keys should be renamed then) and the `show_preview_auto` option has been renamed as mentioned in https://github.com/atuinsh/atuin/pull/991#issuecomment-2081664065

```yaml
[preview]
strategy = auto (default) | static (max_of_all_cmds)   # was show_preview_auto
```

However, I am contemplating whether to change the naming:

strategy -> mode
auto -> dynamic

I believe 
- `mode` is used in other settings and thus it might be more consistent.
- `dynamic` as it determines the height dynamically. `auto` also fits, so I really have no clue which one is better.

@ellie what do you think?

## Checks
- [x] I am happy for maintainers to push small adjustments to this PR, to speed up the review cycle
- [x] I have checked that there are no existing pull requests for the same thing
