### PR TITLE
Better inline height display

### DIFF
--- a/crates/atuin/src/command/client/search/interactive.rs
+++ b/crates/atuin/src/command/client/search/interactive.rs
@@ -1098,6 +1098,10 @@ pub async fn history(
 
     let mut results = app.query_results(&mut db, settings.smart_sort).await?;
 
+    if settings.inline_height > 0 {
+        terminal.clear()?;
+    }
+
     let mut stats: Option<HistoryStats> = None;
     let accept;
     let result = 'render: loop {


### PR DESCRIPTION
Pulled from https://github.com/atuinsh/atuin/pull/2543 Fixes interactive mode in fish where the terminal wasn't being displayed properly.

fixes #1289

Co-authored-by: Lucas Trzesniewski <lucas.trzesniewski@gmail.com>

I will note that this seems to draw over-top the current prompt which seems to be different than what things like fzf do.
here are two photos to constrat:

I think it would better to draw it below the current prompt to match the style of fzf but at least it does fix the corrupted prompt of #1289 

![Screenshot From 2025-02-25 19-15-52](https://github.com/user-attachments/assets/0f2af461-da59-40c5-8509-134084182652)
![Screenshot From 2025-02-25 19-15-31](https://github.com/user-attachments/assets/a5ef71cc-34ef-4cb9-a51d-c13fbd6ba963)

## Checks
- [x] I am happy for maintainers to push small adjustments to this PR, to speed up the review cycle
- [x] I have checked that there are no existing pull requests for the same thing
