### PR TITLE
feat: make new arrow key behavior configurable

### DIFF
--- a/crates/atuin-client/config.toml
+++ b/crates/atuin-client/config.toml
@@ -211,6 +211,7 @@ enter_accept = true
 # scroll_exits = true
 # Defaults to true. The left arrow key will exit the TUI when scrolling before the first character
 # exit_past_line_start = true
+The right arrow key performs the same functionality as Tab and copies the selected line to the command line to be modified.
 # accept_past_line_end = true
 
 [sync]

--- a/crates/atuin-client/config.toml
+++ b/crates/atuin-client/config.toml
@@ -209,6 +209,7 @@ enter_accept = true
 [keys]
 # Defaults to true. If disabled, using the up/down key won't exit the TUI when scrolled past the first/last entry.
 # scroll_exits = true
+# Defaults to true. The right arrow key performs the same functionality as Tab and copies the selected line to the command line to be modified.
 # exit_past_line_start = true
 # accept_past_line_end = true
 

--- a/crates/atuin-client/config.toml
+++ b/crates/atuin-client/config.toml
@@ -211,7 +211,7 @@ enter_accept = true
 # scroll_exits = true
 # Defaults to true. The left arrow key will exit the TUI when scrolling before the first character
 # exit_past_line_start = true
-The right arrow key performs the same functionality as Tab and copies the selected line to the command line to be modified.
+# Defaults to true. The right arrow key performs the same functionality as Tab and copies the selected line to the command line to be modified.
 # accept_past_line_end = true
 
 [sync]

--- a/crates/atuin-client/config.toml
+++ b/crates/atuin-client/config.toml
@@ -209,6 +209,8 @@ enter_accept = true
 [keys]
 # Defaults to true. If disabled, using the up/down key won't exit the TUI when scrolled past the first/last entry.
 # scroll_exits = true
+# exit_past_line_start = true
+# accept_past_line_end = true
 
 [sync]
 # Enable sync v2 by default

--- a/crates/atuin-client/config.toml
+++ b/crates/atuin-client/config.toml
@@ -209,7 +209,7 @@ enter_accept = true
 [keys]
 # Defaults to true. If disabled, using the up/down key won't exit the TUI when scrolled past the first/last entry.
 # scroll_exits = true
-# Defaults to true. The right arrow key performs the same functionality as Tab and copies the selected line to the command line to be modified.
+# Defaults to true. The left arrow key will exit the TUI when scrolling before the first character
 # exit_past_line_start = true
 # accept_past_line_end = true
 

--- a/crates/atuin-client/src/settings.rs
+++ b/crates/atuin-client/src/settings.rs
@@ -330,6 +330,8 @@ pub struct Sync {
 #[derive(Clone, Debug, Deserialize, Default, Serialize)]
 pub struct Keys {
     pub scroll_exits: bool,
+    pub exit_past_line_start: bool,
+    pub accept_past_line_end: bool,
     pub prefix: String,
 }
 
@@ -777,6 +779,8 @@ impl Settings {
             .set_default("enter_accept", false)?
             .set_default("sync.records", true)?
             .set_default("keys.scroll_exits", true)?
+            .set_default("keys.accept_past_line_end", true)?
+            .set_default("keys.exit_past_line_start", true)?
             .set_default("keys.prefix", "a")?
             .set_default("keymap_mode", "emacs")?
             .set_default("keymap_mode_shell", "auto")?

--- a/crates/atuin/src/command/client/search/interactive.rs
+++ b/crates/atuin/src/command/client/search/interactive.rs
@@ -224,10 +224,12 @@ impl State {
             KeyCode::Esc if esc_allow_exit => Some(Self::handle_key_exit(settings)),
             KeyCode::Char('[') if ctrl && esc_allow_exit => Some(Self::handle_key_exit(settings)),
             KeyCode::Tab => Some(InputAction::Accept(self.results_state.selected())),
-            KeyCode::Right if cursor_at_end_of_line => {
+            KeyCode::Right if cursor_at_end_of_line && settings.keys.accept_past_line_end => {
                 Some(InputAction::Accept(self.results_state.selected()))
             }
-            KeyCode::Left if cursor_at_start_of_line => Some(Self::handle_key_exit(settings)),
+            KeyCode::Left if cursor_at_start_of_line && settings.keys.exit_past_line_start => {
+                Some(Self::handle_key_exit(settings))
+            }
             KeyCode::Char('o') if ctrl => {
                 self.tab_index = (self.tab_index + 1) % TAB_TITLES.len();
                 Some(InputAction::Continue)


### PR DESCRIPTION
The arrow key behavior in interactive search was changed in #2453, make it configurable via keys.exit_past_line_start and keys.accept_past_line_end.

<!-- Thank you for making a PR! Bug fixes are always welcome, but if you're adding a new feature or changing an existing one, we'd really appreciate if you open an issue, post on the forum, or drop in on Discord -->

## Checks
- [x] I am happy for maintainers to push small adjustments to this PR, to speed up the review cycle
- [x] I have checked that there are no existing pull requests for the same thing
