### PR TITLE
fix(bash): fix `preexec` of child Bash session started by `enter_accept`

### DIFF
--- a/crates/atuin/src/shell/atuin.bash
+++ b/crates/atuin/src/shell/atuin.bash
@@ -189,6 +189,14 @@ __atuin_accept_line() {
     # If extdebug is turned on and any preexec function returns non-zero
     # exit status, we do not run the user command.
     if ! { shopt -q extdebug && ((__atuin_preexec_ret_value)); }; then
+        # Note: When a child Bash session is started by enter_accept, if the
+        # environment variable READLINE_POINT is present, bash-preexec in the
+        # child session does not fire preexec at all because it considers we
+        # are inside Atuin's keybinding of the current session.  To avoid
+        # propagating the environment variable to the child session, we remove
+        # the export attribute of READLINE_LINE and READLINE_POINT.
+        export -n READLINE_LINE READLINE_POINT
+
         # Juggle the terminal settings so that the command can be interacted
         # with
         local __atuin_stty_backup


### PR DESCRIPTION
<!-- Thank you for making a PR! Bug fixes are always welcome, but if you're adding a new feature or changing an existing one, we'd really appreciate if you open an issue, post on the forum, or drop in on Discord -->

I noticed that if a new child Bash session is started by `enter_accept`, the `preexec` hook provided by bash-preexec is not triggered at all. This is because the child Bash session inherits the environment variable `READLINE_POINT` of the parent shell session, and `bash-preexec` considers we are still processing the Atuin menu even when a new user command is processed inside the child Bash session.

## How to reproduce the issue

Consider the following bashrc:

```bash
# bashrc
source ~/.mwg/git/rcaloras/bash-preexec/bash-preexec.sh
preexec() { echo "[$FUNCNAME]"; }
precmd() { echo "[$FUNCNAME]"; }
eval "$(atuin init bash)"
```

With the current `main` branch, we first start a new child session by manually typing the command `bash` and running it:

```console
$ bash        # <-- This starts a new child Bash session
[preexec]    # <-- preexec by parent session
[precmd]
$ echo 1
[preexec]
1
[precmd]
$ exit
[preexec]
exit
[precmd]     # <-- precmd by parent sesssion
$
```

This registers the history entry "bash" in Atuin's database. Any problems don't happen so far. Then, we next press the keys <kbd>up</kbd><kbd>up</kbd><kbd>up</kbd><kbd>enter</kbd> to select the entry "bash" and execute it through the `enter_accept` feature.

```console
$ bash        # <-- This is executed through Atuin's enter_accept
[preexec]     # <-- preexec by parent session
[precmd]
$ echo 1
1      # <-- preexec is inactive
[precmd]
$ echo 2
2      # <-- preexec is inactive
[precmd]
$ exit
exit      # <-- preexec is inactive
[precmd]     # <-- precmd by parent session
$
```

## Solution

In this PR, the problem is solved by removing the export attribute of `READLINE_POINT` and `READLINE_LINE` before running the user command with `enter_accept`. See the code comments added in this PR for details.

## Checks
- [x] I am happy for maintainers to push small adjustments to this PR, to speed up the review cycle
- [x] I have checked that there are no existing pull requests for the same thing
