### PR TITLE
chore: align daemon and client default sync freq

### DIFF
--- a/crates/atuin-client/src/settings.rs
+++ b/crates/atuin-client/src/settings.rs
@@ -746,7 +746,7 @@ impl Settings {
             .set_default("auto_sync", true)?
             .set_default("update_check", cfg!(feature = "check-update"))?
             .set_default("sync_address", "https://api.atuin.sh")?
-            .set_default("sync_frequency", "10m")?
+            .set_default("sync_frequency", "5m")?
             .set_default("search_mode", "fuzzy")?
             .set_default("filter_mode", None::<String>)?
             .set_default("style", "compact")?


### PR DESCRIPTION
I noticed that the two had drifted - makes sense to go down to 5m anyway. We have no issues with users setting this to 0

## Checks
- [ ] I am happy for maintainers to push small adjustments to this PR, to speed up the review cycle
- [ ] I have checked that there are no existing pull requests for the same thing
