### PR TITLE
fix(bash): fix a workaround for bash-5.2 keybindings

### DIFF
--- a/crates/atuin/src/shell/atuin.bash
+++ b/crates/atuin/src/shell/atuin.bash
@@ -329,12 +329,12 @@ if [[ $__atuin_bind_up_arrow == true ]]; then
         bind -m emacs '"\e[A": "\C-x\C-p"'
         bind -m emacs '"\eOA": "\C-x\C-p"'
         bind -m vi-insert -x '"\C-x\C-p": __atuin_history --shell-up-key-binding --keymap-mode=vim-insert'
-        bind -m vi-insert -x '"\e[A": "\C-x\C-p"'
-        bind -m vi-insert -x '"\eOA": "\C-x\C-p"'
+        bind -m vi-insert '"\e[A": "\C-x\C-p"'
+        bind -m vi-insert '"\eOA": "\C-x\C-p"'
         bind -m vi-command -x '"\C-x\C-p": __atuin_history --shell-up-key-binding --keymap-mode=vim-normal'
-        bind -m vi-command -x '"\e[A": "\C-x\C-p"'
-        bind -m vi-command -x '"\eOA": "\C-x\C-p"'
-        bind -m vi-command -x '"k": "\C-x\C-p"'
+        bind -m vi-command '"\e[A": "\C-x\C-p"'
+        bind -m vi-command '"\eOA": "\C-x\C-p"'
+        bind -m vi-command '"k": "\C-x\C-p"'
     fi
 fi
 


### PR DESCRIPTION
See the commit message. This fixes a problem reported at https://forum.atuin.sh/t/up-arrow-error-commands-not-saved/339

<!-- Thank you for making a PR! Bug fixes are always welcome, but if you're adding a new feature or changing an existing one, we'd really appreciate if you open an issue, post on the forum, or drop in on Discord -->

## Checks
- [x] I am happy for maintainers to push small adjustments to this PR, to speed up the review cycle
- [x] I have checked that there are no existing pull requests for the same thing
