### PR TITLE
Restore default theme

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1001,6 +1001,7 @@ dependencies = [
  "libc",
  "mio",
  "parking_lot",
+ "serde",
  "signal-hook",
  "signal-hook-mio",
  "winapi",

--- a/crates/atuin-client/Cargo.toml
+++ b/crates/atuin-client/Cargo.toml
@@ -71,7 +71,7 @@ indicatif = "0.17.7"
 tiny-bip39 = "1"
 
 # theme
-crossterm = "0.27.0"
+crossterm = { version = "0.27.0", features = ["serde"] }
 palette = { version = "0.7.5", features = ["serializing"] }
 lazy_static = "1.4.0"
 strum_macros = "0.26.3"

--- a/crates/atuin-client/config.toml
+++ b/crates/atuin-client/config.toml
@@ -234,7 +234,7 @@ records = true
 
 # [theme]
 ## Color theme to use for rendering in the terminal.
-## There are some built-in themes, including the base theme which has the default colors,
+## There are some built-in themes, including the base theme ("default"),
 ## "autumn" and "marine". You can add your own themes to the "./themes" subdirectory of your
 ## Atuin config (or ATUIN_THEME_DIR, if provided) as TOML files whose keys should be one or
 ## more of AlertInfo, AlertWarn, AlertError, Annotation, Base, Guidance, Important, and

--- a/crates/atuin-client/src/settings.rs
+++ b/crates/atuin-client/src/settings.rs
@@ -340,7 +340,7 @@ pub struct Preview {
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Theme {
-    /// Name of desired theme ("" for base)
+    /// Name of desired theme ("default" for base)
     pub name: String,
 
     /// Whether any available additional theme debug should be shown
@@ -756,7 +756,7 @@ impl Settings {
             .set_default("daemon.socket_path", socket_path.to_str())?
             .set_default("daemon.systemd_socket", false)?
             .set_default("daemon.tcp_port", 8889)?
-            .set_default("theme.name", "")?
+            .set_default("theme.name", "default")?
             .set_default("theme.debug", None::<bool>)?
             .set_default(
                 "prefers_reduced_motion",

--- a/crates/atuin-client/src/theme.rs
+++ b/crates/atuin-client/src/theme.rs
@@ -188,16 +188,7 @@ fn _from_known(name: &str) -> Color {
 fn make_theme(name: String, parent: Option<&Theme>, overrides: &HashMap<Meaning, Option<Color>>) -> Theme {
     let colors = match parent {
         Some(theme) => Box::new(theme.colors.clone()),
-        None => Box::new(HashMap::from([
-            (Meaning::AlertError, Some(Color::Red)),
-            (Meaning::AlertWarn, Some(Color::Yellow)),
-            (Meaning::AlertInfo, Some(Color::Green)),
-            (Meaning::Annotation, Some(Color::DarkGrey)),
-            (Meaning::Guidance, Some(Color::Blue)),
-            (Meaning::Important, Some(Color::White)),
-            (Meaning::Muted, Some(Color::Grey)),
-            (Meaning::Base, None),
-        ])),
+        None => Box::new(DEFAULT_THEME.colors.clone()),
     }
     .iter()
     .map(|(name, color)| match overrides.get(name) {
@@ -225,6 +216,22 @@ lazy_static! {
             (Meaning::Annotation, Meaning::AlertInfo),
             (Meaning::Title, Meaning::Important),
         ])
+    };
+    static ref DEFAULT_THEME: Theme = {
+        Theme::new(
+            "".to_string(),
+            None,
+            HashMap::from([
+                (Meaning::AlertError, Some(Color::Red)),
+                (Meaning::AlertWarn, Some(Color::Yellow)),
+                (Meaning::AlertInfo, Some(Color::Green)),
+                (Meaning::Annotation, Some(Color::DarkGrey)),
+                (Meaning::Guidance, Some(Color::Blue)),
+                (Meaning::Important, Some(Color::White)),
+                (Meaning::Muted, Some(Color::Grey)),
+                (Meaning::Base, None),
+            ])
+        )
     };
     static ref BUILTIN_THEMES: HashMap<&'static str, Theme> = {
         HashMap::from([

--- a/crates/atuin-client/src/theme.rs
+++ b/crates/atuin-client/src/theme.rs
@@ -43,7 +43,7 @@ pub struct ThemeConfig {
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct ThemeDefinitionConfigBlock {
-    /// Name of theme ("" for base)
+    /// Name of theme ("default" for base)
     pub name: String,
 
     /// Whether any theme should be treated as a parent _if available_
@@ -219,7 +219,7 @@ lazy_static! {
     };
     static ref DEFAULT_THEME: Theme = {
         Theme::new(
-            "".to_string(),
+            "default".to_string(),
             None,
             HashMap::from([
                 (Meaning::AlertError, Some(Color::Red)),
@@ -235,7 +235,7 @@ lazy_static! {
     };
     static ref BUILTIN_THEMES: HashMap<&'static str, Theme> = {
         HashMap::from([
-            ("", HashMap::new()),
+            ("default", HashMap::new()),
             (
                 "autumn",
                 HashMap::from([
@@ -386,7 +386,7 @@ impl ThemeManager {
                 Ok(theme) => theme,
                 Err(err) => {
                     log::warn!("Could not load theme {}: {}", name, err);
-                    built_ins.get("").unwrap()
+                    built_ins.get("default").unwrap()
                 }
             },
         }
@@ -429,7 +429,7 @@ mod theme_tests {
 
         // We use title as an example of a meaning that is not defined
         // even in the base theme.
-        assert!(!BUILTIN_THEMES[""].colors.contains_key(&Meaning::Title));
+        assert!(!DEFAULT_THEME.colors.contains_key(&Meaning::Title));
 
         let config = Config::builder()
             .add_source(ConfigFile::from_str(
@@ -514,7 +514,7 @@ mod theme_tests {
     #[test]
     fn test_can_get_colors_via_convenience_functions() {
         let mut manager = ThemeManager::new(Some(true), Some("".to_string()));
-        let theme = manager.load_theme("", None);
+        let theme = manager.load_theme("default", None);
         assert_eq!(theme.get_error(), Color::Red);
         assert_eq!(theme.get_warning(), Color::Yellow);
         assert_eq!(theme.get_info(), Color::Green);

--- a/crates/atuin-client/src/theme.rs
+++ b/crates/atuin-client/src/theme.rs
@@ -87,7 +87,11 @@ impl Theme {
         self.styles[ALERT_TYPES.get(&severity).unwrap()]
     }
 
-    pub fn new(name: String, parent: Option<String>, styles: HashMap<Meaning, ContentStyle>) -> Theme {
+    pub fn new(
+        name: String,
+        parent: Option<String>,
+        styles: HashMap<Meaning, ContentStyle>,
+    ) -> Theme {
         Theme {
             name,
             parent,
@@ -136,7 +140,7 @@ impl Theme {
                             );
                         }
                         ContentStyle::default()
-                    })
+                    }),
                 )
             })
             .collect();
@@ -145,7 +149,11 @@ impl Theme {
 
     // Boil down a meaning-color hashmap into a theme, by taking the defaults
     // for any unknown colors
-    fn from_map(name: String, parent: Option<&Theme>, overrides: &HashMap<Meaning, ContentStyle>) -> Theme {
+    fn from_map(
+        name: String,
+        parent: Option<&Theme>,
+        overrides: &HashMap<Meaning, ContentStyle>,
+    ) -> Theme {
         let styles = match parent {
             Some(theme) => Box::new(theme.styles.clone()),
             None => Box::new(DEFAULT_THEME.styles.clone()),
@@ -198,7 +206,7 @@ impl StyleFactory {
     fn from_fg_string(name: &str) -> Result<ContentStyle, String> {
         match from_string(name) {
             Ok(color) => Ok(Self::from_fg_color(color)),
-            Err(err) => Err(err)
+            Err(err) => Err(err),
         }
     }
 
@@ -240,14 +248,26 @@ lazy_static! {
             None,
             HashMap::from([
                 (Meaning::AlertError, StyleFactory::from_fg_color(Color::Red)),
-                (Meaning::AlertWarn, StyleFactory::from_fg_color(Color::Yellow)),
-                (Meaning::AlertInfo, StyleFactory::from_fg_color(Color::Green)),
-                (Meaning::Annotation, StyleFactory::from_fg_color(Color::DarkGrey)),
+                (
+                    Meaning::AlertWarn,
+                    StyleFactory::from_fg_color(Color::Yellow),
+                ),
+                (
+                    Meaning::AlertInfo,
+                    StyleFactory::from_fg_color(Color::Green),
+                ),
+                (
+                    Meaning::Annotation,
+                    StyleFactory::from_fg_color(Color::DarkGrey),
+                ),
                 (Meaning::Guidance, StyleFactory::from_fg_color(Color::Blue)),
-                (Meaning::Important, StyleFactory::from_fg_color(Color::White)),
+                (
+                    Meaning::Important,
+                    StyleFactory::from_fg_color(Color::White),
+                ),
                 (Meaning::Muted, StyleFactory::from_fg_color(Color::Grey)),
                 (Meaning::Base, ContentStyle::default()),
-            ])
+            ]),
         )
     };
     static ref BUILTIN_THEMES: HashMap<&'static str, Theme> = {
@@ -256,21 +276,42 @@ lazy_static! {
             (
                 "autumn",
                 HashMap::from([
-                    (Meaning::AlertError, StyleFactory::known_fg_string("saddlebrown")),
-                    (Meaning::AlertWarn, StyleFactory::known_fg_string("darkorange")),
+                    (
+                        Meaning::AlertError,
+                        StyleFactory::known_fg_string("saddlebrown"),
+                    ),
+                    (
+                        Meaning::AlertWarn,
+                        StyleFactory::known_fg_string("darkorange"),
+                    ),
                     (Meaning::AlertInfo, StyleFactory::known_fg_string("gold")),
-                    (Meaning::Annotation, StyleFactory::from_fg_color(Color::DarkGrey)),
+                    (
+                        Meaning::Annotation,
+                        StyleFactory::from_fg_color(Color::DarkGrey),
+                    ),
                     (Meaning::Guidance, StyleFactory::known_fg_string("brown")),
                 ]),
             ),
             (
                 "marine",
                 HashMap::from([
-                    (Meaning::AlertError, StyleFactory::known_fg_string("yellowgreen")),
+                    (
+                        Meaning::AlertError,
+                        StyleFactory::known_fg_string("yellowgreen"),
+                    ),
                     (Meaning::AlertWarn, StyleFactory::known_fg_string("cyan")),
-                    (Meaning::AlertInfo, StyleFactory::known_fg_string("turquoise")),
-                    (Meaning::Annotation, StyleFactory::known_fg_string("steelblue")),
-                    (Meaning::Base, StyleFactory::known_fg_string("lightsteelblue")),
+                    (
+                        Meaning::AlertInfo,
+                        StyleFactory::known_fg_string("turquoise"),
+                    ),
+                    (
+                        Meaning::Annotation,
+                        StyleFactory::known_fg_string("steelblue"),
+                    ),
+                    (
+                        Meaning::Base,
+                        StyleFactory::known_fg_string("lightsteelblue"),
+                    ),
                     (Meaning::Guidance, StyleFactory::known_fg_string("teal")),
                 ]),
             ),
@@ -430,7 +471,10 @@ mod theme_tests {
         let mytheme = Theme::new(
             "mytheme".to_string(),
             None,
-            HashMap::from([(Meaning::AlertError, StyleFactory::known_fg_string("yellowgreen"))]),
+            HashMap::from([(
+                Meaning::AlertError,
+                StyleFactory::known_fg_string("yellowgreen"),
+            )]),
         );
         manager.loaded_themes.insert("mytheme".to_string(), mytheme);
         let theme = manager.load_theme("mytheme", None);
@@ -473,16 +517,10 @@ mod theme_tests {
         );
 
         // Does not fall back to any color.
-        assert_eq!(
-            theme.as_style(Meaning::AlertInfo).foreground_color,
-            None
-        );
+        assert_eq!(theme.as_style(Meaning::AlertInfo).foreground_color, None);
 
         // Even for the base.
-        assert_eq!(
-            theme.as_style(Meaning::Base).foreground_color,
-            None
-        );
+        assert_eq!(theme.as_style(Meaning::Base).foreground_color, None);
 
         // Falls back to red as meaning missing from theme, so picks base default.
         assert_eq!(
@@ -536,7 +574,10 @@ mod theme_tests {
         assert_eq!(theme.get_warning().foreground_color.unwrap(), Color::Yellow);
         assert_eq!(theme.get_info().foreground_color.unwrap(), Color::Green);
         assert_eq!(theme.get_base().foreground_color, None);
-        assert_eq!(theme.get_alert(log::Level::Error).foreground_color.unwrap(), Color::Red)
+        assert_eq!(
+            theme.get_alert(log::Level::Error).foreground_color.unwrap(),
+            Color::Red
+        )
     }
 
     #[test]

--- a/crates/atuin-client/src/theme.rs
+++ b/crates/atuin-client/src/theme.rs
@@ -108,10 +108,6 @@ impl Theme {
     // General access - if you have a meaning, this will give you a (crossterm) style
     pub fn as_style(&self, meaning: Meaning) -> ContentStyle {
         self.styles[self.closest_meaning(&meaning)]
-        // ContentStyle {
-        //     foreground_color: self.styles[self.closest_meaning(&meaning)],
-        //     ..ContentStyle::default()
-        // }
     }
 
     // Turns a map of meanings to colornames into a theme

--- a/crates/atuin-history/src/stats.rs
+++ b/crates/atuin-history/src/stats.rs
@@ -132,15 +132,15 @@ pub fn pretty_print(stats: Stats, ngram_size: usize, theme: &Theme) {
         let in_ten = 10 * count / max;
 
         print!("[");
-        print!("{}", SetForegroundColor(theme.get_error()));
+        print!("{}", SetForegroundColor(theme.get_error().foreground_color.unwrap()));
 
         for i in 0..in_ten {
             if i == 2 {
-                print!("{}", SetForegroundColor(theme.get_warning()));
+                print!("{}", SetForegroundColor(theme.get_warning().foreground_color.unwrap()));
             }
 
             if i == 5 {
-                print!("{}", SetForegroundColor(theme.get_info()));
+                print!("{}", SetForegroundColor(theme.get_info().foreground_color.unwrap()));
             }
 
             print!("▮");

--- a/crates/atuin-history/src/stats.rs
+++ b/crates/atuin-history/src/stats.rs
@@ -1,6 +1,6 @@
 use std::collections::{HashMap, HashSet};
 
-use crossterm::style::{ResetColor, SetAttribute, SetForegroundColor};
+use crossterm::style::{ResetColor, SetAttribute, SetForegroundColor, Color};
 use serde::{Deserialize, Serialize};
 use unicode_segmentation::UnicodeSegmentation;
 
@@ -126,21 +126,33 @@ pub fn pretty_print(stats: Stats, ngram_size: usize, theme: &Theme) {
         });
 
     for (command, count) in stats.top {
-        let gray = SetForegroundColor(theme.as_style(Meaning::Muted).foreground_color.unwrap());
+        let gray = SetForegroundColor(match theme.as_style(Meaning::Muted).foreground_color {
+            Some(color) => color,
+            None => Color::Grey
+        });
         let bold = SetAttribute(crossterm::style::Attribute::Bold);
 
         let in_ten = 10 * count / max;
 
         print!("[");
-        print!("{}", SetForegroundColor(theme.get_error().foreground_color.unwrap()));
+        print!("{}", SetForegroundColor(match theme.get_error().foreground_color {
+            Some(color) => color,
+            None => Color::Red
+        }));
 
         for i in 0..in_ten {
             if i == 2 {
-                print!("{}", SetForegroundColor(theme.get_warning().foreground_color.unwrap()));
+                print!("{}", SetForegroundColor(match theme.get_warning().foreground_color {
+                    Some(color) => color,
+                    None => Color::Yellow
+                }));
             }
 
             if i == 5 {
-                print!("{}", SetForegroundColor(theme.get_info().foreground_color.unwrap()));
+                print!("{}", SetForegroundColor(match theme.get_info().foreground_color {
+                    Some(color) => color,
+                    None => Color::Green
+                }));
             }
 
             print!("▮");

--- a/crates/atuin-history/src/stats.rs
+++ b/crates/atuin-history/src/stats.rs
@@ -4,7 +4,7 @@ use crossterm::style::{ResetColor, SetAttribute, SetForegroundColor};
 use serde::{Deserialize, Serialize};
 use unicode_segmentation::UnicodeSegmentation;
 
-use atuin_client::{history::History, settings::Settings, theme::Theme};
+use atuin_client::{history::History, settings::Settings, theme::Theme, theme::Meaning};
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct Stats {
@@ -126,7 +126,7 @@ pub fn pretty_print(stats: Stats, ngram_size: usize, theme: &Theme) {
         });
 
     for (command, count) in stats.top {
-        let gray = SetForegroundColor(theme.get_base());
+        let gray = SetForegroundColor(theme.as_style(Meaning::Muted).foreground_color.unwrap());
         let bold = SetAttribute(crossterm::style::Attribute::Bold);
 
         let in_ten = 10 * count / max;

--- a/crates/atuin-history/src/stats.rs
+++ b/crates/atuin-history/src/stats.rs
@@ -1,10 +1,10 @@
 use std::collections::{HashMap, HashSet};
 
-use crossterm::style::{ResetColor, SetAttribute, SetForegroundColor, Color};
+use crossterm::style::{Color, ResetColor, SetAttribute, SetForegroundColor};
 use serde::{Deserialize, Serialize};
 use unicode_segmentation::UnicodeSegmentation;
 
-use atuin_client::{history::History, settings::Settings, theme::Theme, theme::Meaning};
+use atuin_client::{history::History, settings::Settings, theme::Meaning, theme::Theme};
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct Stats {
@@ -128,31 +128,40 @@ pub fn pretty_print(stats: Stats, ngram_size: usize, theme: &Theme) {
     for (command, count) in stats.top {
         let gray = SetForegroundColor(match theme.as_style(Meaning::Muted).foreground_color {
             Some(color) => color,
-            None => Color::Grey
+            None => Color::Grey,
         });
         let bold = SetAttribute(crossterm::style::Attribute::Bold);
 
         let in_ten = 10 * count / max;
 
         print!("[");
-        print!("{}", SetForegroundColor(match theme.get_error().foreground_color {
-            Some(color) => color,
-            None => Color::Red
-        }));
+        print!(
+            "{}",
+            SetForegroundColor(match theme.get_error().foreground_color {
+                Some(color) => color,
+                None => Color::Red,
+            })
+        );
 
         for i in 0..in_ten {
             if i == 2 {
-                print!("{}", SetForegroundColor(match theme.get_warning().foreground_color {
-                    Some(color) => color,
-                    None => Color::Yellow
-                }));
+                print!(
+                    "{}",
+                    SetForegroundColor(match theme.get_warning().foreground_color {
+                        Some(color) => color,
+                        None => Color::Yellow,
+                    })
+                );
             }
 
             if i == 5 {
-                print!("{}", SetForegroundColor(match theme.get_info().foreground_color {
-                    Some(color) => color,
-                    None => Color::Green
-                }));
+                print!(
+                    "{}",
+                    SetForegroundColor(match theme.get_info().foreground_color {
+                        Some(color) => color,
+                        None => Color::Green,
+                    })
+                );
             }
 
             print!("▮");

--- a/crates/atuin/src/command/client/search/interactive.rs
+++ b/crates/atuin/src/command/client/search/interactive.rs
@@ -773,11 +773,10 @@ impl State {
                     .fg(theme.get_error().into()),
             )))
         } else {
+            let style: Style = theme.as_style(Meaning::Base).into();
             Paragraph::new(Text::from(Span::styled(
                 format!("Atuin v{VERSION}"),
-                Style::default()
-                    .add_modifier(Modifier::BOLD)
-                    .fg(theme.get_base().into()),
+                style.add_modifier(Modifier::BOLD)
             )))
         };
         title.alignment(Alignment::Left)

--- a/crates/atuin/src/command/client/search/interactive.rs
+++ b/crates/atuin/src/command/client/search/interactive.rs
@@ -766,11 +766,10 @@ impl State {
 
     fn build_title(&mut self, theme: &Theme) -> Paragraph {
         let title = if self.update_needed.is_some() {
+            let error_style: Style = theme.get_error().into();
             Paragraph::new(Text::from(Span::styled(
                 format!("Atuin v{VERSION} - UPGRADE"),
-                Style::default()
-                    .add_modifier(Modifier::BOLD)
-                    .fg(theme.get_error().foreground_color.unwrap().into()),
+                error_style.add_modifier(Modifier::BOLD),
             )))
         } else {
             let style: Style = theme.as_style(Meaning::Base).into();

--- a/crates/atuin/src/command/client/search/interactive.rs
+++ b/crates/atuin/src/command/client/search/interactive.rs
@@ -770,7 +770,7 @@ impl State {
                 format!("Atuin v{VERSION} - UPGRADE"),
                 Style::default()
                     .add_modifier(Modifier::BOLD)
-                    .fg(theme.get_error().into()),
+                    .fg(theme.get_error().foreground_color.unwrap().into()),
             )))
         } else {
             let style: Style = theme.as_style(Meaning::Base).into();

--- a/crates/atuin/src/command/client/search/interactive.rs
+++ b/crates/atuin/src/command/client/search/interactive.rs
@@ -775,7 +775,7 @@ impl State {
             let style: Style = theme.as_style(Meaning::Base).into();
             Paragraph::new(Text::from(Span::styled(
                 format!("Atuin v{VERSION}"),
-                style.add_modifier(Modifier::BOLD)
+                style.add_modifier(Modifier::BOLD),
             )))
         };
         title.alignment(Alignment::Left)


### PR DESCRIPTION
Following the [discussion](https://forum.atuin.sh/t/release-v18-4-0-beta-2/417/9) about the 18-4-0.beta-2 release, I made the suggested styling change. This PR now:

* makes default named "default" not ("")
* uses `ContentStyle` internally, rather than `Color`, allowing for unset colours
* tidies up `theme.rs` for internal consistency
* avoids explicit use of colours _except_ in the stats, where it is colouring the indicator bars, and will fallback to the original set if the colours are unset
* allows any Crossterm-deserializable colour to be given, via an `@` prefix: `@ansi_(255)` or `@dark_grey`, providing a means to reference ANSI codes [**needs documented**]

As a result, changes will be needed in the docs.

## Checks
- [x] I am happy for maintainers to push small adjustments to this PR, to speed up the review cycle
- [x] I have checked that there are no existing pull requests for the same thing
