### PR TITLE
De-couple atuin nix build from nixpkgs rustc version

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,5 +1,26 @@
 {
   "nodes": {
+    "fenix": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ],
+        "rust-analyzer-src": "rust-analyzer-src"
+      },
+      "locked": {
+        "lastModified": 1717827974,
+        "narHash": "sha256-ixopuTeTouxqTxfMuzs6IaRttbT8JqRW5C9Q/57WxQw=",
+        "owner": "nix-community",
+        "repo": "fenix",
+        "rev": "ab655c627777ab5f9964652fe23bbb1dfbd687a8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "fenix",
+        "type": "github"
+      }
+    },
     "flake-compat": {
       "flake": false,
       "locked": {
@@ -52,9 +73,27 @@
     },
     "root": {
       "inputs": {
+        "fenix": "fenix",
         "flake-compat": "flake-compat",
         "flake-utils": "flake-utils",
         "nixpkgs": "nixpkgs"
+      }
+    },
+    "rust-analyzer-src": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1717583671,
+        "narHash": "sha256-+lRAmz92CNUxorqWusgJbL9VE1eKCnQQojglRemzwkw=",
+        "owner": "rust-lang",
+        "repo": "rust-analyzer",
+        "rev": "48bbdd6a74f3176987d5c809894ac33957000d19",
+        "type": "github"
+      },
+      "original": {
+        "owner": "rust-lang",
+        "ref": "nightly",
+        "repo": "rust-analyzer",
+        "type": "github"
       }
     },
     "systems": {

--- a/flake.nix
+++ b/flake.nix
@@ -6,11 +6,16 @@
       url = "github:edolstra/flake-compat";
       flake = false;
     };
+    fenix = {
+      url = "github:nix-community/fenix";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
   };
   outputs = {
     self,
     nixpkgs,
     flake-utils,
+    fenix,
     ...
   }:
     flake-utils.lib.eachDefaultSystem (system: let
@@ -18,6 +23,18 @@
     in {
       packages.atuin = pkgs.callPackage ./atuin.nix {
         inherit (pkgs.darwin.apple_sdk.frameworks) Security SystemConfiguration AppKit;
+        rustPlatform = let
+          toolchain =
+            fenix.packages.${system}.fromToolchainFile
+            {
+              file = ./rust-toolchain.toml;
+              sha256 = "sha256-7QfkHty6hSrgNM0fspycYkRcB82eEqYa4CoAJ9qA3tU=";
+            };
+        in
+          pkgs.makeRustPlatform {
+            cargo = toolchain;
+            rustc = toolchain;
+          };
       };
       packages.default = self.outputs.packages.${system}.atuin;
 


### PR DESCRIPTION
<!-- Thank you for making a PR! Bug fixes are always welcome, but if you're adding a new feature or changing an existing one, we'd really appreciate if you open an issue, post on the forum, or drop in on Discord -->

Closes #2089 

This PR moves the nix flake to using a rust toolchain provided by fenix (https://github.com/nix-community/fenix), which downloads the toolchain declared in `./rust-toolchain.toml`, removing the requirement on nixpkgs to update rustc for us to bump MSRV.

When the value in `./rust-toolchain.toml` is changed, the nix build must be run locally once (with `nix build -L`). This will print the new sha256 hash for the new rust toolchain, that must then be inserted into `flake.nix` before the build will succeed. This may be automatable via a github action - that is not included in this PR.


## Checks
- [x] I am happy for maintainers to push small adjustments to this PR, to speed up the review cycle
- [x] I have checked that there are no existing pull requests for the same thing
