### PR TITLE
test: add env ATUIN_TEST_LOCAL_TIMEOUT to control test timeout of SQLite

### DIFF
--- a/crates/atuin-client/src/database.rs
+++ b/crates/atuin-client/src/database.rs
@@ -762,6 +762,8 @@ impl Database for Sqlite {
 
 #[cfg(test)]
 mod test {
+    use crate::settings::test_local_timeout;
+
     use super::*;
     use std::time::{Duration, Instant};
 
@@ -834,7 +836,9 @@ mod test {
 
     #[tokio::test(flavor = "multi_thread")]
     async fn test_search_prefix() {
-        let mut db = Sqlite::new("sqlite::memory:", 0.1).await.unwrap();
+        let mut db = Sqlite::new("sqlite::memory:", test_local_timeout())
+            .await
+            .unwrap();
         new_history_item(&mut db, "ls /home/ellie").await.unwrap();
 
         assert_search_eq(&db, SearchMode::Prefix, FilterMode::Global, "ls", 1)
@@ -850,7 +854,9 @@ mod test {
 
     #[tokio::test(flavor = "multi_thread")]
     async fn test_search_fulltext() {
-        let mut db = Sqlite::new("sqlite::memory:", 0.1).await.unwrap();
+        let mut db = Sqlite::new("sqlite::memory:", test_local_timeout())
+            .await
+            .unwrap();
         new_history_item(&mut db, "ls /home/ellie").await.unwrap();
 
         assert_search_eq(&db, SearchMode::FullText, FilterMode::Global, "ls", 1)
@@ -934,7 +940,9 @@ mod test {
 
     #[tokio::test(flavor = "multi_thread")]
     async fn test_search_fuzzy() {
-        let mut db = Sqlite::new("sqlite::memory:", 0.1).await.unwrap();
+        let mut db = Sqlite::new("sqlite::memory:", test_local_timeout())
+            .await
+            .unwrap();
         new_history_item(&mut db, "ls /home/ellie").await.unwrap();
         new_history_item(&mut db, "ls /home/frank").await.unwrap();
         new_history_item(&mut db, "cd /home/Ellie").await.unwrap();
@@ -1035,7 +1043,9 @@ mod test {
 
     #[tokio::test(flavor = "multi_thread")]
     async fn test_search_reordered_fuzzy() {
-        let mut db = Sqlite::new("sqlite::memory:", 0.1).await.unwrap();
+        let mut db = Sqlite::new("sqlite::memory:", test_local_timeout())
+            .await
+            .unwrap();
         // test ordering of results: we should choose the first, even though it happened longer ago.
 
         new_history_item(&mut db, "curl").await.unwrap();
@@ -1069,7 +1079,9 @@ mod test {
             git_root: None,
         };
 
-        let mut db = Sqlite::new("sqlite::memory:", 0.1).await.unwrap();
+        let mut db = Sqlite::new("sqlite::memory:", test_local_timeout())
+            .await
+            .unwrap();
         for _i in 1..10000 {
             new_history_item(&mut db, "i am a duplicated command")
                 .await

--- a/crates/atuin-client/src/kv.rs
+++ b/crates/atuin-client/src/kv.rs
@@ -197,7 +197,8 @@ mod tests {
     use crypto_secretbox::{KeyInit, XSalsa20Poly1305};
     use rand::rngs::OsRng;
 
-    use crate::record::sqlite_store::{test_sqlite_store_timeout, SqliteStore};
+    use crate::record::sqlite_store::SqliteStore;
+    use crate::settings::test_local_timeout;
 
     use super::{KvRecord, KvStore, KV_VERSION};
 
@@ -221,7 +222,7 @@ mod tests {
 
     #[tokio::test]
     async fn build_kv() {
-        let mut store = SqliteStore::new(":memory:", test_sqlite_store_timeout())
+        let mut store = SqliteStore::new(":memory:", test_local_timeout())
             .await
             .unwrap();
         let kv = KvStore::new();

--- a/crates/atuin-client/src/record/sqlite_store.rs
+++ b/crates/atuin-client/src/record/sqlite_store.rs
@@ -367,7 +367,7 @@ pub(crate) fn test_sqlite_store_timeout() -> f64 {
     std::env::var("ATUIN_TEST_SQLITE_STORE_TIMEOUT")
         .ok()
         .and_then(|x| x.parse().ok())
-        .unwrap_or(0.1)
+        .unwrap_or(crate::settings::test_local_timeout())
 }
 
 #[cfg(test)]

--- a/crates/atuin-client/src/record/sqlite_store.rs
+++ b/crates/atuin-client/src/record/sqlite_store.rs
@@ -363,14 +363,6 @@ impl Store for SqliteStore {
 }
 
 #[cfg(test)]
-pub(crate) fn test_sqlite_store_timeout() -> f64 {
-    std::env::var("ATUIN_TEST_SQLITE_STORE_TIMEOUT")
-        .ok()
-        .and_then(|x| x.parse().ok())
-        .unwrap_or(crate::settings::test_local_timeout())
-}
-
-#[cfg(test)]
 mod tests {
     use atuin_common::{
         record::{DecryptedData, EncryptedData, Host, HostId, Record},
@@ -380,9 +372,10 @@ mod tests {
     use crate::{
         encryption::generate_encoded_key,
         record::{encryption::PASETO_V4, store::Store},
+        settings::test_local_timeout,
     };
 
-    use super::{test_sqlite_store_timeout, SqliteStore};
+    use super::SqliteStore;
 
     fn test_record() -> Record<EncryptedData> {
         Record::builder()
@@ -399,7 +392,7 @@ mod tests {
 
     #[tokio::test]
     async fn create_db() {
-        let db = SqliteStore::new(":memory:", test_sqlite_store_timeout()).await;
+        let db = SqliteStore::new(":memory:", test_local_timeout()).await;
 
         assert!(
             db.is_ok(),
@@ -410,7 +403,7 @@ mod tests {
 
     #[tokio::test]
     async fn push_record() {
-        let db = SqliteStore::new(":memory:", test_sqlite_store_timeout())
+        let db = SqliteStore::new(":memory:", test_local_timeout())
             .await
             .unwrap();
         let record = test_record();
@@ -420,7 +413,7 @@ mod tests {
 
     #[tokio::test]
     async fn get_record() {
-        let db = SqliteStore::new(":memory:", test_sqlite_store_timeout())
+        let db = SqliteStore::new(":memory:", test_local_timeout())
             .await
             .unwrap();
         let record = test_record();
@@ -433,7 +426,7 @@ mod tests {
 
     #[tokio::test]
     async fn last() {
-        let db = SqliteStore::new(":memory:", test_sqlite_store_timeout())
+        let db = SqliteStore::new(":memory:", test_local_timeout())
             .await
             .unwrap();
         let record = test_record();
@@ -453,7 +446,7 @@ mod tests {
 
     #[tokio::test]
     async fn first() {
-        let db = SqliteStore::new(":memory:", test_sqlite_store_timeout())
+        let db = SqliteStore::new(":memory:", test_local_timeout())
             .await
             .unwrap();
         let record = test_record();
@@ -473,7 +466,7 @@ mod tests {
 
     #[tokio::test]
     async fn len() {
-        let db = SqliteStore::new(":memory:", test_sqlite_store_timeout())
+        let db = SqliteStore::new(":memory:", test_local_timeout())
             .await
             .unwrap();
         let record = test_record();
@@ -489,7 +482,7 @@ mod tests {
 
     #[tokio::test]
     async fn len_tag() {
-        let db = SqliteStore::new(":memory:", test_sqlite_store_timeout())
+        let db = SqliteStore::new(":memory:", test_local_timeout())
             .await
             .unwrap();
         let record = test_record();
@@ -505,7 +498,7 @@ mod tests {
 
     #[tokio::test]
     async fn len_different_tags() {
-        let db = SqliteStore::new(":memory:", test_sqlite_store_timeout())
+        let db = SqliteStore::new(":memory:", test_local_timeout())
             .await
             .unwrap();
 
@@ -527,7 +520,7 @@ mod tests {
 
     #[tokio::test]
     async fn append_a_bunch() {
-        let db = SqliteStore::new(":memory:", test_sqlite_store_timeout())
+        let db = SqliteStore::new(":memory:", test_local_timeout())
             .await
             .unwrap();
 
@@ -554,7 +547,7 @@ mod tests {
 
     #[tokio::test]
     async fn append_a_big_bunch() {
-        let db = SqliteStore::new(":memory:", test_sqlite_store_timeout())
+        let db = SqliteStore::new(":memory:", test_local_timeout())
             .await
             .unwrap();
 
@@ -579,7 +572,7 @@ mod tests {
 
     #[tokio::test]
     async fn re_encrypt() {
-        let store = SqliteStore::new(":memory:", test_sqlite_store_timeout())
+        let store = SqliteStore::new(":memory:", test_local_timeout())
             .await
             .unwrap();
         let (key, _) = generate_encoded_key().unwrap();

--- a/crates/atuin-client/src/record/sync.rs
+++ b/crates/atuin-client/src/record/sync.rs
@@ -328,11 +328,14 @@ mod tests {
     use atuin_common::record::{Diff, EncryptedData, HostId, Record};
     use pretty_assertions::assert_eq;
 
-    use crate::record::{
-        encryption::PASETO_V4,
-        sqlite_store::{test_sqlite_store_timeout, SqliteStore},
-        store::Store,
-        sync::{self, Operation},
+    use crate::{
+        record::{
+            encryption::PASETO_V4,
+            sqlite_store::SqliteStore,
+            store::Store,
+            sync::{self, Operation},
+        },
+        settings::test_local_timeout,
     };
 
     fn test_record() -> Record<EncryptedData> {
@@ -357,10 +360,10 @@ mod tests {
         local_records: Vec<Record<EncryptedData>>,
         remote_records: Vec<Record<EncryptedData>>,
     ) -> (SqliteStore, Vec<Diff>) {
-        let local_store = SqliteStore::new(":memory:", test_sqlite_store_timeout())
+        let local_store = SqliteStore::new(":memory:", test_local_timeout())
             .await
             .expect("failed to open in memory sqlite");
-        let remote_store = SqliteStore::new(":memory:", test_sqlite_store_timeout())
+        let remote_store = SqliteStore::new(":memory:", test_local_timeout())
             .await
             .expect("failed to open in memory sqlite"); // "remote"
 

--- a/crates/atuin-client/src/settings.rs
+++ b/crates/atuin-client/src/settings.rs
@@ -846,6 +846,16 @@ impl Default for Settings {
 }
 
 #[cfg(test)]
+pub(crate) fn test_local_timeout() -> f64 {
+    std::env::var("ATUIN_TEST_LOCAL_TIMEOUT")
+        .ok()
+        .and_then(|x| x.parse().ok())
+        // this hardcoded value should be replaced by a simple way to get the
+        // default local_timeout of Settings if possible
+        .unwrap_or(2.0)
+}
+
+#[cfg(test)]
 mod tests {
     use std::str::FromStr;
 

--- a/crates/atuin-dotfiles/src/store.rs
+++ b/crates/atuin-dotfiles/src/store.rs
@@ -298,11 +298,13 @@ impl AliasStore {
 }
 
 #[cfg(test)]
-pub(crate) fn test_sqlite_store_timeout() -> f64 {
-    std::env::var("ATUIN_TEST_SQLITE_STORE_TIMEOUT")
+pub(crate) fn test_local_timeout() -> f64 {
+    std::env::var("ATUIN_TEST_LOCAL_TIMEOUT")
         .ok()
         .and_then(|x| x.parse().ok())
-        .unwrap_or(0.1)
+        // this hardcoded value should be replaced by a simple way to get the
+        // default local_timeout of Settings if possible
+        .unwrap_or(2.0)
 }
 
 #[cfg(test)]
@@ -313,7 +315,7 @@ mod tests {
 
     use crate::shell::Alias;
 
-    use super::{test_sqlite_store_timeout, AliasRecord, AliasStore, CONFIG_SHELL_ALIAS_VERSION};
+    use super::{test_local_timeout, AliasRecord, AliasStore, CONFIG_SHELL_ALIAS_VERSION};
     use crypto_secretbox::{KeyInit, XSalsa20Poly1305};
 
     #[test]
@@ -335,7 +337,7 @@ mod tests {
 
     #[tokio::test]
     async fn build_aliases() {
-        let store = SqliteStore::new(":memory:", test_sqlite_store_timeout())
+        let store = SqliteStore::new(":memory:", test_local_timeout())
             .await
             .unwrap();
         let key: [u8; 32] = XSalsa20Poly1305::generate_key(&mut OsRng).into();

--- a/crates/atuin-dotfiles/src/store/var.rs
+++ b/crates/atuin-dotfiles/src/store/var.rs
@@ -287,22 +287,14 @@ impl VarStore {
 }
 
 #[cfg(test)]
-pub(crate) fn test_sqlite_store_timeout() -> f64 {
-    std::env::var("ATUIN_TEST_SQLITE_STORE_TIMEOUT")
-        .ok()
-        .and_then(|x| x.parse().ok())
-        .unwrap_or(0.1)
-}
-
-#[cfg(test)]
 mod tests {
     use rand::rngs::OsRng;
 
     use atuin_client::record::sqlite_store::SqliteStore;
 
-    use crate::shell::Var;
+    use crate::{shell::Var, store::test_local_timeout};
 
-    use super::{test_sqlite_store_timeout, VarRecord, VarStore, DOTFILES_VAR_VERSION};
+    use super::{VarRecord, VarStore, DOTFILES_VAR_VERSION};
     use crypto_secretbox::{KeyInit, XSalsa20Poly1305};
 
     #[test]
@@ -327,7 +319,7 @@ mod tests {
 
     #[tokio::test]
     async fn build_vars() {
-        let store = SqliteStore::new(":memory:", test_sqlite_store_timeout())
+        let store = SqliteStore::new(":memory:", test_local_timeout())
             .await
             .unwrap();
         let key: [u8; 32] = XSalsa20Poly1305::generate_key(&mut OsRng).into();


### PR DESCRIPTION
This make it possible to control the timeout of SQLite operations in test. And `ATUIN_TEST_LOCAL_TIMEOUT` defaults to the default local_timeout, which is actually used in the client. Instead of a small timeout (0.1), this change makes the test less likely to fail and better imitate the default behavior.

SQLite operation timeout was first introduced from #1590, including connection and store timeout. The env `ATUIN_TEST_SQLITE_STORE_TIMEOUT` which added by #1703 only specify the store timeout. This commit doesn't deprecate `ATUIN_TEST_SQLITE_STORE_TIMEOUT`, but control it by setting its default to the new env `ATUIN_TEST_LOCAL_TIMEOUT`.

The reason is the same as #1703, but this time it fails due to connection timeout: [archriscv.felixc.at/.status/log.htm?url=logs/atuin/atuin-18.3.0-1.log](https://archriscv.felixc.at/.status/log.htm?url=logs/atuin/atuin-18.3.0-1.log).

And I have two question for this commit if it's acceptable:

- Should we replace the old `ATUIN_TEST_SQLITE_STORE_TIMEOUT` with the new `ATUIN_TEST_LOCAL_TIMEOUT` for simplicity?
- Is there a simple way to get the local_timeout value? Using `Settings::builder()` seems complex.

<!-- Thank you for making a PR! Bug fixes are always welcome, but if you're adding a new feature or changing an existing one, we'd really appreciate if you open an issue, post on the forum, or drop in on Discord -->

## Checks
- [x] I am happy for maintainers to push small adjustments to this PR, to speed up the review cycle
- [x] I have checked that there are no existing pull requests for the same thing
