### PR TITLE
feat: Use readline binding for ctrl-a when it is not the prefix

### DIFF
--- a/crates/atuin/src/command/client/search/interactive.rs
+++ b/crates/atuin/src/command/client/search/interactive.rs
@@ -417,6 +417,7 @@ impl State {
             KeyCode::Right => self.search.input.right(),
             KeyCode::Char('f') if ctrl => self.search.input.right(),
             KeyCode::Home => self.search.input.start(),
+            KeyCode::Char('a') if ctrl => self.search.input.start(),
             KeyCode::Char('e') if ctrl => self.search.input.end(),
             KeyCode::End => self.search.input.end(),
             KeyCode::Backspace if ctrl => self


### PR DESCRIPTION
Previously:
- If the prefix is **not** `ctrl-a`: It will add an `a` character. 
    - expected: Going to the beginning of line

With this fix:
- If the prefix is **not** `ctrl-a`: It will go to the beginning of line

This solves https://github.com/atuinsh/atuin/issues/2548

As I'm understanding it, if `ctrl-a` is the prefix, it will be caught earlier in the function, and if it is not the prefix, then this will act as "go to the beginning of line". 

I have manually tested this on my end and it works on my laptop at least. I didn't see any tests for key inputs specifically in the file. Let me know if there are specific tests that you would like me to add for this!

<!-- Thank you for making a PR! Bug fixes are always welcome, but if you're adding a new feature or changing an existing one, we'd really appreciate if you open an issue, post on the forum, or drop in on Discord -->

## Checks
- [X] I am happy for maintainers to push small adjustments to this PR, to speed up the review cycle
- [X] I have checked that there are no existing pull requests for the same thing
