### PR TITLE
perf: write to the idx cache

### DIFF
--- a/crates/atuin-server/src/settings.rs
+++ b/crates/atuin-server/src/settings.rs
@@ -14,8 +14,10 @@ pub struct Mail {
 
     /// Configuration for the postmark api client
     /// This is what we use for Atuin Cloud, the forum, etc.
+    #[serde(default)]
     pub postmark: Postmark,
 
+    #[serde(default)]
     pub verification: MailVerification,
 }
 


### PR DESCRIPTION
Most of the time, we will only be writing one row. So nothing major!

In the future we may want to use something like redis, but I'd like to keep the stack minimal for as long as possible.

Don't use this data yet - once enough has been written, it can be verified against current behaviour

Follow up on #2140 

## Checks
- [ ] I am happy for maintainers to push small adjustments to this PR, to speed up the review cycle
- [ ] I have checked that there are no existing pull requests for the same thing
