### PR TITLE
chore(codespell): ignore CODE_OF_CONDUCT

### DIFF
--- a/.codespellrc
+++ b/.codespellrc
@@ -1,6 +1,6 @@
 [codespell]
 # Ref: https://github.com/codespell-project/codespell#using-a-config-file
-skip = .git*,*.lock,.codespellrc
+skip = .git*,*.lock,.codespellrc,CODE_OF_CONDUCT.md
 check-hidden = true
 # ignore-regex = 
 ignore-words-list = crate,ratatui,inbetween


### PR DESCRIPTION
Several dictionaries suggest keeping the hyphen. In fact, it's generally a good idea to hyphenate with too many adjacent vowels.

<!-- Thank you for making a PR! Bug fixes are always welcome, but if you're adding a new feature or changing an existing one, we'd really appreciate if you open an issue, post on the forum, or drop in on Discord -->

## Checks
- [ ] I am happy for maintainers to push small adjustments to this PR, to speed up the review cycle
- [ ] I have checked that there are no existing pull requests for the same thing
