### PR TITLE
Fix logic for store_failed=false

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 .vscode/
 result
 publish.sh
+.envrc
 
 ui/backend/target
 ui/backend/gen

--- a/crates/atuin/src/command/client/history.rs
+++ b/crates/atuin/src/command/client/history.rs
@@ -384,7 +384,7 @@ impl Cmd {
             return Ok(());
         }
 
-        if !settings.store_failed && h.exit != 0 {
+        if !settings.store_failed && exit > 0 {
             debug!("history has non-zero exit code, and store_failed is false");
 
             // the history has already been inserted half complete. remove it


### PR DESCRIPTION
<!-- Thank you for making a PR! Bug fixes are always welcome, but if you're adding a new feature or changing an existing one, we'd really appreciate if you open an issue, post on the forum, or drop in on Discord -->

fixes  #2227

Just updated the conditional here to check the `exit` param instead of `h.exit` since it seems like the latter will always be `-1` here as that's the default value. Also changed the operator to `>` instead of `!=` just to reflect the fact that exit codes are expected to only be positive integers 0-255

I also added `.envrc` to the `.gitignore` file as using `direnv` for development was recommended in the CONTRIBUTING doc 

## Checks
- [x] I am happy for maintainers to push small adjustments to this PR, to speed up the review cycle
- [x] I have checked that there are no existing pull requests for the same thing
