### PR TITLE
Fix `scroll_exits` default in `config.toml`

### DIFF
--- a/crates/atuin-client/config.toml
+++ b/crates/atuin-client/config.toml
@@ -196,7 +196,7 @@ enter_accept = true
 
 [keys]
 # Defaults to true. If disabled, using the up/down key won't exit the TUI when scrolled past the first/last entry.
-# scroll_exits = false
+# scroll_exits = true
 
 [sync]
 # Enable sync v2 by default


### PR DESCRIPTION
The commented-out config lines seem to show the default value for each config option.

This isn't true for `scroll_exits`, which actually defaults to `true`.

## Checks
- [x] I am happy for maintainers to push small adjustments to this PR, to speed up the review cycle
- [x] I have checked that there are no existing pull requests for the same thing
