### PR TITLE
feat: Set terminal title to indicate atuin tui is active

### DIFF
--- a/crates/atuin/src/shell/atuin.zsh
+++ b/crates/atuin/src/shell/atuin.zsh
@@ -27,6 +27,12 @@ fi
 export ATUIN_SESSION=$(atuin uuid)
 ATUIN_HISTORY_ID=""
 
+_atuin_update_title() {
+    if [[ "$TERM" == xterm* ]]; then
+        print -n "\e]0;$1\a"
+    fi
+}
+
 _atuin_preexec() {
     local id
     id=$(atuin history start -- "$1")
@@ -51,7 +57,7 @@ _atuin_precmd() {
 _atuin_search() {
     emulate -L zsh
     zle -I
-
+    _atuin_update_title atuin
     # swap stderr and stdout, so that the tui stuff works
     # TODO: not this
     local output
@@ -64,12 +70,12 @@ _atuin_search() {
         RBUFFER=""
         LBUFFER=$output
 
-        if [[ $LBUFFER == __atuin_accept__:* ]]
-        then
+        if [[ $LBUFFER == __atuin_accept__:* ]]; then
             LBUFFER=${LBUFFER#__atuin_accept__:}
             zle accept-line
         fi
     fi
+    _atuin_update_title zsh
 }
 _atuin_search_vicmd() {
     _atuin_search --keymap-mode=vim-normal


### PR DESCRIPTION
Attempts to address #2214 for zsh. Currently this just naively changes the title to "atuin" and back to "zsh". The default zsh settings will auto update the title (unless using zsh setting `DISABLE_AUTO_TITLE="true"`), so possibly setting it back to "zsh" afterwards isn't even needed.

afaict it's not possible to query the current title, so we can't switch it back to what was originally there. So I think this does run the risk of clobbering someones title, if they have set `DISABLE_AUTO_TITLE="true"`, in which case it may be best to have an atuin option that's default to off? I figured I'd send this PR to show the idea anyway, since it's working for my use case, and can start a discussion about how best to do it.