### PR TITLE
Fix 2081: Replace serde_yaml::to_string with serde_json::to_string_yaml

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -234,7 +234,6 @@ dependencies = [
  "semver",
  "serde",
  "serde_json",
- "serde_yaml",
  "sysinfo",
  "time",
  "tiny-bip39",
@@ -3282,19 +3281,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_yaml"
-version = "0.9.34+deprecated"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
-dependencies = [
- "indexmap 2.2.6",
- "itoa",
- "ryu",
- "serde",
- "unsafe-libyaml",
-]
-
-[[package]]
 name = "sha1"
 version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4270,12 +4256,6 @@ dependencies = [
  "crypto-common",
  "subtle",
 ]
-
-[[package]]
-name = "unsafe-libyaml"
-version = "0.2.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
 
 [[package]]
 name = "untrusted"

--- a/crates/atuin/Cargo.toml
+++ b/crates/atuin/Cargo.toml
@@ -83,7 +83,6 @@ tracing = "0.1"
 tracing-subscriber = { workspace = true }
 uuid = { workspace = true }
 unicode-segmentation = "1.11.0"
-serde_yaml = "0.9.34"
 sysinfo = "0.30.7"
 regex="1.10.4"
 

--- a/crates/atuin/src/command/client/doctor.rs
+++ b/crates/atuin/src/command/client/doctor.rs
@@ -349,7 +349,7 @@ pub async fn run(settings: &Settings) -> Result<()> {
 
     checks(&dump);
 
-    let dump = serde_yaml::to_string(&dump)?;
+    let dump = serde_json::to_string_pretty(&dump)?;
 
     println!("\nPlease include the output below with any bug reports or issues\n");
     println!("{dump}");


### PR DESCRIPTION
<!-- Thank you for making a PR! Bug fixes are always welcome, but if you're adding a new feature or changing an existing one, we'd really appreciate if you open an issue, post on the forum, or drop in on Discord -->
Closes #2081. 

The output will look a bit uglier, but it does the job. Here's my machine
```bash
{
  "atuin": {
    "version": "18.2.0",
    "sync": null,
    "sqlite_version": "3.44.0"
  },
  "shell": {
    "name": "bash",
    "default": "bash",
    "plugins": [],
    "preexec": null
  },
  "system": {
    "os": "Ubuntu",
    "arch": "x86_64",
    "version": "23.10",
    "disks": [
      {
        "name": "/dev/sda2",
        "filesystem": "ext4"
      },
      {
        "name": "/dev/sdb1",
        "filesystem": "ext4"
      },
      {
        "name": "/dev/sda2",
        "filesystem": "ext4"
      }
    ]
  }
}
```

## Checks
- [x] I am happy for maintainers to push small adjustments to this PR, to speed up the review cycle
- [x] I have checked that there are no existing pull requests for the same thing
