### PR TITLE
chore: do not use package managers in installer

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,5 +1,6 @@
 #! /usr/bin/env bash
 
+
 if [[ "${BASH_VERSION%%.*}" -eq 3 ]]; then
     echo "Atuin has limited support for Bash 3.2. The Atuin config enter_accept cannot be turned off." >&2
     echo "To turn off enter_accept, please upgrade your version of bash (possibly via homebrew or ports)" >&2
@@ -20,12 +21,17 @@ Magical shell history
 
 Atuin setup
 https://github.com/atuinsh/atuin
+https://forum.atuin.sh
 
-Please file an issue if you encounter any problems!
+Please file an issue or reach out on the forum if you encounter any problems!
 
 ===============================================================================
 
 EOF
+
+__atuin_install_binary(){
+  curl --proto '=https' --tlsv1.2 -LsSf https://github.com/atuinsh/atuin/releases/latest/download/atuin-installer.sh | sh
+}
 
 if ! command -v curl &> /dev/null; then
     echo "curl not installed. Please install curl."
@@ -35,139 +41,8 @@ elif ! command -v sed &> /dev/null; then
     exit
 fi
 
-__atuin_install_arch(){
-	echo "Arch Linux detected!"
 
-	if command -v pacman &> /dev/null
-	then
-		echo "Installing with pacman"
-		sudo pacman -S atuin
-	else
-		echo "Attempting AUR install"
-		if command -v paru &> /dev/null; then
-			echo "Found paru"
-			paru -S atuin
-		elif command -v yaourt &> /dev/null; then
-			echo "Found yaourt"
-			yaourt -S atuin
-		elif command -v yay &> /dev/null; then
-			echo "Found yay"
-			yay -S atuin
-		elif command -v pakku &> /dev/null; then
-			echo "Found pakku"
-			pakku -S atuin
-		elif command -v pamac &> /dev/null; then
-			echo "Found pamac"
-			pamac install atuin
-		else
-			echo "Failed to install atuin! Please try manually: https://aur.archlinux.org/packages/atuin-git/"
-		fi
-	fi
-
-}
-
-__atuin_install_binary(){
-  curl --proto '=https' --tlsv1.2 -LsSf https://github.com/atuinsh/atuin/releases/latest/download/atuin-installer.sh | sh
-}
-
-__atuin_install_linux(){
-	echo "Detected Linux!"
-	echo "Checking distro..."
-	if (uname -a | grep -qi "Microsoft"); then
-    OS="ubuntuwsl"
-  elif ! command -v lsb_release &> /dev/null; then
-    echo "lsb_release could not be found. Falling back to /etc/os-release"
-    OS="$(grep -Po '(?<=^ID=).*$' /etc/os-release | tr '[:upper:]' '[:lower:]')" 2>/dev/null
-  else
-    OS=$(lsb_release -i | awk '{ print $3 }' | tr '[:upper:]' '[:lower:]')
-  fi
-	case "$OS" in
-		"arch" | "manjarolinux" | "endeavouros")
-			__atuin_install_arch;;
-		"ubuntu" | "ubuntuwsl" | "debian" | "linuxmint" | "parrot" | "kali" | "elementary" | "pop" | "neon" | "tuxedo")
-			__atuin_install_binary;;
-		*)
-			__atuin_install_binary;;
-	esac
-}
-
-__atuin_install_mac(){
-	echo "Detected Mac!"
-
-	if command -v brew &> /dev/null
-	then
-		echo "Installing with brew"
-		brew install atuin
-	else
-		echo "Could not find brew, installing a binary"
-		__atuin_install_binary
-	fi
-
-}
-
-__atuin_install_termux(){
-	echo "Termux detected!"
-
-	if command -v pkg &> /dev/null; then
-		echo "Installing with pkg"
-		pkg install atuin
-	else
-		echo "Could not find pkg"
-		__atuin_install_unsupported
-	fi
-}
-
-__atuin_install_cargo(){
-	echo "Attempting install with cargo"
-
-	if ! command -v cargo &> /dev/null
-	then
-		echo "cargo not found! Attempting to install rustup"
-
-		if command -v rustup &> /dev/null
-		then
-			echo "rustup was found, but cargo wasn't. Something is up with your install"
-			exit 1
-		fi
-
-		curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -q
-
-		echo "rustup installed! Attempting cargo install"
-
-	fi
-
- 	# Log cargo and rustc versions for support
-	cargo --version
- 	rustc --version
-  
-	cargo install atuin
-}
-
-__atuin_install_unsupported(){
-	echo "Unknown or unsupported OS or architecture"
-	echo "Please check the README at https://github.com/atuinsh/atuin for manual install instructions"
-	echo "If you have any problems, please open an issue!"
-
-	while true; do
-		read -r -p "Do you wish to attempt an install with 'cargo'? [Y/N] " yn
-		case $yn in
-			[Yy]* ) __atuin_install_cargo; break;;
-			[Nn]* ) exit;;
-			* ) echo "Please answer yes or no.";;
-		esac
-	done
-}
-
-# TODO: would be great to support others!
-case "$OSTYPE" in
-  linux-android*) __atuin_install_termux ;;
-  linux*)         __atuin_install_linux ;;
-  darwin*)        __atuin_install_mac ;;
-  msys*)          __atuin_install_unsupported ;;
-  solaris*)       __atuin_install_unsupported ;;
-  bsd*)           __atuin_install_unsupported ;;
-  *)              __atuin_install_unsupported ;;
-esac
+__atuin_install_binary 
 
 # TODO: Check which shell is in use
 # Use of single quotes around $() is intentional here
@@ -201,10 +76,11 @@ cat << EOF
 
 Thanks for installing Atuin! I really hope you like it.
 
-If you have any issues, please open an issue on GitHub or visit our Discord (https://discord.gg/jR3tfchVvW)!
+If you have any issues, please open an issue on GitHub or visit our forum (https://forum.atuin.sh)!
 
 If you love Atuin, please give us a star on GitHub! It really helps ⭐️ https://github.com/atuinsh/atuin
 
 Please run "atuin register" to get setup with sync, or "atuin login" if you already have an account
 
 EOF
+


### PR DESCRIPTION
For a long time I wanted to try and prioritise using package managers, so we would have the smallest impact on the users machine possible. Unfortunately with this change, the install script will no longer be doing this.

Firstly, we're limited by which package managers we are in. The fallback to build from source _really_ sucks on systems like a raspberry pi (running a flavour of debian). For that specific case, it's worth noting that Debian's repositories are very stable - even if we were packaged there, Atuin would rapidly become so out of date that it would no longer sync. Hence the proliferation of ppas.

Increasing the breadth of package managers we are included in becomes tricky in terms of support. Some have much stricter requirements than others, including dynamic linking as much as possible or high levels of patching - both make supporting users and replicating their issues harder, and is not something we can support. We've already seen a couple of issues that will only occur when using the system sqlite, vs the pinned, tested, and bundled version we build.

Secondly (the primary issue), it's diffcult to tell users _precisely_ what the script has done. The "it depends on your system and package manager" has been met with frustrated responses, and I really want to streamline things there. 

The cargo-dist installer provides a consistent install location, consistent binary, consistent update path, and is much easier for us to support.

I am very aware that some users may have issues with ~/.atuin being used.  Really, the automatic installer _is not for them_. The idea with this installer is to streamline installs as much as possible for users that just wish to have things working quickly, and to make it easier for us to support them. There's more discussion about this on the [forum post
](https://forum.atuin.sh/t/the-new-atuin-directory/372?u=ellie)

If you're someone who prefers to have your setup just how you like it, we provide [a whole bunch](https://docs.atuin.sh/guide/installation/#manual-installation) of alternate install methods that will work well for you! You can probably just go ahead and use your package manager (and then setup the shell plugin!)  

## Checks
- [ ] I am happy for maintainers to push small adjustments to this PR, to speed up the review cycle
- [ ] I have checked that there are no existing pull requests for the same thing
