### PR TITLE
feat(doctor): report sqlite version

### DIFF
--- a/crates/atuin-client/src/database.rs
+++ b/crates/atuin-client/src/database.rs
@@ -154,6 +154,12 @@ impl Sqlite {
         Ok(Self { pool })
     }
 
+    pub async fn sqlite_version(&self) -> Result<String> {
+        sqlx::query_scalar("SELECT sqlite_version()")
+            .fetch_one(&self.pool)
+            .await
+    }
+
     async fn setup_db(pool: &SqlitePool) -> Result<()> {
         debug!("running sqlite database setup");
 

--- a/crates/atuin/src/command/client.rs
+++ b/crates/atuin/src/command/client.rs
@@ -148,7 +148,7 @@ impl Cmd {
                 Ok(())
             }
 
-            Self::Doctor => doctor::run(&settings),
+            Self::Doctor => doctor::run(&settings).await,
 
             Self::DefaultConfig => {
                 default_config::run();

--- a/crates/atuin/src/command/client/doctor.rs
+++ b/crates/atuin/src/command/client/doctor.rs
@@ -1,6 +1,7 @@
 use std::process::Command;
 use std::{env, path::PathBuf, str::FromStr};
 
+use atuin_client::database::Sqlite;
 use atuin_client::settings::Settings;
 use atuin_common::shell::{shell_name, Shell};
 use colored::Colorize;
@@ -261,10 +262,12 @@ struct AtuinInfo {
     /// Whether the main Atuin sync server is in use
     /// I'm just calling it Atuin Cloud for lack of a better name atm
     pub sync: Option<SyncInfo>,
+
+    pub sqlite_version: String,
 }
 
 impl AtuinInfo {
-    pub fn new(settings: &Settings) -> Self {
+    pub async fn new(settings: &Settings) -> Self {
         let session_path = settings.session_path.as_str();
         let logged_in = PathBuf::from(session_path).exists();
 
@@ -274,9 +277,18 @@ impl AtuinInfo {
             None
         };
 
+        let sqlite_version = match Sqlite::new("sqlite::memory:", 0.1).await {
+            Ok(db) => db
+                .sqlite_version()
+                .await
+                .unwrap_or_else(|_| "unknown".to_string()),
+            Err(_) => "error".to_string(),
+        };
+
         Self {
             version: crate::VERSION.to_string(),
             sync,
+            sqlite_version,
         }
     }
 }
@@ -289,9 +301,9 @@ struct DoctorDump {
 }
 
 impl DoctorDump {
-    pub fn new(settings: &Settings) -> Self {
+    pub async fn new(settings: &Settings) -> Self {
         Self {
-            atuin: AtuinInfo::new(settings),
+            atuin: AtuinInfo::new(settings).await,
             shell: ShellInfo::new(),
             system: SystemInfo::new(),
         }
@@ -330,10 +342,10 @@ fn checks(info: &DoctorDump) {
     }
 }
 
-pub fn run(settings: &Settings) -> Result<()> {
+pub async fn run(settings: &Settings) -> Result<()> {
     println!("{}", "Atuin Doctor".bold());
     println!("Checking for diagnostics");
-    let dump = DoctorDump::new(settings);
+    let dump = DoctorDump::new(settings).await;
 
     checks(&dump);
 


### PR DESCRIPTION
Report the sqlite version to detect unsupported versions possibly brought in by third-party patching.

We could also grab the `libsqlite3_sys::SQLITE_VERSION` constant, but it requires listing this transitive dependencies in the deps, as sqlx_sqlite does not re-export this constant. Opening a sqlite connection also allows querying the build flags, which we might want to log too.

## Checks
- [x] I am happy for maintainers to push small adjustments to this PR, to speed up the review cycle
- [x] I have checked that there are no existing pull requests for the same thing
