### PR TITLE
fix: unitless sync_frequence = 0 not parsed by humantime

### DIFF
--- a/crates/atuin-client/src/settings.rs
+++ b/crates/atuin-client/src/settings.rs
@@ -553,6 +553,10 @@ impl Settings {
             return Ok(false);
         }
 
+        if self.sync_frequency == "0" {
+            return Ok(true);
+        }
+
         match parse_duration(self.sync_frequency.as_str()) {
             Ok(d) => {
                 let d = time::Duration::try_from(d).unwrap();


### PR DESCRIPTION
Resolve #2147

<!-- Thank you for making a PR! Bug fixes are always welcome, but if you're adding a new feature or changing an existing one, we'd really appreciate if you open an issue, post on the forum, or drop in on Discord -->

## Checks
- [ ] I am happy for maintainers to push small adjustments to this PR, to speed up the review cycle
- [ ] I have checked that there are no existing pull requests for the same thing
