### PR TITLE
fix(wrapped): fix crash when history is empty

### DIFF
--- a/crates/atuin/src/command/client/wrapped.rs
+++ b/crates/atuin/src/command/client/wrapped.rs
@@ -282,7 +282,7 @@ pub async fn run(
     let history = db.range(start, end).await?;
     if history.is_empty() {
         println!("Your history for {year} is empty!\nMaybe 'atuin import' could help you import your previous history 🪄");
-        return Ok(())
+        return Ok(());
     }
 
     // Compute overall stats using existing functionality

--- a/crates/atuin/src/command/client/wrapped.rs
+++ b/crates/atuin/src/command/client/wrapped.rs
@@ -280,6 +280,10 @@ pub async fn run(
     );
 
     let history = db.range(start, end).await?;
+    if history.is_empty() {
+        println!("Your history for {year} is empty!\nMaybe 'atuin import' could help you import your previous history 🪄");
+        return Ok(())
+    }
 
     // Compute overall stats using existing functionality
     let stats = compute(settings, &history, 10, 1).expect("Failed to compute stats");


### PR DESCRIPTION
## Checks
- [x] I am happy for maintainers to push small adjustments to this PR, to speed up the review cycle
- [x] I have checked that there are no existing pull requests for the same thing

## Details

I noticed a crash when there is no history entries for the specified year, 2023 in my case, so I added a simple check and message.  
I'm not sure of the behavior if someone has no history for 2023 but has some for 2024 and does a `atuin import`. If it's not recommened, please let me know and I will update the error message. Feel free to change it too.

Before:
![image](https://github.com/user-attachments/assets/500fe888-db62-41e7-b268-6df24f1637df)

After:
![image](https://github.com/user-attachments/assets/59883d97-ee27-418d-8a17-23f80496f9a1)
