### PR TITLE
Feature atuin import from file

### DIFF
--- a/crates/atuin-client/src/import/atuin_histdb.rs
+++ b/crates/atuin-client/src/import/atuin_histdb.rs
@@ -1,0 +1,73 @@
+// import old shell history from atuin-histdb file!
+// automatically hoover up all that we can find
+
+use std::path::{Path, PathBuf};
+
+use async_trait::async_trait;
+use eyre::{eyre, Result};
+
+use crate::database::{Sqlite, Database, current_context};
+use crate::settings::FilterMode;
+
+use super::Importer;
+use crate::history::History;
+use crate::import::Loader;
+
+pub struct AtuinExternalDb {
+    histdb: Vec<History>,
+}
+impl AtuinExternalDb {
+    pub fn histpath() -> Result<PathBuf> {
+        let path = Path::new("/tmp/history.db").to_path_buf();
+        if path.exists() {
+            Ok(path)
+        } else {
+            Err(eyre!("Could not find history file hardcodded at /tmp/history.db"))
+        }
+    }
+}
+
+/// Read db at given file, return vector of entries.
+async fn hist_from_db(dbpath: PathBuf) -> Result<Vec<History>> {
+    let db_to_migrate = Sqlite::new(dbpath, 0.1).await?;
+    let external_history = db_to_migrate.list(
+        &[FilterMode::Global],
+        &current_context(), // this is passed to list, but only used for the workspace
+        None,
+        false,
+        true,
+    ).await.unwrap();
+    // debug!("{}", external_history);
+    Ok(external_history)
+}
+
+#[async_trait]
+impl Importer for AtuinExternalDb {
+    const NAME: &'static str = "history.db";
+
+    /// Creates a new AtuinExternalDb imports the history
+    /// Does no duplicate checking.
+    async fn new() -> Result<Self> {
+        let dbpath = AtuinExternalDb::histpath()?;
+        let histdb_entry_vec = hist_from_db(dbpath).await?;
+        Ok(Self {
+            histdb: histdb_entry_vec,
+        })
+    }
+
+    async fn entries(&mut self) -> Result<usize> {
+        Ok(self.histdb.len())
+    }
+
+    async fn load(self, h: &mut impl Loader) -> Result<()> {
+        for entry in self.histdb {
+            h.push(entry).await?;
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod test {
+    // TODO
+}

--- a/crates/atuin-client/src/import/mod.rs
+++ b/crates/atuin-client/src/import/mod.rs
@@ -18,6 +18,7 @@ pub mod xonsh;
 pub mod xonsh_sqlite;
 pub mod zsh;
 pub mod zsh_histdb;
+pub mod atuin_histdb;
 
 #[async_trait]
 pub trait Importer: Sized {

--- a/crates/atuin-client/src/import/zsh_histdb.rs
+++ b/crates/atuin-client/src/import/zsh_histdb.rs
@@ -48,11 +48,6 @@ use crate::import::Loader;
 use crate::utils::{get_hostname, get_username};
 
 #[derive(sqlx::FromRow, Debug)]
-pub struct HistDbEntryCount {
-    pub count: usize,
-}
-
-#[derive(sqlx::FromRow, Debug)]
 pub struct HistDbEntry {
     pub id: i64,
     pub start_time: PrimitiveDateTime,

--- a/crates/atuin/src/command/client/import.rs
+++ b/crates/atuin/src/command/client/import.rs
@@ -9,7 +9,7 @@ use atuin_client::{
     database::Database,
     history::History,
     import::{
-        bash::Bash, fish::Fish, nu::Nu, nu_histdb::NuHistDb, replxx::Replxx, resh::Resh,
+        atuin_histdb::AtuinExternalDb, bash::Bash, fish::Fish, nu::Nu, nu_histdb::NuHistDb, replxx::Replxx, resh::Resh,
         xonsh::Xonsh, xonsh_sqlite::XonshSqlite, zsh::Zsh, zsh_histdb::ZshHistDb, Importer, Loader,
     },
 };
@@ -40,6 +40,8 @@ pub enum Cmd {
     Xonsh,
     /// Import history from xonsh sqlite db
     XonshSqlite,
+    /// Import history from a separate atuin history.db file
+    AtuinExternalDb
 }
 
 const BATCH_SIZE: usize = 100;
@@ -116,6 +118,7 @@ impl Cmd {
             Self::NuHistDb => import::<NuHistDb, DB>(db).await,
             Self::Xonsh => import::<Xonsh, DB>(db).await,
             Self::XonshSqlite => import::<XonshSqlite, DB>(db).await,
+            Self::AtuinExternalDb => import::<AtuinExternalDb, DB>(db).await,
         }
     }
 }


### PR DESCRIPTION
Hi, I wanted a one-off offline sync for my atuin history.db. I've left it in a rough and ready state to see if there's any interest in it, and to get feedback on if the feedback is wanted.

(would address https://github.com/atuinsh/atuin/issues/816 ).

Reasons I'd personally like this feature:
* People aren't always in a situation where they have access to the internet, and a one-off import to copy history across can be useful.
* The syncing server seems non-trivial to self-host, and there is a lot of code to review if you want to be sure you can trust the external syncing server.

Either way, figured it was easy enough to write some code to start a discussion. Let me know your thoughts.

## Checks
- [x] I am happy for maintainers to push small adjustments to this PR, to speed up the review cycle
- [x] I have checked that there are no existing pull requests for the same thing
