### PR TITLE
chore: Add systemd user units for atuin daemon

### DIFF
--- a/systemd/atuin-daemon.service
+++ b/systemd/atuin-daemon.service
@@ -1,0 +1,10 @@
+[Unit]
+Description=atuin shell history daemon
+Requires=atuin-daemon.socket
+
+[Service]
+ExecStart=atuin daemon
+
+[Install]
+Also=atuin-daemon.socket
+WantedBy=default.target

--- a/systemd/atuin-daemon.socket
+++ b/systemd/atuin-daemon.socket
@@ -1,0 +1,9 @@
+[Unit]
+Description=Unix socket activation for atuin shell history daemon
+
+[Socket]
+ListenStream=%t/atuin.socket
+SocketMode=0600
+
+[Install]
+WantedBy=sockets.target


### PR DESCRIPTION
Now that https://github.com/atuinsh/atuin/pull/2171 is merged, we can add sensible systemd user units for atuin daemon.

## Checks
- [x] I am happy for maintainers to push small adjustments to this PR, to speed up the review cycle
- [x] I have checked that there are no existing pull requests for the same thing
