### PR TITLE
install.sh: log cargo and rustc version

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -156,6 +156,10 @@ __atuin_install_cargo(){
 
 	fi
 
+ 	# Log cargo and rustc versions for support
+	cargo --version
+ 	rustc --version
+  
 	cargo install atuin
 }
 


### PR DESCRIPTION
Issue https://github.com/atuinsh/atuin/issues/2031 was caused by an outdated rustc version. 

The build should ideally fail with a better error message (is the workspace's `rust-version` lower than this dep's?), but in the meantime let's log both cargo and rustc versions to help with support.

## Checks
- [x] I am happy for maintainers to push small adjustments to this PR, to speed up the review cycle
- [ ] I have checked that there are no existing pull requests for the same thing
