### PR TITLE
chore: add audit config, ignore RUSTSEC-2023-0071

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -1,0 +1,9 @@
+[advisories]
+ignore = [
+  # This is a vuln on RSA. RSA is in our lockfile, but not in cargo-tree. 
+  # It is a issue with sqlx/cargo, and does not affect Atuin.
+  # See:
+  # - https://github.com/launchbadge/sqlx/issues/3211
+  # - https://github.com/rust-lang/cargo/issues/10801
+  "RUSTSEC-2023-0071"
+]


### PR DESCRIPTION
Ignore RUSTSEC-2023-0071

This is because rsa is in our lockfile. We do not actually require rsa, and it is not a part of `cargo tree`

It's pulled in by sqlx, even though we're not using it. This is a known bug with cargo

See

- https://github.com/launchbadge/sqlx/issues/3211
- https://github.com/rust-lang/cargo/issues/10801

Also note that Atuin's encryption does not use RSA, and never has

## Checks
- [ ] I am happy for maintainers to push small adjustments to this PR, to speed up the review cycle
- [ ] I have checked that there are no existing pull requests for the same thing
