### PR TITLE
chore(deps): raise MSRV to 1.74 to match dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,5 @@
 [workspace]
-members = [
-    "crates/*",
-]
+members = ["crates/*"]
 
 resolver = "2"
 exclude = ["ui/backend"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [workspace]
 members = [
-  "crates/*",
+    "crates/*",
 ]
 
 resolver = "2"
@@ -9,7 +9,7 @@ exclude = ["ui/backend"]
 [workspace.package]
 version = "18.2.0"
 authors = ["Ellie Huxtable <ellie@elliehuxtable.com>"]
-rust-version = "1.70"
+rust-version = "1.74"
 license = "MIT"
 homepage = "https://atuin.sh"
 repository = "https://github.com/atuinsh/atuin"


### PR DESCRIPTION
`rust-version` on the workspace is set to 1.70 while env_logger requires 1.71 and  clap requires 1.74. Bumping accordingly.

You can check it with `cargo hack check --rust-version -p atuin --all-targets --ignore-private`, as documented in [the cargo book](https://doc.rust-lang.org/cargo/guide/continuous-integration.html#verifying-rust-version). This could be automated before releases if you have the insanity points to spend on GA.

Fixes #2031

## Checks
- [x] I am happy for maintainers to push small adjustments to this PR, to speed up the review cycle
- [x] I have checked that there are no existing pull requests for the same thing
