### PR TITLE
chore(ci): don't run "Update Nix Deps" CI on forks

### DIFF
--- a/.github/workflows/update-nix-deps.yml
+++ b/.github/workflows/update-nix-deps.yml
@@ -7,6 +7,7 @@ on:
 jobs:
   lockfile:
     runs-on: ubuntu-latest
+    if: github.repository == 'atuinsh/atuin'
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3


### PR DESCRIPTION
This CI schedule runs on forks, creating PR notification that could be confusing to contributors. Change workflow setup to only run on the canonical repo. People can still run it manually if they wish.

## Checks
- [x] I am happy for maintainers to push small adjustments to this PR, to speed up the review cycle
- [x] I have checked that there are no existing pull requests for the same thing
