### PR TITLE
fix: redact password in database URI when logging

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -442,6 +442,7 @@ dependencies = [
  "sqlx",
  "time",
  "tracing",
+ "url",
  "uuid",
 ]
 

--- a/crates/atuin-server-postgres/Cargo.toml
+++ b/crates/atuin-server-postgres/Cargo.toml
@@ -21,3 +21,4 @@ sqlx = { workspace = true }
 async-trait = { workspace = true }
 uuid = { workspace = true }
 futures-util = "0.3"
+url = "2.5.0"


### PR DESCRIPTION
Hi,

I think this is a bit of a niche fix since I imagine not tons of people self-host and perhaps it's something those who are running servers _do_ want, so I won't be the least bit bothered if this isn't merged.

Previously, in the event that there was a configuration issue and the atuin server failed to connect to PostgreSQL, it would log the database URI including the password.

For example, if the password authentication failed the following log message would be printed:

Error: failed to connect to db: PostgresSettings { db_uri: "postgres://atuin:definitelymypassword@db.example.com/atuin" }

This change sets the password to "****" when printing it via Debug:

Error: failed to connect to db: PostgresSettings { db_uri: "postgres://atuin:****@db.example.com/atuin" }

Hopefully few people use **** as the actual password.

<!-- Thank you for making a PR! Bug fixes are always welcome, but if you're adding a new feature or changing an existing one, we'd really appreciate if you open an issue, post on the forum, or drop in on Discord -->

## Checks
- [x] I am happy for maintainers to push small adjustments to this PR, to speed up the review cycle
- [x] I have checked that there are no existing pull requests for the same thing
