### PR TITLE
fix: alias enable/enabled in settings

### DIFF
--- a/crates/atuin-client/src/settings.rs
+++ b/crates/atuin-client/src/settings.rs
@@ -346,6 +346,7 @@ pub struct Preview {
 pub struct Daemon {
     /// Use the daemon to sync
     /// If enabled, requires a running daemon with `atuin daemon`
+    #[serde(alias = "enable")]
     pub enabled: bool,
 
     /// The daemon will handle sync on an interval. How often to sync, in seconds.

--- a/crates/atuin-client/src/settings/dotfiles.rs
+++ b/crates/atuin-client/src/settings/dotfiles.rs
@@ -2,5 +2,6 @@ use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Serialize, Deserialize, Clone, Default)]
 pub struct Settings {
+    #[serde(alias = "enable")]
     pub enabled: bool,
 }

--- a/crates/atuin-server/src/settings.rs
+++ b/crates/atuin-server/src/settings.rs
@@ -104,6 +104,7 @@ pub fn example_config() -> &'static str {
 
 #[derive(Clone, Debug, Default, Deserialize, Serialize)]
 pub struct Tls {
+    #[serde(alias = "enabled")]
     pub enable: bool,
 
     pub cert_path: PathBuf,


### PR DESCRIPTION
The server has enable, the client has enabled. I've seen at least one person make this mistake, so imo it makes sense to alias the two

## Checks
- [ ] I am happy for maintainers to push small adjustments to this PR, to speed up the review cycle
- [ ] I have checked that there are no existing pull requests for the same thing
