### PR TITLE
feat(client): update AWS secrets env var handling checks

### DIFF
--- a/crates/atuin-client/src/secrets.rs
+++ b/crates/atuin-client/src/secrets.rs
@@ -13,14 +13,14 @@ pub static SECRET_PATTERNS: &[(&str, &str, TestValue)] = &[
         TestValue::Single("AKIAIOSFODNN7EXAMPLE"),
     ),
     (
-        "AWS secret access key env var",
-        "AWS_ACCESS_KEY_ID",
-        TestValue::Single("export AWS_ACCESS_KEY_ID=KEYDATA"),
+        "AWS Secret Access Key env var",
+        "AWS_SECRET_ACCESS_KEY",
+        TestValue::Single("AWS_SECRET_ACCESS_KEY=KEYDATA"),
     ),
     (
-        "AWS secret access key env var",
-        "AWS_ACCESS_KEY_ID",
-        TestValue::Single("export AWS_ACCESS_KEY_ID=KEYDATA"),
+        "AWS Session Token env var",
+        "AWS_SESSION_TOKEN",
+        TestValue::Single("AWS_SESSION_TOKEN=KEYDATA"),
     ),
     (
         "Microsoft Azure secret access key env var",


### PR DESCRIPTION
Update to use AWS env vars, replace duplicated entries.

`AWS_SECRET_ACCESS_KEY` the secret paired to Access Key IDs

`AWS_SESSION_TOKEN` the secret session token for STS sessions

AWS Access Keys should be caught by the test above for `"AKIA[0-9A-Z]{16}"` though this might also be updated to use a matching format with these two entries (including the env var name).

Relates to https://github.com/atuinsh/atuin/pull/2174

AWS documentation: https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-envvars.html

<!-- Thank you for making a PR! Bug fixes are always welcome, but if you're adding a new feature or changing an existing one, we'd really appreciate if you open an issue, post on the forum, or drop in on Discord -->

## Checks
- [x] I am happy for maintainers to push small adjustments to this PR, to speed up the review cycle
- [x] I have checked that there are no existing pull requests for the same thing