### PR TITLE
perf(dotfiles): remove defunct bind feature detection for fish

### DIFF
--- a/crates/atuin/src/command/client/init/fish.rs
+++ b/crates/atuin/src/command/client/init/fish.rs
@@ -18,19 +18,12 @@ bind -M insert \e\[A _atuin_bind_up";
 
         if !disable_ctrl_r {
             println!("{BIND_CTRL_R}");
-        }
-        if !disable_up_arrow {
-            println!("{BIND_UP_ARROW}");
-        }
-
-        println!("if bind -M insert > /dev/null 2>&1");
-        if !disable_ctrl_r {
             println!("{BIND_CTRL_R_INS}");
         }
         if !disable_up_arrow {
+            println!("{BIND_UP_ARROW}");
             println!("{BIND_UP_ARROW_INS}");
         }
-        println!("end");
     }
 }
 


### PR DESCRIPTION
This was originally proposed in #265 to detect support for `bind -M`, but versions _not_ supporting the feature were long archaic, and the detection practically becomes `if true`:

```shellsession
$ codespace:/> fish --version
fish, version 3.1.0
$ codespace:/> bind -M insert # By default there's no mode-specific bindings
$ codespace:/> if bind -M insert &> /dev/null; echo true; end
true
```

It also has a small cost for users with considerable mode-specific bindings, e.g. with `fish_vi_key_bindings` enabled:

```shellsession
$ time bind -M insert &> /dev/null

________________________________________________________
Executed in    1.34 millis    fish           external 
   usr time  541.00 micros  541.00 micros    0.00 micros 
   sys time  492.00 micros  492.00 micros    0.00 micros
```

(Note in this very case it's just ~1ms, but this check is prevalent and can add up. I'd like to address this in other programs too.)