### PR TITLE
fix(settings): fix #2012 exceptions thrown by non-unicode environment variables

### DIFF
--- a/crates/atuin-client/src/settings.rs
+++ b/crates/atuin-client/src/settings.rs
@@ -729,7 +729,7 @@ impl Settings {
 
         create_dir_all(&data_dir).wrap_err_with(|| format!("could not create dir {data_dir:?}"))?;
 
-        let mut config_file = if let Ok(p) = std::env::var("ATUIN_CONFIG_DIR") {
+        let mut config_file = if let Some(p) = crate::utils::get_env_var("ATUIN_CONFIG_DIR") {
             PathBuf::from(p)
         } else {
             let mut config_file = PathBuf::new();

--- a/crates/atuin-client/src/utils.rs
+++ b/crates/atuin-client/src/utils.rs
@@ -18,17 +18,16 @@ pub(crate) fn get_host_user() -> String {
 pub(crate) fn get_env_var<K: AsRef<OsStr>>(key: K) -> Option<String> {
     // Try to retrieve the environment variable using std::env::var.
     // If it fails (e.g., variable contains non-UTF-8 bytes), fall back to std::env::var_os and convert it lossily.
-    std::env::var(key.as_ref()).ok().or_else(|| {
-        std::env::var_os(key.as_ref())
-            .map(|v| v.to_string_lossy().into_owned())
-    })
+    std::env::var(key.as_ref())
+        .ok()
+        .or_else(|| std::env::var_os(key.as_ref()).map(|v| v.to_string_lossy().into_owned()))
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::{env, ffi};
     use std::os::unix::ffi::OsStrExt;
+    use std::{env, ffi};
 
     #[test]
     fn test_get_env_var_existing() {
@@ -53,7 +52,10 @@ mod tests {
 
         // Set an environment variable with non-UTF-8 bytes for the purpose of this test.
         env::set_var("TEST_NON_UTF8", os_str);
-        assert_eq!(get_env_var("TEST_NON_UTF8").unwrap(), "\u{FFFD}\u{FFFD}\u{FFFD}");
+        assert_eq!(
+            get_env_var("TEST_NON_UTF8").unwrap(),
+            "\u{FFFD}\u{FFFD}\u{FFFD}"
+        );
         env::remove_var("TEST_NON_UTF8");
     }
 }

--- a/crates/atuin-client/src/utils.rs
+++ b/crates/atuin-client/src/utils.rs
@@ -1,3 +1,5 @@
+use std::ffi::OsStr;
+
 pub(crate) fn get_hostname() -> String {
     std::env::var("ATUIN_HOST_NAME").unwrap_or_else(|_| {
         whoami::fallible::hostname().unwrap_or_else(|_| "unknown-host".to_string())
@@ -11,4 +13,47 @@ pub(crate) fn get_username() -> String {
 /// Returns a pair of the hostname and username, separated by a colon.
 pub(crate) fn get_host_user() -> String {
     format!("{}:{}", get_hostname(), get_username())
+}
+
+pub(crate) fn get_env_var<K: AsRef<OsStr>>(key: K) -> Option<String> {
+    // Try to retrieve the environment variable using std::env::var.
+    // If it fails (e.g., variable contains non-UTF-8 bytes), fall back to std::env::var_os and convert it lossily.
+    std::env::var(key.as_ref()).ok().or_else(|| {
+        std::env::var_os(key.as_ref())
+            .map(|v| v.to_string_lossy().into_owned())
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::{env, ffi};
+    use std::os::unix::ffi::OsStrExt;
+
+    #[test]
+    fn test_get_env_var_existing() {
+        // Set an environment variable for the purpose of this test.
+        env::set_var("TEST_ENV_VAR", "123");
+        assert_eq!(get_env_var("TEST_ENV_VAR"), Some("123".to_string()));
+        env::remove_var("TEST_ENV_VAR");
+    }
+
+    #[test]
+    fn test_get_env_var_non_existing() {
+        // Ensure the environment variable does not exist.
+        env::remove_var("NON_EXISTING_ENV_VAR");
+        assert_eq!(get_env_var("NON_EXISTING_ENV_VAR"), None);
+    }
+
+    #[test]
+    fn test_get_env_var_non_utf8() {
+        // Create a non-UTF-8 sequence.
+        let invalid_utf8: &[u8] = &[0xff, 0xfe, 0xfd];
+        let os_str = ffi::OsStr::from_bytes(invalid_utf8);
+
+        // Set an environment variable with non-UTF-8 bytes for the purpose of this test.
+        env::set_var("TEST_NON_UTF8", os_str);
+        assert_eq!(get_env_var("TEST_NON_UTF8").unwrap(), "\u{FFFD}\u{FFFD}\u{FFFD}");
+        env::remove_var("TEST_NON_UTF8");
+    }
 }


### PR DESCRIPTION
fix #2012 an exception caused by the presence of non-unicode environment variables.

scope: atuin-client
changes:
1. add get_env_var in utils.rs
2. change load env in settings.rs

<!-- Thank you for making a PR! Bug fixes are always welcome, but if you're adding a new feature or changing an existing one, we'd really appreciate if you open an issue, post on the forum, or drop in on Discord -->

## Checks
- [x] I am happy for maintainers to push small adjustments to this PR, to speed up the review cycle
- [x] I have checked that there are no existing pull requests for the same thing
