### PR TITLE
fix: clear screen before showing interactive search

### DIFF
--- a/crates/atuin/src/command/client/search/interactive.rs
+++ b/crates/atuin/src/command/client/search/interactive.rs
@@ -1101,6 +1101,9 @@ pub async fn history(
 
     let mut stats: Option<HistoryStats> = None;
     let accept;
+    
+    // to avoid overlapping with prompt
+    terminal.clear()?;
     let result = 'render: loop {
         terminal.draw(|f| app.draw(f, &results, stats.clone(), settings, theme))?;
 


### PR DESCRIPTION
This clears the terminal screen before showing the prompt.

The benefit of this is that it prevents the shell prompt from being overlapped by the Atuin inline search menu.


Without change: 

![CleanShot 2024-12-27 at 13 00 49@2x](https://github.com/user-attachments/assets/a97157ad-e168-4d2a-b973-543f3cd5e9e8)

With change: 
![CleanShot 2024-12-27 at 13 00 28@2x](https://github.com/user-attachments/assets/953e4a28-9166-4bb1-96ad-3f66ac60b0b8)


<!-- Thank you for making a PR! Bug fixes are always welcome, but if you're adding a new feature or changing an existing one, we'd really appreciate if you open an issue, post on the forum, or drop in on Discord -->

## Checks
- [x] I am happy for maintainers to push small adjustments to this PR, to speed up the review cycle
- [x] I have checked that there are no existing pull requests for the same thing
