### PR TITLE
feat: add user account verification

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -300,8 +300,10 @@ dependencies = [
 name = "atuin-common"
 version = "18.3.0"
 dependencies = [
+ "base64 0.22.1",
  "directories",
  "eyre",
+ "getrandom",
  "lazy_static",
  "pretty_assertions",
  "rand",
@@ -401,6 +403,7 @@ dependencies = [
  "fs-err",
  "metrics",
  "metrics-exporter-prometheus",
+ "postmark",
  "rand",
  "reqwest",
  "rustls",
@@ -2742,6 +2745,23 @@ name = "portable-atomic"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7170ef9988bc169ba16dd36a7fa041e5c4cbeb6a35b76d4c03daded371eae7c0"
+
+[[package]]
+name = "postmark"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3bc71e3fdb4e15d2636d67f5784f17488a612324235086dde765ab6016a43fa"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "http 0.2.12",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "thiserror",
+ "typed-builder",
+ "url",
+]
 
 [[package]]
 name = "powerfmt"

--- a/crates/atuin-common/Cargo.toml
+++ b/crates/atuin-common/Cargo.toml
@@ -24,6 +24,8 @@ semver = { workspace = true }
 thiserror = { workspace = true }
 directories = { workspace = true }
 sysinfo = "0.30.7"
+base64 = { workspace = true }
+getrandom = "0.2"
 
 lazy_static = "1.4.0"
 

--- a/crates/atuin-common/src/api.rs
+++ b/crates/atuin-common/src/api.rs
@@ -34,6 +34,12 @@ pub struct RegisterResponse {
 pub struct DeleteUserResponse {}
 
 #[derive(Debug, Serialize, Deserialize)]
+pub struct SendVerificationResponse {
+    pub email_sent: bool,
+    pub verified: bool,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
 pub struct ChangePasswordRequest {
     pub current_password: String,
     pub new_password: String,

--- a/crates/atuin-common/src/api.rs
+++ b/crates/atuin-common/src/api.rs
@@ -40,6 +40,16 @@ pub struct SendVerificationResponse {
 }
 
 #[derive(Debug, Serialize, Deserialize)]
+pub struct VerificationTokenRequest {
+    pub token: String,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct VerificationTokenResponse {
+    pub verified: bool,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
 pub struct ChangePasswordRequest {
     pub current_password: String,
     pub new_password: String,

--- a/crates/atuin-common/src/utils.rs
+++ b/crates/atuin-common/src/utils.rs
@@ -4,7 +4,7 @@ use std::path::PathBuf;
 
 use eyre::{eyre, Result};
 
-use base64::prelude::{Engine, BASE64_STANDARD};
+use base64::prelude::{Engine, BASE64_URL_SAFE_NO_PAD};
 use getrandom::getrandom;
 use uuid::Uuid;
 
@@ -23,7 +23,9 @@ pub fn crypto_random_bytes<const N: usize>() -> [u8; N] {
 pub fn crypto_random_string<const N: usize>() -> String {
     let bytes = crypto_random_bytes::<N>();
 
-    BASE64_STANDARD.encode(bytes)
+    // We only use this to create a random string, and won't be reversing it to find the original
+    // data - no padding is OK there. It may be in URLs.
+    BASE64_URL_SAFE_NO_PAD.encode(bytes)
 }
 
 pub fn uuid_v7() -> Uuid {

--- a/crates/atuin-common/src/utils.rs
+++ b/crates/atuin-common/src/utils.rs
@@ -4,15 +4,26 @@ use std::path::PathBuf;
 
 use eyre::{eyre, Result};
 
-use rand::RngCore;
+use base64::prelude::{Engine, BASE64_STANDARD};
+use getrandom::getrandom;
 use uuid::Uuid;
 
-pub fn random_bytes<const N: usize>() -> [u8; N] {
+/// Generate N random bytes, using a cryptographically secure source
+pub fn crypto_random_bytes<const N: usize>() -> [u8; N] {
+    // rand say they are in principle safe for crypto purposes, but that it is perhaps a better
+    // idea to use getrandom for things such as passwords.
     let mut ret = [0u8; N];
 
-    rand::thread_rng().fill_bytes(&mut ret);
+    getrandom(&mut ret).expect("Failed to generate random bytes!");
 
     ret
+}
+
+/// Generate N random bytes using a cryptographically secure source, return encoded as a string
+pub fn crypto_random_string<const N: usize>() -> String {
+    let bytes = crypto_random_bytes::<N>();
+
+    BASE64_STANDARD.encode(bytes)
 }
 
 pub fn uuid_v7() -> Uuid {
@@ -178,6 +189,7 @@ impl<T: AsRef<str>> Escapable for T {}
 
 #[cfg(test)]
 mod tests {
+    use pretty_assertions::assert_ne;
     use time::Month;
 
     use super::*;
@@ -291,5 +303,18 @@ mod tests {
             "with \x1b[31mcontrol\x1b[0m characters".escape_control(),
             Cow::Owned(_)
         ));
+    }
+
+    #[test]
+    fn dumb_random_test() {
+        // Obviously not a test of randomness, but make sure we haven't made some
+        // catastrophic error
+
+        assert_ne!(crypto_random_string::<1>(), crypto_random_string::<1>());
+        assert_ne!(crypto_random_string::<2>(), crypto_random_string::<2>());
+        assert_ne!(crypto_random_string::<4>(), crypto_random_string::<4>());
+        assert_ne!(crypto_random_string::<8>(), crypto_random_string::<8>());
+        assert_ne!(crypto_random_string::<16>(), crypto_random_string::<16>());
+        assert_ne!(crypto_random_string::<32>(), crypto_random_string::<32>());
     }
 }

--- a/crates/atuin-server-database/src/lib.rs
+++ b/crates/atuin-server-database/src/lib.rs
@@ -53,8 +53,11 @@ pub trait Database: Sized + Clone + Send + Sync + 'static {
     async fn get_user(&self, username: &str) -> DbResult<User>;
     async fn get_user_session(&self, u: &User) -> DbResult<Session>;
     async fn add_user(&self, user: &NewUser) -> DbResult<i64>;
+
     async fn user_verified(&self, id: i64) -> DbResult<bool>;
     async fn verify_user(&self, id: i64) -> DbResult<()>;
+    async fn user_verification_token(&self, id: i64) -> DbResult<String>;
+
     async fn update_user_password(&self, u: &User) -> DbResult<()>;
 
     async fn total_history(&self) -> DbResult<i64>;

--- a/crates/atuin-server-database/src/lib.rs
+++ b/crates/atuin-server-database/src/lib.rs
@@ -53,6 +53,8 @@ pub trait Database: Sized + Clone + Send + Sync + 'static {
     async fn get_user(&self, username: &str) -> DbResult<User>;
     async fn get_user_session(&self, u: &User) -> DbResult<Session>;
     async fn add_user(&self, user: &NewUser) -> DbResult<i64>;
+    async fn user_verified(&self, id: i64) -> DbResult<bool>;
+    async fn verify_user(&self, id: i64) -> DbResult<()>;
     async fn update_user_password(&self, u: &User) -> DbResult<()>;
 
     async fn total_history(&self) -> DbResult<i64>;

--- a/crates/atuin-server-database/src/models.rs
+++ b/crates/atuin-server-database/src/models.rs
@@ -32,6 +32,7 @@ pub struct User {
     pub username: String,
     pub email: String,
     pub password: String,
+    pub verified: Option<OffsetDateTime>,
 }
 
 pub struct Session {

--- a/crates/atuin-server-postgres/migrations/20240621110731_user-verified.sql
+++ b/crates/atuin-server-postgres/migrations/20240621110731_user-verified.sql
@@ -1,1 +1,8 @@
 alter table users add verified_at timestamp with time zone default null;
+
+create table user_verification_token(
+  id bigserial primary key, 
+  user_id bigint unique references users(id), 
+  token text, 
+  valid_until timestamp with time zone
+);

--- a/crates/atuin-server-postgres/migrations/20240621110731_user-verified.sql
+++ b/crates/atuin-server-postgres/migrations/20240621110731_user-verified.sql
@@ -1,0 +1,1 @@
+alter table users add verified timestamp with time zone default null;

--- a/crates/atuin-server-postgres/migrations/20240621110731_user-verified.sql
+++ b/crates/atuin-server-postgres/migrations/20240621110731_user-verified.sql
@@ -1,1 +1,1 @@
-alter table users add verified timestamp with time zone default null;
+alter table users add verified_at timestamp with time zone default null;

--- a/crates/atuin-server-postgres/src/wrappers.rs
+++ b/crates/atuin-server-postgres/src/wrappers.rs
@@ -16,7 +16,7 @@ impl<'a> FromRow<'a, PgRow> for DbUser {
             username: row.try_get("username")?,
             email: row.try_get("email")?,
             password: row.try_get("password")?,
-            verified: row.try_get("verified")?,
+            verified: row.try_get("verified_at")?,
         }))
     }
 }

--- a/crates/atuin-server-postgres/src/wrappers.rs
+++ b/crates/atuin-server-postgres/src/wrappers.rs
@@ -16,6 +16,7 @@ impl<'a> FromRow<'a, PgRow> for DbUser {
             username: row.try_get("username")?,
             email: row.try_get("email")?,
             password: row.try_get("password")?,
+            verified: row.try_get("verified")?,
         }))
     }
 }

--- a/crates/atuin-server/Cargo.toml
+++ b/crates/atuin-server/Cargo.toml
@@ -37,3 +37,4 @@ argon2 = "0.5"
 semver = { workspace = true }
 metrics-exporter-prometheus = "0.12.1"
 metrics = "0.21.1"
+postmark = {version= "0.10.0", features=["reqwest"]}

--- a/crates/atuin-server/src/handlers/user.rs
+++ b/crates/atuin-server/src/handlers/user.rs
@@ -12,9 +12,11 @@ use axum::{
     Json,
 };
 use metrics::counter;
+
+use postmark::{reqwest::PostmarkClient, Query};
+
 use rand::rngs::OsRng;
 use tracing::{debug, error, info, instrument};
-use uuid::Uuid;
 
 use super::{ErrorResponse, ErrorResponseStatus, RespExt};
 use crate::router::{AppState, UserAuth};
@@ -25,7 +27,7 @@ use atuin_server_database::{
 
 use reqwest::header::CONTENT_TYPE;
 
-use atuin_common::api::*;
+use atuin_common::{api::*, utils::crypto_random_string};
 
 pub fn verify_str(hash: &str, password: &str) -> bool {
     let arg2 = Argon2::new(Algorithm::Argon2id, Version::V0x13, Params::default());
@@ -126,7 +128,8 @@ pub async fn register<DB: Database>(
         }
     };
 
-    let token = Uuid::new_v4().as_simple().to_string();
+    // 24 bytes encoded as base64
+    let token = crypto_random_string::<24>();
 
     let new_session = NewSession {
         user_id,
@@ -173,6 +176,91 @@ pub async fn delete<DB: Database>(
     counter!("atuin_users_deleted", 1);
 
     Ok(Json(DeleteUserResponse {}))
+}
+
+#[instrument(skip_all, fields(user.id = user.id))]
+pub async fn send_verification<DB: Database>(
+    UserAuth(user): UserAuth,
+    state: State<AppState<DB>>,
+) -> Result<Json<SendVerificationResponse>, ErrorResponseStatus<'static>> {
+    let settings = state.0.settings;
+
+    if !settings.mail.enabled {
+        return Ok(Json(SendVerificationResponse {
+            email_sent: false,
+            verified: false,
+        }));
+    }
+
+    if user.verified.is_some() {
+        return Ok(Json(SendVerificationResponse {
+            email_sent: false,
+            verified: true,
+        }));
+    }
+
+    // TODO: if we ever add another mail provider, can match on them all here.
+    let postmark_token = if let Some(token) = settings.mail.postmark.token {
+        token
+    } else {
+        return Err(ErrorResponse::reply("mail not configured")
+            .with_status(StatusCode::INTERNAL_SERVER_ERROR));
+    };
+
+    let db = &state.0.database;
+
+    match db.user_verified(user.id).await {
+        Ok(true) => {
+            info!("User requested verification, but is already verified");
+
+            return Ok(Json(SendVerificationResponse {
+                email_sent: false,
+                verified: true,
+            }));
+        }
+
+        Ok(false) => {}
+
+        Err(e) => {
+            error!("failed to check if user is verified: {}", e);
+
+            return Err(ErrorResponse::reply("internal error")
+                .with_status(StatusCode::INTERNAL_SERVER_ERROR));
+        }
+    }
+
+    let verification_token = db
+        .user_verification_token(user.id)
+        .await
+        .expect("Failed to verify");
+
+    debug!("Generated verification token, emailing user");
+
+    let client = PostmarkClient::builder()
+        .base_url("https://api.postmarkapp.com/")
+        .token(postmark_token)
+        .build();
+
+    let req = postmark::api::email::SendEmailRequest::builder()
+        .from(settings.mail.verification.from)
+        .subject(settings.mail.verification.subject)
+        .to(user.email)
+        .body(postmark::api::Body::text(format!(
+            "Your verification token is {}",
+            verification_token
+        )))
+        .build();
+
+    req.execute(&client)
+        .await
+        .expect("postmark email request failed");
+
+    debug!("Email sent");
+
+    Ok(Json(SendVerificationResponse {
+        email_sent: true,
+        verified: false,
+    }))
 }
 
 #[instrument(skip_all, fields(user.id = user.id, change_password))]

--- a/crates/atuin-server/src/handlers/user.rs
+++ b/crates/atuin-server/src/handlers/user.rs
@@ -226,7 +226,7 @@ pub async fn send_verification<DB: Database>(
         .subject(settings.mail.verification.subject)
         .to(user.email)
         .body(postmark::api::Body::text(format!(
-            "Your verification token is {}",
+            "Please run the following command to finalize your Atuin account verification. It is valid for 15 minutes:\n\natuin account verify --token '{}'",
             verification_token
         )))
         .build();

--- a/crates/atuin-server/src/router.rs
+++ b/crates/atuin-server/src/router.rs
@@ -126,6 +126,10 @@ pub fn router<DB: Database>(database: DB, settings: Settings<DB::Settings>) -> R
         .route("/record", get(handlers::record::index::<DB>))
         .route("/record/next", get(handlers::record::next))
         .route("/api/v0/me", get(handlers::v0::me::get))
+        .route(
+            "/api/v0/send-verification",
+            post(handlers::user::send_verification),
+        )
         .route("/api/v0/record", post(handlers::v0::record::post))
         .route("/api/v0/record", get(handlers::v0::record::index))
         .route("/api/v0/record/next", get(handlers::v0::record::next))

--- a/crates/atuin-server/src/router.rs
+++ b/crates/atuin-server/src/router.rs
@@ -126,6 +126,7 @@ pub fn router<DB: Database>(database: DB, settings: Settings<DB::Settings>) -> R
         .route("/record", get(handlers::record::index::<DB>))
         .route("/record/next", get(handlers::record::next))
         .route("/api/v0/me", get(handlers::v0::me::get))
+        .route("/api/v0/verify", post(handlers::user::verify_user))
         .route(
             "/api/v0/send-verification",
             post(handlers::user::send_verification),

--- a/crates/atuin-server/src/router.rs
+++ b/crates/atuin-server/src/router.rs
@@ -126,9 +126,9 @@ pub fn router<DB: Database>(database: DB, settings: Settings<DB::Settings>) -> R
         .route("/record", get(handlers::record::index::<DB>))
         .route("/record/next", get(handlers::record::next))
         .route("/api/v0/me", get(handlers::v0::me::get))
-        .route("/api/v0/verify", post(handlers::user::verify_user))
+        .route("/api/v0/account/verify", post(handlers::user::verify_user))
         .route(
-            "/api/v0/send-verification",
+            "/api/v0/account/send-verification",
             post(handlers::user::send_verification),
         )
         .route("/api/v0/record", post(handlers::v0::record::post))

--- a/crates/atuin-server/src/settings.rs
+++ b/crates/atuin-server/src/settings.rs
@@ -7,7 +7,7 @@ use serde::{de::DeserializeOwned, Deserialize, Serialize};
 
 static EXAMPLE_CONFIG: &str = include_str!("../server.toml");
 
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Default, Clone, Debug, Deserialize, Serialize)]
 pub struct Mail {
     #[serde(alias = "enable")]
     pub enabled: bool,
@@ -19,13 +19,13 @@ pub struct Mail {
     pub verification: MailVerification,
 }
 
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Default, Clone, Debug, Deserialize, Serialize)]
 pub struct Postmark {
     #[serde(alias = "enable")]
     pub token: Option<String>,
 }
 
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Default, Clone, Debug, Deserialize, Serialize)]
 pub struct MailVerification {
     #[serde(alias = "enable")]
     pub from: String,

--- a/crates/atuin-server/src/settings.rs
+++ b/crates/atuin-server/src/settings.rs
@@ -8,7 +8,33 @@ use serde::{de::DeserializeOwned, Deserialize, Serialize};
 static EXAMPLE_CONFIG: &str = include_str!("../server.toml");
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct Mail {
+    #[serde(alias = "enable")]
+    pub enabled: bool,
+
+    /// Configuration for the postmark api client
+    /// This is what we use for Atuin Cloud, the forum, etc.
+    pub postmark: Postmark,
+
+    pub verification: MailVerification,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct Postmark {
+    #[serde(alias = "enable")]
+    pub token: Option<String>,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct MailVerification {
+    #[serde(alias = "enable")]
+    pub from: String,
+    pub subject: String,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Metrics {
+    #[serde(alias = "enabled")]
     pub enable: bool,
     pub host: String,
     pub port: u16,
@@ -37,6 +63,7 @@ pub struct Settings<DbSettings> {
     pub register_webhook_username: String,
     pub metrics: Metrics,
     pub tls: Tls,
+    pub mail: Mail,
 
     #[serde(flatten)]
     pub db_settings: DbSettings,

--- a/crates/atuin/src/command/client/account.rs
+++ b/crates/atuin/src/command/client/account.rs
@@ -34,7 +34,7 @@ pub enum Commands {
     /// Change your password
     ChangePassword(change_password::Cmd),
 
-    /// Change your password
+    /// Verify your account
     Verify(verify::Cmd),
 }
 

--- a/crates/atuin/src/command/client/account.rs
+++ b/crates/atuin/src/command/client/account.rs
@@ -9,6 +9,7 @@ pub mod delete;
 pub mod login;
 pub mod logout;
 pub mod register;
+pub mod verify;
 
 #[derive(Args, Debug)]
 pub struct Cmd {
@@ -32,6 +33,9 @@ pub enum Commands {
 
     /// Change your password
     ChangePassword(change_password::Cmd),
+
+    /// Change your password
+    Verify(verify::Cmd),
 }
 
 impl Cmd {
@@ -42,6 +46,7 @@ impl Cmd {
             Commands::Logout => logout::run(&settings),
             Commands::Delete => delete::run(&settings).await,
             Commands::ChangePassword(c) => c.run(&settings).await,
+            Commands::Verify(c) => c.run(&settings).await,
         }
     }
 }

--- a/crates/atuin/src/command/client/account/verify.rs
+++ b/crates/atuin/src/command/client/account/verify.rs
@@ -1,0 +1,48 @@
+use clap::Parser;
+use eyre::{bail, Result};
+
+use atuin_client::{api_client, settings::Settings};
+use rpassword::prompt_password;
+
+#[derive(Parser, Debug)]
+pub struct Cmd {
+    #[clap(long, short)]
+    pub token: Option<String>,
+}
+
+impl Cmd {
+    pub async fn run(self, settings: &Settings) -> Result<()> {
+        run(settings, self.token).await
+    }
+}
+
+pub async fn run(settings: &Settings, token: Option<String>) -> Result<()> {
+    let client = api_client::Client::new(
+        &settings.sync_address,
+        settings.session_token()?.as_str(),
+        settings.network_connect_timeout,
+        settings.network_timeout,
+    )?;
+
+    let (email_sent, verified) = client.verify(token).await?;
+
+    match (email_sent, verified) {
+        (true, false) => {
+            println!("Verification sent! Please check your inbox");
+        }
+
+        (false, true) => {
+            println!("Your account is verified");
+        }
+
+        (false, false) => {
+            println!("Your Atuin server does not have mail setup. This is not required, though your account cannot be verified. Speak to your admin.");
+        }
+
+        _ => {
+            println!("Invalid email and verification status. This is a bug. Please open an issue: https://github.com/atuinsh/atuin");
+        }
+    }
+
+    Ok(())
+}

--- a/crates/atuin/src/command/client/account/verify.rs
+++ b/crates/atuin/src/command/client/account/verify.rs
@@ -1,8 +1,7 @@
 use clap::Parser;
-use eyre::{bail, Result};
+use eyre::Result;
 
 use atuin_client::{api_client, settings::Settings};
-use rpassword::prompt_password;
 
 #[derive(Parser, Debug)]
 pub struct Cmd {

--- a/crates/atuin/tests/common/mod.rs
+++ b/crates/atuin/tests/common/mod.rs
@@ -38,6 +38,7 @@ pub async fn start_server(path: &str) -> (String, oneshot::Sender<()>, JoinHandl
         db_settings: PostgresSettings { db_uri },
         metrics: atuin_server::settings::Metrics::default(),
         tls: atuin_server::settings::Tls::default(),
+        mail: atuin_server::settings::Mail::default(),
     };
 
     let (shutdown_tx, shutdown_rx) = tokio::sync::oneshot::channel();


### PR DESCRIPTION
Add `atuin account verify` for verifying the user account email address

This is not required, and so far has no real benefit. It can be used in a follow up for resetting passwords. 

We've used Postmark for the forum for a long while now, and I'm super happy with it. Verified emails is only really beneficial for Atuin Cloud, so I'm not currently considering a generic SMTP server approach. Happy to do so if people want it, but I'd rather not maintain something nobody is using.

## Checks
- [ ] I am happy for maintainers to push small adjustments to this PR, to speed up the review cycle
- [ ] I have checked that there are no existing pull requests for the same thing
