### PR TITLE
fix #2586 by adding .histfile as file to look for when doing atuin im…

### DIFF
--- a/crates/atuin-client/src/import/zsh.rs
+++ b/crates/atuin-client/src/import/zsh.rs
@@ -21,11 +21,12 @@ pub struct Zsh {
 fn default_histpath() -> Result<PathBuf> {
     // oh-my-zsh sets HISTFILE=~/.zhistory
     // zsh has no default value for this var, but uses ~/.zhistory.
+    // zsh-newuser-install propose as default .histfile https://github.com/zsh-users/zsh/blob/master/Functions/Newuser/zsh-newuser-install#L794
     // we could maybe be smarter about this in the future :)
     let user_dirs = UserDirs::new().ok_or_else(|| eyre!("could not find user directories"))?;
     let home_dir = user_dirs.home_dir();
 
-    let mut candidates = [".zhistory", ".zsh_history"].iter();
+    let mut candidates = [".zhistory", ".zsh_history", ".histfile"].iter();
     loop {
         match candidates.next() {
             Some(candidate) => {


### PR DESCRIPTION
fix #2586 by adding .histfile as file to look for when doing `atuin import zsh`

<!-- Thank you for making a PR! Bug fixes are always welcome, but if you're adding a new feature or changing an existing one, we'd really appreciate if you open an issue, post on the forum, or drop in on Discord -->

## Checks
- [X] I am happy for maintainers to push small adjustments to this PR, to speed up the review cycle
- [X] I have checked that there are no existing pull requests for the same thing
