### PR TITLE
fix(mail): incorrect alias and error logs

### DIFF
--- a/crates/atuin-server/src/handlers/user.rs
+++ b/crates/atuin-server/src/handlers/user.rs
@@ -203,6 +203,7 @@ pub async fn send_verification<DB: Database>(
     let postmark_token = if let Some(token) = settings.mail.postmark.token {
         token
     } else {
+        error!("Failed to verify email: got None for postmark token");
         return Err(ErrorResponse::reply("mail not configured")
             .with_status(StatusCode::INTERNAL_SERVER_ERROR));
     };

--- a/crates/atuin-server/src/settings.rs
+++ b/crates/atuin-server/src/settings.rs
@@ -23,7 +23,7 @@ pub struct Mail {
 
 #[derive(Default, Clone, Debug, Deserialize, Serialize)]
 pub struct Postmark {
-    #[serde(alias = "enable")]
+    #[serde(alias = "token")]
     pub token: Option<String>,
 }
 


### PR DESCRIPTION
Looks like verification emails are currently throwing a 502

## Checks
- [ ] I am happy for maintainers to push small adjustments to this PR, to speed up the review cycle
- [ ] I have checked that there are no existing pull requests for the same thing
