### PR TITLE
fix: ensure we cleanup all tables when deleting

### DIFF
--- a/crates/atuin-server-postgres/src/lib.rs
+++ b/crates/atuin-server-postgres/src/lib.rs
@@ -401,19 +401,31 @@ impl Database for Postgres {
             .await
             .map_err(fix_error)?;
 
-        sqlx::query("delete from users where id = $1")
-            .bind(u.id)
-            .execute(&self.pool)
-            .await
-            .map_err(fix_error)?;
-
         sqlx::query("delete from history where user_id = $1")
             .bind(u.id)
             .execute(&self.pool)
             .await
             .map_err(fix_error)?;
 
+        sqlx::query("delete from store where user_id = $1")
+            .bind(u.id)
+            .execute(&self.pool)
+            .await
+            .map_err(fix_error)?;
+
+        sqlx::query("delete from user_verification_token where user_id = $1")
+            .bind(u.id)
+            .execute(&self.pool)
+            .await
+            .map_err(fix_error)?;
+
         sqlx::query("delete from total_history_count_user where user_id = $1")
+            .bind(u.id)
+            .execute(&self.pool)
+            .await
+            .map_err(fix_error)?;
+
+        sqlx::query("delete from users where id = $1")
             .bind(u.id)
             .execute(&self.pool)
             .await


### PR DESCRIPTION
A couple of newer tables were missed - data is correctly cleaned up

## Checks
- [ ] I am happy for maintainers to push small adjustments to this PR, to speed up the review cycle
- [ ] I have checked that there are no existing pull requests for the same thing
