### PR TITLE
feat: add option to set the position of the preview window

### DIFF
--- a/crates/atuin-client/config.toml
+++ b/crates/atuin-client/config.toml
@@ -211,6 +211,10 @@ records = true
 ## static: length of the longest command stored in the history.
 # strategy = "auto"
 
+## Sets the position of the preview window.
+## possible values: bottom, top
+#position = "bottom"
+
 [daemon]
 ## Enables using the daemon to sync. Requires the daemon to be running in the background. Start it with `atuin daemon`
 # enabled = false

--- a/crates/atuin-client/src/settings.rs
+++ b/crates/atuin-client/src/settings.rs
@@ -336,6 +336,7 @@ pub struct Keys {
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Preview {
     pub strategy: PreviewStrategy,
+    pub position: PreviewPosition,
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -374,6 +375,7 @@ impl Default for Preview {
     fn default() -> Self {
         Self {
             strategy: PreviewStrategy::Auto,
+            position: PreviewPosition::Bottom,
         }
     }
 }
@@ -410,6 +412,18 @@ pub enum PreviewStrategy {
     // Preview height is calculated for the length of the longest command stored in the history.
     #[serde(rename = "static")]
     Static,
+}
+
+// The preview position.
+#[derive(Clone, Debug, Deserialize, Copy, PartialEq, Eq, ValueEnum, Serialize)]
+pub enum PreviewPosition {
+    // Preview position Top.
+    #[serde(rename = "top")]
+    Top,
+
+    // Preview position Bottom.
+    #[serde(rename = "bottom")]
+    Bottom,
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -715,6 +729,7 @@ impl Settings {
             .set_default("inline_height", 0)?
             .set_default("show_preview", true)?
             .set_default("preview.strategy", "auto")?
+            .set_default("preview.position", "bottom")?
             .set_default("max_preview_height", 4)?
             .set_default("show_help", true)?
             .set_default("show_tabs", true)?

--- a/crates/atuin/src/command/client/search/interactive.rs
+++ b/crates/atuin/src/command/client/search/interactive.rs
@@ -729,7 +729,7 @@ impl State {
 
         let title = self.build_title(theme);
         f.render_widget(title, header_chunks[0]);
-        
+
         let help = self.build_help(settings, theme);
         f.render_widget(help, header_chunks[1]);
 


### PR DESCRIPTION
This change adds an option to set the position of the preview window.
The default is `bottom`, which is the current behavior.

```yaml
## Sets the position of the preview window.
## possible values: bottom, top
#position = "bottom"
```

See the forum discussion [here](https://forum.atuin.sh/t/weekly-release-2024-17/296/4?u=tessus).

For this particular TUI change there are no test cases to write. I thought how I could write any, but none of them made any sense.
I tested all variations (compact/invert/preview) manually.

# `invert = false`

<img width="795" alt="image" src="https://github.com/atuinsh/atuin/assets/223439/9bab1c69-a549-4bf5-928b-911f7a8f47d6">

# `invert = true`

<img width="793" alt="image" src="https://github.com/atuinsh/atuin/assets/223439/98093a00-c989-4899-a15a-dd711056fc9b">


<!-- Thank you for making a PR! Bug fixes are always welcome, but if you're adding a new feature or changing an existing one, we'd really appreciate if you open an issue, post on the forum, or drop in on Discord -->

## Checks
- [x] I am happy for maintainers to push small adjustments to this PR, to speed up the review cycle
- [x] I have checked that there are no existing pull requests for the same thing


