### PR TITLE
feat(health): add health check endpoint

### DIFF
--- a/crates/atuin-server/src/handlers/health.rs
+++ b/crates/atuin-server/src/handlers/health.rs
@@ -1,6 +1,4 @@
-use axum::http;
-use axum::response::IntoResponse;
-use axum::Json;
+use axum::{http, response::IntoResponse, Json};
 
 use serde::Serialize;
 

--- a/crates/atuin-server/src/handlers/health.rs
+++ b/crates/atuin-server/src/handlers/health.rs
@@ -1,0 +1,17 @@
+use axum::http;
+use axum::response::IntoResponse;
+use axum::Json;
+
+use serde::Serialize;
+
+#[derive(Serialize)]
+pub struct HealthResponse {
+    pub status: &'static str,
+}
+
+pub async fn health_check() -> impl IntoResponse {
+    (
+        http::StatusCode::OK,
+        Json(HealthResponse { status: "healthy" }),
+    )
+}

--- a/crates/atuin-server/src/handlers/mod.rs
+++ b/crates/atuin-server/src/handlers/mod.rs
@@ -4,6 +4,7 @@ use axum::{extract::State, http, response::IntoResponse, Json};
 
 use crate::router::AppState;
 
+pub mod health;
 pub mod history;
 pub mod record;
 pub mod status;

--- a/crates/atuin-server/src/router.rs
+++ b/crates/atuin-server/src/router.rs
@@ -111,7 +111,7 @@ pub struct AppState<DB: Database> {
 pub fn router<DB: Database>(database: DB, settings: Settings<DB::Settings>) -> Router {
     let routes = Router::new()
         .route("/", get(handlers::index))
-        .route("/health", get(handlers::health::health_check))
+        .route("/healthz", get(handlers::health::health_check))
         .route("/sync/count", get(handlers::history::count))
         .route("/sync/history", get(handlers::history::list))
         .route("/sync/calendar/:focus", get(handlers::history::calendar))

--- a/crates/atuin-server/src/router.rs
+++ b/crates/atuin-server/src/router.rs
@@ -111,6 +111,7 @@ pub struct AppState<DB: Database> {
 pub fn router<DB: Database>(database: DB, settings: Settings<DB::Settings>) -> Router {
     let routes = Router::new()
         .route("/", get(handlers::index))
+        .route("/health", get(handlers::health::health_check))
         .route("/sync/count", get(handlers::history::count))
         .route("/sync/history", get(handlers::history::list))
         .route("/sync/calendar/:focus", get(handlers::history::calendar))

--- a/k8s/atuin.yaml
+++ b/k8s/atuin.yaml
@@ -43,13 +43,13 @@ spec:
               memory: 1Gi
           startupProbe:
             httpGet:
-              path: /health
+              path: /healthz
               port: *port
             failureThreshold: 30
             periodSeconds: 10
           livenessProbe:
             httpGet:
-              path: /health
+              path: /healthz
               port: *port
             initialDelaySeconds: 3
             periodSeconds: 3

--- a/k8s/atuin.yaml
+++ b/k8s/atuin.yaml
@@ -33,7 +33,7 @@ spec:
           image: ghcr.io/atuinsh/atuin:latest
           name: atuin
           ports:
-            - containerPort: 8888
+            - containerPort: &port 8888
           resources:
             limits:
               cpu: 250m
@@ -41,6 +41,23 @@ spec:
             requests:
               cpu: 250m
               memory: 1Gi
+          startupProbe:
+            httpGet:
+              path: /health
+              port: *port
+            failureThreshold: 30
+            periodSeconds: 10
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: *port
+            initialDelaySeconds: 3
+            periodSeconds: 3
+          readinessProbe:
+            tcpSocket:
+              port: *port
+            initialDelaySeconds: 15
+            periodSeconds: 10
           volumeMounts:
             - mountPath: /config
               name: atuin-claim0


### PR DESCRIPTION
This adds an endpoint at `/healthz` which returns successful. This is useful for both docker-compose and Kubernetes deployments to ensure the server is still running.

<s>Future improvements could implement deep health checks with ensure connectivity to the database.</s> Index connects to the database.

## Checks
- [x] I am happy for maintainers to push small adjustments to this PR, to speed up the review cycle
- [x] I have checked that there are no existing pull requests for the same thing