### PR TITLE
feat: monitor idx cache consistency before switching

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -447,6 +447,7 @@ dependencies = [
  "atuin-server-database",
  "eyre",
  "futures-util",
+ "metrics",
  "serde",
  "sqlx",
  "time",

--- a/crates/atuin-server-postgres/Cargo.toml
+++ b/crates/atuin-server-postgres/Cargo.toml
@@ -20,5 +20,6 @@ serde = { workspace = true }
 sqlx = { workspace = true }
 async-trait = { workspace = true }
 uuid = { workspace = true }
+metrics = "0.21.1"
 futures-util = "0.3"
 url = "2.5.2"


### PR DESCRIPTION
I've tested it, but let's run with a consistency check for a while. We're not exposing cached data to users just yet, and will switch over once we've confirmed the cache does not serve stale data.

Risks of stale data are mostly clients DoS-ing the server, as they won't see up-to-date information.

## Checks
- [ ] I am happy for maintainers to push small adjustments to this PR, to speed up the review cycle
- [ ] I have checked that there are no existing pull requests for the same thing
