### PR TITLE
Remove debug statement when changing account password

### DIFF
--- a/crates/atuin-client/src/api_client.rs
+++ b/crates/atuin-client/src/api_client.rs
@@ -392,8 +392,6 @@ impl<'a> Client<'a> {
             .send()
             .await?;
 
-        dbg!(&resp);
-
         if resp.status() == 401 {
             bail!("current password is incorrect")
         } else if resp.status() == 403 {


### PR DESCRIPTION
<!-- Thank you for making a PR! Bug fixes are always welcome, but if you're adding a new feature or changing an existing one, we'd really appreciate if you open an issue, post on the forum, or drop in on Discord -->
This was introduced in my PR #1615 without being noticed somehow, I just happened to look at the diff of that PR and saw the macro I must have accidentally left in it. I just checked and it does indeed print the request when you attempt to change your password in the CLI, whoops!

## Checks
- [x] I am happy for maintainers to push small adjustments to this PR, to speed up the review cycle
- [x] I have checked that there are no existing pull requests for the same thing
