### PR TITLE
perf: create idx cache table

### DIFF
--- a/crates/atuin-server-postgres/migrations/20240614104159_idx-cache.sql
+++ b/crates/atuin-server-postgres/migrations/20240614104159_idx-cache.sql
@@ -1,6 +1,3 @@
--- using group by and max is slow. as the store grows, latency is creeping up.
--- get a handle on it!
-
 create table store_idx_cache(
   id bigserial primary key, 
   user_id bigint,
@@ -9,33 +6,3 @@ create table store_idx_cache(
   tag text,
   idx bigint
 );
-
-
-create or replace function cache_store_idx()
-returns trigger as 
-$func$
-begin
-  if (TG_OP='INSERT') then
-    update store_idx_cache set idx = (select max(idx) from store where user_id=new.user_id and host=new.host and tag=new.tag) where user_id=new.user_id and host=new.host and tag=new.tag;
-
-    if not found then
-      insert into store_idx_cache(user_id, host, tag, idx) 
-      values (
-        new.user_id, 
-        new.host,
-        new.tag,
-        (select max(idx) from store where user_id = new.user_id and host=new.host and tag=new.tag)
-      );
-    end if;
-  end if;
-
-  return NEW; -- this is actually ignored for an after trigger, but oh well
-end;
-$func$
-language plpgsql volatile -- pldfplplpflh
-cost 100; -- default value
-
-create or replace trigger tg_cache_store_idx
-after insert on store
-for each row 
-execute procedure cache_store_idx();

--- a/crates/atuin-server-postgres/migrations/20240614104159_idx-cache.sql
+++ b/crates/atuin-server-postgres/migrations/20240614104159_idx-cache.sql
@@ -15,27 +15,27 @@ create or replace function cache_store_idx()
 returns trigger as 
 $func$
 begin
-	if (TG_OP='INSERT') then
-		update store_idx_cache set idx = (select max(idx) from store where user_id=new.user_id and host=new.host and tag=new.tag) where user_id=new.user_id and host=new.host and tag=new.tag;
+  if (TG_OP='INSERT') then
+    update store_idx_cache set idx = (select max(idx) from store where user_id=new.user_id and host=new.host and tag=new.tag) where user_id=new.user_id and host=new.host and tag=new.tag;
 
-		if not found then
-			insert into store_idx_cache(user_id, host, tag, idx) 
-			values (
-				new.user_id, 
+    if not found then
+      insert into store_idx_cache(user_id, host, tag, idx) 
+      values (
+        new.user_id, 
         new.host,
         new.tag,
-				(select max(idx) from store where user_id = new.user_id and host=new.host and tag=new.tag)
-			);
-		end if;
-	end if;
+        (select max(idx) from store where user_id = new.user_id and host=new.host and tag=new.tag)
+      );
+    end if;
+  end if;
 
-	return NEW; -- this is actually ignored for an after trigger, but oh well
+  return NEW; -- this is actually ignored for an after trigger, but oh well
 end;
 $func$
 language plpgsql volatile -- pldfplplpflh
 cost 100; -- default value
 
 create or replace trigger tg_cache_store_idx
-	after insert on store
-	for each row 
-	execute procedure cache_store_idx();
+after insert on store
+for each row 
+execute procedure cache_store_idx();

--- a/crates/atuin-server-postgres/migrations/20240614104159_idx-cache.sql
+++ b/crates/atuin-server-postgres/migrations/20240614104159_idx-cache.sql
@@ -1,7 +1,5 @@
 -- using group by and max is slow. as the store grows, latency is creeping up.
 -- get a handle on it!
--- Really this sort of workload (lots of aggregation) is better suited to OLAP,
--- but let's just stick with postgres until we can't any more
 
 create table store_idx_cache(
   id bigserial primary key, 

--- a/crates/atuin-server-postgres/migrations/20240614104159_idx-cache.sql
+++ b/crates/atuin-server-postgres/migrations/20240614104159_idx-cache.sql
@@ -1,0 +1,43 @@
+-- using group by and max is slow. as the store grows, latency is creeping up.
+-- get a handle on it!
+-- Really this sort of workload (lots of aggregation) is better suited to OLAP,
+-- but let's just stick with postgres until we can't any more
+
+create table store_idx_cache(
+  id bigserial primary key, 
+  user_id bigint,
+
+  host uuid,
+  tag text,
+  idx bigint
+);
+
+
+create or replace function cache_store_idx()
+returns trigger as 
+$func$
+begin
+	if (TG_OP='INSERT') then
+		update store_idx_cache set idx = (select max(idx) from store where user_id=new.user_id and host=new.host and tag=new.tag) where user_id=new.user_id and host=new.host and tag=new.tag;
+
+		if not found then
+			insert into store_idx_cache(user_id, host, tag, idx) 
+			values (
+				new.user_id, 
+        new.host,
+        new.tag,
+				(select max(idx) from store where user_id = new.user_id and host=new.host and tag=new.tag)
+			);
+		end if;
+	end if;
+
+	return NEW; -- this is actually ignored for an after trigger, but oh well
+end;
+$func$
+language plpgsql volatile -- pldfplplpflh
+cost 100; -- default value
+
+create or replace trigger tg_cache_store_idx
+	after insert on store
+	for each row 
+	execute procedure cache_store_idx();


### PR DESCRIPTION
Let's stop that P99 from creeping up eh?

<img width="1404" alt="Screenshot 2024-07-01 at 13 48 15" src="https://github.com/atuinsh/atuin/assets/53315310/0238fd15-94a2-4456-a7fa-dc88a915a1b9">

Postgres doesn't like group by aggregates very much (it's OLTP afterall). I'll follow up with the actual caching logic


## Checks
- [ ] I am happy for maintainers to push small adjustments to this PR, to speed up the review cycle
- [ ] I have checked that there are no existing pull requests for the same thing
