### PR TITLE
Fix zsh_histdb import issue

### DIFF
--- a/crates/atuin-client/src/import/zsh_histdb.rs
+++ b/crates/atuin-client/src/import/zsh_histdb.rs
@@ -84,7 +84,7 @@ async fn hist_from_db_conn(pool: Pool<sqlx::Sqlite>) -> Result<Vec<HistDbEntry>>
         FROM history
         LEFT JOIN commands ON history.command_id = commands.id
         LEFT JOIN places ON history.place_id = places.id
-        ORDER BY history.start_time
+        ORDER BY history.id
     "#;
     let histdb_vec: Vec<HistDbEntry> = sqlx::query_as::<_, HistDbEntry>(query)
         .fetch_all(&pool)


### PR DESCRIPTION
## Fix Import Error by Modifying Order Clause

This PR addresses an import zsh-hist-db error by changing the order clause in the query. 
The current implementation uses `ORDER BY history.start_time`, which is causing issues. The fix involves using `ORDER BY history.id` instead. The order by `id` and `start_time` produces the same sequence, and since `id` is the primary key, this change may improve the query performance.

#### Screenshots

###### Error Screenshot:
<img width="1059" alt="image" src="https://github.com/user-attachments/assets/ebc562f5-e352-4dd7-ab02-0656e5cef780">

###### Histdb Query Testing:
<img width="709" alt="image" src="https://github.com/user-attachments/assets/e5241488-bc6f-4a82-af47-99103cba320e">

<img width="750" alt="image" src="https://github.com/user-attachments/assets/ad6a9ee8-f851-4549-8898-f3359bbe20da">


## Checks
- [x] I am happy for maintainers to push small adjustments to this PR, to speed up the review cycle
- [x] I have checked that there are no existing pull requests for the same thing
