### PR TITLE
Added "accept-to-edit" for (Back)Space / Home / Left

### DIFF
--- a/crates/atuin-client/src/settings.rs
+++ b/crates/atuin-client/src/settings.rs
@@ -413,6 +413,12 @@ pub struct Settings {
     pub enter_accept: bool,
     pub smart_sort: bool,
 
+    pub exit_with_backspace: bool,
+    pub exit_with_space: bool,
+    pub exit_with_home: bool,
+    pub exit_with_cursor_left: bool,
+    pub exit_positions_cursor: bool,
+
     #[serde(default)]
     pub stats: Stats,
 
@@ -674,6 +680,11 @@ impl Settings {
             .set_default("keymap_mode_shell", "auto")?
             .set_default("keymap_cursor", HashMap::<String, String>::new())?
             .set_default("smart_sort", false)?
+            .set_default("exit_with_backspace", false)?
+            .set_default("exit_with_space", false)?
+            .set_default("exit_with_home", false)?
+            .set_default("exit_with_cursor_left", false)?
+            .set_default("exit_positions_cursor", false)?
             .set_default("store_failed", true)?
             .set_default(
                 "prefers_reduced_motion",

--- a/crates/atuin/src/command/client/search/cursor.rs
+++ b/crates/atuin/src/command/client/search/cursor.rs
@@ -101,6 +101,11 @@ impl Cursor {
         self.source
     }
 
+    /// Checks if there's currently no input
+    pub fn is_empty(&self) -> bool {
+        self.source.is_empty()
+    }
+
     /// Returns the string before the cursor
     pub fn substring(&self) -> &str {
         &self.source[..self.index]

--- a/crates/atuin/src/command/client/search/interactive.rs
+++ b/crates/atuin/src/command/client/search/interactive.rs
@@ -49,13 +49,19 @@ use ratatui::{
 const TAB_TITLES: [&str; 2] = ["Search", "Inspect"];
 
 pub enum InputAction {
-    Accept(usize),
+    Accept(usize, InputAcceptKind),
     Copy(usize),
     Delete(usize),
     ReturnOriginal,
     ReturnQuery,
     Continue,
     Redraw,
+}
+pub enum InputAcceptKind {
+    Default,
+    Backspace,
+    Space,
+    Offset(i64),
 }
 
 #[allow(clippy::struct_field_names)]
@@ -214,7 +220,10 @@ impl State {
             KeyCode::Char('c' | 'g') if ctrl => Some(InputAction::ReturnOriginal),
             KeyCode::Esc if esc_allow_exit => Some(Self::handle_key_exit(settings)),
             KeyCode::Char('[') if ctrl && esc_allow_exit => Some(Self::handle_key_exit(settings)),
-            KeyCode::Tab => Some(InputAction::Accept(self.results_state.selected())),
+            KeyCode::Tab => Some(InputAction::Accept(
+                self.results_state.selected(),
+                InputAcceptKind::Default,
+            )),
             KeyCode::Char('o') if ctrl => {
                 self.tab_index = (self.tab_index + 1) % TAB_TITLES.len();
 
@@ -273,7 +282,7 @@ impl State {
         if settings.enter_accept {
             self.accept = true;
         }
-        InputAction::Accept(self.results_state.selected())
+        InputAction::Accept(self.results_state.selected(), InputAcceptKind::Default)
     }
 
     #[allow(clippy::too_many_lines)]
@@ -374,7 +383,10 @@ impl State {
             }
             KeyCode::Char(c @ '1'..='9') if modfr => {
                 return c.to_digit(10).map_or(InputAction::Continue, |c| {
-                    InputAction::Accept(self.results_state.selected() + c as usize)
+                    InputAction::Accept(
+                        self.results_state.selected() + c as usize,
+                        InputAcceptKind::Default,
+                    )
                 })
             }
             KeyCode::Left if ctrl => self
@@ -386,6 +398,12 @@ impl State {
                 .input
                 .prev_word(&settings.word_chars, settings.word_jump_mode),
             KeyCode::Left => {
+                if settings.exit_with_cursor_left && self.search.input.is_empty() {
+                    return InputAction::Accept(
+                        self.results_state.selected(),
+                        InputAcceptKind::Offset(-1),
+                    );
+                }
                 self.search.input.left();
             }
             KeyCode::Char('b') if ctrl => {
@@ -401,7 +419,15 @@ impl State {
                 .next_word(&settings.word_chars, settings.word_jump_mode),
             KeyCode::Right => self.search.input.right(),
             KeyCode::Char('f') if ctrl => self.search.input.right(),
-            KeyCode::Home => self.search.input.start(),
+            KeyCode::Home => {
+                if settings.exit_with_home && self.search.input.is_empty() {
+                    return InputAction::Accept(
+                        self.results_state.selected(),
+                        InputAcceptKind::Offset(0),
+                    );
+                }
+                self.search.input.start();
+            }
             KeyCode::Char('e') if ctrl => self.search.input.end(),
             KeyCode::End => self.search.input.end(),
             KeyCode::Backspace if ctrl => self
@@ -409,6 +435,12 @@ impl State {
                 .input
                 .remove_prev_word(&settings.word_chars, settings.word_jump_mode),
             KeyCode::Backspace => {
+                if settings.exit_with_backspace && self.search.input.is_empty() {
+                    return InputAction::Accept(
+                        self.results_state.selected(),
+                        InputAcceptKind::Backspace,
+                    );
+                }
                 self.search.input.back();
             }
             KeyCode::Char('h' | '?') if ctrl => {
@@ -493,6 +525,15 @@ impl State {
             }
             KeyCode::Char('l') if ctrl => {
                 return InputAction::Redraw;
+            }
+            KeyCode::Char(' ') => {
+                if settings.exit_with_space && self.search.input.is_empty() {
+                    return InputAction::Accept(
+                        self.results_state.selected(),
+                        InputAcceptKind::Space,
+                    );
+                }
+                self.search.input.insert(' ');
             }
             KeyCode::Char(c) => {
                 self.search.input.insert(c);
@@ -1134,12 +1175,53 @@ pub async fn history(
     }
 
     match result {
-        InputAction::Accept(index) if index < results.len() => {
+        InputAction::Accept(index, kind) if index < results.len() => {
             let mut command = results.swap_remove(index).command;
             if accept
                 && (utils::is_zsh() || utils::is_fish() || utils::is_bash() || utils::is_xonsh())
             {
                 command = String::from("__atuin_accept__:") + &command;
+            } else {
+                match kind {
+                    InputAcceptKind::Default => {}
+                    InputAcceptKind::Backspace => {
+                        // trim the end of the selected command *and* remove the
+                        // last character, as tab-completion might have added
+                        // trailing whitespace (which can't be seen in the UI)
+                        command = command.trim_end().to_string();
+                        command.pop();
+                    }
+                    InputAcceptKind::Space => {
+                        // trim the end and add one space character
+                        command = command.trim_end().to_string() + " ";
+                    }
+                    InputAcceptKind::Offset(offset) => {
+                        if settings.exit_positions_cursor {
+                            // for negative offsets (move left), remove trailing whitespace
+                            if offset < 0 {
+                                command = command.trim_end().to_string();
+                            }
+                            #[allow(clippy::cast_possible_wrap)]
+                            let length = command.len() as i64;
+                            let position = if offset >= 0 {
+                                // start editing at specified position,
+                                // counting from the start
+                                length.min(offset)
+                            } else {
+                                // start editing at specified position,
+                                // counting from the (trimmed) end
+                                0.max(length - offset.abs())
+                            };
+                            // Bash's READLINE_POINT is required or positioning the cursor; we still allow
+                            // to go back to the shell even when not using bash (if user's configure the
+                            // respective options), but the actual positioning is only possible with bash
+                            // (and only implemented in the bash shell integration)
+                            if utils::is_bash() {
+                                command = format!("__atuin_edit_at__:{position}:{command}");
+                            }
+                        }
+                    }
+                }
             }
 
             // index is in bounds so we return that entry
@@ -1151,7 +1233,7 @@ pub async fn history(
             set_clipboard(cmd);
             Ok(String::new())
         }
-        InputAction::ReturnQuery | InputAction::Accept(_) => {
+        InputAction::ReturnQuery | InputAction::Accept(_, _) => {
             // Either:
             // * index == RETURN_QUERY, in which case we should return the input
             // * out of bounds -> usually implies no selected entry so we return the input

--- a/crates/atuin/src/shell/atuin.bash
+++ b/crates/atuin/src/shell/atuin.bash
@@ -252,6 +252,7 @@ __atuin_history() {
     [[ $__atuin_output ]] || return 0
 
     if [[ $__atuin_output == __atuin_accept__:* ]]; then
+        # Execute selected command
         __atuin_output=${__atuin_output#__atuin_accept__:}
 
         if [[ ${BLE_ATTACHED-} ]]; then
@@ -263,6 +264,17 @@ __atuin_history() {
 
         READLINE_LINE=""
         READLINE_POINT=${#READLINE_LINE}
+    elif [[ $__atuin_output == __atuin_edit_at__:* ]]; then
+        # Edit selected command at specified cursor position
+        __atuin_output=${__atuin_output#__atuin_edit_at__:}
+        local __atuin_edit_at_rx='^([0-9]+):(.*)$'
+        if [[ $__atuin_output =~ $__atuin_edit_at_rx ]]; then
+            READLINE_LINE="${BASH_REMATCH[2]}"
+            READLINE_POINT=${BASH_REMATCH[1]}
+        else
+            READLINE_LINE=$__atuin_output
+            READLINE_POINT=${#READLINE_LINE}
+        fi
     else
         READLINE_LINE=$__atuin_output
         READLINE_POINT=${#READLINE_LINE}


### PR DESCRIPTION
The above keys edit the selected command (as with hitting Tab), but like if using them in the shell. They only trigger when the search input is currently empty, and must be enabled individually with the respective boolean config options:

* exit_with_backspace: right-trim command and remove last character

* exit_with_space: right-trim and append a space character

* exit_with_home: start editing at position 0

* exit_with_cursor_left: right-trim and start editing at last character

* exit_positions_cursor: enable cursor positioning for Home and Left keys (bash-only)

Updated bash init to support cursor positioning. For other shells, Home and Left keys will behave like Tab.

Resolves #1906

<!-- Thank you for making a PR! Bug fixes are always welcome, but if you're adding a new feature or changing an existing one, we'd really appreciate if you open an issue, post on the forum, or drop in on Discord -->

## Checks
- [x] I am happy for maintainers to push small adjustments to this PR, to speed up the review cycle
- [x] I have checked that there are no existing pull requests for the same thing
