### PR TITLE
chore: show host and user in inspector

### DIFF
--- a/crates/atuin/src/command/client/search/inspector.rs
+++ b/crates/atuin/src/command/client/search/inspector.rs
@@ -90,9 +90,11 @@ pub fn draw_stats_table(
 ) {
     let duration = Duration::from_nanos(u64_or_zero(history.duration));
     let avg_duration = Duration::from_nanos(stats.average_duration);
+    let (host, user) = history.hostname.split_once(':').unwrap_or(("", ""));
 
     let rows = [
-        Row::new(vec!["Host:User".to_string(), history.hostname.to_string()]),
+        Row::new(vec!["Host".to_string(), host.to_string()]),
+        Row::new(vec!["User".to_string(), user.to_string()]),
         Row::new(vec!["Time".to_string(), history.timestamp.to_string()]),
         Row::new(vec!["Duration".to_string(), format_duration(duration)]),
         Row::new(vec![

--- a/crates/atuin/src/command/client/search/inspector.rs
+++ b/crates/atuin/src/command/client/search/inspector.rs
@@ -92,6 +92,7 @@ pub fn draw_stats_table(
     let avg_duration = Duration::from_nanos(stats.average_duration);
 
     let rows = [
+        Row::new(vec!["Host:User".to_string(), history.hostname.to_string()]),
         Row::new(vec!["Time".to_string(), history.timestamp.to_string()]),
         Row::new(vec!["Duration".to_string(), format_duration(duration)]),
         Row::new(vec![


### PR DESCRIPTION
<!-- Thank you for making a PR! Bug fixes are always welcome, but if you're adding a new feature or changing an existing one, we'd really appreciate if you open an issue, post on the forum, or drop in on Discord -->

## Checks
- [x] I am happy for maintainers to push small adjustments to this PR, to speed up the review cycle
- [x] I have checked that there are no existing pull requests for the same thing

Changes
---

Fixes https://github.com/atuinsh/atuin/issues/1578.

Adds two new rows for HOST and USER info in the inspector. Looks like this:
![image](https://github.com/user-attachments/assets/4b9ac3da-52e8-4508-896e-d60cfbc0754e)
