### PR TITLE
fix: idx cache inconsistency

### DIFF
--- a/crates/atuin-client/src/record/sqlite_store.rs
+++ b/crates/atuin-client/src/record/sqlite_store.rs
@@ -219,15 +219,16 @@ impl Store for SqliteStore {
         idx: RecordIdx,
         limit: u64,
     ) -> Result<Vec<Record<EncryptedData>>> {
-        let res =
-            sqlx::query("select * from store where idx >= ?1 and host = ?2 and tag = ?3 limit ?4")
-                .bind(idx as i64)
-                .bind(host.0.as_hyphenated().to_string())
-                .bind(tag)
-                .bind(limit as i64)
-                .map(Self::query_row)
-                .fetch_all(&self.pool)
-                .await?;
+        let res = sqlx::query(
+            "select * from store where idx >= ?1 and host = ?2 and tag = ?3 order by idx asc limit ?4",
+        )
+        .bind(idx as i64)
+        .bind(host.0.as_hyphenated().to_string())
+        .bind(tag)
+        .bind(limit as i64)
+        .map(Self::query_row)
+        .fetch_all(&self.pool)
+        .await?;
 
         Ok(res)
     }

--- a/crates/atuin-server-postgres/src/lib.rs
+++ b/crates/atuin-server-postgres/src/lib.rs
@@ -571,7 +571,7 @@ impl Database for Postgres {
                 "insert into store_idx_cache
                     (user_id, host, tag, idx) 
                 values ($1, $2, $3, $4)
-                on conflict(user_id, host, tag) do update set idx = $4
+                on conflict(user_id, host, tag) do update set idx = greatest(idx, $4)
                 ",
             )
             .bind(user.id)


### PR DESCRIPTION
While the idx cache has been consistent in almost all cases, there have been some inconsistencies.

1. They existed temporarily, but seem to have sorted themselves out with further sync traffic
2. They only existed for a small number of users, and for a very small period of time

I suspect this is because the cache was updating the max idx to be the max from a single request. This meant that if records were uploaded slightly out of order, the idx in the cache would potentially be reduced temporarily

Fixes as follows:

First, only update the idx cache to be the greatest of either the existing value or the new one. It should never decrease.

Second, ensure that when the client pages through the record store, it does so in order

## Checks
- [ ] I am happy for maintainers to push small adjustments to this PR, to speed up the review cycle
- [ ] I have checked that there are no existing pull requests for the same thing
