### PR TITLE
fix(config): add quotes for strategy value in comment

### DIFF
--- a/crates/atuin-client/config.toml
+++ b/crates/atuin-client/config.toml
@@ -209,4 +209,4 @@ records = true
 ## possible values: auto, static
 ## auto: length of the selected command.
 ## static: length of the longest command stored in the history.
-# strategy = auto
+# strategy = "auto"


### PR DESCRIPTION
Sorry, I forgot the quotes...

```toml
# strategy = "auto"
```

## Checks
- [x] I am happy for maintainers to push small adjustments to this PR, to speed up the review cycle
- [x] I have checked that there are no existing pull requests for the same thing
