### PR TITLE
fix(dotfiles): allow clearing aliases, disable import

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -207,6 +207,7 @@ dependencies = [
  "itertools",
  "log",
  "ratatui",
+ "regex",
  "rpassword",
  "runtime-format",
  "rustix",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ exclude = ["ui/backend"]
 [workspace.package]
 version = "18.2.0"
 authors = ["Ellie Huxtable <ellie@elliehuxtable.com>"]
-rust-version = "1.67"
+rust-version = "1.70"
 license = "MIT"
 homepage = "https://atuin.sh"
 repository = "https://github.com/atuinsh/atuin"

--- a/crates/atuin-client/src/sync.rs
+++ b/crates/atuin-client/src/sync.rs
@@ -37,7 +37,7 @@ async fn sync_download(
     key: &Key,
     force: bool,
     client: &api_client::Client<'_>,
-    db: &(impl Database + Send),
+    db: &impl Database,
 ) -> Result<(i64, i64)> {
     debug!("starting sync download");
 
@@ -127,7 +127,7 @@ async fn sync_upload(
     key: &Key,
     _force: bool,
     client: &api_client::Client<'_>,
-    db: &(impl Database + Send),
+    db: &impl Database,
 ) -> Result<()> {
     debug!("starting sync upload");
 
@@ -188,7 +188,7 @@ async fn sync_upload(
     Ok(())
 }
 
-pub async fn sync(settings: &Settings, force: bool, db: &(impl Database + Send)) -> Result<()> {
+pub async fn sync(settings: &Settings, force: bool, db: &impl Database) -> Result<()> {
     let client = api_client::Client::new(
         &settings.sync_address,
         &settings.session_token,

--- a/crates/atuin-dotfiles/src/shell.rs
+++ b/crates/atuin-dotfiles/src/shell.rs
@@ -136,7 +136,7 @@ pub fn existing_aliases(shell: Option<Shell>) -> Result<Vec<Alias>, ShellError> 
 /// Import aliases from the current shell
 /// This will not import aliases already in the store
 /// Returns aliases that were set
-pub async fn import_aliases(store: AliasStore) -> Result<Vec<Alias>> {
+pub async fn import_aliases(store: &AliasStore) -> Result<Vec<Alias>> {
     let shell_aliases = existing_aliases(None)?;
     let store_aliases = store.aliases().await?;
 

--- a/crates/atuin/Cargo.toml
+++ b/crates/atuin/Cargo.toml
@@ -82,6 +82,7 @@ uuid = { workspace = true }
 unicode-segmentation = "1.11.0"
 serde_yaml = "0.9.32"
 sysinfo = "0.30.7"
+regex="1.10.4"
 
 [target.'cfg(any(target_os = "windows", target_os = "macos", target_os = "linux"))'.dependencies]
 cli-clipboard = { version = "0.4.0", optional = true }

--- a/crates/atuin/src/command/client/search/interactive.rs
+++ b/crates/atuin/src/command/client/search/interactive.rs
@@ -308,13 +308,7 @@ impl State {
         // handle keymap specific keybindings.
         match self.keymap_mode {
             KeymapMode::VimNormal => match input.code {
-                KeyCode::Char('/') if !ctrl => {
-                    self.search.input.clear();
-                    self.set_keymap_cursor(settings, "vim_insert");
-                    self.keymap_mode = KeymapMode::VimInsert;
-                    return InputAction::Continue;
-                }
-                KeyCode::Char('?') if !ctrl => {
+                KeyCode::Char('?' | '/') if !ctrl => {
                     self.search.input.clear();
                     self.set_keymap_cursor(settings, "vim_insert");
                     self.keymap_mode = KeymapMode::VimInsert;

--- a/crates/atuin/src/command/client/stats.rs
+++ b/crates/atuin/src/command/client/stats.rs
@@ -13,7 +13,7 @@ use atuin_history::stats::{compute, pretty_print};
 #[derive(Parser, Debug)]
 #[command(infer_subcommands = true)]
 pub struct Cmd {
-    /// Compute statistics for the specified period, leave blank for statistics since the beginning. See https://docs.atuin.sh/reference/stats/ for more details.
+    /// Compute statistics for the specified period, leave blank for statistics since the beginning. See [this](https://docs.atuin.sh/reference/stats/) for more details.
     period: Vec<String>,
 
     /// How many top commands to list


### PR DESCRIPTION
At the moment there are far too many edge cases to handle importing aliases.

1. We need an interactive shell to print aliases. Without it, most shells won't report much.
2. Many people have their shells print things on startup (graphics, fortunes, etc). This could be detected as an attempt to set an alias.

 Rather than spend the next year finding import edge cases, I'm
 disabling it for now. There's probably a better way we can do this?

<!-- Thank you for making a PR! Bug fixes are always welcome, but if you're adding a new feature or changing an existing one, we'd really appreciate if you open an issue, post on the forum, or drop in on Discord -->

## Checks
- [ ] I am happy for maintainers to push small adjustments to this PR, to speed up the review cycle
- [ ] I have checked that there are no existing pull requests for the same thing
