### PR TITLE
Fix wrapped command if not full year - fix issue #2507

### DIFF
--- a/crates/atuin/src/command/client/wrapped.rs
+++ b/crates/atuin/src/command/client/wrapped.rs
@@ -89,7 +89,11 @@ impl WrappedStats {
 
         // Error analysis
         let mut command_errors: HashMap<String, (usize, usize)> = HashMap::new(); // (total_uses, errors)
-        let midyear = history[0].timestamp + Duration::days(182); // Split year in half
+
+        // Find number of days commands have been collected
+        let days =
+            (history[history.len() - 1].timestamp.ordinal() - history[0].timestamp.ordinal()) / 2;
+        let midyear = history[0].timestamp + Duration::days(days.into()); // Split year in half
 
         let mut first_half_commands: HashMap<String, usize> = HashMap::new();
         let mut second_half_commands: HashMap<String, usize> = HashMap::new();


### PR DESCRIPTION
If atuin has not been used the whole year, then the "Command Evolution" will be misleading, as the year is split 182 days after the first command.

This change set the mid-point of the year mid-ways between the first and last command in the year.

<!-- Thank you for making a PR! Bug fixes are always welcome, but if you're adding a new feature or changing an existing one, we'd really appreciate if you open an issue, post on the forum, or drop in on Discord -->

## Checks
- [X] I am happy for maintainers to push small adjustments to this PR, to speed up the review cycle
- [X] I have checked that there are no existing pull requests for the same thing
