### PR TITLE
fix: don't save empty commands

### DIFF
--- a/crates/atuin-client/src/history.rs
+++ b/crates/atuin-client/src/history.rs
@@ -375,6 +375,7 @@ impl History {
 
     pub fn should_save(&self, settings: &Settings) -> bool {
         !(self.command.starts_with(' ')
+            || self.command.is_empty()
             || settings.history_filter.is_match(&self.command)
             || settings.cwd_filter.is_match(&self.cwd)
             || (settings.secrets_filter && SECRET_PATTERNS_RE.is_match(&self.command)))
@@ -413,6 +414,13 @@ mod tests {
             .build()
             .into();
 
+        let empty: History = History::capture()
+            .timestamp(time::OffsetDateTime::now_utc())
+            .command("")
+            .cwd("/")
+            .build()
+            .into();
+
         let stripe_key: History = History::capture()
             .timestamp(time::OffsetDateTime::now_utc())
             .command("curl foo.com/bar?key=sk_test_1234567890abcdefghijklmnop")
@@ -436,6 +444,7 @@ mod tests {
 
         assert!(normal_command.should_save(&settings));
         assert!(!with_space.should_save(&settings));
+        assert!(!empty.should_save(&settings));
         assert!(!stripe_key.should_save(&settings));
         assert!(!secret_dir.should_save(&settings));
         assert!(!with_psql.should_save(&settings));


### PR DESCRIPTION
I noticed the following after working on #2543:

![image](https://github.com/user-attachments/assets/2e99eeb3-3ebc-4e11-9195-fbff5fc7675e)

I pressed and held the enter key a few times in order to go to the bottom of the screen to check how Atuin behaved, and now it thinks I love empty commands. 😄 

Even if it shouldn't happen for others that much, I suppose it makes no sense saving these, so this PR removes that.

<!-- Thank you for making a PR! Bug fixes are always welcome, but if you're adding a new feature or changing an existing one, we'd really appreciate if you open an issue, post on the forum, or drop in on Discord -->

## Checks
- [x] I am happy for maintainers to push small adjustments to this PR, to speed up the review cycle
- [x] I have checked that there are no existing pull requests for the same thing
