### PR TITLE
perf: cache `SECRET_PATTERNS`'s `RegexSet`

### DIFF
--- a/crates/atuin-client/src/history.rs
+++ b/crates/atuin-client/src/history.rs
@@ -8,10 +8,10 @@ use atuin_common::record::DecryptedData;
 use atuin_common::utils::uuid_v7;
 
 use eyre::{bail, eyre, Result};
-use regex::RegexSet;
 
+use crate::secrets::SECRET_PATTERNS_RE;
+use crate::settings::Settings;
 use crate::utils::get_host_user;
-use crate::{secrets::SECRET_PATTERNS, settings::Settings};
 use time::OffsetDateTime;
 
 mod builder;
@@ -374,13 +374,10 @@ impl History {
     }
 
     pub fn should_save(&self, settings: &Settings) -> bool {
-        let secret_regex = SECRET_PATTERNS.iter().map(|f| f.1);
-        let secret_regex = RegexSet::new(secret_regex).expect("Failed to build secrets regex");
-
         !(self.command.starts_with(' ')
             || settings.history_filter.is_match(&self.command)
             || settings.cwd_filter.is_match(&self.cwd)
-            || (secret_regex.is_match(&self.command)) && settings.secrets_filter)
+            || (settings.secrets_filter && SECRET_PATTERNS_RE.is_match(&self.command)))
     }
 }
 

--- a/crates/atuin-client/src/secrets.rs
+++ b/crates/atuin-client/src/secrets.rs
@@ -1,11 +1,14 @@
 // This file will probably trigger a lot of scanners. Sorry.
 
+use regex::RegexSet;
+use std::sync::LazyLock;
+
 pub enum TestValue<'a> {
     Single(&'a str),
     Multiple(&'a [&'a str]),
 }
 
-// A list of (name, regex, test), where test should match against regex
+/// A list of `(name, regex, test)`, where `test` should match against `regex`.
 pub static SECRET_PATTERNS: &[(&str, &str, TestValue)] = &[
     (
         "AWS Access Key ID",
@@ -113,6 +116,12 @@ pub static SECRET_PATTERNS: &[(&str, &str, TestValue)] = &[
         TestValue::Single("pul-683c2770662c51d960d72ec27613be7653c5cb26"),
     ),
 ];
+
+/// The `regex` expressions from [`SECRET_PATTERNS`] compiled into a `RegexSet`.
+pub static SECRET_PATTERNS_RE: LazyLock<RegexSet> = LazyLock::new(|| {
+    let exprs = SECRET_PATTERNS.iter().map(|f| f.1);
+    RegexSet::new(exprs).expect("Failed to build secrets regex")
+});
 
 #[cfg(test)]
 mod tests {


### PR DESCRIPTION
Improves the performance of `History::should_save` by constructing the `SECRET_PATTERNS` `RegexSet` only once with a `LazyLock`.

This speeds up `atuin history prune` by ~100x (~7s to ~70ms on my machine) (lol).

<!-- Thank you for making a PR! Bug fixes are always welcome, but if you're adding a new feature or changing an existing one, we'd really appreciate if you open an issue, post on the forum, or drop in on Discord -->

## Checks
- [x] I am happy for maintainers to push small adjustments to this PR, to speed up the review cycle
- [x] I have checked that there are no existing pull requests for the same thing
