### PR TITLE
fix(deps): pin tiny_bip to 1.0.0 until breaking change resolved

### DIFF
--- a/crates/atuin-client/Cargo.toml
+++ b/crates/atuin-client/Cargo.toml
@@ -68,7 +68,7 @@ reqwest = { workspace = true, optional = true }
 hex = { version = "0.4", optional = true }
 sha2 = { version = "0.10", optional = true }
 indicatif = "0.17.7"
-tiny-bip39 = "1"
+tiny-bip39 = "=1.0.0"
 
 # theme
 crossterm = { version = "0.27.0", features = ["serde"] }


### PR DESCRIPTION
Ref #2410, https://github.com/maciejhirsz/tiny-bip39/issues/52

Will revert once it's fixed, I'd rather not set dependencies with this level of granularity 

## Checks
- [ ] I am happy for maintainers to push small adjustments to this PR, to speed up the review cycle
- [ ] I have checked that there are no existing pull requests for the same thing
