### PR TITLE
fix(search): Press ctrl-a twice should jump to beginning of line

### DIFF
--- a/crates/atuin/src/command/client/search/interactive.rs
+++ b/crates/atuin/src/command/client/search/interactive.rs
@@ -206,7 +206,10 @@ impl State {
         let esc_allow_exit = !(self.tab_index == 0 && self.keymap_mode == KeymapMode::VimInsert);
 
         // support ctrl-a prefix, like screen or tmux
-        if ctrl && input.code == KeyCode::Char(settings.keys.prefix.chars().next().unwrap_or('a')) {
+        if !self.prefix
+            && ctrl
+            && input.code == KeyCode::Char(settings.keys.prefix.chars().next().unwrap_or('a'))
+        {
             self.prefix = true;
             return InputAction::Continue;
         }
@@ -301,6 +304,8 @@ impl State {
                 }
                 KeyCode::Char('a') => {
                     self.search.input.start();
+                    //  This prevents pressing ctrl-a twice while still in prefix mode
+                    self.prefix = false;
                     return InputAction::Continue;
                 }
                 _ => {}


### PR DESCRIPTION
Previously, you could only navigate to the beginning of the line using `ctrl-a a`. Pressing `ctrl-a` twice (`ctrl-a ctrl-a`) was captured by the prefix mode trigger, preventing navigation to the beginning of the line. This PR makes it possible to navigate to the beginning of the line using either `ctrl-a a` or `ctrl-a ctrl-a`.
## Checks
- [x] I am happy for maintainers to push small adjustments to this PR, to speed up the review cycle
- [x] I have checked that there are no existing pull requests for the same thing
