### PR TITLE
fix(daemon): do not try to sync if logged out

### DIFF
--- a/crates/atuin-client/src/record/sync.rs
+++ b/crates/atuin-client/src/record/sync.rs
@@ -55,7 +55,10 @@ pub async fn diff(
 ) -> Result<(Vec<Diff>, RecordStatus), SyncError> {
     let client = Client::new(
         &settings.sync_address,
-        &settings.session_token,
+        settings
+            .session_token()
+            .map_err(|e| SyncError::RemoteRequestError { msg: e.to_string() })?
+            .as_str(),
         settings.network_connect_timeout,
         settings.network_timeout,
     )
@@ -270,7 +273,10 @@ pub async fn sync_remote(
 ) -> Result<(i64, Vec<RecordId>), SyncError> {
     let client = Client::new(
         &settings.sync_address,
-        &settings.session_token,
+        settings
+            .session_token()
+            .map_err(|e| SyncError::RemoteRequestError { msg: e.to_string() })?
+            .as_str(),
         settings.network_connect_timeout,
         settings.network_timeout,
     )

--- a/crates/atuin-client/src/settings.rs
+++ b/crates/atuin-client/src/settings.rs
@@ -568,6 +568,12 @@ impl Settings {
         }
     }
 
+    pub fn logged_in(&self) -> bool {
+        let session_path = self.session_path.as_str();
+
+        PathBuf::from(session_path).exists()
+    }
+
     #[cfg(feature = "check-update")]
     fn needs_update_check(&self) -> Result<bool> {
         let last_check = Settings::last_version_check()?;

--- a/crates/atuin-client/src/sync.rs
+++ b/crates/atuin-client/src/sync.rs
@@ -191,7 +191,7 @@ async fn sync_upload(
 pub async fn sync(settings: &Settings, force: bool, db: &impl Database) -> Result<()> {
     let client = api_client::Client::new(
         &settings.sync_address,
-        &settings.session_token,
+        settings.session_token()?.as_str(),
         settings.network_connect_timeout,
         settings.network_timeout,
     )?;

--- a/crates/atuin-daemon/src/server/sync.rs
+++ b/crates/atuin-daemon/src/server/sync.rs
@@ -39,7 +39,7 @@ pub async fn worker(
         tracing::info!("sync worker tick");
 
         if !settings.logged_in() {
-            tracing::trace!("not logged in, skipping sync tick");
+            tracing::debug!("not logged in, skipping sync tick");
             continue;
         }
 

--- a/crates/atuin-daemon/src/server/sync.rs
+++ b/crates/atuin-daemon/src/server/sync.rs
@@ -38,6 +38,11 @@ pub async fn worker(
         ticker.tick().await;
         tracing::info!("sync worker tick");
 
+        if !settings.logged_in() {
+            tracing::trace!("not logged in, skipping sync tick");
+            continue;
+        }
+
         let res = sync::sync(&settings, &store).await;
 
         if let Err(e) = res {

--- a/crates/atuin/src/command/client/account/change_password.rs
+++ b/crates/atuin/src/command/client/account/change_password.rs
@@ -26,7 +26,7 @@ pub async fn run(
 ) -> Result<()> {
     let client = api_client::Client::new(
         &settings.sync_address,
-        &settings.session_token,
+        settings.session_token()?.as_str(),
         settings.network_connect_timeout,
         settings.network_timeout,
     )?;

--- a/crates/atuin/src/command/client/account/delete.rs
+++ b/crates/atuin/src/command/client/account/delete.rs
@@ -12,7 +12,7 @@ pub async fn run(settings: &Settings) -> Result<()> {
 
     let client = api_client::Client::new(
         &settings.sync_address,
-        &settings.session_token,
+        settings.session_token()?.as_str(),
         settings.network_connect_timeout,
         settings.network_timeout,
     )?;

--- a/crates/atuin/src/command/client/account/login.rs
+++ b/crates/atuin/src/command/client/account/login.rs
@@ -35,9 +35,7 @@ fn get_input() -> Result<String> {
 
 impl Cmd {
     pub async fn run(&self, settings: &Settings, store: &SqliteStore) -> Result<()> {
-        let session_path = settings.session_path.as_str();
-
-        if PathBuf::from(session_path).exists() {
+        if settings.logged_in() {
             println!(
                 "You are already logged in! Please run 'atuin logout' if you wish to login again"
             );

--- a/crates/atuin/src/command/client/account/logout.rs
+++ b/crates/atuin/src/command/client/account/logout.rs
@@ -1,5 +1,3 @@
-use std::path::PathBuf;
-
 use eyre::{Context, Result};
 use fs_err::remove_file;
 
@@ -8,7 +6,7 @@ use atuin_client::settings::Settings;
 pub fn run(settings: &Settings) -> Result<()> {
     let session_path = settings.session_path.as_str();
 
-    if PathBuf::from(session_path).exists() {
+    if settings.logged_in() {
         remove_file(session_path).context("Failed to remove session file")?;
         println!("You have logged out!");
     } else {

--- a/crates/atuin/src/command/client/store/push.rs
+++ b/crates/atuin/src/command/client/store/push.rs
@@ -37,7 +37,7 @@ impl Push {
 
             let client = Client::new(
                 &settings.sync_address,
-                &settings.session_token,
+                settings.session_token()?.as_str(),
                 settings.network_connect_timeout,
                 settings.network_timeout * 10, // we may be deleting a lot of data... so up the
                                                // timeout

--- a/crates/atuin/src/command/client/sync/status.rs
+++ b/crates/atuin/src/command/client/sync/status.rs
@@ -16,7 +16,7 @@ pub async fn run(settings: &Settings, db: &impl Database) -> Result<()> {
 
     let client = api_client::Client::new(
         &settings.sync_address,
-        &settings.session_token,
+        settings.session_token()?.as_str(),
         settings.network_connect_timeout,
         settings.network_timeout,
     )?;


### PR DESCRIPTION
I've also added Settings::logged_in, as there are a few places where we switch on login state.

With this change, logging out/in with the daemon running is ok! Previously, sync would stop working. It would either always be logged out, or keep trying to make requests but get a 403.

<!-- Thank you for making a PR! Bug fixes are always welcome, but if you're adding a new feature or changing an existing one, we'd really appreciate if you open an issue, post on the forum, or drop in on Discord -->

## Checks
- [ ] I am happy for maintainers to push small adjustments to this PR, to speed up the review cycle
- [ ] I have checked that there are no existing pull requests for the same thing
