### PR TITLE
filter out various environment variables containing potential secrets

### DIFF
--- a/crates/atuin-client/src/secrets.rs
+++ b/crates/atuin-client/src/secrets.rs
@@ -8,6 +8,26 @@ pub static SECRET_PATTERNS: &[(&str, &str, &str)] = &[
         "AKIAIOSFODNN7EXAMPLE",
     ),
     (
+        "AWS secret access key env var",
+        "AWS_ACCESS_KEY_ID",
+        "export AWS_ACCESS_KEY_ID=KEYDATA",
+    ),
+    (
+        "AWS secret access key env var",
+        "AWS_ACCESS_KEY_ID",
+        "export AWS_ACCESS_KEY_ID=KEYDATA",
+    ),
+    (
+        "Microsoft Azure secret access key env var",
+        "AZURE_.*_KEY",
+        "export AZURE_STORAGE_ACCOUNT_KEY=KEYDATA",
+    ),
+    (
+        "Google cloud platform key env var",
+        "GOOGLE_SERVICE_ACCOUNT_KEY",
+        "export GOOGLE_SERVICE_ACCOUNT_KEY=KEYDATA",
+    ),
+    (
         "Atuin login",
         r"atuin\s+login",
         "atuin login -u mycoolusername -p mycoolpassword -k \"lots of random words\"",


### PR DESCRIPTION
Add secret key filters for `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AZURE_STORAGE_ACCOUNT_KEY`, and `GOOGLE_SERVICE_ACCOUNT_KEY`.

I don't know how common these environment variables are. I know there are a lot of libraries that look in AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY env vars for credentials, but I've done a bunch of searching and it seems like that pattern is less common for the other cloud providers?

## Checks
- [x] I am happy for maintainers to push small adjustments to this PR, to speed up the review cycle
- [x] I have checked that there are no existing pull requests for the same thing
