### PR TITLE
Ultracompact Mode (search-only)

### DIFF
--- a/crates/atuin-client/config.toml
+++ b/crates/atuin-client/config.toml
@@ -127,8 +127,8 @@
 
 ## Configure whether or not the tabs row may be auto-hidden, which includes the current Atuin
 ## tab, such as Search or Inspector, and other tabs you may wish to see. This will
-## only be hidden if there is likely not space to be useful, and does not affect the use
-## of keyboard shortcuts to switch tab. 0 to never auto-hide, default is 8.
+## only be hidden if there are fewer than this count of lines available, and does not affect the use
+## of keyboard shortcuts to switch tab. 0 to never auto-hide, default is 8 (lines).
 ## This is ignored except in `compact` mode.
 # auto_hide_height = 8
 

--- a/crates/atuin-client/config.toml
+++ b/crates/atuin-client/config.toml
@@ -128,9 +128,9 @@
 ## Configure whether or not the tabs row may be auto-hidden, which includes the current Atuin
 ## tab, such as Search or Inspector, and other tabs you may wish to see. This will
 ## only be hidden if there is likely not space to be useful, and does not affect the use
-## of keyboard shortcuts to switch tab.
-## TODO: is this still useful given the option above?
-# always_show_tabs = true
+## of keyboard shortcuts to switch tab. 0 to never auto-hide, default is 8.
+## This is ignored except in `compact` mode.
+# auto_hide_height = 8
 
 ## Defaults to true. This matches history against a set of default regex, and will not save it if we get a match. Defaults include
 ## 1. AWS key id

--- a/crates/atuin-client/config.toml
+++ b/crates/atuin-client/config.toml
@@ -125,6 +125,13 @@
 ## Configure whether or not to show tabs for search and inspect
 # show_tabs = true
 
+## Configure whether or not the tabs row may be auto-hidden, which includes the current Atuin
+## tab, such as Search or Inspector, and other tabs you may wish to see. This will
+## only be hidden if there is likely not space to be useful, and does not affect the use
+## of keyboard shortcuts to switch tab.
+## TODO: is this still useful given the option above?
+# always_show_tabs = true
+
 ## Defaults to true. This matches history against a set of default regex, and will not save it if we get a match. Defaults include
 ## 1. AWS key id
 ## 2. Github pat (old and new)

--- a/crates/atuin-client/src/settings.rs
+++ b/crates/atuin-client/src/settings.rs
@@ -440,7 +440,7 @@ pub struct Settings {
     pub max_preview_height: u16,
     pub show_help: bool,
     pub show_tabs: bool,
-    pub always_show_tabs: bool,
+    pub auto_hide_height: u16,
     pub exit_mode: ExitMode,
     pub keymap_mode: KeymapMode,
     pub keymap_mode_shell: KeymapMode,
@@ -723,7 +723,7 @@ impl Settings {
             .set_default("max_preview_height", 4)?
             .set_default("show_help", true)?
             .set_default("show_tabs", true)?
-            .set_default("always_show_tabs", false)?
+            .set_default("auto_hide_height", 8)?
             .set_default("invert", false)?
             .set_default("exit_mode", "return-original")?
             .set_default("word_jump_mode", "emacs")?

--- a/crates/atuin-client/src/settings.rs
+++ b/crates/atuin-client/src/settings.rs
@@ -440,6 +440,7 @@ pub struct Settings {
     pub max_preview_height: u16,
     pub show_help: bool,
     pub show_tabs: bool,
+    pub always_show_tabs: bool,
     pub exit_mode: ExitMode,
     pub keymap_mode: KeymapMode,
     pub keymap_mode_shell: KeymapMode,
@@ -722,6 +723,7 @@ impl Settings {
             .set_default("max_preview_height", 4)?
             .set_default("show_help", true)?
             .set_default("show_tabs", true)?
+            .set_default("always_show_tabs", false)?
             .set_default("invert", false)?
             .set_default("exit_mode", "return-original")?
             .set_default("word_jump_mode", "emacs")?

--- a/crates/atuin-client/src/theme.rs
+++ b/crates/atuin-client/src/theme.rs
@@ -53,8 +53,8 @@ pub struct ThemeDefinitionConfigBlock {
 
 use crossterm::style::{Color, ContentStyle};
 
-// For now, a theme is specifically a mapping of meanings to colors, but it may be desirable to
-// expand that in the future to general styles.
+// For now, a theme is loaded as a mapping of meanings to colors, but it may be desirable to
+// expand that in the future to general styles, so we populate a Meaning->ContentStyle hashmap.
 pub struct Theme {
     pub name: String,
     pub parent: Option<String>,

--- a/crates/atuin/src/command/client/search/history_list.rs
+++ b/crates/atuin/src/command/client/search/history_list.rs
@@ -22,6 +22,7 @@ pub struct HistoryList<'a> {
     /// Apply an alternative highlighting to the selected row
     alternate_highlight: bool,
     now: &'a dyn Fn() -> OffsetDateTime,
+    indicator: &'a str,
     theme: &'a Theme,
 }
 
@@ -74,6 +75,7 @@ impl<'a> StatefulWidget for HistoryList<'a> {
             inverted: self.inverted,
             alternate_highlight: self.alternate_highlight,
             now: &self.now,
+            indicator: self.indicator,
             theme: self.theme,
         };
 
@@ -96,6 +98,7 @@ impl<'a> HistoryList<'a> {
         inverted: bool,
         alternate_highlight: bool,
         now: &'a dyn Fn() -> OffsetDateTime,
+        indicator: &'a str,
         theme: &'a Theme,
     ) -> Self {
         Self {
@@ -104,6 +107,7 @@ impl<'a> HistoryList<'a> {
             inverted,
             alternate_highlight,
             now,
+            indicator,
             theme,
         }
     }
@@ -137,6 +141,7 @@ struct DrawState<'a> {
     inverted: bool,
     alternate_highlight: bool,
     now: &'a dyn Fn() -> OffsetDateTime,
+    indicator: &'a str,
     theme: &'a Theme,
 }
 
@@ -155,7 +160,12 @@ impl DrawState<'_> {
         let i = self.y as usize + self.state.offset;
         let i = i.checked_sub(self.state.selected);
         let i = i.unwrap_or(10).min(10) * 2;
-        self.draw(&SLICES[i..i + 3], Style::default());
+        let prompt: &str = if i == 0 {
+            self.indicator
+        } else {
+            &SLICES[i..i + 3]
+        };
+        self.draw(prompt, Style::default());
     }
 
     fn duration(&mut self, h: &History) {

--- a/crates/atuin/src/command/client/search/interactive.rs
+++ b/crates/atuin/src/command/client/search/interactive.rs
@@ -623,7 +623,7 @@ impl State {
         let show_help = settings.show_help && (!compact || f.size().height > 1);
         // This is an OR, as it seems more likely for someone to wish to override
         // tabs unexpectedly being missed, than unexpectedly present.
-        let hide_extra = !settings.always_show_tabs && (compact && f.size().height < 8);
+        let hide_extra = settings.auto_hide_height != 0 && compact && f.size().height <= settings.auto_hide_height;
         let show_tabs = settings.show_tabs && !hide_extra;
         let chunks = Layout::default()
             .direction(Direction::Vertical)

--- a/crates/atuin/src/command/client/search/interactive.rs
+++ b/crates/atuin/src/command/client/search/interactive.rs
@@ -623,7 +623,9 @@ impl State {
         let show_help = settings.show_help && (!compact || f.size().height > 1);
         // This is an OR, as it seems more likely for someone to wish to override
         // tabs unexpectedly being missed, than unexpectedly present.
-        let hide_extra = settings.auto_hide_height != 0 && compact && f.size().height <= settings.auto_hide_height;
+        let hide_extra = settings.auto_hide_height != 0
+            && compact
+            && f.size().height <= settings.auto_hide_height;
         let show_tabs = settings.show_tabs && !hide_extra;
         let chunks = Layout::default()
             .direction(Direction::Vertical)
@@ -641,7 +643,7 @@ impl State {
                 } else if hide_extra {
                     [
                         Constraint::Length(if show_help { 1 } else { 0 }), // header
-                        Constraint::Length(0), // tabs
+                        Constraint::Length(0),                             // tabs
                         Constraint::Min(1),                                // results list
                         Constraint::Length(0),
                         Constraint::Length(0),
@@ -712,13 +714,22 @@ impl State {
         } else if self.switched_search_mode {
             format!("S{}>", self.search_mode.as_str().chars().next().unwrap())
         } else {
-            format!("{}> ", self.search.filter_mode.as_str().chars().next().unwrap())
+            format!(
+                "{}> ",
+                self.search.filter_mode.as_str().chars().next().unwrap()
+            )
         };
 
         match self.tab_index {
             0 => {
-                let results_list =
-                    Self::build_results_list(style, results, self.keymap_mode, &self.now, indicator.as_str(), theme);
+                let results_list = Self::build_results_list(
+                    style,
+                    results,
+                    self.keymap_mode,
+                    &self.now,
+                    indicator.as_str(),
+                    theme,
+                );
                 f.render_stateful_widget(results_list, results_list_chunk, &mut self.results_state);
             }
 

--- a/crates/atuin/src/command/client/search/interactive.rs
+++ b/crates/atuin/src/command/client/search/interactive.rs
@@ -621,7 +621,9 @@ impl State {
             preview_width,
         );
         let show_help = settings.show_help && (!compact || f.size().height > 1);
-        let show_tabs = settings.show_tabs;
+        // This is an OR, as it seems more likely for someone to wish to override
+        // tabs unexpectedly being missed, than unexpectedly present.
+        let show_tabs = settings.show_tabs && (settings.always_show_tabs || (!compact || f.size().height > 10));
         let chunks = Layout::default()
             .direction(Direction::Vertical)
             .margin(0)
@@ -659,13 +661,15 @@ impl State {
         // also allocate less 🙈
         let titles: Vec<_> = TAB_TITLES.iter().copied().map(Line::from).collect();
 
-        let tabs = Tabs::new(titles)
-            .block(Block::default().borders(Borders::NONE))
-            .select(self.tab_index)
-            .style(Style::default())
-            .highlight_style(Style::default().bold().white().on_black());
+        if show_tabs {
+            let tabs = Tabs::new(titles)
+                .block(Block::default().borders(Borders::NONE))
+                .select(self.tab_index)
+                .style(Style::default())
+                .highlight_style(Style::default().bold().white().on_black());
 
-        f.render_widget(tabs, tabs_chunk);
+            f.render_widget(tabs, tabs_chunk);
+        }
 
         let style = StyleState {
             compact,


### PR DESCRIPTION
### What does this PR do?

Adds an ultracompact mode only for search (interactive.rs) and not the inspector.

* adds a config parameter to set a line height at which to switch to ultracompact
* ~~introduces a simplified inspector tab, with only previous-current-next commands as rows, in compact mode~~
* ~~allows navigation through session history within the inspector (so compact inspector view is still useful)~~
* in ultracompact view, compresses indicator row into prompt, removes any non-command lines (except help if show_help is true)

### TODO

* additional tests, although keen for input on how best to do these
* documentation (once configuration/semantics are aligned on)

<!-- Thank you for making a PR! Bug fixes are always welcome, but if you're adding a new feature or changing an existing one, we'd really appreciate if you open an issue, post on the forum, or drop in on Discord -->

## Checks
- [x] I am happy for maintainers to push small adjustments to this PR, to speed up the review cycle
- [x] I have checked that there are no existing pull requests for the same thing
