### PR TITLE
fix: panic when invoking delete on empty tui

### DIFF
--- a/crates/atuin/src/command/client/search/interactive.rs
+++ b/crates/atuin/src/command/client/search/interactive.rs
@@ -1116,6 +1116,9 @@ pub async fn history(
                         match app.handle_input(settings, &event::read()?, &mut std::io::stdout())? {
                             InputAction::Continue => {},
                             InputAction::Delete(index) => {
+                                if results.is_empty() {
+                                    break;
+                                }
                                 app.results_len -= 1;
                                 let selected = app.results_state.selected();
                                 if selected == app.results_len {


### PR DESCRIPTION
If the result set is empty and thus the TUI does not show any entries, a panic occurs when a user invokes 'delete' via `Prefix (Ctrl-A) d` or `Ctrl-D` in the inspector..

<img width="926" alt="image" src="https://github.com/user-attachments/assets/c5ed592a-0c3c-4669-ad18-d0dbd3e3218c" />


<!-- Thank you for making a PR! Bug fixes are always welcome, but if you're adding a new feature or changing an existing one, we'd really appreciate if you open an issue, post on the forum, or drop in on Discord -->

## Checks
- [x] I am happy for maintainers to push small adjustments to this PR, to speed up the review cycle
- [x] I have checked that there are no existing pull requests for the same thing
