### PR TITLE
feat: allow advertising a fake version to clients

### DIFF
--- a/crates/atuin-server/src/handlers/mod.rs
+++ b/crates/atuin-server/src/handlers/mod.rs
@@ -19,10 +19,16 @@ pub async fn index<DB: Database>(state: State<AppState<DB>>) -> Json<IndexRespon
     // It's super unlikely this will happen
     let count = state.database.total_history().await.unwrap_or(-1);
 
+    let version = state
+        .settings
+        .fake_version
+        .clone()
+        .unwrap_or(VERSION.to_string());
+
     Json(IndexResponse {
         homage: homage.to_string(),
-        version: VERSION.to_string(),
         total_history: count,
+        version,
     })
 }
 

--- a/crates/atuin-server/src/settings.rs
+++ b/crates/atuin-server/src/settings.rs
@@ -67,6 +67,13 @@ pub struct Settings<DbSettings> {
     pub tls: Tls,
     pub mail: Mail,
 
+    /// Advertise a version that is not what we are _actually_ running
+    /// Many clients compare their version with api.atuin.sh, and if they differ, notify the user
+    /// that an update is available.
+    /// Now that we take beta releases, we should be able to advertise a different version to avoid
+    /// notifying users when the server runs something that is not a stable release.
+    pub fake_version: Option<String>,
+
     #[serde(flatten)]
     pub db_settings: DbSettings,
 }

--- a/crates/atuin/tests/common/mod.rs
+++ b/crates/atuin/tests/common/mod.rs
@@ -39,6 +39,7 @@ pub async fn start_server(path: &str) -> (String, oneshot::Sender<()>, JoinHandl
         metrics: atuin_server::settings::Metrics::default(),
         tls: atuin_server::settings::Tls::default(),
         mail: atuin_server::settings::Mail::default(),
+        fake_version: None,
     };
 
     let (shutdown_tx, shutdown_rx) = tokio::sync::oneshot::channel();


### PR DESCRIPTION
The server usually runs unstable Atuin, and is well monitored. But let's not advertised the unstable version to clients, as they will notify users there is an update available.

<!-- Thank you for making a PR! Bug fixes are always welcome, but if you're adding a new feature or changing an existing one, we'd really appreciate if you open an issue, post on the forum, or drop in on Discord -->

## Checks
- [ ] I am happy for maintainers to push small adjustments to this PR, to speed up the review cycle
- [ ] I have checked that there are no existing pull requests for the same thing
