### PR TITLE
Fix reverse import order for zsh and nu

### DIFF
--- a/crates/atuin-client/src/import/mod.rs
+++ b/crates/atuin-client/src/import/mod.rs
@@ -38,7 +38,7 @@ fn unix_byte_lines(input: &[u8]) -> impl DoubleEndedIterator<Item = &[u8]> {
         bytes: input,
         i: 0,
         // Set to the last element
-        i_rev: input.len().checked_sub(1).unwrap_or(0),
+        i_rev: input.len().saturating_sub(1),
     }
 }
 

--- a/crates/atuin-client/src/import/nu.rs
+++ b/crates/atuin-client/src/import/nu.rs
@@ -46,7 +46,8 @@ impl Importer for Nu {
         let now = OffsetDateTime::now_utc();
 
         let mut counter = 0;
-        for b in unix_byte_lines(&self.bytes) {
+        // Reverse order so that recency is preserved
+        for b in unix_byte_lines(&self.bytes).rev() {
             let s = match std::str::from_utf8(b) {
                 Ok(s) => s,
                 Err(_) => continue, // we can skip past things like invalid utf8

--- a/crates/atuin-client/src/import/zsh.rs
+++ b/crates/atuin-client/src/import/zsh.rs
@@ -71,9 +71,7 @@ impl Importer for Zsh {
                 line.insert_str(0, "\\\n");
                 line.insert_str(0, s);
             } else {
-                if !line.is_empty() {
-                    add_command(&mut line, &mut counter, h).await?;
-                }
+                add_command(&mut line, &mut counter, h).await?;
                 line.push_str(&s);
             }
         }

--- a/crates/atuin-client/src/import/zsh.rs
+++ b/crates/atuin-client/src/import/zsh.rs
@@ -57,42 +57,52 @@ impl Importer for Zsh {
     }
 
     async fn load(self, h: &mut impl Loader) -> Result<()> {
-        let now = OffsetDateTime::now_utc();
         let mut line = String::new();
 
         let mut counter = 0;
-        for b in unix_byte_lines(&self.bytes) {
+        // Reverse order so that recency of history is preserved
+        for b in unix_byte_lines(&self.bytes).rev() {
             let s = match unmetafy(b) {
                 Some(s) => s,
                 _ => continue, // we can skip past things like invalid utf8
             };
-
             if let Some(s) = s.strip_suffix('\\') {
-                line.push_str(s);
-                line.push_str("\\\n");
+                // Prepend command from previous line in the history
+                line.insert_str(0, "\\\n");
+                line.insert_str(0, s);
             } else {
-                line.push_str(&s);
-                let command = std::mem::take(&mut line);
-
-                if let Some(command) = command.strip_prefix(": ") {
-                    counter += 1;
-                    h.push(parse_extended(command, counter)).await?;
-                } else {
-                    let offset = time::Duration::seconds(counter);
-                    counter += 1;
-
-                    let imported = History::import()
-                        // preserve ordering
-                        .timestamp(now - offset)
-                        .command(command.trim_end().to_string());
-
-                    h.push(imported.build().into()).await?;
+                if !line.is_empty() {
+                    add_command(&mut line, &mut counter, h).await?;
                 }
+                line.push_str(&s);
             }
         }
-
+        add_command(&mut line, &mut counter, h).await?;
         Ok(())
     }
+}
+
+async fn add_command(line: &mut String, counter: &mut i64, h: &mut impl Loader) -> Result<()> {
+    if line.is_empty() {
+        return Ok(());
+    }
+    let now = OffsetDateTime::now_utc();
+    let command = std::mem::take(line);
+    if let Some(command) = command.strip_prefix(": ") {
+        *counter += 1;
+        h.push(parse_extended(command, *counter)).await?;
+    } else {
+        let offset = time::Duration::seconds(*counter);
+        *counter += 1;
+
+        let imported = History::import()
+            // preserve ordering
+            .timestamp(now - offset)
+            .command(command.trim_end().to_string());
+
+        h.push(imported.build().into()).await?;
+    }
+    Ok(())
 }
 
 fn parse_extended(line: &str, counter: i64) -> History {
@@ -203,11 +213,23 @@ cargo update
         assert_equal(
             loader.buf.iter().map(|h| h.command.as_str()),
             [
-                "cargo install atuin",
-                "cargo install atuin; \\\ncargo update",
                 "cargo :b̷i̶t̴r̵o̴t̴ ̵i̷s̴ ̷r̶e̵a̸l̷",
+                "cargo install atuin; \\\ncargo update",
+                "cargo install atuin",
             ],
         );
+    }
+
+    #[tokio::test]
+    async fn test_parse_empty_file() {
+        let bytes = vec![];
+
+        let mut zsh = Zsh { bytes };
+        assert_eq!(zsh.entries().await.unwrap(), 0);
+
+        let mut loader = TestLoader::default();
+        zsh.load(&mut loader).await.unwrap();
+        assert!(loader.buf.is_empty());
     }
 
     #[tokio::test]
@@ -223,7 +245,7 @@ cargo update
 
         assert_equal(
             loader.buf.iter().map(|h| h.command.as_str()),
-            ["echo 你好", "ls ~/音乐"],
+            ["ls ~/音乐", "echo 你好"],
         );
     }
 }


### PR DESCRIPTION
Should fix https://github.com/atuinsh/atuin/issues/178

Contains the following changes:

1. Added `DoubleEndedIterator` implementation for `UnixByteLines`.

2. Reversed import order for `zsh`
I had to make some additional changes to handle commands spanning multiple lines: the previous command is prepended to the current one if it contains a line break (i.e. we need to keep the original import order for commands on multiple lines).

3. Reversed import order for `nu`
Simply reversed the order for `nu`. Commands spanning multiple lines do not need to be handled differently since they are stored in a single line in the history.

The import order for `bash`, `fish` and `replxx` seem to be correct already.
I also did not touch `resh` as I could not test locally since it tries importing `".resh_history.json"` whereas `resh` [seems to be storing its history](https://github.com/curusarn/resh/blob/master/troubleshooting.md#recorded-history) in `history.reshjson`. So that appears to be a separate issue unless I missed something.



## Checks
- [X] I am happy for maintainers to push small adjustments to this PR, to speed up the review cycle
- [X] I have checked that there are no existing pull requests for the same thing
