### PR TITLE
chore: handle rate limited responses

### DIFF
--- a/crates/atuin-client/src/api_client.rs
+++ b/crates/atuin-client/src/api_client.rs
@@ -86,6 +86,10 @@ pub async fn login(address: &str, req: LoginRequest) -> Result<LoginResponse> {
         .send()
         .await?;
 
+    if resp.status() == StatusCode::TOO_MANY_REQUESTS {
+        bail!("Rate limited. Too many login attempts.");
+    }
+
     if !ensure_version(&resp)? {
         bail!("could not login due to version mismatch");
     }
@@ -155,6 +159,10 @@ async fn handle_resp_error(resp: Response) -> Result<Response> {
         bail!(
             "Service unavailable: check https://status.atuin.sh (or get in touch with your host)"
         );
+    }
+
+    if status == StatusCode::TOO_MANY_REQUESTS {
+        bail!("Rate limited; please wait before doing that again");
     }
 
     if !status.is_success() {


### PR DESCRIPTION
For Atuin Cloud, we rate limit login attempts (and a few other endpoints). Ensure that the user gets a descriptive response

For self hosted users, if you wish to rate limit, I'd suggest configuring this with your reverse proxy.

<!-- Thank you for making a PR! Bug fixes are always welcome, but if you're adding a new feature or changing an existing one, we'd really appreciate if you open an issue, post on the forum, or drop in on Discord -->

## Checks
- [ ] I am happy for maintainers to push small adjustments to this PR, to speed up the review cycle
- [ ] I have checked that there are no existing pull requests for the same thing
