### PR TITLE
fix: save sync time in daemon

### DIFF
--- a/crates/atuin-daemon/src/server/sync.rs
+++ b/crates/atuin-daemon/src/server/sync.rs
@@ -75,6 +75,9 @@ pub async fn worker(
             if ticker.period().as_secs() != settings.daemon.sync_frequency {
                 ticker = time::interval(time::Duration::from_secs(settings.daemon.sync_frequency));
             }
+
+            // store sync time
+            tokio::task::spawn_blocking(Settings::save_sync_time).await??;
         }
     }
 }


### PR DESCRIPTION
I'm not super keen on storing this in a text file, realistically we need some sort of generic not-synced kv store for this sort of thing

## Checks
- [ ] I am happy for maintainers to push small adjustments to this PR, to speed up the review cycle
- [ ] I have checked that there are no existing pull requests for the same thing
