### PR TITLE
Fixed preview height

### DIFF
--- a/crates/atuin-client/config.toml
+++ b/crates/atuin-client/config.toml
@@ -209,6 +209,7 @@ records = true
 ## possible values: auto, static
 ## auto: length of the selected command.
 ## static: length of the longest command stored in the history.
+## fixed: use max_preview_height as fixed height.
 # strategy = "auto"
 
 [daemon]

--- a/crates/atuin-client/src/settings.rs
+++ b/crates/atuin-client/src/settings.rs
@@ -410,6 +410,10 @@ pub enum PreviewStrategy {
     // Preview height is calculated for the length of the longest command stored in the history.
     #[serde(rename = "static")]
     Static,
+
+    // max_preview_height is used as fixed height.
+    #[serde(rename = "fixed")]
+    Fixed,
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]

--- a/crates/atuin/src/command/client/search/interactive.rs
+++ b/crates/atuin/src/command/client/search/interactive.rs
@@ -1246,6 +1246,15 @@ mod tests {
             ..Settings::utc()
         };
 
+        let settings_preview_fixed = Settings {
+            preview: Preview {
+                strategy: PreviewStrategy::Fixed,
+            },
+            show_preview: true,
+            max_preview_height: 15,
+            ..Settings::utc()
+        };
+
         let cmd_60: History = History::capture()
             .timestamp(time::OffsetDateTime::now_utc())
             .command("for i in $(seq -w 10); do echo \"item number $i - abcd\"; done")
@@ -1339,14 +1348,26 @@ mod tests {
             1,
             20,
         );
+        // the longest command requires 10 lines, but we have a max preview height of 15 and a fixed preview strategy
+        let settings_preview_fixed = State::calc_preview_height(
+            &settings_preview_fixed,
+            &results,
+            1 as usize,
+            0 as usize,
+            false,
+            1,
+            20,
+        );
 
         assert_eq!(no_preview, 1);
-        // 1*2 is the space for the border
-        assert_eq!(preview_h2, 2 + 1 * 2);
-        assert_eq!(preview_h3, 3 + 1 * 2);
-        assert_eq!(preview_one_line, 1 + 1 * 2);
-        assert_eq!(preview_limit_at_2, 2 + 1 * 2);
-        assert_eq!(preview_static_h3, 3 + 1 * 2);
-        assert_eq!(preview_static_limit_at_4, 4 + 1 * 2);
+        // 1 * 2 is the space for the border
+        let border_space = 1 * 2;
+        assert_eq!(preview_h2, 2 + border_space);
+        assert_eq!(preview_h3, 3 + border_space);
+        assert_eq!(preview_one_line, 1 + border_space);
+        assert_eq!(preview_limit_at_2, 2 + border_space);
+        assert_eq!(preview_static_h3, 3 + border_space);
+        assert_eq!(preview_static_limit_at_4, 4 + border_space);
+        assert_eq!(settings_preview_fixed, 15 + border_space);
     }
 }

--- a/crates/atuin/src/command/client/search/interactive.rs
+++ b/crates/atuin/src/command/client/search/interactive.rs
@@ -583,6 +583,8 @@ impl State {
                         .sum(),
                 )
             }) + border_size * 2
+        } else if settings.show_preview && settings.preview.strategy == PreviewStrategy::Fixed {
+            settings.max_preview_height + border_size * 2
         } else if compact || tab_index == 1 {
             0
         } else {


### PR DESCRIPTION
Uses max_preview_height as a fixed value to prevent the list from "jumping".

<!-- Thank you for making a PR! Bug fixes are always welcome, but if you're adding a new feature or changing an existing one, we'd really appreciate if you open an issue, post on the forum, or drop in on Discord -->

## Checks
- [x] I am happy for maintainers to push small adjustments to this PR, to speed up the review cycle
- [x] I have checked that there are no existing pull requests for the same thing
