### PR TITLE
chore: enable inline height and compact by default

### DIFF
--- a/crates/atuin-client/src/settings.rs
+++ b/crates/atuin-client/src/settings.rs
@@ -686,8 +686,8 @@ impl Settings {
             .set_default("sync_frequency", "10m")?
             .set_default("search_mode", "fuzzy")?
             .set_default("filter_mode", "global")?
-            .set_default("style", "auto")?
-            .set_default("inline_height", 0)?
+            .set_default("style", "compact")?
+            .set_default("inline_height", 40)?
             .set_default("show_preview", true)?
             .set_default("preview.strategy", "auto")?
             .set_default("max_preview_height", 4)?


### PR DESCRIPTION
I've been running Atuin this way for a really long time, and have heard from quite a few users now that they weren't a fan of Atuin using the whole screen.

This is how it looks:

![inline-height](https://github.com/atuinsh/atuin/assets/53315310/d5508cfe-b5c8-46e2-bbe5-7d5630cf47f1)

However I have also learned that you only hear from people who _don't_ like the way things currently are, right up until you change them - and then hear from everyone that was happy and quiet.

I'll try and circulate this PR as much as I can. It's the same as adding

```
style = "compact"
inline_height = 40
```

to the config file.

If this change is merged, it will change how Atuin looks for people who don't have anything set in their config. If they don't like it, they can restore how things were with

```
style = "auto"
inline_height = 0
```

We could change the default config file so this only happens for new users, but I'd like to be able to change defaults at some point and would like to see the general opinion first.

I can't think of a better way of getting feedback, short of opt-in telemetry. That's a different discussion :)

**If you like this, please react with 👍**

**If you don't, please react with 👎** 

## Checks
- [ ] I am happy for maintainers to push small adjustments to this PR, to speed up the review cycle
- [ ] I have checked that there are no existing pull requests for the same thing
