### PR TITLE
Right Arrow to modify selected command

### DIFF
--- a/crates/atuin/src/command/client/search/cursor.rs
+++ b/crates/atuin/src/command/client/search/cursor.rs
@@ -203,6 +203,10 @@ impl Cursor {
     pub fn start(&mut self) {
         self.index = 0;
     }
+
+    pub fn position(&self) -> usize {
+        self.index
+    }
 }
 
 #[cfg(test)]

--- a/crates/atuin/src/command/client/search/interactive.rs
+++ b/crates/atuin/src/command/client/search/interactive.rs
@@ -205,7 +205,8 @@ impl State {
 
         let ctrl = input.modifiers.contains(KeyModifiers::CONTROL);
         let esc_allow_exit = !(self.tab_index == 0 && self.keymap_mode == KeymapMode::VimInsert);
-        let cursor_at_end_of_line = self.search.input.position() == UnicodeWidthStr::width(self.search.input.as_str());
+        let cursor_at_end_of_line =
+            self.search.input.position() == UnicodeWidthStr::width(self.search.input.as_str());
         let cursor_at_start_of_line = self.search.input.position() == 0;
 
         // support ctrl-a prefix, like screen or tmux
@@ -223,12 +224,14 @@ impl State {
             KeyCode::Esc if esc_allow_exit => Some(Self::handle_key_exit(settings)),
             KeyCode::Char('[') if ctrl && esc_allow_exit => Some(Self::handle_key_exit(settings)),
             KeyCode::Tab => Some(InputAction::Accept(self.results_state.selected())),
-            KeyCode::Right if cursor_at_end_of_line => Some(InputAction::Accept(self.results_state.selected())),
+            KeyCode::Right if cursor_at_end_of_line => {
+                Some(InputAction::Accept(self.results_state.selected()))
+            }
             KeyCode::Left if cursor_at_start_of_line => Some(Self::handle_key_exit(settings)),
             KeyCode::Char('o') if ctrl => {
                 self.tab_index = (self.tab_index + 1) % TAB_TITLES.len();
                 Some(InputAction::Continue)
-            },
+            }
             _ => None,
         };
 

--- a/crates/atuin/src/command/client/search/interactive.rs
+++ b/crates/atuin/src/command/client/search/interactive.rs
@@ -206,6 +206,7 @@ impl State {
         let ctrl = input.modifiers.contains(KeyModifiers::CONTROL);
         let esc_allow_exit = !(self.tab_index == 0 && self.keymap_mode == KeymapMode::VimInsert);
         let cursor_at_end_of_line = self.search.input.position() == UnicodeWidthStr::width(self.search.input.as_str());
+        let cursor_at_start_of_line = self.search.input.position() == 0;
 
         // support ctrl-a prefix, like screen or tmux
         if !self.prefix
@@ -223,6 +224,7 @@ impl State {
             KeyCode::Char('[') if ctrl && esc_allow_exit => Some(Self::handle_key_exit(settings)),
             KeyCode::Tab => Some(InputAction::Accept(self.results_state.selected())),
             KeyCode::Right if cursor_at_end_of_line => Some(InputAction::Accept(self.results_state.selected())),
+            KeyCode::Left if cursor_at_start_of_line => Some(Self::handle_key_exit(settings)),
             KeyCode::Char('o') if ctrl => {
                 self.tab_index = (self.tab_index + 1) % TAB_TITLES.len();
                 Some(InputAction::Continue)

--- a/crates/atuin/src/command/client/search/interactive.rs
+++ b/crates/atuin/src/command/client/search/interactive.rs
@@ -221,6 +221,7 @@ impl State {
             KeyCode::Esc if esc_allow_exit => Some(Self::handle_key_exit(settings)),
             KeyCode::Char('[') if ctrl && esc_allow_exit => Some(Self::handle_key_exit(settings)),
             KeyCode::Tab => Some(InputAction::Accept(self.results_state.selected())),
+            KeyCode::Right => Some(InputAction::Accept(self.results_state.selected())),
             KeyCode::Char('o') if ctrl => {
                 self.tab_index = (self.tab_index + 1) % TAB_TITLES.len();
 

--- a/crates/atuin/src/command/client/search/interactive.rs
+++ b/crates/atuin/src/command/client/search/interactive.rs
@@ -220,14 +220,11 @@ impl State {
             KeyCode::Char('c' | 'g') if ctrl => Some(InputAction::ReturnOriginal),
             KeyCode::Esc if esc_allow_exit => Some(Self::handle_key_exit(settings)),
             KeyCode::Char('[') if ctrl && esc_allow_exit => Some(Self::handle_key_exit(settings)),
-            KeyCode::Tab => Some(InputAction::Accept(self.results_state.selected())),
-            KeyCode::Right => Some(InputAction::Accept(self.results_state.selected())),
             KeyCode::Char('o') if ctrl => {
                 self.tab_index = (self.tab_index + 1) % TAB_TITLES.len();
-
                 Some(InputAction::Continue)
-            }
-
+            },
+            KeyCode::Tab | KeyCode::Right => Some(InputAction::Accept(self.results_state.selected())),
             _ => None,
         };
 

--- a/crates/atuin/src/command/client/search/interactive.rs
+++ b/crates/atuin/src/command/client/search/interactive.rs
@@ -205,6 +205,7 @@ impl State {
 
         let ctrl = input.modifiers.contains(KeyModifiers::CONTROL);
         let esc_allow_exit = !(self.tab_index == 0 && self.keymap_mode == KeymapMode::VimInsert);
+        let cursor_at_end_of_line = self.search.input.position() == UnicodeWidthStr::width(self.search.input.as_str());
 
         // support ctrl-a prefix, like screen or tmux
         if !self.prefix
@@ -220,11 +221,12 @@ impl State {
             KeyCode::Char('c' | 'g') if ctrl => Some(InputAction::ReturnOriginal),
             KeyCode::Esc if esc_allow_exit => Some(Self::handle_key_exit(settings)),
             KeyCode::Char('[') if ctrl && esc_allow_exit => Some(Self::handle_key_exit(settings)),
+            KeyCode::Tab => Some(InputAction::Accept(self.results_state.selected())),
+            KeyCode::Right if cursor_at_end_of_line => Some(InputAction::Accept(self.results_state.selected())),
             KeyCode::Char('o') if ctrl => {
                 self.tab_index = (self.tab_index + 1) % TAB_TITLES.len();
                 Some(InputAction::Continue)
             },
-            KeyCode::Tab | KeyCode::Right => Some(InputAction::Accept(self.results_state.selected())),
             _ => None,
         };
 


### PR DESCRIPTION
<!-- Thank you for making a PR! Bug fixes are always welcome, but if you're adding a new feature or changing an existing one, we'd really appreciate if you open an issue, post on the forum, or drop in on Discord -->

This PR adds an additional key response for the right arrow key in the interactive history view. The right arrow key performs the same functionality as Tab and copies the selected line to the command line to be modified.

The command is only selected if the cursor is in the right-most position, otherwise it allows for scrolling through the input text.

Left arrow exits if cursor is at the beginning of the line.

Closes issue #2005 

## Checks
- [x] I am happy for maintainers to push small adjustments to this PR, to speed up the review cycle
- [x] I have checked that there are no existing pull requests for the same thing
