### PR TITLE
Support importing from replxx history files

### DIFF
--- a/crates/atuin-client/Cargo.toml
+++ b/crates/atuin-client/Cargo.toml
@@ -23,7 +23,7 @@ atuin-common = { path = "../atuin-common", version = "18.2.0" }
 
 log = { workspace = true }
 base64 = { workspace = true }
-time = { workspace = true, features = ["macros", "formatting"] }
+time = { workspace = true, features = ["macros", "formatting", "parsing"] }
 clap = { workspace = true }
 eyre = { workspace = true }
 directories = { workspace = true }

--- a/crates/atuin-client/src/import/mod.rs
+++ b/crates/atuin-client/src/import/mod.rs
@@ -12,6 +12,7 @@ pub mod bash;
 pub mod fish;
 pub mod nu;
 pub mod nu_histdb;
+pub mod replxx;
 pub mod resh;
 pub mod xonsh;
 pub mod xonsh_sqlite;

--- a/crates/atuin-client/src/import/replxx.rs
+++ b/crates/atuin-client/src/import/replxx.rs
@@ -1,0 +1,70 @@
+use std::{path::PathBuf, str};
+
+use async_trait::async_trait;
+use directories::UserDirs;
+use eyre::{eyre, Result};
+use time::{macros::format_description, OffsetDateTime, PrimitiveDateTime};
+
+use super::{get_histpath, unix_byte_lines, Importer, Loader};
+use crate::history::History;
+use crate::import::read_to_end;
+
+#[derive(Debug)]
+pub struct Replxx {
+    bytes: Vec<u8>,
+}
+
+fn default_histpath() -> Result<PathBuf> {
+    let user_dirs = UserDirs::new().ok_or_else(|| eyre!("could not find user directories"))?;
+    let home_dir = user_dirs.home_dir();
+
+    // There is no default histfile for replxx.
+    // For simplicity let's use the most common one.
+    Ok(home_dir.join(".histfile"))
+}
+
+#[async_trait]
+impl Importer for Replxx {
+    const NAME: &'static str = "replxx";
+
+    async fn new() -> Result<Self> {
+        let bytes = read_to_end(get_histpath(default_histpath)?)?;
+        Ok(Self { bytes })
+    }
+
+    async fn entries(&mut self) -> Result<usize> {
+        Ok(super::count_lines(&self.bytes) / 2)
+    }
+
+    async fn load(self, h: &mut impl Loader) -> Result<()> {
+        let mut timestamp = OffsetDateTime::UNIX_EPOCH;
+
+        for b in unix_byte_lines(&self.bytes) {
+            let s = std::str::from_utf8(b)?;
+            match try_parse_line_as_timestamp(s) {
+                Some(t) => timestamp = t,
+                None => {
+                    // replxx uses ETB character (0x17) as line breaker
+                    let cmd = s.replace("\u{0017}", "\n");
+                    let imported = History::import().timestamp(timestamp).command(cmd);
+
+                    h.push(imported.build().into()).await?;
+                }
+            }
+        }
+
+        Ok(())
+    }
+}
+
+fn try_parse_line_as_timestamp(line: &str) -> Option<OffsetDateTime> {
+    // replxx history date time format: ### yyyy-mm-dd hh:mm:ss.xxx
+    let date_time_str = line.strip_prefix("### ")?;
+    let format =
+        format_description!("[year]-[month]-[day] [hour]:[minute]:[second].[subsecond digits:3]");
+
+    let primitive_date_time = PrimitiveDateTime::parse(date_time_str, format).ok()?;
+    // There is no safe way to get local time offset.
+    // For simplicity let's just assume UTC.
+    Some(primitive_date_time.assume_utc())
+}

--- a/crates/atuin-client/src/import/replxx.rs
+++ b/crates/atuin-client/src/import/replxx.rs
@@ -45,7 +45,7 @@ impl Importer for Replxx {
                 Some(t) => timestamp = t,
                 None => {
                     // replxx uses ETB character (0x17) as line breaker
-                    let cmd = s.replace("\u{0017}", "\n");
+                    let cmd = s.replace('\u{0017}', "\n");
                     let imported = History::import().timestamp(timestamp).command(cmd);
 
                     h.push(imported.build().into()).await?;

--- a/crates/atuin/src/command/client/import.rs
+++ b/crates/atuin/src/command/client/import.rs
@@ -9,8 +9,8 @@ use atuin_client::{
     database::Database,
     history::History,
     import::{
-        bash::Bash, fish::Fish, nu::Nu, nu_histdb::NuHistDb, resh::Resh, xonsh::Xonsh,
-        xonsh_sqlite::XonshSqlite, zsh::Zsh, zsh_histdb::ZshHistDb, Importer, Loader,
+        bash::Bash, fish::Fish, nu::Nu, nu_histdb::NuHistDb, replxx::Replxx, resh::Resh,
+        xonsh::Xonsh, xonsh_sqlite::XonshSqlite, zsh::Zsh, zsh_histdb::ZshHistDb, Importer, Loader,
     },
 };
 
@@ -26,6 +26,8 @@ pub enum Cmd {
     ZshHistDb,
     /// Import history from the bash history file
     Bash,
+    /// Import history from the replxx history file
+    Replxx,
     /// Import history from the resh history file
     Resh,
     /// Import history from the fish history file
@@ -98,6 +100,9 @@ impl Cmd {
                         println!("Detected Nushell");
                         import::<Nu, DB>(db).await
                     }
+                } else if shell.ends_with("/replxx") {
+                    println!("Detected Replxx");
+                    import::<Replxx, DB>(db).await
                 } else {
                     println!("cannot import {shell} history");
                     Ok(())
@@ -107,6 +112,7 @@ impl Cmd {
             Self::Zsh => import::<Zsh, DB>(db).await,
             Self::ZshHistDb => import::<ZshHistDb, DB>(db).await,
             Self::Bash => import::<Bash, DB>(db).await,
+            Self::Replxx => import::<Replxx, DB>(db).await,
             Self::Resh => import::<Resh, DB>(db).await,
             Self::Fish => import::<Fish, DB>(db).await,
             Self::Nu => import::<Nu, DB>(db).await,

--- a/crates/atuin/src/command/client/import.rs
+++ b/crates/atuin/src/command/client/import.rs
@@ -100,9 +100,6 @@ impl Cmd {
                         println!("Detected Nushell");
                         import::<Nu, DB>(db).await
                     }
-                } else if shell.ends_with("/replxx") {
-                    println!("Detected Replxx");
-                    import::<Replxx, DB>(db).await
                 } else {
                     println!("cannot import {shell} history");
                     Ok(())


### PR DESCRIPTION
<!-- Thank you for making a PR! Bug fixes are always welcome, but if you're adding a new feature or changing an existing one, we'd really appreciate if you open an issue, post on the forum, or drop in on Discord -->

As discussed in Discord, this feature should be useful for managing history of applications which use https://github.com/AmokHuginnsson/replxx . One notable example would be ClickHouse.

I'll try to integrate atuin into clickhouse-client later.

## Checks
- [X] I am happy for maintainers to push small adjustments to this PR, to speed up the review cycle
- [X] I have checked that there are no existing pull requests for the same thing
