### PR TITLE
Add the --print0 option to search

### DIFF
--- a/crates/atuin/src/command/client/search.rs
+++ b/crates/atuin/src/command/client/search.rs
@@ -90,6 +90,10 @@ pub struct Cmd {
     #[arg(long)]
     cmd_only: bool,
 
+    /// Terminate the output with a null, for better multiline handling
+    #[arg(long)]
+    print0: bool,
+
     /// Delete anything matching this query. Will not print out the match
     #[arg(long)]
     delete: bool,
@@ -255,7 +259,7 @@ impl Cmd {
                     &entries,
                     ListMode::from_flags(self.human, self.cmd_only),
                     format,
-                    false,
+                    self.print0,
                     true,
                     tz,
                 );


### PR DESCRIPTION
-------

This mirrors the addition to `history` from #1274, but with search too.
Ther are history search implementations for shells that are set to
search instead of running the history command.

## Checks
- [x] I am happy for maintainers to push small adjustments to this PR, to speed up the review cycle
- [x] I have checked that there are no existing pull requests for the same thing