### PR TITLE
fix(gui): kill child on block stop

### DIFF
--- a/ui/backend/src/run/pty.rs
+++ b/ui/backend/src/run/pty.rs
@@ -87,6 +87,7 @@ pub(crate) async fn pty_kill(
     state: tauri::State<'_, AtuinState>,
 ) -> Result<(), String> {
     let pty = state.pty_sessions.write().await.remove(&pid).unwrap();
+    pty.kill_child().await.map_err(|e|e.to_string())?;
     println!("RIP {pid:?}");
 
     Ok(())


### PR DESCRIPTION
Ensure that when the users presses "stop", the child process is properly terminated

Previously _most_ processes would stop ok, but some would not. An example of one that didn't would be an interactive ssh process. 

With this patch, the process is sent KILL and stops. 

We should probably consider being a bit gentler.

## Checks
- [ ] I am happy for maintainers to push small adjustments to this PR, to speed up the review cycle
- [ ] I have checked that there are no existing pull requests for the same thing
