### PR TITLE
feat(bash/blesh): hook into BLE_ONLOAD to resolve loading order issue

### DIFF
--- a/crates/atuin/src/command/client/doctor.rs
+++ b/crates/atuin/src/command/client/doctor.rs
@@ -315,7 +315,7 @@ fn checks(info: &DoctorDump) {
                 //
     let zfs_error = "[Filesystem] ZFS is known to have some issues with SQLite. Atuin uses SQLite heavily. If you are having poor performance, there are some workarounds here: https://github.com/atuinsh/atuin/issues/952".bold().red();
     let bash_plugin_error = "[Shell] If you are using Bash, Atuin requires that either bash-preexec or ble.sh be installed. An older ble.sh may not be detected. so ignore this if you have it set up! Read more here: https://docs.atuin.sh/guide/installation/#bash".bold().red();
-    let blesh_loading_order_error = "[Shell] Atuin seems to be loaded before ble.sh is sourced. In .bashrc, make sure to initialize Atuin after sourcing ble.sh.".bold().red();
+    let blesh_integration_error = "[Shell] Atuin and ble.sh seem to be loaded in the session, but the integration does not seem to be working. Please check the setup in .bashrc.".bold().red();
 
     // ZFS: https://github.com/atuinsh/atuin/issues/952
     if info.system.disks.iter().any(|d| d.filesystem == "zfs") {
@@ -337,7 +337,7 @@ fn checks(info: &DoctorDump) {
             && info.shell.plugins.iter().any(|plugin| plugin == "blesh")
             && info.shell.preexec.as_ref().is_some_and(|val| val == "none")
         {
-            println!("{blesh_loading_order_error}");
+            println!("{blesh_integration_error}");
         }
     }
 }

--- a/crates/atuin/src/shell/atuin.bash
+++ b/crates/atuin/src/shell/atuin.bash
@@ -269,8 +269,10 @@ __atuin_history() {
     fi
 }
 
-# shellcheck disable=SC2154
-if [[ ${BLE_VERSION-} ]] && ((_ble_version >= 400)); then
+__atuin_initialize_blesh() {
+    # shellcheck disable=SC2154
+    [[ ${BLE_VERSION-} ]] && ((_ble_version >= 400)) || return 0
+
     ble-import contrib/integration/bash-preexec
 
     # Define and register an autosuggestion source for ble.sh's auto-complete.
@@ -295,7 +297,9 @@ if [[ ${BLE_VERSION-} ]] && ((_ble_version >= 400)); then
     # BLE_SESSION_ID.  We explicitly export the variable because it was not
     # exported in older versions of ble.sh.
     [[ ${BLE_SESSION_ID-} ]] && export BLE_SESSION_ID
-fi
+}
+__atuin_initialize_blesh
+BLE_ONLOAD+=(__atuin_initialize_blesh)
 precmd_functions+=(__atuin_precmd)
 preexec_functions+=(__atuin_preexec)
 


### PR DESCRIPTION
<!-- Thank you for making a PR! Bug fixes are always welcome, but if you're adding a new feature or changing an existing one, we'd really appreciate if you open an issue, post on the forum, or drop in on Discord -->

Currently, to set up Atuin with ble.sh in Bash, we require `ble.sh` to be loaded before `eval "$(atuin init bash)"`. This PR removes this requirement by using the shell variable `BLE_ONLOAD`, which is a hook called by `ble.sh` in its loading phase.

The hook has existed for a long time, but I was forgetting it. I remembered it and used it to run Atuin's integration on ble.sh's loading. I also update the corresponding message in `atuin doctor`.

## Checks
- [x] I am happy for maintainers to push small adjustments to this PR, to speed up the review cycle
- [x] I have checked that there are no existing pull requests for the same thing
