### PR TITLE
Add snap packaging

### DIFF
--- a/.github/workflows/snap.yaml
+++ b/.github/workflows/snap.yaml
@@ -1,0 +1,70 @@
+name: snap
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    outputs:
+      snap-file: ${{ steps.build-snap.outputs.snap }}
+    steps:
+    - name: Checkout snapcraft.yaml branch
+      uses: actions/checkout@v4
+
+    - name: Build snap
+      uses: snapcore/action-build@v1
+      id: build-snap
+
+    - name: Upload snap artifact
+      uses: actions/upload-artifact@v4
+      with:
+        name: atuin-snap
+        path: ${{ steps.build-snap.outputs.snap }}
+        retention-days: 7
+
+  test:
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Download snap artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: atuin-snap
+
+      - name: Install snap
+        run: |
+          sudo snap install ${{needs.build.outputs.snap-file}} --dangerous
+
+      - name: Snap info
+        run: |
+          snap info atuin
+
+      - name: Run custom test script
+        shell: bash
+        run: |
+          atuin --help
+
+  publish:
+    if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/')
+    runs-on: ubuntu-latest
+    needs: [build, test]
+    steps:
+    - name: Download snap artifact
+      uses: actions/download-artifact@v4
+      with:
+        name: atuin-snap
+
+    - name: Publish snap
+      uses: snapcore/action-publish@v1
+      env:
+        SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.store-login }}
+      if: env.SNAPCRAFT_STORE_CREDENTIALS
+      with:
+        snap: ${{ needs.build.outputs.snap-file }}
+        release: ${{ startsWith(github.ref, 'refs/tags/') && 'candidate' || 'edge'}}

--- a/snap/hooks/install
+++ b/snap/hooks/install
@@ -1,0 +1,28 @@
+#!/bin/sh -e
+
+# Print to the journal
+# sudo journalctl -r -t ${SNAP_NAME}
+
+logger -t ${SNAP_NAME} << EOF
+
+
+
+ _______  __   __  _______  __    _  ___   _    __   __  _______  __   __
+|       ||  | |  ||   _   ||  |  | ||   | | |  |  | |  ||       ||  | |  |
+|_     _||  |_|  ||  |_|  ||   |_| ||   |_| |  |  |_|  ||   _   ||  | |  |
+  |   |  |       ||       ||       ||      _|  |       ||  | |  ||  |_|  |
+  |   |  |       ||       ||  _    ||     |_   |_     _||  |_|  ||       |
+  |   |  |   _   ||   _   || | |   ||    _  |    |   |  |       ||       |
+  |___|  |__| |__||__| |__||_|  |__||___| |_|    |___|  |_______||_______|
+
+
+
+Thanks for installing Atuin! I really hope you like it.
+
+If you have any issues, please open an issue on GitHub or visit our Discord (https://discord.gg/jR3tfchVvW)!
+
+If you love Atuin, please give us a star on GitHub! It really helps ⭐️ https://github.com/atuinsh/atuin
+
+Please run "atuin register" to get setup with sync, or "atuin login" if you already have an account
+
+EOF

--- a/snap/local/launcher
+++ b/snap/local/launcher
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+if [ "$#" -eq 3 ] && [ "$2" == "import" ]; then
+  if ! snapctl is-connected dot-bash-history && \
+     ! snapctl is-connected dot-fish-history && \
+     ! snapctl is-connected dot-resh-history && \
+     ! snapctl is-connected dot-zsh-history; then
+    echo "Error: Requested to import existing history but no interface connected which would allow this."
+    echo "Please connect the appropriate interface such as: "
+    echo ""
+    echo "sudo snap connect $SNAP_NAME:dot-bash-history"
+    echo ""
+    echo "and try again."
+    echo "To see which interfaces are available and whether they are connected:"
+    echo ""
+    echo "snap connections $SNAP_NAME"
+    exit 1
+  fi
+
+  # Atuin looks for the bash history using directories::UserDirs::UserDir
+  # which relies on $HOME. This env var is remapped in Snaps.
+  # We thus workaround that by setting HISTFILE which takes precedence
+  # in atuin loading logic.
+  if snapctl is-connected dot-bash-history && [[ -z "${HISTFILE}" ]]; then
+    export HISTFILE="${SNAP_REAL_HOME}/.bash_history"
+  fi
+fi
+
+if snapctl is-connected atuin-existing-config-and-data; then
+  export XDG_CONFIG_HOME="${SNAP_REAL_HOME}/.config"
+  export XDG_DATA_HOME="${SNAP_REAL_HOME}/.local/share"
+fi
+
+exec "$@"

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,0 +1,106 @@
+name: atuin
+adopt-info: atuin
+summary: Magical shell history
+description: |
+  Atuin replaces your existing shell history with a SQLite database,
+  and records additional context for your commands.
+  Additionally, it provides optional and fully encrypted synchronisation of your history between machines,
+  via an Atuin server.
+
+  To import existing history,
+  make sure to connect the appropriate interface such as:
+
+  `sudo snap connect atuin:dot-bash-history`
+
+  To see which interfaces are available and whether they are connected:
+
+  `snap connections atuin`
+
+  Furthermore, when using `atuin import auto`,
+  you must export your current shell such as,
+
+  `SHELL=${SHELL} atuin import auto`
+
+  When using this snap, atuin's configuration and data file live respectively at
+  - $HOME/snap/atuin/.config/atuin
+  - $HOME/snap/atuin/local/share/atuin
+
+issues: https://github.com/atuinsh/atuin/issues
+contact: https://github.com/atuinsh/atuin/issues
+source-code: https://github.com/atuinsh/atuin
+donation: https://github.com/sponsors/atuinsh
+website: https://atuin.sh/
+license: MIT
+
+confinement: strict
+base: core24
+
+apps:
+  atuin:
+    command: atuin
+    command-chain: [usr/local/atuin/launcher]
+    completer: usr/share/bash-completion/completions/atuin-completion.bash
+    plugs:
+      - dot-bash-history
+      - dot-fish-history
+      - dot-resh-history
+      - dot-zsh-history
+      - network
+      - network-bind
+
+plugs:
+  dot-bash-history:
+    interface: personal-files
+    read: [$HOME/.bash_history]
+  dot-fish-history:
+    interface: personal-files
+    read: [$HOME/.local/share/fish/fish_history]
+  dot-resh-history:
+    interface: personal-files
+    read: [$HOME/.local/share/resh/history.reshjson]
+  dot-zsh-history:
+    interface: personal-files
+    read: [$HOME/.zsh_history]
+
+parts:
+  atuin:
+    plugin: rust
+    source: .
+    override-pull: |
+      craftctl default
+
+      git config --global --add safe.directory '*'
+      version="$(git describe --always --tags --exclude='weekly' | sed -e 's/^v//;s/-/+git/;y/-/./')"
+      [ -n "$(echo $version | grep "+git")" ] && grade=devel || grade=stable
+      craftctl set version="$version"
+      craftctl set grade="$grade"
+
+  atuin-launcher:
+    after: [atuin]
+    plugin: dump
+    source: snap/local/
+    organize:
+      'launcher': usr/local/atuin/
+
+  atuin-completer:
+    after: [atuin]
+    plugin: nil
+    organize:
+      'atuin-completion.bash': usr/share/bash-completion/completions/
+    override-build: |
+      $CRAFT_STAGE/atuin gen-completions --shell bash > $CRAFT_PART_INSTALL/atuin-completion.bash
+
+  ble:
+    plugin: make
+    build-packages: [gawk]
+    source: https://github.com/akinomyoga/ble.sh.git
+    make-parameters:
+      - PREFIX=/usr
+
+  bash-preexec:
+    plugin: nil
+    build-packages: [curl]
+    organize:
+      'bash-preexec.sh': usr/share/
+    override-build: |
+      curl https://raw.githubusercontent.com/rcaloras/bash-preexec/master/bash-preexec.sh -o $CRAFT_PART_INSTALL/bash-preexec.sh


### PR DESCRIPTION
<!-- Thank you for making a PR! Bug fixes are always welcome, but if you're adding a new feature or changing an existing one, we'd really appreciate if you open an issue, post on the forum, or drop in on Discord -->

This PR adds [snap packaging](https://snapcraft.io/about) together with a ci workflow that builds the snap on pr/merge and publishes it on merge.

The snap is already [available on the Store](https://snapcraft.io/atuin) at the latest release (18.4.0), it is however unlisted at the moment. To give it a shot:

```bash
snap install atuin --beta
```

I've already used it a little while and it seems to work fine. 
But I'm not (yet) an atuin power user and I've only been using it with bash.
However zsh/resh/fish should be supported and I'd love to get some feedback about those other shell.

A couple notes:
- in snaps, `$HOME` is re-mapped and atuin's config files and such are located at `$HOME/snap/atuin/current/`. 
- snaps are sandboxed, therefore to import an existing history the user must connect the appropriate snap interface (e.g. `snap connect atuin:dot-bash-history`). The `import` command in the snap has a wrapper that informs the user if no such connection is established.
- the snap ships [ble.sh](https://github.com/akinomyoga/ble.sh) and [Bash-preexec](https://github.com/rcaloras/bash-preexec) for convenience (e.g. `source /snap/atuin/current/usr/share/blesh/ble.sh`)

I currently own the app on the store and I'd be happy to transfer it to you if you're interested in this pr!

## Checks
- [x] I am happy for maintainers to push small adjustments to this PR, to speed up the review cycle
- [x] I have checked that there are no existing pull requests for the same thing
