### PR TITLE
style: Avoid calling `unwrap()` when we don't have to

### DIFF
--- a/crates/atuin-client/src/settings.rs
+++ b/crates/atuin-client/src/settings.rs
@@ -613,7 +613,7 @@ impl Settings {
 
         match parse_duration(self.sync_frequency.as_str()) {
             Ok(d) => {
-                let d = time::Duration::try_from(d).unwrap();
+                let d = time::Duration::try_from(d)?;
                 Ok(OffsetDateTime::now_utc() - Settings::last_sync()? >= d)
             }
             Err(e) => Err(eyre!("failed to check sync: {}", e)),

--- a/crates/atuin/src/command/client/search.rs
+++ b/crates/atuin/src/command/client/search.rs
@@ -172,14 +172,14 @@ impl Cmd {
             return Ok(());
         }
 
-        if self.search_mode.is_some() {
-            settings.search_mode = self.search_mode.unwrap();
+        if let Some(search_mode) = self.search_mode {
+            settings.search_mode = search_mode;
         }
-        if self.filter_mode.is_some() {
-            settings.filter_mode = self.filter_mode;
+        if let Some(filter_mode) = self.filter_mode {
+            settings.filter_mode = Some(filter_mode);
         }
-        if self.inline_height.is_some() {
-            settings.inline_height = self.inline_height.unwrap();
+        if let Some(inline_height) = self.inline_height {
+            settings.inline_height = inline_height;
         }
 
         settings.shell_up_key_binding = self.shell_up_key_binding;


### PR DESCRIPTION
Use `if let` rather than `is_some()` followed by `unwrap()`, and coerce errors instead of calling `unwrap()` when available.

<!-- Thank you for making a PR! Bug fixes are always welcome, but if you're adding a new feature or changing an existing one, we'd really appreciate if you open an issue, post on the forum, or drop in on Discord -->

## Checks
- [X] I am happy for maintainers to push small adjustments to this PR, to speed up the review cycle
- [X] I have checked that there are no existing pull requests for the same thing
