### PR TITLE
chore: migrate to rust 2024

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -36,7 +36,7 @@ dependencies = [
  "cfg-if",
  "once_cell",
  "version_check",
- "zerocopy",
+ "zerocopy 0.7.35",
 ]
 
 [[package]]
@@ -110,19 +110,20 @@ dependencies = [
 
 [[package]]
 name = "anstyle-wincon"
-version = "3.0.6"
+version = "3.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2109dbce0e72be3ec00bed26e6a7479ca384ad226efdd66db8fa2e3a38c83125"
+checksum = "ca3534e77181a9cc07539ad51f2141fe32f6c3ffd4df76db8ad92346b003ae4e"
 dependencies = [
  "anstyle",
+ "once_cell",
  "windows-sys 0.59.0",
 ]
 
 [[package]]
 name = "anyhow"
-version = "1.0.95"
+version = "1.0.97"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34ac096ce696dc2fcabef30516bb13c0a68a11d30131d3df6f04711467681b04"
+checksum = "dcfed56ad506cb2c684a14971b8861fdc3baaaae314b9e5f9bb532cbe3ba7a4f"
 
 [[package]]
 name = "approx"
@@ -194,9 +195,9 @@ dependencies = [
 
 [[package]]
 name = "async-trait"
-version = "0.1.83"
+version = "0.1.88"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "721cae7de5c34fbb2acd27e21e6d2cf7b886dce0c27388d46c4e6c47ea4318dd"
+checksum = "e539d3fca749fcee5236ab05e93a52867dd549cc157c8cb7f99595f3cedffdb5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -237,18 +238,18 @@ dependencies = [
  "colored",
  "crossterm",
  "eyre",
- "fs-err",
+ "fs-err 2.11.0",
  "futures-util",
  "fuzzy-matcher",
  "indicatif",
  "interim",
- "itertools",
+ "itertools 0.13.0",
  "log",
  "ratatui",
  "regex",
  "rpassword",
  "runtime-format",
- "rustix",
+ "rustix 0.38.44",
  "semver",
  "serde",
  "serde_json",
@@ -276,21 +277,21 @@ dependencies = [
  "crypto_secretbox",
  "directories",
  "eyre",
- "fs-err",
+ "fs-err 2.11.0",
  "futures",
  "generic-array",
  "hex",
  "humantime",
  "indicatif",
  "interim",
- "itertools",
+ "itertools 0.13.0",
  "lazy_static",
  "log",
  "memchr",
  "minspan",
  "palette",
  "pretty_assertions",
- "rand",
+ "rand 0.8.5",
  "regex",
  "reqwest 0.11.27",
  "rmp",
@@ -325,7 +326,7 @@ dependencies = [
  "base64 0.22.1",
  "directories",
  "eyre",
- "getrandom",
+ "getrandom 0.2.15",
  "lazy_static",
  "pretty_assertions",
  "semver",
@@ -352,7 +353,7 @@ dependencies = [
  "prost",
  "prost-types",
  "protox",
- "rand",
+ "rand 0.8.5",
  "time",
  "tokio",
  "tokio-stream",
@@ -373,7 +374,7 @@ dependencies = [
  "atuin-common",
  "crypto_secretbox",
  "eyre",
- "rand",
+ "rand 0.8.5",
  "rmp",
  "serde",
  "tokio",
@@ -386,7 +387,7 @@ dependencies = [
  "atuin-client",
  "crossterm",
  "divan",
- "rand",
+ "rand 0.8.5",
  "serde",
  "time",
  "unicode-segmentation",
@@ -404,13 +405,13 @@ dependencies = [
  "axum-server",
  "config",
  "eyre",
- "fs-err",
+ "fs-err 2.11.0",
  "metrics",
  "metrics-exporter-prometheus",
  "postmark",
- "rand",
+ "rand 0.8.5",
  "reqwest 0.11.27",
- "rustls 0.23.20",
+ "rustls 0.23.25",
  "semver",
  "serde",
  "serde_json",
@@ -467,10 +468,10 @@ dependencies = [
  "axum-core",
  "bytes",
  "futures-util",
- "http 1.2.0",
+ "http 1.3.1",
  "http-body 1.0.1",
  "http-body-util",
- "hyper 1.5.2",
+ "hyper 1.6.0",
  "hyper-util",
  "itoa",
  "matchit",
@@ -500,7 +501,7 @@ dependencies = [
  "async-trait",
  "bytes",
  "futures-util",
- "http 1.2.0",
+ "http 1.3.1",
  "http-body 1.0.1",
  "http-body-util",
  "mime",
@@ -514,25 +515,23 @@ dependencies = [
 
 [[package]]
 name = "axum-server"
-version = "0.7.1"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56bac90848f6a9393ac03c63c640925c4b7c8ca21654de40d53f55964667c7d8"
+checksum = "495c05f60d6df0093e8fb6e74aa5846a0ad06abaf96d76166283720bf740f8ab"
 dependencies = [
  "arc-swap",
  "bytes",
- "futures-util",
- "http 1.2.0",
+ "fs-err 3.1.0",
+ "http 1.3.1",
  "http-body 1.0.1",
- "http-body-util",
- "hyper 1.5.2",
+ "hyper 1.6.0",
  "hyper-util",
  "pin-project-lite",
- "rustls 0.23.20",
+ "rustls 0.23.25",
  "rustls-pemfile 2.2.0",
  "rustls-pki-types",
  "tokio",
- "tokio-rustls 0.26.1",
- "tower 0.4.13",
+ "tokio-rustls 0.26.2",
  "tower-service",
 ]
 
@@ -565,9 +564,9 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "base64ct"
-version = "1.6.0"
+version = "1.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
+checksum = "89e25b6adfb930f02d1981565a6e5d9c547ac15a96606256d3b59040e5cd4ca3"
 
 [[package]]
 name = "beef"
@@ -583,9 +582,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.6.0"
+version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de"
+checksum = "5c8214115b7bf84099f1309324e63141d4c5d7cc26862f97a0a857dbefe165bd"
 dependencies = [
  "serde",
 ]
@@ -619,9 +618,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.16.0"
+version = "3.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79296716171880943b8470b5f8d03aa55eb2e645a4874bdbb28adb49162e012c"
+checksum = "1628fb46dfa0b37568d12e5edd512553eccf6a22a78e8bde00bb4aed84d5bdbf"
 
 [[package]]
 name = "by_address"
@@ -631,9 +630,9 @@ checksum = "64fa3c856b712db6612c019f14756e64e4bcea13337a6b33b696333a9eaa2d06"
 
 [[package]]
 name = "bytemuck"
-version = "1.21.0"
+version = "1.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef657dfab802224e671f5818e9a4935f9b1957ed18e58292690cc39e7a4092a3"
+checksum = "b6b1fc10dbac614ebc03540c9dbd60e83887fda27794998c6528f1782047d540"
 
 [[package]]
 name = "byteorder"
@@ -649,9 +648,9 @@ checksum = "8f1fe948ff07f4bd06c30984e69f5b4899c516a3ef74f34df92a2df2ab535495"
 
 [[package]]
 name = "bytes"
-version = "1.9.0"
+version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "325918d6fe32f23b19878fe4b34794ae41fc19ddbe53b10571a4874d44ffd39b"
+checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
 
 [[package]]
 name = "cassowary"
@@ -670,9 +669,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.6"
+version = "1.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d6dbb628b8f8555f86d0323c2eb39e3ec81901f4b83e091db8a6a76d316a333"
+checksum = "be714c154be609ec7f5dad223a33bf1482fff90472de28f7362806e6d4832b8c"
 dependencies = [
  "shlex",
 ]
@@ -708,15 +707,15 @@ dependencies = [
 
 [[package]]
 name = "chrono"
-version = "0.4.39"
+version = "0.4.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e36cc9d416881d2e24f9a963be5fb1cd90966419ac844274161d10488b3e825"
+checksum = "1a7964611d71df112cb1730f2ee67324fcf4d0fc6606acbbe9bfe06df124637c"
 dependencies = [
  "android-tzdata",
  "iana-time-zone",
  "num-traits",
  "serde",
- "windows-targets 0.52.6",
+ "windows-link",
 ]
 
 [[package]]
@@ -732,9 +731,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.23"
+version = "4.5.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3135e7ec2ef7b10c6ed8950f0f792ed96ee093fa088608f1c76e569722700c84"
+checksum = "6088f3ae8c3608d19260cd7445411865a485688711b78b5be70d78cd96136f83"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -742,9 +741,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.23"
+version = "4.5.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30582fc632330df2bd26877bde0c1f4470d57c582bbc070376afcd04d8cb4838"
+checksum = "22a7ef7f676155edfb82daa97f99441f3ebf4a58d5e32f295a56259f1b6facc8"
 dependencies = [
  "anstream",
  "anstyle",
@@ -755,18 +754,18 @@ dependencies = [
 
 [[package]]
 name = "clap_complete"
-version = "4.5.40"
+version = "4.5.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac2e663e3e3bed2d32d065a8404024dad306e699a04263ec59919529f803aee9"
+checksum = "f5c5508ea23c5366f77e53f5a0070e5a84e51687ec3ef9e0464c86dc8d13ce98"
 dependencies = [
  "clap",
 ]
 
 [[package]]
 name = "clap_complete_nushell"
-version = "4.5.4"
+version = "4.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "315902e790cc6e5ddd20cbd313c1d0d49db77f191e149f96397230fb82a17677"
+checksum = "c6a8b1593457dfc2fe539002b795710d022dc62a65bf15023f039f9760c7b18a"
 dependencies = [
  "clap",
  "clap_complete",
@@ -774,9 +773,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.18"
+version = "4.5.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ac6a0c7b1a9e9a5186361f67dfa1b88213572f427fb9ab038efb2bd8c582dab"
+checksum = "09176aae279615badda0765c0c0b3f6ed53f4709118af73cf4655d85d1530cd7"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -817,9 +816,9 @@ dependencies = [
 
 [[package]]
 name = "compact_str"
-version = "0.8.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6050c3a16ddab2e412160b31f2c871015704239bca62f72f6e5f0be631d3f644"
+checksum = "3b79c4069c6cad78e2e0cdfcbd26275770669fb39fd308a752dc110e83b9af32"
 dependencies = [
  "castaway",
  "cfg-if",
@@ -846,9 +845,9 @@ checksum = "baf0a07a401f374238ab8e2f11a104d2851bf9ce711ec69804834de8af45c7af"
 
 [[package]]
 name = "config"
-version = "0.15.8"
+version = "0.15.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8cf9dc8d4ef88e27a8cb23e85cb116403dedd57f7971964dc4b18ccead548901"
+checksum = "595aae20e65c3be792d05818e8c63025294ac3cb7e200f11459063a352a6ef80"
 dependencies = [
  "pathdiff",
  "serde",
@@ -858,9 +857,9 @@ dependencies = [
 
 [[package]]
 name = "console"
-version = "0.15.10"
+version = "0.15.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea3c6ecd8059b57859df5c69830340ed3c41d30e3da0c1cbed90a96ac853041b"
+checksum = "054ccb5b10f9f2cbf51eb355ca1d05c2d279ce1804688d0db74b4733a5aeafd8"
 dependencies = [
  "encode_unicode",
  "libc",
@@ -917,9 +916,9 @@ dependencies = [
 
 [[package]]
 name = "cpufeatures"
-version = "0.2.16"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16b80225097f2e5ae4e7179dd2266824648f3e2f49d9134d584b76389d31c4c3"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
 dependencies = [
  "libc",
 ]
@@ -988,12 +987,12 @@ version = "0.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "829d955a0bb380ef178a640b91779e3987da38c9aea133b20614cfed8cdea9c6"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags 2.9.0",
  "crossterm_winapi",
  "filedescriptor",
  "mio",
  "parking_lot",
- "rustix",
+ "rustix 0.38.44",
  "serde",
  "signal-hook",
  "signal-hook-mio",
@@ -1016,7 +1015,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
 dependencies = [
  "generic-array",
- "rand_core",
+ "rand_core 0.6.4",
  "typenum",
 ]
 
@@ -1123,9 +1122,9 @@ dependencies = [
 
 [[package]]
 name = "deranged"
-version = "0.3.11"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b42b6fa04a440b495c8b04d0e71b707c585f83cb9cb28cf8cd0d976c315e31b4"
+checksum = "9c9e6a11ca8224451684bc0d7d5a7adbf8f2fd6887261a1cfc3c0432f9d4068e"
 dependencies = [
  "powerfmt",
  "serde",
@@ -1227,15 +1226,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "dlib"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "330c60081dcc4c72131f8eb70510f1ac07223e5d4163db481a04a0befcffa412"
-dependencies = [
- "libloading",
-]
-
-[[package]]
 name = "dotenvy"
 version = "0.15.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1273,9 +1263,9 @@ dependencies = [
 
 [[package]]
 name = "either"
-version = "1.13.0"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60b1af1c220855b6ceac025d3f6ecdd2b7c4894bfe9cd9bda4fbb4bc7c0d4cf0"
+checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 dependencies = [
  "serde",
 ]
@@ -1297,9 +1287,9 @@ dependencies = [
 
 [[package]]
 name = "equivalent"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "errno"
@@ -1330,9 +1320,9 @@ dependencies = [
 
 [[package]]
 name = "event-listener"
-version = "5.3.1"
+version = "5.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6032be9bd27023a771701cc49f9f053c751055f71efb2e0ae5c15809093675ba"
+checksum = "3492acde4c3fc54c845eaab3eed8bd00c7a7d881f78bfc801e43a93dec1331ae"
 dependencies = [
  "concurrent-queue",
  "parking",
@@ -1378,9 +1368,9 @@ checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
 
 [[package]]
 name = "filedescriptor"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7199d965852c3bac31f779ef99cbb4537f80e952e2d6aa0ffeb30cce00f4f46e"
+checksum = "e40758ed24c9b2eeb76c35fb0aebc66c626084edd827e07e1552279814c6682d"
 dependencies = [
  "libc",
  "thiserror 1.0.69",
@@ -1394,10 +1384,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
 
 [[package]]
-name = "flate2"
-version = "1.0.35"
+name = "fixedbitset"
+version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c936bfdafb507ebbf50b8074c54fa31c5be9a1e7e5f467dd659697041407d07c"
+checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
+
+[[package]]
+name = "flate2"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11faaf5a5236997af9848be0bef4db95824b1d534ebc64d0f0c6cf3e67bd38dc"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
@@ -1422,9 +1418,9 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "foldhash"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0d2fde1f7b3d48b8395d5f2de76c18a528bd6a9cdde438df747bfcba3e05d6f"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
 name = "foreign-types"
@@ -1469,6 +1465,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "88a41f105fe1d5b6b34b2055e3dc59bb79b46b48b2040b9e6c7b4b5de097aa41"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "fs-err"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f89bda4c2a21204059a977ed3bfe746677dfd137b83c339e702b0ac91d482aa"
+dependencies = [
+ "autocfg",
+ "tokio",
 ]
 
 [[package]]
@@ -1611,7 +1617,21 @@ dependencies = [
  "cfg-if",
  "js-sys",
  "libc",
- "wasi",
+ "wasi 0.11.0+wasi-snapshot-preview1",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73fea8450eea4bac3940448fb7ae50d91f034f941199fcd9d909a5a07aa455f0"
+dependencies = [
+ "cfg-if",
+ "js-sys",
+ "libc",
+ "r-efi",
+ "wasi 0.14.2+wasi-0.2.4",
  "wasm-bindgen",
 ]
 
@@ -1633,7 +1653,7 @@ dependencies = [
  "futures-sink",
  "futures-util",
  "http 0.2.12",
- "indexmap 2.7.0",
+ "indexmap 2.8.0",
  "slab",
  "tokio",
  "tokio-util",
@@ -1642,17 +1662,17 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.7"
+version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ccae279728d634d083c00f6099cb58f01cc99c145b84b8be2f6c74618d79922e"
+checksum = "5017294ff4bb30944501348f6f8e42e6ad28f42c8bbef7a74029aff064a4e3c2"
 dependencies = [
  "atomic-waker",
  "bytes",
  "fnv",
  "futures-core",
  "futures-sink",
- "http 1.2.0",
- "indexmap 2.7.0",
+ "http 1.3.1",
+ "indexmap 2.8.0",
  "slab",
  "tokio",
  "tokio-util",
@@ -1679,10 +1699,6 @@ name = "hashbrown"
 version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
-dependencies = [
- "ahash",
- "allocator-api2",
-]
 
 [[package]]
 name = "hashbrown"
@@ -1697,11 +1713,11 @@ dependencies = [
 
 [[package]]
 name = "hashlink"
-version = "0.9.1"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ba4ff7128dee98c7dc9794b6a411377e1404dba1c97deb8d1a55297bd25d8af"
+checksum = "7382cf6263419f2d8df38c55d7da83da5c18aef87fc7a7fc1fb1e344edfe14c1"
 dependencies = [
- "hashbrown 0.14.5",
+ "hashbrown 0.15.2",
 ]
 
 [[package]]
@@ -1762,9 +1778,9 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "1.2.0"
+version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f16ca2af56261c99fba8bac40a10251ce8188205a4c448fbb745a2e4daa76fea"
+checksum = "f4a85d31aea989eead29a3aaf9e1115a180df8282431156e533de47660892565"
 dependencies = [
  "bytes",
  "fnv",
@@ -1789,27 +1805,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
 dependencies = [
  "bytes",
- "http 1.2.0",
+ "http 1.3.1",
 ]
 
 [[package]]
 name = "http-body-util"
-version = "0.1.2"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "793429d76616a256bcb62c2a2ec2bed781c8307e797e2598c50010f2bee2544f"
+checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
 dependencies = [
  "bytes",
- "futures-util",
- "http 1.2.0",
+ "futures-core",
+ "http 1.3.1",
  "http-body 1.0.1",
  "pin-project-lite",
 ]
 
 [[package]]
 name = "httparse"
-version = "1.9.5"
+version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d71d3574edd2771538b901e6549113b4006ece66150fb69c0fb6d9a2adae946"
+checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
 name = "httpdate"
@@ -1819,9 +1835,9 @@ checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
 name = "humantime"
-version = "2.1.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
+checksum = "9b112acc8b3adf4b107a8ec20977da0273a8c386765a3ec0229bd500a1443f9f"
 
 [[package]]
 name = "hyper"
@@ -1849,15 +1865,15 @@ dependencies = [
 
 [[package]]
 name = "hyper"
-version = "1.5.2"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "256fb8d4bd6413123cc9d91832d78325c48ff41677595be797d90f42969beae0"
+checksum = "cc2b571658e38e0c01b1fdca3bbbe93c00d3d71693ff2770043f8c29bc7d6f80"
 dependencies = [
  "bytes",
  "futures-channel",
  "futures-util",
- "h2 0.4.7",
- "http 1.2.0",
+ "h2 0.4.8",
+ "http 1.3.1",
  "http-body 1.0.1",
  "httparse",
  "httpdate",
@@ -1889,13 +1905,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2d191583f3da1305256f22463b9bb0471acad48a4e534a5218b9963e9c1f59b2"
 dependencies = [
  "futures-util",
- "http 1.2.0",
- "hyper 1.5.2",
+ "http 1.3.1",
+ "hyper 1.6.0",
  "hyper-util",
- "rustls 0.23.20",
+ "rustls 0.23.25",
  "rustls-pki-types",
  "tokio",
- "tokio-rustls 0.26.1",
+ "tokio-rustls 0.26.2",
  "tower-service",
  "webpki-roots",
 ]
@@ -1906,7 +1922,7 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b90d566bffbce6a75bd8b09a05aa8c2cb1fabb6cb348f8840c9e4c90a0d83b0"
 dependencies = [
- "hyper 1.5.2",
+ "hyper 1.6.0",
  "hyper-util",
  "pin-project-lite",
  "tokio",
@@ -1922,9 +1938,9 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-util",
- "http 1.2.0",
+ "http 1.3.1",
  "http-body 1.0.1",
- "hyper 1.5.2",
+ "hyper 1.6.0",
  "pin-project-lite",
  "socket2",
  "tokio",
@@ -2132,9 +2148,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.7.0"
+version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62f822373a4fe84d4bb149bf54e584a7f4abec90e072ed49cda0edea5b95471f"
+checksum = "3954d50fe15b02142bf25d3b8bdadb634ec3948f103d04ffe3031bc8fe9d7058"
 dependencies = [
  "equivalent",
  "hashbrown 0.15.2",
@@ -2143,9 +2159,9 @@ dependencies = [
 
 [[package]]
 name = "indicatif"
-version = "0.17.9"
+version = "0.17.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cbf675b85ed934d3c67b5c5469701eec7db22689d0a2139d856e0925fa28b281"
+checksum = "183b3088984b400f4cfac3620d5e076c84da5364016b4f49473de574b2586235"
 dependencies = [
  "console",
  "number_prefix",
@@ -2156,28 +2172,27 @@ dependencies = [
 
 [[package]]
 name = "indoc"
-version = "2.0.5"
+version = "2.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b248f5224d1d606005e02c97f5aa4e88eeb230488bcc03bc9ca4d7991399f2b5"
+checksum = "f4c7245a08504955605670dbf141fceab975f15ca21570696aebe9d2e71576bd"
 
 [[package]]
 name = "inout"
-version = "0.1.3"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0c10553d664a4d0bcff9f4215d0aac67a639cc68ef660840afe309b807bc9f5"
+checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
 dependencies = [
  "generic-array",
 ]
 
 [[package]]
 name = "instability"
-version = "0.3.5"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "898e106451f7335950c9cc64f8ec67b5f65698679ac67ed00619aeef14e1cf75"
+checksum = "0bf9fed6d91cfb734e7476a06bde8300a1b94e217e1b523b6f0cd1a01998c71d"
 dependencies = [
  "darling",
  "indoc",
- "pretty_assertions",
  "proc-macro2",
  "quote",
  "syn",
@@ -2195,9 +2210,9 @@ dependencies = [
 
 [[package]]
 name = "ipnet"
-version = "2.10.1"
+version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddc24109865250148c2e0f3d25d4f0f479571723792d3802153c60922a4fb708"
+checksum = "469fb0b9cefa57e3ef31275ee7cacb78f2fdca44e4765491884a2b119d4eb130"
 
 [[package]]
 name = "is_terminal_polyfill"
@@ -2207,11 +2222,11 @@ checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
 
 [[package]]
 name = "iso8601"
-version = "0.6.1"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "924e5d73ea28f59011fec52a0d12185d496a9b075d360657aed2a5707f701153"
+checksum = "c5c177cff824ab21a6f41079a4c401241c4e8be14f316c4c6b07d5fca351c98d"
 dependencies = [
- "nom",
+ "nom 8.0.0",
 ]
 
 [[package]]
@@ -2224,10 +2239,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "itoa"
-version = "1.0.14"
+name = "itertools"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d75a2a4b1b190afb6f5425f10f6a8f959d2ea0b9c2b1d79553551850539e4674"
+checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itoa"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
 name = "jpeg-decoder"
@@ -2237,9 +2261,9 @@ checksum = "f5d4a7da358eff58addd2877a45865158f0d78c911d43a5784ceb7bbf52833b0"
 
 [[package]]
 name = "js-sys"
-version = "0.3.76"
+version = "0.3.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6717b6b5b077764fb5966237269cb3c64edddde4b14ce42647430a78ced9e7b7"
+checksum = "1cfaf33c695fc6e08064efbc1f72ec937429614f25eef83af942d0e227c3a28f"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
@@ -2256,19 +2280,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.169"
+version = "0.2.171"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5aba8db14291edd000dfcc4d620c7ebfb122c613afb886ca8803fa4e128a20a"
-
-[[package]]
-name = "libloading"
-version = "0.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc2f4eb4bc735547cfed7c0a4922cbd04a4655978c09b54f1f7b228750664c34"
-dependencies = [
- "cfg-if",
- "windows-targets 0.52.6",
-]
+checksum = "c19937216e9d3aa9956d9bb8dfc0b0c8beb6058fc4f7a4dc4d850edf86a237d6"
 
 [[package]]
 name = "libm"
@@ -2282,7 +2296,7 @@ version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0ff37bd590ca25063e35af745c343cb7a0271906fb7b37e4813e8f79f00268d"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags 2.9.0",
  "libc",
 ]
 
@@ -2299,15 +2313,21 @@ dependencies = [
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.4.14"
+version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78b3ae25bc7c8c38cec158d1f2757ee79e9b3740fbc7ccf0e59e4b08d793fa89"
+checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe7db12097d22ec582439daf8618b8fdd1a7bef6270e9af3b1ebcd30893cf413"
 
 [[package]]
 name = "listenfd"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0500463acd96259d219abb05dc57e5a076ef04b2db9a2112846929b5f174c96"
+checksum = "b87bc54a4629b4294d0b3ef041b64c40c611097a677d9dc07b2c67739fe39dba"
 dependencies = [
  "libc",
  "uuid",
@@ -2316,9 +2336,9 @@ dependencies = [
 
 [[package]]
 name = "litemap"
-version = "0.7.4"
+version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ee93343901ab17bd981295f2cf0026d4ad018c7c31ba84549a4ddbb47a45104"
+checksum = "23fb14cb19457329c82206317a5663005a4d404783dc74f4252769b0d5f42856"
 
 [[package]]
 name = "lock_api"
@@ -2332,9 +2352,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.22"
+version = "0.4.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
+checksum = "30bde2b3dc3671ae49d8e2e9f044c7c005836e7a023ee57cffa25ab82764bb9e"
 
 [[package]]
 name = "logos"
@@ -2475,9 +2495,9 @@ dependencies = [
 
 [[package]]
 name = "miette"
-version = "7.4.0"
+version = "7.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "317f146e2eb7021892722af37cf1b971f0a70c8406f487e24952667616192c64"
+checksum = "1a955165f87b37fd1862df2a59547ac542c77ef6d17c666f619d1ad22dd89484"
 dependencies = [
  "cfg-if",
  "miette-derive",
@@ -2487,9 +2507,9 @@ dependencies = [
 
 [[package]]
 name = "miette-derive"
-version = "7.4.0"
+version = "7.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23c9b935fbe1d6cbd1dac857b54a688145e2d93f48db36010514d0f612d0ad67"
+checksum = "bf45bf44ab49be92fd1227a3be6fc6f617f1a337c06af54981048574d8783147"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2510,9 +2530,9 @@ checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "miniz_oxide"
-version = "0.8.2"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ffbe83022cedc1d264172192511ae958937694cd57ce297164951b8b3568394"
+checksum = "8e3e04debbb59698c15bacbb6d93584a8c0ca9cc3213cb423d31f760d8843ce5"
 dependencies = [
  "adler2",
  "simd-adler32",
@@ -2532,7 +2552,7 @@ checksum = "2886843bf800fba2e3377cff24abf6379b4c4d5c6681eaf9ea5b0d15090450bd"
 dependencies = [
  "libc",
  "log",
- "wasi",
+ "wasi 0.11.0+wasi-snapshot-preview1",
  "windows-sys 0.52.0",
 ]
 
@@ -2548,7 +2568,7 @@ version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab2156c4fce2f8df6c499cc1c763e4394b7482525bf2a9701c9d79d215f519e4"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags 2.9.0",
  "cfg-if",
  "cfg_aliases 0.1.1",
  "libc",
@@ -2562,6 +2582,15 @@ checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
 dependencies = [
  "memchr",
  "minimal-lexical",
+]
+
+[[package]]
+name = "nom"
+version = "8.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df9761775871bdef83bee530e60050f7e54b1105350d6884eb0fb4f46c2f9405"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -2604,7 +2633,7 @@ dependencies = [
  "num-integer",
  "num-iter",
  "num-traits",
- "rand",
+ "rand 0.8.5",
  "smallvec",
  "zeroize",
 ]
@@ -2692,7 +2721,7 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e4e89ad9e3d7d297152b17d39ed92cd50ca8063a89a9fa569046d41568891eff"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags 2.9.0",
  "block2",
  "libc",
  "objc2",
@@ -2708,7 +2737,7 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "617fbf49e071c178c0b24c080767db52958f716d9eabdf0890523aeae54773ef"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags 2.9.0",
  "block2",
  "objc2",
  "objc2-foundation",
@@ -2728,9 +2757,9 @@ dependencies = [
 
 [[package]]
 name = "objc2-encode"
-version = "4.0.3"
+version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7891e71393cd1f227313c9379a26a584ff3d7e6e7159e988851f0934c993f0f8"
+checksum = "ef25abbcd74fb2609453eb695bd2f860d389e457f67dc17cafc8b8cbc89d0c33"
 
 [[package]]
 name = "objc2-foundation"
@@ -2738,7 +2767,7 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ee638a5da3799329310ad4cfa62fbf045d5f56e3ef5ba4149e7452dcf89d5a8"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags 2.9.0",
  "block2",
  "libc",
  "objc2",
@@ -2750,7 +2779,7 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd0cba1276f6023976a406a14ffa85e1fdd19df6b0f737b063b95f6c8c7aadd6"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags 2.9.0",
  "block2",
  "objc2",
  "objc2-foundation",
@@ -2762,7 +2791,7 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e42bee7bff906b14b167da2bac5efe6b6a07e6f7c0a21a7308d40c960242dc7a"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags 2.9.0",
  "block2",
  "objc2",
  "objc2-foundation",
@@ -2780,9 +2809,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.20.2"
+version = "1.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1261fe7e33c73b354eab43b1273a57c8f967d0391e80353e51f764ac02cf6775"
+checksum = "d75b0bedcc4fe52caa0e03d9f1151a323e4aa5e2d78ba3580400cd3c9e2bc4bc"
 
 [[package]]
 name = "opaque-debug"
@@ -2792,9 +2821,9 @@ checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
 name = "openssl-probe"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
+checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
 
 [[package]]
 name = "option-ext"
@@ -2879,7 +2908,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "346f04948ba92c43e8469c1ee6736c7563d71012b17d40745260fe106aac2166"
 dependencies = [
  "base64ct",
- "rand_core",
+ "rand_core 0.6.4",
  "subtle",
 ]
 
@@ -2925,15 +2954,25 @@ version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4c5cc86750666a3ed20bdaf5ca2a0344f9c67674cae0515bec2da16fbaa47db"
 dependencies = [
- "fixedbitset",
- "indexmap 2.7.0",
+ "fixedbitset 0.4.2",
+ "indexmap 2.8.0",
+]
+
+[[package]]
+name = "petgraph"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3672b37090dbd86368a4145bc067582552b29c27377cad4e0a306c97f9bd7772"
+dependencies = [
+ "fixedbitset 0.5.7",
+ "indexmap 2.8.0",
 ]
 
 [[package]]
 name = "phf"
-version = "0.11.2"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ade2d8b8f33c7333b51bcf0428d37e217e9f32192ae4772156f65063b8ce03dc"
+checksum = "1fd6780a80ae0c52cc120a26a1a42c1ae51b247a253e4e06113d23d2c2edd078"
 dependencies = [
  "phf_macros",
  "phf_shared",
@@ -2941,19 +2980,19 @@ dependencies = [
 
 [[package]]
 name = "phf_generator"
-version = "0.11.2"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48e4cc64c2ad9ebe670cb8fd69dd50ae301650392e81c05f9bfcb2d5bdbc24b0"
+checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
 dependencies = [
  "phf_shared",
- "rand",
+ "rand 0.8.5",
 ]
 
 [[package]]
 name = "phf_macros"
-version = "0.11.2"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3444646e286606587e49f3bcf1679b8cef1dc2c5ecc29ddacaffc305180d464b"
+checksum = "f84ac04429c13a7ff43785d75ad27569f2951ce0ffd30a3321230db2fc727216"
 dependencies = [
  "phf_generator",
  "phf_shared",
@@ -2964,27 +3003,27 @@ dependencies = [
 
 [[package]]
 name = "phf_shared"
-version = "0.11.2"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90fcb95eef784c2ac79119d1dd819e162b5da872ce6f3c3abe1e8ca1c082f72b"
+checksum = "67eabc2ef2a60eb7faa00097bd1ffdb5bd28e62bf39990626a582201b7a754e5"
 dependencies = [
  "siphasher",
 ]
 
 [[package]]
 name = "pin-project"
-version = "1.1.7"
+version = "1.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be57f64e946e500c8ee36ef6331845d40a93055567ec57e8fae13efd33759b95"
+checksum = "677f1add503faace112b9f1373e43e9e054bfdd22ff1a63c1bc485eaec6a6a8a"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "1.1.7"
+version = "1.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c0f5fad0874fc7abcd4d750e76917eaebbecaa2c20bde22e1dbeeba8beb758c"
+checksum = "6e918e4ff8c4549eb882f14b3a4bc8c8bc93de829416eacf579f1207a8fbf861"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2993,9 +3032,9 @@ dependencies = [
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.15"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "915a1e146535de9163f3987b8944ed8cf49a18bb0056bcebcdcece385cece4ff"
+checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
 
 [[package]]
 name = "pin-utils"
@@ -3026,9 +3065,9 @@ dependencies = [
 
 [[package]]
 name = "pkg-config"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "953ec861398dccce10c670dfeaf3ec4911ca479e9c02154b3a215178c5f566f2"
+checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
 name = "png"
@@ -3056,9 +3095,9 @@ dependencies = [
 
 [[package]]
 name = "portable-atomic"
-version = "1.10.0"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "280dc24453071f1b63954171985a0b0d30058d287960968b9b2aca264c8d4ee6"
+checksum = "350e9b48cbc6b0e028b0473b114454c6316e57336ee184ceab6e53f72c178b3e"
 
 [[package]]
 name = "postmark"
@@ -3068,8 +3107,8 @@ checksum = "a8c1982389836857cc378c3f46992bb6712464aa30567831ba0985495b0f6d83"
 dependencies = [
  "async-trait",
  "bytes",
- "http 1.2.0",
- "reqwest 0.12.11",
+ "http 1.3.1",
+ "reqwest 0.12.15",
  "serde",
  "serde_json",
  "thiserror 1.0.69",
@@ -3085,11 +3124,11 @@ checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "ppv-lite86"
-version = "0.2.20"
+version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77957b295656769bb8ad2b6a6b09d897d94f05c41b069aede1fcdaa675eaea04"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
 dependencies = [
- "zerocopy",
+ "zerocopy 0.8.23",
 ]
 
 [[package]]
@@ -3104,9 +3143,9 @@ dependencies = [
 
 [[package]]
 name = "prettyplease"
-version = "0.2.25"
+version = "0.2.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64d1ec885c64d0457d564db4ec299b2dae3f9c02808b8ad9c3a089c591b18033"
+checksum = "5316f57387668042f561aae71480de936257848f9c43ce528e311d89a07cadeb"
 dependencies = [
  "proc-macro2",
  "syn",
@@ -3114,18 +3153,18 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.92"
+version = "1.0.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37d3544b3f2748c54e147655edb5025752e2303145b5aefb3c3ea2c78b973bb0"
+checksum = "a31971752e70b8b2686d7e46ec17fb38dad4051d94024c88df49b667caea9c84"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "prost"
-version = "0.13.4"
+version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c0fef6c4230e4ccf618a35c59d7ede15dea37de8427500f50aff708806e42ec"
+checksum = "2796faa41db3ec313a31f7624d9286acf277b52de526150b7e69f3debf891ee5"
 dependencies = [
  "bytes",
  "prost-derive",
@@ -3133,16 +3172,16 @@ dependencies = [
 
 [[package]]
 name = "prost-build"
-version = "0.13.4"
+version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0f3e5beed80eb580c68e2c600937ac2c4eedabdfd5ef1e5b7ea4f3fba84497b"
+checksum = "be769465445e8c1474e9c5dac2018218498557af32d9ed057325ec9a41ae81bf"
 dependencies = [
  "heck",
- "itertools",
+ "itertools 0.14.0",
  "log",
  "multimap",
  "once_cell",
- "petgraph",
+ "petgraph 0.7.1",
  "prettyplease",
  "prost",
  "prost-types",
@@ -3153,12 +3192,12 @@ dependencies = [
 
 [[package]]
 name = "prost-derive"
-version = "0.13.4"
+version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "157c5a9d7ea5c2ed2d9fb8f495b64759f7816c7eaea54ba3978f0d63000162e3"
+checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
 dependencies = [
  "anyhow",
- "itertools",
+ "itertools 0.14.0",
  "proc-macro2",
  "quote",
  "syn",
@@ -3166,9 +3205,9 @@ dependencies = [
 
 [[package]]
 name = "prost-reflect"
-version = "0.14.3"
+version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20ae544fca2892fd4b7e9ff26cba1090cedf1d4d95c2aded1af15d2f93f270b8"
+checksum = "7b5edd582b62f5cde844716e66d92565d7faf7ab1445c8cebce6e00fba83ddb2"
 dependencies = [
  "logos",
  "miette",
@@ -3179,18 +3218,18 @@ dependencies = [
 
 [[package]]
 name = "prost-types"
-version = "0.13.4"
+version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc2f1e56baa61e93533aebc21af4d2134b70f66275e0fcdf3cbe43d77ff7e8fc"
+checksum = "52c2c1bf36ddb1a1c396b3601a3cec27c2462e45f07c386894ec3ccf5332bd16"
 dependencies = [
  "prost",
 ]
 
 [[package]]
 name = "protox"
-version = "0.7.1"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "873f359bdecdfe6e353752f97cb9ee69368df55b16363ed2216da85e03232a58"
+checksum = "6f352af331bf637b8ecc720f7c87bf903d2571fa2e14a66e9b2558846864b54a"
 dependencies = [
  "bytes",
  "miette",
@@ -3224,53 +3263,55 @@ dependencies = [
  "mach2",
  "once_cell",
  "raw-cpuid",
- "wasi",
+ "wasi 0.11.0+wasi-snapshot-preview1",
  "web-sys",
  "winapi",
 ]
 
 [[package]]
 name = "quick-xml"
-version = "0.36.2"
+version = "0.37.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7649a7b4df05aed9ea7ec6f628c67c9953a43869b8bc50929569b2999d443fe"
+checksum = "165859e9e55f79d67b96c5d96f4e88b6f2695a1972849c15a6a3f5c59fc2c003"
 dependencies = [
  "memchr",
 ]
 
 [[package]]
 name = "quinn"
-version = "0.11.6"
+version = "0.11.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62e96808277ec6f97351a2380e6c25114bc9e67037775464979f3037c92d05ef"
+checksum = "c3bd15a6f2967aef83887dcb9fec0014580467e33720d073560cf015a5683012"
 dependencies = [
  "bytes",
+ "cfg_aliases 0.2.1",
  "pin-project-lite",
  "quinn-proto",
  "quinn-udp",
- "rustc-hash 2.1.0",
- "rustls 0.23.20",
+ "rustc-hash 2.1.1",
+ "rustls 0.23.25",
  "socket2",
- "thiserror 2.0.9",
+ "thiserror 2.0.12",
  "tokio",
  "tracing",
+ "web-time",
 ]
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.9"
+version = "0.11.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2fe5ef3495d7d2e377ff17b1a8ce2ee2ec2a18cde8b6ad6619d65d0701c135d"
+checksum = "b820744eb4dc9b57a3398183639c511b5a26d2ed702cedd3febaa1393caa22cc"
 dependencies = [
  "bytes",
- "getrandom",
- "rand",
+ "getrandom 0.3.2",
+ "rand 0.9.0",
  "ring",
- "rustc-hash 2.1.0",
- "rustls 0.23.20",
+ "rustc-hash 2.1.1",
+ "rustls 0.23.25",
  "rustls-pki-types",
  "slab",
- "thiserror 2.0.9",
+ "thiserror 2.0.12",
  "tinyvec",
  "tracing",
  "web-time",
@@ -3278,9 +3319,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-udp"
-version = "0.5.9"
+version = "0.5.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c40286217b4ba3a71d644d752e6a0b71f13f1b6a2c5311acfcbe0c2418ed904"
+checksum = "e46f3055866785f6b92bc6164b76be02ca8f2eb4b002c0354b28cf4c119e5944"
 dependencies = [
  "cfg_aliases 0.2.1",
  "libc",
@@ -3292,12 +3333,18 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.38"
+version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e4dccaaaf89514f546c693ddc140f729f958c247918a13380cccc6078391acc"
+checksum = "1885c039570dc00dcb4ff087a89e185fd56bae234ddc7f056a945bf36467248d"
 dependencies = [
  "proc-macro2",
 ]
+
+[[package]]
+name = "r-efi"
+version = "5.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74765f6d916ee2faa39bc8e68e4f3ed8949b48cccdac59983d287a7cb71ce9c5"
 
 [[package]]
 name = "rand"
@@ -3306,8 +3353,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "libc",
- "rand_chacha",
- "rand_core",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3779b94aeb87e8bd4e834cee3650289ee9e0d5677f976ecdb6d219e5f4f6cd94"
+dependencies = [
+ "rand_chacha 0.9.0",
+ "rand_core 0.9.3",
+ "zerocopy 0.8.23",
 ]
 
 [[package]]
@@ -3317,7 +3375,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.9.3",
 ]
 
 [[package]]
@@ -3326,7 +3394,16 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.15",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
+dependencies = [
+ "getrandom 0.3.2",
 ]
 
 [[package]]
@@ -3335,13 +3412,13 @@ version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eabd94c2f37801c20583fc49dd5cd6b0ba68c716787c2dd6ed18571e1e63117b"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags 2.9.0",
  "cassowary",
  "compact_str",
  "crossterm",
  "indoc",
  "instability",
- "itertools",
+ "itertools 0.13.0",
  "lru",
  "paste",
  "strum",
@@ -3381,11 +3458,11 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.5.8"
+version = "0.5.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03a862b389f93e68874fbf580b9de08dd02facb9a788ebadaf4a3fd33cf58834"
+checksum = "0b8c0c260b63a8219631167be35e6a988e9554dbd323f8bd08439c8ed1302bd1"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags 2.9.0",
 ]
 
 [[package]]
@@ -3394,7 +3471,7 @@ version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.15",
  "libredox",
  "thiserror 1.0.69",
 ]
@@ -3492,18 +3569,18 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
-version = "0.12.11"
+version = "0.12.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fe060fe50f524be480214aba758c71f99f90ee8c83c5a36b5e9e1d568eb4eb3"
+checksum = "d19c46a6fdd48bc4dab94b6103fccc55d34c67cc0ad04653aad4ea2a07cd7bbb"
 dependencies = [
  "base64 0.22.1",
  "bytes",
  "futures-core",
  "futures-util",
- "http 1.2.0",
+ "http 1.3.1",
  "http-body 1.0.1",
  "http-body-util",
- "hyper 1.5.2",
+ "hyper 1.6.0",
  "hyper-rustls 0.27.5",
  "hyper-util",
  "ipnet",
@@ -3514,7 +3591,7 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "quinn",
- "rustls 0.23.20",
+ "rustls 0.23.25",
  "rustls-pemfile 2.2.0",
  "rustls-pki-types",
  "serde",
@@ -3522,7 +3599,7 @@ dependencies = [
  "serde_urlencoded",
  "sync_wrapper 1.0.2",
  "tokio",
- "tokio-rustls 0.26.1",
+ "tokio-rustls 0.26.2",
  "tower 0.5.2",
  "tower-service",
  "url",
@@ -3535,15 +3612,14 @@ dependencies = [
 
 [[package]]
 name = "ring"
-version = "0.17.8"
+version = "0.17.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c17fa4cb658e3583423e915b9f3acc01cceaee1860e33d59ebae66adc3a2dc0d"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
 dependencies = [
  "cc",
  "cfg-if",
- "getrandom",
+ "getrandom 0.2.15",
  "libc",
- "spin",
  "untrusted",
  "windows-sys 0.52.0",
 ]
@@ -3572,9 +3648,9 @@ dependencies = [
 
 [[package]]
 name = "rsa"
-version = "0.9.7"
+version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47c75d7c5c6b673e58bf54d8544a9f432e3a925b0e80f7cd3602ab5c50c55519"
+checksum = "78928ac1ed176a5ca1d17e578a1825f3d81ca54cf41053a592584b020cfd691b"
 dependencies = [
  "const-oid",
  "digest",
@@ -3583,7 +3659,7 @@ dependencies = [
  "num-traits",
  "pkcs1",
  "pkcs8",
- "rand_core",
+ "rand_core 0.6.4",
  "signature",
  "spki",
  "subtle",
@@ -3623,9 +3699,9 @@ checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
 name = "rustc-hash"
-version = "2.1.0"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7fb8039b3032c191086b10f11f319a6e99e1e82889c5cc6046f515c9db1d497"
+checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
 
 [[package]]
 name = "rustc_version"
@@ -3638,14 +3714,27 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.38.42"
+version = "0.38.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f93dc38ecbab2eb790ff964bb77fa94faf256fd3e73285fd7ba0903b76bedb85"
+checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags 2.9.0",
  "errno",
  "libc",
- "linux-raw-sys",
+ "linux-raw-sys 0.4.15",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "rustix"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e56a18552996ac8d29ecc3b190b4fdbb2d91ca4ec396de7bbffaf43f3d637e96"
+dependencies = [
+ "bitflags 2.9.0",
+ "errno",
+ "libc",
+ "linux-raw-sys 0.9.3",
  "windows-sys 0.59.0",
 ]
 
@@ -3663,14 +3752,14 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.20"
+version = "0.23.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5065c3f250cbd332cd894be57c40fa52387247659b14a2d6041d121547903b1b"
+checksum = "822ee9188ac4ec04a2f0531e55d035fb2de73f18b41a63c70c2712503b6fb13c"
 dependencies = [
  "once_cell",
  "ring",
  "rustls-pki-types",
- "rustls-webpki 0.102.8",
+ "rustls-webpki 0.103.0",
  "subtle",
  "zeroize",
 ]
@@ -3707,9 +3796,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.10.1"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2bf47e6ff922db3825eb750c4e2ff784c6ff8fb9e13046ef6a1d1c5401b0b37"
+checksum = "917ce264624a4b4db1c364dcc35bfca9ded014d0a958cd47ad3e960e988ea51c"
 dependencies = [
  "web-time",
 ]
@@ -3726,9 +3815,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.102.8"
+version = "0.103.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64ca1bc8749bd4cf37b5ce386cc146580777b4e8572c7b97baf22c83f444bee9"
+checksum = "0aa4eeac2588ffff23e9d7a7e9b3f971c5fb5b7ebc9452745e0c232c64f83b2f"
 dependencies = [
  "ring",
  "rustls-pki-types",
@@ -3737,9 +3826,9 @@ dependencies = [
 
 [[package]]
 name = "rustversion"
-version = "1.0.19"
+version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7c45b9784283f1b2e7fb61b42047c2fd678ef0960d4f6f1eba131594cc369d4"
+checksum = "eded382c5f5f786b989652c49544c4877d9f015cc22e145a5ea8ea66c2921cd2"
 
 [[package]]
 name = "rusty_paserk"
@@ -3757,7 +3846,7 @@ dependencies = [
  "digest",
  "ed25519-dalek",
  "generic-array",
- "rand",
+ "rand 0.8.5",
  "rusty_paseto",
  "serde",
  "sha2",
@@ -3777,7 +3866,7 @@ dependencies = [
  "ed25519-dalek",
  "hex",
  "iso8601",
- "rand_core",
+ "rand_core 0.6.4",
  "ring",
  "thiserror 1.0.69",
  "time",
@@ -3786,9 +3875,9 @@ dependencies = [
 
 [[package]]
 name = "ryu"
-version = "1.0.18"
+version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3cb5ba0dc43242ce17de99c180e96db90b235b8a9fdc9543c96d2209116bd9f"
+checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
 
 [[package]]
 name = "salsa20"
@@ -3807,12 +3896,6 @@ checksum = "1f29ebaa345f945cec9fbbc532eb307f0fdad8161f281b6369539c8d84876b3d"
 dependencies = [
  "windows-sys 0.59.0",
 ]
-
-[[package]]
-name = "scoped-tls"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1cf6437eb19a8f4a6cc0f7dca544973b0b78843adbfeb3683d1a94a0024a294"
 
 [[package]]
 name = "scopeguard"
@@ -3836,7 +3919,7 @@ version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags 2.9.0",
  "core-foundation",
  "core-foundation-sys",
  "libc",
@@ -3845,9 +3928,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework-sys"
-version = "2.13.0"
+version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1863fd3768cd83c56a7f60faa4dc0d403f1b6df0a38c3c25f44b7894e45370d5"
+checksum = "49db231d56a190491cb4aeda9527f1ad45345af50b0851622a7adb8c03b01c32"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -3855,24 +3938,24 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.24"
+version = "1.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3cb6eb87a131f756572d7fb904f6e7b68633f09cca868c5df1c4b8d1a694bbba"
+checksum = "56e6fa9c48d24d85fb3de5ad847117517440f6beceb7798af16b4a87d616b8d0"
 
 [[package]]
 name = "serde"
-version = "1.0.217"
+version = "1.0.219"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02fc4265df13d6fa1d00ecff087228cc0a2b5f3c0e87e258d8b94a156e984c70"
+checksum = "5f0e2c6ed6606019b4e29e69dbaba95b11854410e5347d525002456dbbb786b6"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.217"
+version = "1.0.219"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a9bf7cf98d04a2b28aead066b7496853d4779c9cc183c440dbac457641e19a0"
+checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3881,9 +3964,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.134"
+version = "1.0.140"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d00f4175c42ee48b15416f6193a959ba3a0d67fc699a0db9ad12df9f83991c7d"
+checksum = "20068b6e96dc6c9bd23e01df8827e6c7e1f2fddd43c21810382803c136b99373"
 dependencies = [
  "itoa",
  "memchr",
@@ -3893,9 +3976,9 @@ dependencies = [
 
 [[package]]
 name = "serde_path_to_error"
-version = "0.1.16"
+version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af99884400da37c88f5e9146b7f1fd0fbcae8f6eec4e9da38b67d05486f814a6"
+checksum = "59fab13f937fa393d08645bf3a84bdfe86e296747b506ada67bb15f10f218b2a"
 dependencies = [
  "itoa",
  "serde",
@@ -3942,7 +4025,7 @@ dependencies = [
  "chrono",
  "hex",
  "indexmap 1.9.3",
- "indexmap 2.7.0",
+ "indexmap 2.8.0",
  "serde",
  "serde_derive",
  "serde_json",
@@ -4045,7 +4128,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
  "digest",
- "rand_core",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -4056,9 +4139,9 @@ checksum = "d66dc143e6b11c1eddc06d5c423cfc97062865baf299914ab64caa38182078fe"
 
 [[package]]
 name = "siphasher"
-version = "0.3.11"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38b58827f4464d87d377d175e90bf58eb00fd8716ff0a62f80356b5e61555d0d"
+checksum = "56199f7ddabf13fe5074ce809e7d3f42b42ae711800501b5b16ea82ad029c39d"
 
 [[package]]
 name = "sketches-ddsketch"
@@ -4077,9 +4160,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.13.2"
+version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
+checksum = "7fcf8323ef1faaee30a44a340193b1ac6814fd9b7b4e88e9d4519a3e4abe1cfd"
 dependencies = [
  "serde",
 ]
@@ -4124,20 +4207,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "sqlformat"
-version = "0.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7bba3a93db0cc4f7bdece8bb09e77e2e785c20bfebf79eb8340ed80708048790"
-dependencies = [
- "nom",
- "unicode_categories",
-]
-
-[[package]]
 name = "sqlx"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93334716a037193fac19df402f8571269c84a00852f6a7066b5d2616dcd64d3e"
+checksum = "4410e73b3c0d8442c5f99b425d7a435b5ee0ae4167b3196771dd3f7a01be745f"
 dependencies = [
  "sqlx-core",
  "sqlx-macros",
@@ -4148,39 +4221,33 @@ dependencies = [
 
 [[package]]
 name = "sqlx-core"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4d8060b456358185f7d50c55d9b5066ad956956fddec42ee2e8567134a8936e"
+checksum = "6a007b6936676aa9ab40207cde35daab0a04b823be8ae004368c0793b96a61e0"
 dependencies = [
- "atoi",
- "byteorder",
  "bytes",
  "crc",
  "crossbeam-queue",
  "either",
  "event-listener",
- "futures-channel",
  "futures-core",
  "futures-intrusive",
  "futures-io",
  "futures-util",
- "hashbrown 0.14.5",
+ "hashbrown 0.15.2",
  "hashlink",
- "hex",
- "indexmap 2.7.0",
+ "indexmap 2.8.0",
  "log",
  "memchr",
  "once_cell",
- "paste",
  "percent-encoding",
- "rustls 0.23.20",
+ "rustls 0.23.25",
  "rustls-pemfile 2.2.0",
  "serde",
  "serde_json",
  "sha2",
  "smallvec",
- "sqlformat",
- "thiserror 1.0.69",
+ "thiserror 2.0.12",
  "time",
  "tokio",
  "tokio-stream",
@@ -4192,9 +4259,9 @@ dependencies = [
 
 [[package]]
 name = "sqlx-macros"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cac0692bcc9de3b073e8d747391827297e075c7710ff6276d9f7a1f3d58c6657"
+checksum = "3112e2ad78643fef903618d78cf0aec1cb3134b019730edb039b69eaf531f310"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4205,9 +4272,9 @@ dependencies = [
 
 [[package]]
 name = "sqlx-macros-core"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1804e8a7c7865599c9c79be146dc8a9fd8cc86935fa641d3ea58e5f0688abaa5"
+checksum = "4e9f90acc5ab146a99bf5061a7eb4976b573f560bc898ef3bf8435448dd5e7ad"
 dependencies = [
  "dotenvy",
  "either",
@@ -4231,13 +4298,13 @@ dependencies = [
 
 [[package]]
 name = "sqlx-mysql"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64bb4714269afa44aef2755150a0fc19d756fb580a67db8885608cf02f47d06a"
+checksum = "4560278f0e00ce64938540546f59f590d60beee33fffbd3b9cd47851e5fff233"
 dependencies = [
  "atoi",
  "base64 0.22.1",
- "bitflags 2.6.0",
+ "bitflags 2.9.0",
  "byteorder",
  "bytes",
  "crc",
@@ -4258,7 +4325,7 @@ dependencies = [
  "memchr",
  "once_cell",
  "percent-encoding",
- "rand",
+ "rand 0.8.5",
  "rsa",
  "serde",
  "sha1",
@@ -4266,7 +4333,7 @@ dependencies = [
  "smallvec",
  "sqlx-core",
  "stringprep",
- "thiserror 1.0.69",
+ "thiserror 2.0.12",
  "time",
  "tracing",
  "uuid",
@@ -4275,20 +4342,19 @@ dependencies = [
 
 [[package]]
 name = "sqlx-postgres"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6fa91a732d854c5d7726349bb4bb879bb9478993ceb764247660aee25f67c2f8"
+checksum = "c5b98a57f363ed6764d5b3a12bfedf62f07aa16e1856a7ddc2a0bb190a959613"
 dependencies = [
  "atoi",
  "base64 0.22.1",
- "bitflags 2.6.0",
+ "bitflags 2.9.0",
  "byteorder",
  "crc",
  "dotenvy",
  "etcetera",
  "futures-channel",
  "futures-core",
- "futures-io",
  "futures-util",
  "hex",
  "hkdf",
@@ -4299,14 +4365,14 @@ dependencies = [
  "md-5",
  "memchr",
  "once_cell",
- "rand",
+ "rand 0.8.5",
  "serde",
  "serde_json",
  "sha2",
  "smallvec",
  "sqlx-core",
  "stringprep",
- "thiserror 1.0.69",
+ "thiserror 2.0.12",
  "time",
  "tracing",
  "uuid",
@@ -4315,9 +4381,9 @@ dependencies = [
 
 [[package]]
 name = "sqlx-sqlite"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5b2cf34a45953bfd3daaf3db0f7a7878ab9b7a6b91b422d24a7a9e4c857b680"
+checksum = "f85ca71d3a5b24e64e1d08dd8fe36c6c95c339a896cc33068148906784620540"
 dependencies = [
  "atoi",
  "flume",
@@ -4398,9 +4464,9 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
-version = "2.0.92"
+version = "2.0.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70ae51629bf965c5c098cc9e87908a3df5301051a9e087d6f9bef5c9771ed126"
+checksum = "b09a44accad81e1ba1cd74a32461ba89dee89095ba17b32f5d03683b1b1fc2a0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4471,24 +4537,24 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.14.0"
+version = "3.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28cce251fcbc87fac86a866eeb0d6c2d536fc16d06f184bb61aeae11aa4cee0c"
+checksum = "488960f40a3fd53d72c2a29a58722561dee8afdd175bd88e3db4677d7b2ba600"
 dependencies = [
- "cfg-if",
  "fastrand",
+ "getrandom 0.3.2",
  "once_cell",
- "rustix",
+ "rustix 1.0.3",
  "windows-sys 0.59.0",
 ]
 
 [[package]]
 name = "terminal_size"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5352447f921fda68cf61b4101566c0bdb5104eff6804d0678e5227580ab6a4e9"
+checksum = "45c6481c4829e4cc63825e62c49186a34538b7b2750b73b266581ffb612fb5ed"
 dependencies = [
- "rustix",
+ "rustix 1.0.3",
  "windows-sys 0.59.0",
 ]
 
@@ -4512,11 +4578,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.9"
+version = "2.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f072643fd0190df67a8bab670c20ef5d8737177d6ac6b2e9a236cb096206b2cc"
+checksum = "567b8a2dae586314f7be2a752ec7474332959c6460e02bde30d702a66d488708"
 dependencies = [
- "thiserror-impl 2.0.9",
+ "thiserror-impl 2.0.12",
 ]
 
 [[package]]
@@ -4532,9 +4598,9 @@ dependencies = [
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.9"
+version = "2.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b50fa271071aae2e6ee85f842e2e28ba8cd2c5fb67f11fcb1fd70b276f9e7d4"
+checksum = "7f7cf42b4507d8ea322120659672cf1b9dbb93f8f2d4ecfd6e51350ff5b17a1d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4564,9 +4630,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.37"
+version = "0.3.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35e7868883861bd0e56d9ac6efcaaca0d6d5d82a2a7ec8209ff492c07cf37b21"
+checksum = "9d9c75b47bdff86fa3334a3db91356b8d7d86a9b839dab7d0bdc5c3d3a077618"
 dependencies = [
  "deranged",
  "itoa",
@@ -4581,15 +4647,15 @@ dependencies = [
 
 [[package]]
 name = "time-core"
-version = "0.1.2"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef927ca75afb808a4d64dd374f00a2adf8d0fcff8e7b184af886c3c87ec4a3f3"
+checksum = "c9e9a38711f559d9e3ce1cdb06dd7c5b8ea546bc90052da6d06bb76da74bb07c"
 
 [[package]]
 name = "time-macros"
-version = "0.2.19"
+version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2834e6017e3e5e4b9834939793b282bc03b37a3336245fa820e35e233e2a85de"
+checksum = "29aa485584182073ed57fd5004aa09c371f021325014694e432313345865fd04"
 dependencies = [
  "num-conv",
  "time-core",
@@ -4605,7 +4671,7 @@ dependencies = [
  "hmac",
  "once_cell",
  "pbkdf2",
- "rand",
+ "rand 0.8.5",
  "rustc-hash 1.1.0",
  "sha2",
  "thiserror 1.0.69",
@@ -4626,9 +4692,9 @@ dependencies = [
 
 [[package]]
 name = "tinyvec"
-version = "1.8.1"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "022db8904dfa342efe721985167e9fcd16c29b226db4397ed752a761cfce81e8"
+checksum = "09b3661f17e86524eccd4371ab0429194e0d7c008abb45f7a7495b1719463c71"
 dependencies = [
  "tinyvec_macros",
 ]
@@ -4641,9 +4707,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.42.0"
+version = "1.44.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5cec9b21b0450273377fc97bd4c33a8acffc8c996c987a7c5b319a0083707551"
+checksum = "f382da615b842244d4b8738c82ed1275e6c5dd90c459a30941cd07080b06c91a"
 dependencies = [
  "backtrace",
  "bytes",
@@ -4659,9 +4725,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.4.0"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "693d596312e88961bc67d7f1f97af8a70227d9f90c31bba5806eec004978d752"
+checksum = "6e06d43f1345a3bcd39f6a56dbb7dcab2ba47e68e8ac134855e7e2bdbaf8cab8"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4680,11 +4746,11 @@ dependencies = [
 
 [[package]]
 name = "tokio-rustls"
-version = "0.26.1"
+version = "0.26.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f6d0975eaace0cf0fcadee4e4aaa5da15b5c079146f2cffb67c113be122bf37"
+checksum = "8e727b36a1a0e8b74c376ac2211e40c2c8af09fb4013c60d910495810f008e9b"
 dependencies = [
- "rustls 0.23.20",
+ "rustls 0.23.25",
  "tokio",
 ]
 
@@ -4701,9 +4767,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.13"
+version = "0.7.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7fcaa8d55a2bdd6b83ace262b016eca0d79ee02818c5c1bcdf0305114081078"
+checksum = "6b9590b93e6fcc1739458317cccd391ad3955e2bde8913edf6f95f9e65a8f034"
 dependencies = [
  "bytes",
  "futures-core",
@@ -4735,11 +4801,11 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.22.23"
+version = "0.22.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02a8b472d1a3d7c18e2d61a489aee3453fd9031c33e4f55bd533f4a7adca1bee"
+checksum = "17b4795ff5edd201c7cd6dca065ae59972ce77d1b80fa0a84d94950ece7d1474"
 dependencies = [
- "indexmap 2.7.0",
+ "indexmap 2.8.0",
  "serde",
  "serde_spanned",
  "toml_datetime",
@@ -4757,11 +4823,11 @@ dependencies = [
  "axum",
  "base64 0.22.1",
  "bytes",
- "h2 0.4.7",
- "http 1.2.0",
+ "h2 0.4.8",
+ "http 1.3.1",
  "http-body 1.0.1",
  "http-body-util",
- "hyper 1.5.2",
+ "hyper 1.6.0",
  "hyper-timeout",
  "hyper-util",
  "percent-encoding",
@@ -4812,7 +4878,7 @@ dependencies = [
  "indexmap 1.9.3",
  "pin-project",
  "pin-project-lite",
- "rand",
+ "rand 0.8.5",
  "slab",
  "tokio",
  "tokio-util",
@@ -4843,9 +4909,9 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e9cd434a998747dd2c4276bc96ee2e0c7a2eadf3cae88e52be55a05fa9053f5"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags 2.9.0",
  "bytes",
- "http 1.2.0",
+ "http 1.3.1",
  "http-body 1.0.1",
  "http-body-util",
  "pin-project-lite",
@@ -4948,9 +5014,9 @@ checksum = "aac5e8971f245c3389a5a76e648bfc80803ae066a1243a75db0064d7c1129d63"
 dependencies = [
  "fnv",
  "memchr",
- "nom",
+ "nom 7.1.3",
  "once_cell",
- "petgraph",
+ "petgraph 0.6.5",
 ]
 
 [[package]]
@@ -4981,9 +5047,9 @@ dependencies = [
 
 [[package]]
 name = "typenum"
-version = "1.17.0"
+version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
+checksum = "1dccffe3ce07af9386bfd29e80c0ab1a8205a2fc34e4bcd40364df902cfa8f3f"
 
 [[package]]
 name = "unicode-bidi"
@@ -4993,9 +5059,9 @@ checksum = "5c1cb5db39152898a79168971543b1cb5020dff7fe43c8dc468b0885f5e29df5"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.14"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adb9e6ca4f869e1180728b7950e35922a7fc6397f7b641499e8f3ef06e50dc83"
+checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
 
 [[package]]
 name = "unicode-normalization"
@@ -5024,7 +5090,7 @@ version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b3644627a5af5fa321c95b9b235a72fd24cd29c648c2c379431e6628655627bf"
 dependencies = [
- "itertools",
+ "itertools 0.13.0",
  "unicode-segmentation",
  "unicode-width 0.1.14",
 ]
@@ -5040,12 +5106,6 @@ name = "unicode-width"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fc81956842c57dac11422a97c3b8195a1ff727f06e85c84ed2e8aa277c9a0fd"
-
-[[package]]
-name = "unicode_categories"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39ec24b3121d976906ece63c9daad25b85969647682eee313cb5779fdd69e14e"
 
 [[package]]
 name = "universal-hash"
@@ -5100,19 +5160,19 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.11.0"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8c5f0a0af699448548ad1a2fbf920fb4bee257eae39953ba95cb84891a0446a"
+checksum = "458f7a779bf54acc9f347480ac654f68407d3aab21269a6e3c9f922acd9e2da9"
 dependencies = [
- "getrandom",
+ "getrandom 0.3.2",
  "serde",
 ]
 
 [[package]]
 name = "valuable"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
+checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "vcpkg"
@@ -5142,6 +5202,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
+name = "wasi"
+version = "0.14.2+wasi-0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9683f9a5a998d873c0d21fcbe3c083009670149a8fab228644b8bd36b2c48cb3"
+dependencies = [
+ "wit-bindgen-rt",
+]
+
+[[package]]
 name = "wasite"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5149,20 +5218,21 @@ checksum = "b8dad83b4f25e74f184f64c43b150b91efe7647395b42289f38e50566d82855b"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.99"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a474f6281d1d70c17ae7aa6a613c87fce69a127e2624002df63dcb39d6cf6396"
+checksum = "1edc8929d7499fc4e8f0be2262a241556cfc54a0bea223790e71446f2aab1ef5"
 dependencies = [
  "cfg-if",
  "once_cell",
+ "rustversion",
  "wasm-bindgen-macro",
 ]
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.99"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f89bb38646b4f81674e8f5c3fb81b562be1fd936d84320f3264486418519c79"
+checksum = "2f0a0651a5c2bc21487bde11ee802ccaf4c51935d0d3d42a6101f98161700bc6"
 dependencies = [
  "bumpalo",
  "log",
@@ -5174,9 +5244,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.49"
+version = "0.4.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38176d9b44ea84e9184eff0bc34cc167ed044f816accfe5922e54d84cf48eca2"
+checksum = "555d470ec0bc3bb57890405e5d4322cc9ea83cebb085523ced7be4144dac1e61"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -5187,9 +5257,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.99"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2cc6181fd9a7492eef6fef1f33961e3695e4579b9872a6f7c83aee556666d4fe"
+checksum = "7fe63fc6d09ed3792bd0897b314f53de8e16568c2b3f7982f468c0bf9bd0b407"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -5197,9 +5267,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.99"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30d7a95b763d3c45903ed6c81f156801839e5ee968bb07e534c44df0fcd330c2"
+checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5210,32 +5280,34 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.99"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "943aab3fdaaa029a6e0271b35ea10b72b943135afe9bffca82384098ad0e06a6"
+checksum = "1a05d73b933a847d6cccdda8f838a22ff101ad9bf93e33684f39c1f5f0eece3d"
+dependencies = [
+ "unicode-ident",
+]
 
 [[package]]
 name = "wayland-backend"
-version = "0.3.7"
+version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "056535ced7a150d45159d3a8dc30f91a2e2d588ca0b23f70e56033622b8016f6"
+checksum = "b7208998eaa3870dad37ec8836979581506e0c5c64c20c9e79e9d2a10d6f47bf"
 dependencies = [
  "cc",
  "downcast-rs",
- "rustix",
- "scoped-tls",
+ "rustix 0.38.44",
  "smallvec",
  "wayland-sys",
 ]
 
 [[package]]
 name = "wayland-client"
-version = "0.31.7"
+version = "0.31.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b66249d3fc69f76fd74c82cc319300faa554e9d865dab1f7cd66cc20db10b280"
+checksum = "c2120de3d33638aaef5b9f4472bff75f07c56379cf76ea320bd3a3d65ecaf73f"
 dependencies = [
- "bitflags 2.6.0",
- "rustix",
+ "bitflags 2.9.0",
+ "rustix 0.38.44",
  "wayland-backend",
  "wayland-scanner",
 ]
@@ -5246,7 +5318,7 @@ version = "0.31.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f81f365b8b4a97f422ac0e8737c438024b5951734506b0e1d775c73030561f4"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags 2.9.0",
  "wayland-backend",
  "wayland-client",
  "wayland-scanner",
@@ -5258,7 +5330,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ad1f61b76b6c2d8742e10f9ba5c3737f6530b4c243132c2a2ccc8aa96fe25cd6"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags 2.9.0",
  "wayland-backend",
  "wayland-client",
  "wayland-protocols",
@@ -5267,9 +5339,9 @@ dependencies = [
 
 [[package]]
 name = "wayland-scanner"
-version = "0.31.5"
+version = "0.31.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "597f2001b2e5fc1121e3d5b9791d3e78f05ba6bfa4641053846248e3a13661c3"
+checksum = "896fdafd5d28145fce7958917d69f2fd44469b1d4e861cb5961bcbeebc6d1484"
 dependencies = [
  "proc-macro2",
  "quick-xml",
@@ -5278,20 +5350,18 @@ dependencies = [
 
 [[package]]
 name = "wayland-sys"
-version = "0.31.5"
+version = "0.31.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "efa8ac0d8e8ed3e3b5c9fc92c7881406a268e11555abe36493efabe649a29e09"
+checksum = "dbcebb399c77d5aa9fa5db874806ee7b4eba4e73650948e8f93963f128896615"
 dependencies = [
- "dlib",
- "log",
  "pkg-config",
 ]
 
 [[package]]
 name = "web-sys"
-version = "0.3.76"
+version = "0.3.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04dd7223427d52553d3702c004d3b2fe07c148165faa56313cb00211e31c12bc"
+checksum = "33b6dd2ef9186f1f2072e409e99cd22a975331a6b3591b12c764e0e55c60d5d2"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -5309,9 +5379,9 @@ dependencies = [
 
 [[package]]
 name = "webpki-roots"
-version = "0.26.7"
+version = "0.26.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d642ff16b7e79272ae451b7322067cdc17cadf68c23264be9d94a32319efe7e"
+checksum = "2210b291f7ea53617fbafcc4939f10914214ec15aace5ba62293a668f322c5c9"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -5375,33 +5445,38 @@ dependencies = [
 ]
 
 [[package]]
-name = "windows-registry"
-version = "0.2.0"
+name = "windows-link"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e400001bb720a623c1c69032f8e3e4cf09984deec740f007dd2b03ec864804b0"
+checksum = "76840935b766e1b0a05c0066835fb9ec80071d4c09a16f6bd5f7e655e3c14c38"
+
+[[package]]
+name = "windows-registry"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4286ad90ddb45071efd1a66dfa43eb02dd0dfbae1545ad6cc3c51cf34d7e8ba3"
 dependencies = [
  "windows-result",
  "windows-strings",
- "windows-targets 0.52.6",
+ "windows-targets 0.53.0",
 ]
 
 [[package]]
 name = "windows-result"
-version = "0.2.0"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d1043d8214f791817bab27572aaa8af63732e11bf84aa21a45a78d6c317ae0e"
+checksum = "c64fd11a4fd95df68efcfee5f44a294fe71b8bc6a91993e2791938abcc712252"
 dependencies = [
- "windows-targets 0.52.6",
+ "windows-link",
 ]
 
 [[package]]
 name = "windows-strings"
-version = "0.1.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cd9b125c486025df0eabcb585e62173c6c9eddcec5d117d3b6e8c30e2ee4d10"
+checksum = "87fa48cc5d406560701792be122a10132491cff9d0aeb23583cc2dcafc847319"
 dependencies = [
- "windows-result",
- "windows-targets 0.52.6",
+ "windows-link",
 ]
 
 [[package]]
@@ -5455,11 +5530,27 @@ dependencies = [
  "windows_aarch64_gnullvm 0.52.6",
  "windows_aarch64_msvc 0.52.6",
  "windows_i686_gnu 0.52.6",
- "windows_i686_gnullvm",
+ "windows_i686_gnullvm 0.52.6",
  "windows_i686_msvc 0.52.6",
  "windows_x86_64_gnu 0.52.6",
  "windows_x86_64_gnullvm 0.52.6",
  "windows_x86_64_msvc 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1e4c7e8ceaaf9cb7d7507c974735728ab453b67ef8f18febdd7c11fe59dca8b"
+dependencies = [
+ "windows_aarch64_gnullvm 0.53.0",
+ "windows_aarch64_msvc 0.53.0",
+ "windows_i686_gnu 0.53.0",
+ "windows_i686_gnullvm 0.53.0",
+ "windows_i686_msvc 0.53.0",
+ "windows_x86_64_gnu 0.53.0",
+ "windows_x86_64_gnullvm 0.53.0",
+ "windows_x86_64_msvc 0.53.0",
 ]
 
 [[package]]
@@ -5475,6 +5566,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86b8d5f90ddd19cb4a147a5fa63ca848db3df085e25fee3cc10b39b6eebae764"
+
+[[package]]
 name = "windows_aarch64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5485,6 +5582,12 @@ name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7651a1f62a11b8cbd5e0d42526e55f2c99886c77e007179efff86c2b137e66c"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -5499,10 +5602,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
+name = "windows_i686_gnu"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1dc67659d35f387f5f6c479dc4e28f1d4bb90ddd1a5d3da2e5d97b42d6272c3"
+
+[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ce6ccbdedbf6d6354471319e781c0dfef054c81fbc7cf83f338a4296c0cae11"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -5517,6 +5632,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
+name = "windows_i686_msvc"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "581fee95406bb13382d2f65cd4a908ca7b1e4c2f1917f143ba16efe98a589b5d"
+
+[[package]]
 name = "windows_x86_64_gnu"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5527,6 +5648,12 @@ name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e55b5ac9ea33f2fc1716d1742db15574fd6fc8dadc51caab1c16a3d3b4190ba"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -5541,6 +5668,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a6e035dd0599267ce1ee132e51c27dd29437f63325753051e71dd9e42406c57"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5553,10 +5686,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
-name = "winnow"
-version = "0.7.2"
+name = "windows_x86_64_msvc"
+version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59690dea168f2198d1a3b0cac23b8063efcd11012f10ae4698f284808c8ef603"
+checksum = "271414315aff87387382ec3d271b52d7ae78726f5d44ac98b4f4030c91880486"
+
+[[package]]
+name = "winnow"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e97b544156e9bebe1a0ffbc03484fc1ffe3100cbce3ffb17eac35f7cdd7ab36"
 dependencies = [
  "memchr",
 ]
@@ -5569,6 +5708,15 @@ checksum = "524e57b2c537c0f9b1e69f1965311ec12182b4122e45035b1508cd24d2adadb1"
 dependencies = [
  "cfg-if",
  "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "wit-bindgen-rt"
+version = "0.39.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f42320e61fe2cfd34354ecb597f86f413484a798ba44a8ca1165c58d42da6c1"
+dependencies = [
+ "bitflags 2.9.0",
 ]
 
 [[package]]
@@ -5610,7 +5758,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d91ffca73ee7f68ce055750bf9f6eca0780b8c85eff9bc046a3b0da41755e12"
 dependencies = [
  "gethostname",
- "rustix",
+ "rustix 0.38.44",
  "x11rb-protocol",
 ]
 
@@ -5656,8 +5804,16 @@ version = "0.7.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0"
 dependencies = [
- "byteorder",
- "zerocopy-derive",
+ "zerocopy-derive 0.7.35",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd97444d05a4328b90e75e503a34bad781f14e28a823ad3557f0750df1ebcbc6"
+dependencies = [
+ "zerocopy-derive 0.8.23",
 ]
 
 [[package]]
@@ -5672,19 +5828,30 @@ dependencies = [
 ]
 
 [[package]]
-name = "zerofrom"
-version = "0.1.5"
+name = "zerocopy-derive"
+version = "0.8.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cff3ee08c995dee1859d998dea82f7374f2826091dd9cd47def953cae446cd2e"
+checksum = "6352c01d0edd5db859a63e2605f4ea3183ddbd15e2c4a9e7d32184df75e4f154"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "zerofrom"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50cc42e0333e05660c3587f3bf9d0478688e15d870fab3346451ce7f8c9fbea5"
 dependencies = [
  "zerofrom-derive",
 ]
 
 [[package]]
 name = "zerofrom-derive"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "595eed982f7d355beb85837f651fa22e90b3c044842dc7f2c2842c086f295808"
+checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/crates/atuin-client/Cargo.toml
+++ b/crates/atuin-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "atuin-client"
-edition = "2021"
+edition = "2024"
 description = "client library for atuin"
 
 rust-version = { workspace = true }

--- a/crates/atuin-client/src/api_client.rs
+++ b/crates/atuin-client/src/api_client.rs
@@ -2,12 +2,16 @@ use std::collections::HashMap;
 use std::env;
 use std::time::Duration;
 
-use eyre::{bail, Result};
+use eyre::{Result, bail};
 use reqwest::{
-    header::{HeaderMap, AUTHORIZATION, USER_AGENT},
     Response, StatusCode, Url,
+    header::{AUTHORIZATION, HeaderMap, USER_AGENT},
 };
 
+use atuin_common::{
+    api::{ATUIN_CARGO_VERSION, ATUIN_HEADER_VERSION, ATUIN_VERSION},
+    record::{EncryptedData, HostId, Record, RecordIdx},
+};
 use atuin_common::{
     api::{
         AddHistoryRequest, ChangePasswordRequest, CountResponse, DeleteHistoryRequest,
@@ -17,14 +21,10 @@ use atuin_common::{
     },
     record::RecordStatus,
 };
-use atuin_common::{
-    api::{ATUIN_CARGO_VERSION, ATUIN_HEADER_VERSION, ATUIN_VERSION},
-    record::{EncryptedData, HostId, Record, RecordIdx},
-};
 
 use semver::Version;
-use time::format_description::well_known::Rfc3339;
 use time::OffsetDateTime;
+use time::format_description::well_known::Rfc3339;
 
 use crate::{history::History, sync::hash_str, utils::get_host_user};
 
@@ -126,7 +126,9 @@ pub fn ensure_version(response: &Response) -> Result<bool> {
 
     // If the client is newer than the server
     if version.major < ATUIN_VERSION.major {
-        println!("Atuin version mismatch! In order to successfully sync, the server needs to run a newer version of Atuin");
+        println!(
+            "Atuin version mismatch! In order to successfully sync, the server needs to run a newer version of Atuin"
+        );
         println!("Client: {}", ATUIN_CARGO_VERSION);
         println!("Server: {}", version);
 
@@ -157,10 +159,14 @@ async fn handle_resp_error(resp: Response) -> Result<Response> {
                 bail!("Invalid request to the service: {status} - {reason}.")
             }
 
-            bail!("There was an error with the atuin sync service, server error {status}: {reason}.\nIf the problem persists, contact the host")
+            bail!(
+                "There was an error with the atuin sync service, server error {status}: {reason}.\nIf the problem persists, contact the host"
+            )
         }
 
-        bail!("There was an error with the atuin sync service: Status {status:?}.\nIf the problem persists, contact the host")
+        bail!(
+            "There was an error with the atuin sync service: Status {status:?}.\nIf the problem persists, contact the host"
+        )
     }
 
     Ok(resp)

--- a/crates/atuin-client/src/database.rs
+++ b/crates/atuin-client/src/database.rs
@@ -10,14 +10,14 @@ use async_trait::async_trait;
 use atuin_common::utils;
 use fs_err as fs;
 use itertools::Itertools;
-use rand::{distributions::Alphanumeric, Rng};
-use sql_builder::{bind::Bind, esc, quote, SqlBuilder, SqlName};
+use rand::{Rng, distributions::Alphanumeric};
+use sql_builder::{SqlBuilder, SqlName, bind::Bind, esc, quote};
 use sqlx::{
+    Result, Row,
     sqlite::{
         SqliteConnectOptions, SqliteJournalMode, SqlitePool, SqlitePoolOptions, SqliteRow,
         SqliteSynchronous,
     },
-    Result, Row,
 };
 use time::OffsetDateTime;
 
@@ -55,7 +55,9 @@ pub struct OptFilters {
 
 pub fn current_context() -> Context {
     let Ok(session) = env::var("ATUIN_SESSION") else {
-        eprintln!("ERROR: Failed to find $ATUIN_SESSION in the environment. Check that you have correctly set up your shell.");
+        eprintln!(
+            "ERROR: Failed to find $ATUIN_SESSION in the environment. Check that you have correctly set up your shell."
+        );
         std::process::exit(1);
     };
     let hostname = get_host_user();
@@ -131,7 +133,9 @@ impl Sqlite {
         debug!("opening sqlite database at {:?}", path);
 
         if utils::broken_symlink(path) {
-            eprintln!("Atuin: Sqlite db path ({path:?}) is a broken symlink. Unable to read or create replacement.");
+            eprintln!(
+                "Atuin: Sqlite db path ({path:?}) is a broken symlink. Unable to read or create replacement."
+            );
             std::process::exit(1);
         }
 

--- a/crates/atuin-client/src/encryption.rs
+++ b/crates/atuin-client/src/encryption.rs
@@ -10,17 +10,17 @@
 
 use std::{io::prelude::*, path::PathBuf};
 
-use base64::prelude::{Engine, BASE64_STANDARD};
+use base64::prelude::{BASE64_STANDARD, Engine};
 pub use crypto_secretbox::Key;
 use crypto_secretbox::{
-    aead::{Nonce, OsRng},
     AeadCore, AeadInPlace, KeyInit, XSalsa20Poly1305,
+    aead::{Nonce, OsRng},
 };
-use eyre::{bail, ensure, eyre, Context, Result};
+use eyre::{Context, Result, bail, ensure, eyre};
 use fs_err as fs;
-use rmp::{decode::Bytes, Marker};
+use rmp::{Marker, decode::Bytes};
 use serde::{Deserialize, Serialize};
-use time::{format_description::well_known::Rfc3339, macros::format_description, OffsetDateTime};
+use time::{OffsetDateTime, format_description::well_known::Rfc3339, macros::format_description};
 
 use crate::{history::History, settings::Settings};
 
@@ -265,9 +265,9 @@ fn error_report<E: std::fmt::Debug>(err: E) -> eyre::Report {
 
 #[cfg(test)]
 mod test {
-    use crypto_secretbox::{aead::OsRng, KeyInit, XSalsa20Poly1305};
+    use crypto_secretbox::{KeyInit, XSalsa20Poly1305, aead::OsRng};
     use pretty_assertions::assert_eq;
-    use time::{macros::datetime, OffsetDateTime};
+    use time::{OffsetDateTime, macros::datetime};
 
     use crate::history::History;
 
@@ -392,7 +392,7 @@ mod test {
 
     #[test]
     fn key_encodings() {
-        use super::{decode_key, encode_key, Key};
+        use super::{Key, decode_key, encode_key};
 
         // a history of our key encodings.
         // v11.0.0 xCAbWypb0msJ2Kq+8j4GVEWUlDX7deKnrTRSIopuqXxc5Q==

--- a/crates/atuin-client/src/history.rs
+++ b/crates/atuin-client/src/history.rs
@@ -1,13 +1,13 @@
 use core::fmt::Formatter;
 use rmp::decode::ValueReadError;
-use rmp::{decode::Bytes, Marker};
+use rmp::{Marker, decode::Bytes};
 use std::env;
 use std::fmt::Display;
 
 use atuin_common::record::DecryptedData;
 use atuin_common::utils::uuid_v7;
 
-use eyre::{bail, eyre, Result};
+use eyre::{Result, bail, eyre};
 
 use crate::secrets::SECRET_PATTERNS_RE;
 use crate::settings::Settings;

--- a/crates/atuin-client/src/history/store.rs
+++ b/crates/atuin-client/src/history/store.rs
@@ -246,11 +246,11 @@ impl HistoryStore {
         for id in ids {
             let record = self.store.get(*id).await;
 
-            let record = if let Ok(record) = record {
+            let record = match record { Ok(record) => {
                 record
-            } else {
+            } _ => {
                 continue;
-            };
+            }};
 
             if record.tag != HISTORY_TAG {
                 continue;

--- a/crates/atuin-client/src/history/store.rs
+++ b/crates/atuin-client/src/history/store.rs
@@ -1,16 +1,16 @@
 use std::{collections::HashSet, fmt::Write, time::Duration};
 
-use eyre::{bail, eyre, Result};
+use eyre::{Result, bail, eyre};
 use indicatif::{ProgressBar, ProgressState, ProgressStyle};
 use rmp::decode::Bytes;
 
 use crate::{
-    database::{current_context, Database},
+    database::{Database, current_context},
     record::{encryption::PASETO_V4, sqlite_store::SqliteStore, store::Store},
 };
 use atuin_common::record::{DecryptedData, Host, HostId, Record, RecordId, RecordIdx};
 
-use super::{History, HistoryId, HISTORY_TAG, HISTORY_VERSION};
+use super::{HISTORY_TAG, HISTORY_VERSION, History, HistoryId};
 
 #[derive(Debug, Clone)]
 pub struct HistoryStore {
@@ -246,11 +246,12 @@ impl HistoryStore {
         for id in ids {
             let record = self.store.get(*id).await;
 
-            let record = match record { Ok(record) => {
-                record
-            } _ => {
-                continue;
-            }};
+            let record = match record {
+                Ok(record) => record,
+                _ => {
+                    continue;
+                }
+            };
 
             if record.tag != HISTORY_TAG {
                 continue;
@@ -342,7 +343,7 @@ mod tests {
     use atuin_common::record::DecryptedData;
     use time::macros::datetime;
 
-    use crate::history::{store::HistoryRecord, HISTORY_VERSION};
+    use crate::history::{HISTORY_VERSION, store::HistoryRecord};
 
     use super::History;
 

--- a/crates/atuin-client/src/import/bash.rs
+++ b/crates/atuin-client/src/import/bash.rs
@@ -2,11 +2,11 @@ use std::{path::PathBuf, str};
 
 use async_trait::async_trait;
 use directories::UserDirs;
-use eyre::{eyre, Result};
+use eyre::{Result, eyre};
 use itertools::Itertools;
 use time::{Duration, OffsetDateTime};
 
-use super::{get_histpath, unix_byte_lines, Importer, Loader};
+use super::{Importer, Loader, get_histpath, unix_byte_lines};
 use crate::history::History;
 use crate::import::read_to_end;
 
@@ -73,7 +73,9 @@ impl Importer for Bash {
                 LineType::Empty => {}                // do nothing
                 LineType::Timestamp(t) => {
                     if t < next_timestamp {
-                        warn!("Time reversal detected in Bash history! Commands may be ordered incorrectly.");
+                        warn!(
+                            "Time reversal detected in Bash history! Commands may be ordered incorrectly."
+                        );
                     }
                     next_timestamp = t;
                 }
@@ -126,9 +128,9 @@ fn try_parse_line_as_timestamp(line: &str) -> Option<OffsetDateTime> {
 mod test {
     use std::cmp::Ordering;
 
-    use itertools::{assert_equal, Itertools};
+    use itertools::{Itertools, assert_equal};
 
-    use crate::import::{tests::TestLoader, Importer};
+    use crate::import::{Importer, tests::TestLoader};
 
     use super::Bash;
 

--- a/crates/atuin-client/src/import/fish.rs
+++ b/crates/atuin-client/src/import/fish.rs
@@ -5,10 +5,10 @@ use std::path::PathBuf;
 
 use async_trait::async_trait;
 use directories::BaseDirs;
-use eyre::{eyre, Result};
+use eyre::{Result, eyre};
 use time::OffsetDateTime;
 
-use super::{unix_byte_lines, Importer, Loader};
+use super::{Importer, Loader, unix_byte_lines};
 use crate::history::History;
 use crate::import::read_to_end;
 
@@ -110,7 +110,7 @@ impl Importer for Fish {
 #[cfg(test)]
 mod test {
 
-    use crate::import::{tests::TestLoader, Importer};
+    use crate::import::{Importer, tests::TestLoader};
 
     use super::Fish;
 

--- a/crates/atuin-client/src/import/fish.rs
+++ b/crates/atuin-client/src/import/fish.rs
@@ -160,7 +160,7 @@ ERROR
 
         // simple wrapper for fish history entry
         macro_rules! fishtory {
-            ($timestamp:expr, $command:expr) => {
+            ($timestamp:expr_2021, $command:expr_2021) => {
                 let h = history.next().expect("missing entry in history");
                 assert_eq!(h.command.as_str(), $command);
                 assert_eq!(h.timestamp.unix_timestamp(), $timestamp);

--- a/crates/atuin-client/src/import/mod.rs
+++ b/crates/atuin-client/src/import/mod.rs
@@ -3,7 +3,7 @@ use std::io::Read;
 use std::path::PathBuf;
 
 use async_trait::async_trait;
-use eyre::{bail, Result};
+use eyre::{Result, bail};
 use memchr::Memchr;
 
 use crate::history::History;

--- a/crates/atuin-client/src/import/nu.rs
+++ b/crates/atuin-client/src/import/nu.rs
@@ -5,10 +5,10 @@ use std::path::PathBuf;
 
 use async_trait::async_trait;
 use directories::BaseDirs;
-use eyre::{eyre, Result};
+use eyre::{Result, eyre};
 use time::OffsetDateTime;
 
-use super::{unix_byte_lines, Importer, Loader};
+use super::{Importer, Loader, unix_byte_lines};
 use crate::history::History;
 use crate::import::read_to_end;
 

--- a/crates/atuin-client/src/import/nu_histdb.rs
+++ b/crates/atuin-client/src/import/nu_histdb.rs
@@ -5,8 +5,8 @@ use std::path::PathBuf;
 
 use async_trait::async_trait;
 use directories::BaseDirs;
-use eyre::{eyre, Result};
-use sqlx::{sqlite::SqlitePool, Pool};
+use eyre::{Result, eyre};
+use sqlx::{Pool, sqlite::SqlitePool};
 use time::{Duration, OffsetDateTime};
 
 use super::Importer;

--- a/crates/atuin-client/src/import/replxx.rs
+++ b/crates/atuin-client/src/import/replxx.rs
@@ -100,7 +100,7 @@ CREATE TABLE test( stamp DateTime('UTC'))ENGINE = MergeTreePARTITION BY toDat
 
         // simple wrapper for replxx history entry
         macro_rules! history {
-            ($timestamp:expr, $command:expr) => {
+            ($timestamp:expr_2021, $command:expr_2021) => {
                 let h = history.next().expect("missing entry in history");
                 assert_eq!(h.command.as_str(), $command);
                 assert_eq!(h.timestamp.unix_timestamp(), $timestamp);

--- a/crates/atuin-client/src/import/replxx.rs
+++ b/crates/atuin-client/src/import/replxx.rs
@@ -2,10 +2,10 @@ use std::{path::PathBuf, str};
 
 use async_trait::async_trait;
 use directories::UserDirs;
-use eyre::{eyre, Result};
-use time::{macros::format_description, OffsetDateTime, PrimitiveDateTime};
+use eyre::{Result, eyre};
+use time::{OffsetDateTime, PrimitiveDateTime, macros::format_description};
 
-use super::{get_histpath, unix_byte_lines, Importer, Loader};
+use super::{Importer, Loader, get_histpath, unix_byte_lines};
 use crate::history::History;
 use crate::import::read_to_end;
 
@@ -72,7 +72,7 @@ fn try_parse_line_as_timestamp(line: &str) -> Option<OffsetDateTime> {
 #[cfg(test)]
 mod test {
 
-    use crate::import::{tests::TestLoader, Importer};
+    use crate::import::{Importer, tests::TestLoader};
 
     use super::Replxx;
 
@@ -114,6 +114,9 @@ CREATE TABLE test( stamp DateTime('UTC'))ENGINE = MergeTreePARTITION BY toDat
         history!(1707603396, "select * from numbers(10)");
         history!(1707603401, "select * from system.numbers");
         history!(1707603568, "select 1");
-        history!(1708600533, "CREATE TABLE test\n( stamp DateTime('UTC'))\nENGINE = MergeTree\nPARTITION BY toDate(stamp)\norder by tuple() as select toDateTime('2020-01-01')+number*60 from numbers(80000);");
+        history!(
+            1708600533,
+            "CREATE TABLE test\n( stamp DateTime('UTC'))\nENGINE = MergeTree\nPARTITION BY toDate(stamp)\norder by tuple() as select toDateTime('2020-01-01')+number*60 from numbers(80000);"
+        );
     }
 }

--- a/crates/atuin-client/src/import/resh.rs
+++ b/crates/atuin-client/src/import/resh.rs
@@ -2,13 +2,13 @@ use std::path::PathBuf;
 
 use async_trait::async_trait;
 use directories::UserDirs;
-use eyre::{eyre, Result};
+use eyre::{Result, eyre};
 use serde::Deserialize;
 
 use atuin_common::utils::uuid_v7;
 use time::OffsetDateTime;
 
-use super::{get_histpath, unix_byte_lines, Importer, Loader};
+use super::{Importer, Loader, get_histpath, unix_byte_lines};
 use crate::history::History;
 use crate::import::read_to_end;
 

--- a/crates/atuin-client/src/import/xonsh.rs
+++ b/crates/atuin-client/src/import/xonsh.rs
@@ -4,13 +4,13 @@ use std::path::{Path, PathBuf};
 
 use async_trait::async_trait;
 use directories::BaseDirs;
-use eyre::{eyre, Result};
+use eyre::{Result, eyre};
 use serde::Deserialize;
 use time::OffsetDateTime;
-use uuid::timestamp::{context::NoContext, Timestamp};
 use uuid::Uuid;
+use uuid::timestamp::{Timestamp, context::NoContext};
 
-use super::{get_histpath, Importer, Loader};
+use super::{Importer, Loader, get_histpath};
 use crate::history::History;
 use crate::utils::get_host_user;
 

--- a/crates/atuin-client/src/import/xonsh_sqlite.rs
+++ b/crates/atuin-client/src/import/xonsh_sqlite.rs
@@ -3,14 +3,14 @@ use std::path::PathBuf;
 
 use async_trait::async_trait;
 use directories::BaseDirs;
-use eyre::{eyre, Result};
+use eyre::{Result, eyre};
 use futures::TryStreamExt;
-use sqlx::{sqlite::SqlitePool, FromRow, Row};
+use sqlx::{FromRow, Row, sqlite::SqlitePool};
 use time::OffsetDateTime;
-use uuid::timestamp::{context::NoContext, Timestamp};
 use uuid::Uuid;
+use uuid::timestamp::{Timestamp, context::NoContext};
 
-use super::{get_histpath, Importer, Loader};
+use super::{Importer, Loader, get_histpath};
 use crate::history::History;
 use crate::utils::get_host_user;
 

--- a/crates/atuin-client/src/import/zsh.rs
+++ b/crates/atuin-client/src/import/zsh.rs
@@ -6,10 +6,10 @@ use std::path::PathBuf;
 
 use async_trait::async_trait;
 use directories::UserDirs;
-use eyre::{eyre, Result};
+use eyre::{Result, eyre};
 use time::OffsetDateTime;
 
-use super::{get_histpath, unix_byte_lines, Importer, Loader};
+use super::{Importer, Loader, get_histpath, unix_byte_lines};
 use crate::history::History;
 use crate::import::read_to_end;
 
@@ -38,7 +38,7 @@ fn default_histpath() -> Result<PathBuf> {
             None => {
                 break Err(eyre!(
                     "Could not find history file. Try setting and exporting $HISTFILE"
-                ))
+                ));
             }
         }
     }

--- a/crates/atuin-client/src/import/zsh_histdb.rs
+++ b/crates/atuin-client/src/import/zsh_histdb.rs
@@ -181,7 +181,8 @@ mod test {
     async fn test_env_vars() {
         let test_env_db = "nonstd-zsh-history.db";
         let key = "HISTDB_FILE";
-        env::set_var(key, test_env_db);
+        // TODO: Audit that the environment access only happens in single-threaded code.
+        unsafe { env::set_var(key, test_env_db) };
 
         // test the env got set
         assert_eq!(env::var(key).unwrap(), test_env_db.to_string());

--- a/crates/atuin-client/src/import/zsh_histdb.rs
+++ b/crates/atuin-client/src/import/zsh_histdb.rs
@@ -38,8 +38,8 @@ use std::path::{Path, PathBuf};
 use async_trait::async_trait;
 use atuin_common::utils::uuid_v7;
 use directories::UserDirs;
-use eyre::{eyre, Result};
-use sqlx::{sqlite::SqlitePool, Pool};
+use eyre::{Result, eyre};
+use sqlx::{Pool, sqlite::SqlitePool};
 use time::PrimitiveDateTime;
 
 use super::Importer;
@@ -178,7 +178,6 @@ mod test {
     use sqlx::sqlite::SqlitePoolOptions;
     use std::env;
     #[tokio::test(flavor = "multi_thread")]
-
     #[allow(unsafe_code)]
     async fn test_env_vars() {
         let test_env_db = "nonstd-zsh-history.db";

--- a/crates/atuin-client/src/import/zsh_histdb.rs
+++ b/crates/atuin-client/src/import/zsh_histdb.rs
@@ -178,6 +178,8 @@ mod test {
     use sqlx::sqlite::SqlitePoolOptions;
     use std::env;
     #[tokio::test(flavor = "multi_thread")]
+
+    #[allow(unsafe_code)]
     async fn test_env_vars() {
         let test_env_db = "nonstd-zsh-history.db";
         let key = "HISTDB_FILE";

--- a/crates/atuin-client/src/kv.rs
+++ b/crates/atuin-client/src/kv.rs
@@ -1,7 +1,7 @@
 use std::collections::BTreeMap;
 
 use atuin_common::record::{DecryptedData, Host, HostId};
-use eyre::{bail, ensure, eyre, Result};
+use eyre::{Result, bail, ensure, eyre};
 use serde::Deserialize;
 
 use crate::record::encryption::PASETO_V4;
@@ -200,7 +200,7 @@ mod tests {
     use crate::record::sqlite_store::SqliteStore;
     use crate::settings::test_local_timeout;
 
-    use super::{KvRecord, KvStore, KV_VERSION};
+    use super::{KV_VERSION, KvRecord, KvStore};
 
     #[test]
     fn encode_decode() {

--- a/crates/atuin-client/src/lib.rs
+++ b/crates/atuin-client/src/lib.rs
@@ -1,4 +1,4 @@
-#![forbid(unsafe_code)]
+#![deny(unsafe_code)]
 
 #[macro_use]
 extern crate log;

--- a/crates/atuin-client/src/login.rs
+++ b/crates/atuin-client/src/login.rs
@@ -23,7 +23,7 @@ pub async fn login(
     let key = match bip39::Mnemonic::from_phrase(&key, bip39::Language::English) {
         Ok(mnemonic) => encode_key(Key::from_slice(mnemonic.entropy()))?,
         Err(err) => {
-            if let Some(err) = err.downcast_ref::<bip39::ErrorKind>() {
+            match err.downcast_ref::<bip39::ErrorKind>() { Some(err) => {
                 match err {
                     // assume they copied in the base64 key
                     bip39::ErrorKind::InvalidWord => key,
@@ -36,10 +36,10 @@ pub async fn login(
                         bail!("key was not the correct length")
                     }
                 }
-            } else {
+            } _ => {
                 // unknown error. assume they copied the base64 key
                 key
-            }
+            }}
         }
     };
 

--- a/crates/atuin-client/src/login.rs
+++ b/crates/atuin-client/src/login.rs
@@ -1,13 +1,13 @@
 use std::path::PathBuf;
 
 use atuin_common::api::LoginRequest;
-use eyre::{bail, Context, Result};
+use eyre::{Context, Result, bail};
 use tokio::fs::File;
 use tokio::io::AsyncWriteExt;
 
 use crate::{
     api_client,
-    encryption::{decode_key, encode_key, load_key, Key},
+    encryption::{Key, decode_key, encode_key, load_key},
     record::{sqlite_store::SqliteStore, store::Store},
     settings::Settings,
 };
@@ -23,23 +23,26 @@ pub async fn login(
     let key = match bip39::Mnemonic::from_phrase(&key, bip39::Language::English) {
         Ok(mnemonic) => encode_key(Key::from_slice(mnemonic.entropy()))?,
         Err(err) => {
-            match err.downcast_ref::<bip39::ErrorKind>() { Some(err) => {
-                match err {
-                    // assume they copied in the base64 key
-                    bip39::ErrorKind::InvalidWord => key,
-                    bip39::ErrorKind::InvalidChecksum => {
-                        bail!("key mnemonic was not valid")
-                    }
-                    bip39::ErrorKind::InvalidKeysize(_)
-                    | bip39::ErrorKind::InvalidWordLength(_)
-                    | bip39::ErrorKind::InvalidEntropyLength(_, _) => {
-                        bail!("key was not the correct length")
+            match err.downcast_ref::<bip39::ErrorKind>() {
+                Some(err) => {
+                    match err {
+                        // assume they copied in the base64 key
+                        bip39::ErrorKind::InvalidWord => key,
+                        bip39::ErrorKind::InvalidChecksum => {
+                            bail!("key mnemonic was not valid")
+                        }
+                        bip39::ErrorKind::InvalidKeysize(_)
+                        | bip39::ErrorKind::InvalidWordLength(_)
+                        | bip39::ErrorKind::InvalidEntropyLength(_, _) => {
+                            bail!("key was not the correct length")
+                        }
                     }
                 }
-            } _ => {
-                // unknown error. assume they copied the base64 key
-                key
-            }}
+                _ => {
+                    // unknown error. assume they copied the base64 key
+                    key
+                }
+            }
         }
     };
 

--- a/crates/atuin-client/src/record/encryption.rs
+++ b/crates/atuin-client/src/record/encryption.rs
@@ -1,8 +1,8 @@
 use atuin_common::record::{
     AdditionalData, DecryptedData, EncryptedData, Encryption, HostId, RecordId, RecordIdx,
 };
-use base64::{engine::general_purpose, Engine};
-use eyre::{ensure, Context, Result};
+use base64::{Engine, engine::general_purpose};
+use eyre::{Context, Result, ensure};
 use rusty_paserk::{Key, KeyId, Local, PieWrappedKey};
 use rusty_paseto::core::{
     ImplicitAssertion, Key as DataKey, Local as LocalPurpose, Paseto, PasetoNonce, Payload, V4,

--- a/crates/atuin-client/src/record/sqlite_store.rs
+++ b/crates/atuin-client/src/record/sqlite_store.rs
@@ -6,12 +6,12 @@ use std::str::FromStr;
 use std::{path::Path, time::Duration};
 
 use async_trait::async_trait;
-use eyre::{eyre, Result};
+use eyre::{Result, eyre};
 use fs_err as fs;
 
 use sqlx::{
-    sqlite::{SqliteConnectOptions, SqliteJournalMode, SqlitePool, SqlitePoolOptions, SqliteRow},
     Row,
+    sqlite::{SqliteConnectOptions, SqliteJournalMode, SqlitePool, SqlitePoolOptions, SqliteRow},
 };
 
 use atuin_common::record::{
@@ -35,7 +35,9 @@ impl SqliteStore {
         debug!("opening sqlite database at {:?}", path);
 
         if utils::broken_symlink(path) {
-            eprintln!("Atuin: Sqlite db path ({path:?}) is a broken symlink. Unable to read or create replacement.");
+            eprintln!(
+                "Atuin: Sqlite db path ({path:?}) is a broken symlink. Unable to read or create replacement."
+            );
             std::process::exit(1);
         }
 

--- a/crates/atuin-client/src/record/sync.rs
+++ b/crates/atuin-client/src/record/sync.rs
@@ -133,7 +133,7 @@ pub async fn operations(
                     msg: String::from(
                         "diff has nothing for local or remote - (host, tag) does not exist",
                     ),
-                })
+                });
             }
         };
 

--- a/crates/atuin-client/src/secrets.rs
+++ b/crates/atuin-client/src/secrets.rs
@@ -38,7 +38,9 @@ pub static SECRET_PATTERNS: &[(&str, &str, TestValue)] = &[
     (
         "Atuin login",
         r"atuin\s+login",
-        TestValue::Single("atuin login -u mycoolusername -p mycoolpassword -k \"lots of random words\""),
+        TestValue::Single(
+            "atuin login -u mycoolusername -p mycoolpassword -k \"lots of random words\"",
+        ),
     ),
     (
         "GitHub PAT (old)",
@@ -51,32 +53,34 @@ pub static SECRET_PATTERNS: &[(&str, &str, TestValue)] = &[
         TestValue::Multiple(&[
             "gh1_1234567890abcdefghijk_1234567890abcdefghijklmnopqrstuvwxyz1234567890abcdefghijklm",
             "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", // also legit, also expired
-        ])
+        ]),
     ),
     (
         "GitHub OAuth Access Token",
         "gho_[A-Za-z0-9]{36}",
-        TestValue::Single("gho_1234567890abcdefghijklmnopqrstuvwx000"),  // not a real token
+        TestValue::Single("gho_1234567890abcdefghijklmnopqrstuvwx000"), // not a real token
     ),
     (
         "GitHub OAuth Access Token (user)",
         "ghu_[A-Za-z0-9]{36}",
-        TestValue::Single("ghu_1234567890abcdefghijklmnopqrstuvwx000"),  // not a real token
+        TestValue::Single("ghu_1234567890abcdefghijklmnopqrstuvwx000"), // not a real token
     ),
     (
         "GitHub App Installation Access Token",
         "ghs_[A-Za-z0-9]{36}",
-        TestValue::Single("ghs_1234567890abcdefghijklmnopqrstuvwx000"),  // not a real token
+        TestValue::Single("ghs_1234567890abcdefghijklmnopqrstuvwx000"), // not a real token
     ),
     (
         "GitHub Refresh Token",
         "ghr_[A-Za-z0-9]{76}",
-        TestValue::Single("ghr_1234567890abcdefghijklmnopqrstuvwx1234567890abcdefghijklmnopqrstuvwx1234567890abcdefghijklmnopqrstuvwx"),  // not a real token
+        TestValue::Single(
+            "ghr_1234567890abcdefghijklmnopqrstuvwx1234567890abcdefghijklmnopqrstuvwx1234567890abcdefghijklmnopqrstuvwx",
+        ), // not a real token
     ),
     (
         "GitHub App Installation Access Token v1",
         "v1\\.[0-9A-Fa-f]{40}",
-        TestValue::Single("v1.1234567890abcdef1234567890abcdef12345678"),  // not a real token
+        TestValue::Single("v1.1234567890abcdef1234567890abcdef12345678"), // not a real token
     ),
     (
         "GitLab PAT",
@@ -96,10 +100,20 @@ pub static SECRET_PATTERNS: &[(&str, &str, TestValue)] = &[
     (
         "Slack webhook",
         "T[a-zA-Z0-9_]{8}/B[a-zA-Z0-9_]{8}/[a-zA-Z0-9_]{24}",
-        TestValue::Single("https://hooks.slack.com/services/T00000000/B00000000/XXXXXXXXXXXXXXXXXXXXXXXX"),
+        TestValue::Single(
+            "https://hooks.slack.com/services/T00000000/B00000000/XXXXXXXXXXXXXXXXXXXXXXXX",
+        ),
     ),
-    ("Stripe test key", "sk_test_[0-9a-zA-Z]{24}", TestValue::Single("sk_test_1234567890abcdefghijklmnop")),
-    ("Stripe live key", "sk_live_[0-9a-zA-Z]{24}", TestValue::Single("sk_live_1234567890abcdefghijklmnop")),
+    (
+        "Stripe test key",
+        "sk_test_[0-9a-zA-Z]{24}",
+        TestValue::Single("sk_test_1234567890abcdefghijklmnop"),
+    ),
+    (
+        "Stripe live key",
+        "sk_live_[0-9a-zA-Z]{24}",
+        TestValue::Single("sk_live_1234567890abcdefghijklmnop"),
+    ),
     (
         "Netlify authentication token",
         "nf[pcoub]_[0-9a-zA-Z]{36}",
@@ -127,7 +141,7 @@ pub static SECRET_PATTERNS_RE: LazyLock<RegexSet> = LazyLock::new(|| {
 mod tests {
     use regex::Regex;
 
-    use crate::secrets::{TestValue, SECRET_PATTERNS};
+    use crate::secrets::{SECRET_PATTERNS, TestValue};
 
     #[test]
     fn test_secrets() {

--- a/crates/atuin-client/src/settings.rs
+++ b/crates/atuin-client/src/settings.rs
@@ -6,19 +6,19 @@ use atuin_common::record::HostId;
 use atuin_common::utils;
 use clap::ValueEnum;
 use config::{
-    builder::DefaultState, Config, ConfigBuilder, Environment, File as ConfigFile, FileFormat,
+    Config, ConfigBuilder, Environment, File as ConfigFile, FileFormat, builder::DefaultState,
 };
-use eyre::{bail, eyre, Context, Error, Result};
-use fs_err::{create_dir_all, File};
+use eyre::{Context, Error, Result, bail, eyre};
+use fs_err::{File, create_dir_all};
 use humantime::parse_duration;
 use regex::RegexSet;
 use semver::Version;
 use serde::{Deserialize, Serialize};
 use serde_with::DeserializeFromStr;
 use time::{
-    format_description::{well_known::Rfc3339, FormatItem},
-    macros::format_description,
     OffsetDateTime, UtcOffset,
+    format_description::{FormatItem, well_known::Rfc3339},
+    macros::format_description,
 };
 use uuid::Uuid;
 
@@ -141,8 +141,9 @@ impl fmt::Display for Timezone {
     }
 }
 /// format: <+|-><hour>[:<minute>[:<second>]]
-static OFFSET_FMT: &[FormatItem<'_>] =
-    format_description!("[offset_hour sign:mandatory padding:none][optional [:[offset_minute padding:none][optional [:[offset_second padding:none]]]]]");
+static OFFSET_FMT: &[FormatItem<'_>] = format_description!(
+    "[offset_hour sign:mandatory padding:none][optional [:[offset_minute padding:none][optional [:[offset_second padding:none]]]]]"
+);
 impl FromStr for Timezone {
     type Err = Error;
 

--- a/crates/atuin-client/src/sync.rs
+++ b/crates/atuin-client/src/sync.rs
@@ -109,14 +109,17 @@ async fn sync_download(
     for i in remote_status.deleted {
         // we will update the stored history to have this data
         // pretty much everything can be nullified
-        match db.load(i.as_str()).await? { Some(h) => {
-            db.delete(h).await?;
-        } _ => {
-            info!(
-                "could not delete history with id {}, not found locally",
-                i.as_str()
-            );
-        }}
+        match db.load(i.as_str()).await? {
+            Some(h) => {
+                db.delete(h).await?;
+            }
+            _ => {
+                info!(
+                    "could not delete history with id {}, not found locally",
+                    i.as_str()
+                );
+            }
+        }
     }
 
     Ok((local_count - initial_local, local_count))

--- a/crates/atuin-client/src/sync.rs
+++ b/crates/atuin-client/src/sync.rs
@@ -109,14 +109,14 @@ async fn sync_download(
     for i in remote_status.deleted {
         // we will update the stored history to have this data
         // pretty much everything can be nullified
-        if let Some(h) = db.load(i.as_str()).await? {
+        match db.load(i.as_str()).await? { Some(h) => {
             db.delete(h).await?;
-        } else {
+        } _ => {
             info!(
                 "could not delete history with id {}, not found locally",
                 i.as_str()
             );
-        }
+        }}
     }
 
     Ok((local_count - initial_local, local_count))

--- a/crates/atuin-client/src/theme.rs
+++ b/crates/atuin-client/src/theme.rs
@@ -416,7 +416,7 @@ impl ThemeManager {
                             "set theme debug on for more info".to_string()
                         }
                     ),
-                )))
+                )));
             }
         };
         let colors: HashMap<Meaning, String> = theme_config.colors;
@@ -697,7 +697,8 @@ mod theme_tests {
 
         testing_logger::validate(|captured_logs| {
             assert_eq!(captured_logs.len(), 1);
-            assert_eq!(captured_logs[0].body,
+            assert_eq!(
+                captured_logs[0].body,
                 "Could not load theme nonsolarized: Empty theme directory override and could not find theme elsewhere"
             );
             assert_eq!(captured_logs[0].level, log::Level::Warn)

--- a/crates/atuin-common/Cargo.toml
+++ b/crates/atuin-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "atuin-common"
-edition = "2021"
+edition = "2024"
 description = "common library for atuin"
 
 rust-version = { workspace = true }

--- a/crates/atuin-common/src/lib.rs
+++ b/crates/atuin-common/src/lib.rs
@@ -1,4 +1,4 @@
-#![forbid(unsafe_code)]
+#![deny(unsafe_code)]
 
 /// Defines a new UUID type wrapper
 macro_rules! new_uuid {

--- a/crates/atuin-common/src/shell.rs
+++ b/crates/atuin-common/src/shell.rs
@@ -1,7 +1,7 @@
 use std::{ffi::OsStr, path::Path, process::Command};
 
 use serde::Serialize;
-use sysinfo::{get_current_pid, Process, System};
+use sysinfo::{Process, System, get_current_pid};
 use thiserror::Error;
 
 #[derive(PartialEq)]

--- a/crates/atuin-common/src/utils.rs
+++ b/crates/atuin-common/src/utils.rs
@@ -214,36 +214,48 @@ mod tests {
     }
 
     fn test_config_dir_xdg() {
-        env::remove_var("HOME");
-        env::set_var("XDG_CONFIG_HOME", "/home/user/custom_config");
+        // TODO: Audit that the environment access only happens in single-threaded code.
+        unsafe { env::remove_var("HOME") };
+        // TODO: Audit that the environment access only happens in single-threaded code.
+        unsafe { env::set_var("XDG_CONFIG_HOME", "/home/user/custom_config") };
         assert_eq!(
             config_dir(),
             PathBuf::from("/home/user/custom_config/atuin")
         );
-        env::remove_var("XDG_CONFIG_HOME");
+        // TODO: Audit that the environment access only happens in single-threaded code.
+        unsafe { env::remove_var("XDG_CONFIG_HOME") };
     }
 
     fn test_config_dir() {
-        env::set_var("HOME", "/home/user");
-        env::remove_var("XDG_CONFIG_HOME");
+        // TODO: Audit that the environment access only happens in single-threaded code.
+        unsafe { env::set_var("HOME", "/home/user") };
+        // TODO: Audit that the environment access only happens in single-threaded code.
+        unsafe { env::remove_var("XDG_CONFIG_HOME") };
 
         assert_eq!(config_dir(), PathBuf::from("/home/user/.config/atuin"));
 
-        env::remove_var("HOME");
+        // TODO: Audit that the environment access only happens in single-threaded code.
+        unsafe { env::remove_var("HOME") };
     }
 
     fn test_data_dir_xdg() {
-        env::remove_var("HOME");
-        env::set_var("XDG_DATA_HOME", "/home/user/custom_data");
+        // TODO: Audit that the environment access only happens in single-threaded code.
+        unsafe { env::remove_var("HOME") };
+        // TODO: Audit that the environment access only happens in single-threaded code.
+        unsafe { env::set_var("XDG_DATA_HOME", "/home/user/custom_data") };
         assert_eq!(data_dir(), PathBuf::from("/home/user/custom_data/atuin"));
-        env::remove_var("XDG_DATA_HOME");
+        // TODO: Audit that the environment access only happens in single-threaded code.
+        unsafe { env::remove_var("XDG_DATA_HOME") };
     }
 
     fn test_data_dir() {
-        env::set_var("HOME", "/home/user");
-        env::remove_var("XDG_DATA_HOME");
+        // TODO: Audit that the environment access only happens in single-threaded code.
+        unsafe { env::set_var("HOME", "/home/user") };
+        // TODO: Audit that the environment access only happens in single-threaded code.
+        unsafe { env::remove_var("XDG_DATA_HOME") };
         assert_eq!(data_dir(), PathBuf::from("/home/user/.local/share/atuin"));
-        env::remove_var("HOME");
+        // TODO: Audit that the environment access only happens in single-threaded code.
+        unsafe { env::remove_var("HOME") };
     }
 
     #[test]

--- a/crates/atuin-common/src/utils.rs
+++ b/crates/atuin-common/src/utils.rs
@@ -2,9 +2,9 @@ use std::borrow::Cow;
 use std::env;
 use std::path::PathBuf;
 
-use eyre::{eyre, Result};
+use eyre::{Result, eyre};
 
-use base64::prelude::{Engine, BASE64_URL_SAFE_NO_PAD};
+use base64::prelude::{BASE64_URL_SAFE_NO_PAD, Engine};
 use getrandom::getrandom;
 use uuid::Uuid;
 

--- a/crates/atuin-common/src/utils.rs
+++ b/crates/atuin-common/src/utils.rs
@@ -194,6 +194,7 @@ pub fn unquote(s: &str) -> Result<String> {
 
 impl<T: AsRef<str>> Escapable for T {}
 
+#[allow(unsafe_code)]
 #[cfg(test)]
 mod tests {
     use pretty_assertions::assert_ne;

--- a/crates/atuin-daemon/Cargo.toml
+++ b/crates/atuin-daemon/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "atuin-daemon"
-edition = "2021"
+edition = "2024"
 version = { workspace = true }
 description = "The daemon crate for Atuin"
 

--- a/crates/atuin-daemon/src/client.rs
+++ b/crates/atuin-daemon/src/client.rs
@@ -12,7 +12,7 @@ use tokio::net::UnixStream;
 use atuin_client::history::History;
 
 use crate::history::{
-    history_client::HistoryClient as HistoryServiceClient, EndHistoryRequest, StartHistoryRequest,
+    EndHistoryRequest, StartHistoryRequest, history_client::HistoryClient as HistoryServiceClient,
 };
 
 pub struct HistoryClient {

--- a/crates/atuin-daemon/src/server.rs
+++ b/crates/atuin-daemon/src/server.rs
@@ -7,13 +7,13 @@ use atuin_client::settings::Settings;
 use std::path::PathBuf;
 use std::sync::Arc;
 use time::OffsetDateTime;
-use tracing::{instrument, Level};
+use tracing::{Level, instrument};
 
 use atuin_client::database::{Database, Sqlite as HistoryDatabase};
 use atuin_client::history::{History, HistoryId};
 use dashmap::DashMap;
 use eyre::Result;
-use tonic::{transport::Server, Request, Response, Status};
+use tonic::{Request, Response, Status, transport::Server};
 
 use crate::history::history_server::{History as HistorySvc, HistoryServer};
 
@@ -194,7 +194,9 @@ async fn start_server(settings: Settings, history: HistoryService) -> Result<()>
                     }
                 }
                 Err(err) => {
-                    tracing::warn!("could not detect systemd socket path, ensure that it's at the configured path: {socket_path:?}, error: {err:?}");
+                    tracing::warn!(
+                        "could not detect systemd socket path, ensure that it's at the configured path: {socket_path:?}, error: {err:?}"
+                    );
                 }
             }
             (UnixListener::from_std(listener)?, false)

--- a/crates/atuin-daemon/src/server/sync.rs
+++ b/crates/atuin-daemon/src/server/sync.rs
@@ -10,7 +10,7 @@ use atuin_client::{
     settings::Settings,
 };
 
-use atuin_dotfiles::store::{var::VarStore, AliasStore};
+use atuin_dotfiles::store::{AliasStore, var::VarStore};
 
 pub async fn worker(
     settings: Settings,

--- a/crates/atuin-dotfiles/Cargo.toml
+++ b/crates/atuin-dotfiles/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "atuin-dotfiles"
 description = "The dotfiles crate for Atuin"
-edition = "2021"
+edition = "2024"
 version = { workspace = true }
 
 authors.workspace = true

--- a/crates/atuin-dotfiles/src/shell.rs
+++ b/crates/atuin-dotfiles/src/shell.rs
@@ -1,4 +1,4 @@
-use eyre::{ensure, eyre, Result};
+use eyre::{Result, ensure, eyre};
 use rmp::{decode, encode};
 use serde::Serialize;
 
@@ -158,7 +158,7 @@ pub async fn import_aliases(store: &AliasStore) -> Result<Vec<Alias>> {
 
 #[cfg(test)]
 mod tests {
-    use crate::shell::{parse_alias, Alias};
+    use crate::shell::{Alias, parse_alias};
 
     #[test]
     fn test_parse_simple_alias() {
@@ -177,7 +177,10 @@ mod tests {
 
         let git_alias = super::parse_alias("gwip='git add -A; git rm $(git ls-files --deleted) 2> /dev/null; git commit --no-verify --no-gpg-sign --message \"--wip-- [skip ci]\"'").expect("failed to parse alias");
         assert_eq!(git_alias.name, "gwip");
-        assert_eq!(git_alias.value, "'git add -A; git rm $(git ls-files --deleted) 2> /dev/null; git commit --no-verify --no-gpg-sign --message \"--wip-- [skip ci]\"'");
+        assert_eq!(
+            git_alias.value,
+            "'git add -A; git rm $(git ls-files --deleted) 2> /dev/null; git commit --no-verify --no-gpg-sign --message \"--wip-- [skip ci]\"'"
+        );
     }
 
     #[test]

--- a/crates/atuin-dotfiles/src/shell/bash.rs
+++ b/crates/atuin-dotfiles/src/shell/bash.rs
@@ -1,6 +1,6 @@
 use std::path::PathBuf;
 
-use crate::store::{var::VarStore, AliasStore};
+use crate::store::{AliasStore, var::VarStore};
 
 async fn cached_aliases(path: PathBuf, store: &AliasStore) -> String {
     match tokio::fs::read_to_string(path).await {

--- a/crates/atuin-dotfiles/src/shell/fish.rs
+++ b/crates/atuin-dotfiles/src/shell/fish.rs
@@ -1,7 +1,7 @@
 // Configuration for fish
 use std::path::PathBuf;
 
-use crate::store::{var::VarStore, AliasStore};
+use crate::store::{AliasStore, var::VarStore};
 
 async fn cached_aliases(path: PathBuf, store: &AliasStore) -> String {
     match tokio::fs::read_to_string(path).await {

--- a/crates/atuin-dotfiles/src/shell/xonsh.rs
+++ b/crates/atuin-dotfiles/src/shell/xonsh.rs
@@ -1,6 +1,6 @@
 use std::path::PathBuf;
 
-use crate::store::{var::VarStore, AliasStore};
+use crate::store::{AliasStore, var::VarStore};
 
 async fn cached_aliases(path: PathBuf, store: &AliasStore) -> String {
     match tokio::fs::read_to_string(path).await {

--- a/crates/atuin-dotfiles/src/shell/zsh.rs
+++ b/crates/atuin-dotfiles/src/shell/zsh.rs
@@ -1,6 +1,6 @@
 use std::path::PathBuf;
 
-use crate::store::{var::VarStore, AliasStore};
+use crate::store::{AliasStore, var::VarStore};
 
 async fn cached_aliases(path: PathBuf, store: &AliasStore) -> String {
     match tokio::fs::read_to_string(path).await {

--- a/crates/atuin-dotfiles/src/store.rs
+++ b/crates/atuin-dotfiles/src/store.rs
@@ -7,7 +7,7 @@ use atuin_client::record::sqlite_store::SqliteStore;
 // + stores, rather than one mega config store.
 use atuin_common::record::{DecryptedData, Host, HostId};
 use atuin_common::utils::unquote;
-use eyre::{bail, ensure, eyre, Result};
+use eyre::{Result, bail, ensure, eyre};
 
 use atuin_client::record::encryption::PASETO_V4;
 use atuin_client::record::store::Store;
@@ -315,7 +315,7 @@ mod tests {
 
     use crate::shell::Alias;
 
-    use super::{test_local_timeout, AliasRecord, AliasStore, CONFIG_SHELL_ALIAS_VERSION};
+    use super::{AliasRecord, AliasStore, CONFIG_SHELL_ALIAS_VERSION, test_local_timeout};
     use crypto_secretbox::{KeyInit, XSalsa20Poly1305};
 
     #[test]

--- a/crates/atuin-dotfiles/src/store/var.rs
+++ b/crates/atuin-dotfiles/src/store/var.rs
@@ -6,7 +6,7 @@ use std::collections::BTreeMap;
 
 use atuin_client::record::sqlite_store::SqliteStore;
 use atuin_common::record::{DecryptedData, Host, HostId};
-use eyre::{bail, ensure, eyre, Result};
+use eyre::{Result, bail, ensure, eyre};
 
 use atuin_client::record::encryption::PASETO_V4;
 use atuin_client::record::store::Store;
@@ -294,7 +294,7 @@ mod tests {
 
     use crate::{shell::Var, store::test_local_timeout};
 
-    use super::{VarRecord, VarStore, DOTFILES_VAR_VERSION};
+    use super::{DOTFILES_VAR_VERSION, VarRecord, VarStore};
     use crypto_secretbox::{KeyInit, XSalsa20Poly1305};
 
     #[test]

--- a/crates/atuin-history/Cargo.toml
+++ b/crates/atuin-history/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "atuin-history"
 description = "The history crate for Atuin"
-edition = "2021"
+edition = "2024"
 version = { workspace = true }
 
 authors.workspace = true

--- a/crates/atuin-history/src/stats.rs
+++ b/crates/atuin-history/src/stats.rs
@@ -178,7 +178,9 @@ pub fn pretty_print(stats: Stats, ngram_size: usize, theme: &Theme) {
             .collect::<Vec<_>>()
             .join(" | ");
 
-        println!("{ResetColor}] {gray}{count:num_pad$}{ResetColor} {bold}{formatted_command}{ResetColor}");
+        println!(
+            "{ResetColor}] {gray}{count:num_pad$}{ResetColor} {bold}{formatted_command}{ResetColor}"
+        );
     }
     println!("Total commands:   {}", stats.total_commands);
     println!("Unique commands:  {}", stats.unique_commands);

--- a/crates/atuin-server-database/Cargo.toml
+++ b/crates/atuin-server-database/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "atuin-server-database"
-edition = "2021"
+edition = "2024"
 description = "server database library for atuin"
 
 version = { workspace = true }

--- a/crates/atuin-server-database/src/lib.rs
+++ b/crates/atuin-server-database/src/lib.rs
@@ -15,7 +15,7 @@ use self::{
 };
 use async_trait::async_trait;
 use atuin_common::record::{EncryptedData, HostId, Record, RecordIdx, RecordStatus};
-use serde::{de::DeserializeOwned, Serialize};
+use serde::{Serialize, de::DeserializeOwned};
 use time::{Date, Duration, Month, OffsetDateTime, Time, UtcOffset};
 use tracing::instrument;
 
@@ -83,7 +83,7 @@ pub trait Database: Sized + Clone + Send + Sync + 'static {
     async fn status(&self, user: &User) -> DbResult<RecordStatus>;
 
     async fn count_history_range(&self, user: &User, range: Range<OffsetDateTime>)
-        -> DbResult<i64>;
+    -> DbResult<i64>;
 
     async fn list_history(
         &self,

--- a/crates/atuin-server-postgres/Cargo.toml
+++ b/crates/atuin-server-postgres/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "atuin-server-postgres"
-edition = "2021"
+edition = "2024"
 description = "server postgres database library for atuin"
 
 version = { workspace = true }

--- a/crates/atuin-server-postgres/src/lib.rs
+++ b/crates/atuin-server-postgres/src/lib.rs
@@ -10,8 +10,8 @@ use atuin_server_database::{Database, DbError, DbResult};
 use futures_util::TryStreamExt;
 use metrics::counter;
 use serde::{Deserialize, Serialize};
-use sqlx::postgres::PgPoolOptions;
 use sqlx::Row;
+use sqlx::postgres::PgPoolOptions;
 
 use time::{OffsetDateTime, PrimitiveDateTime, UtcOffset};
 use tracing::{instrument, trace};

--- a/crates/atuin-server-postgres/src/wrappers.rs
+++ b/crates/atuin-server-postgres/src/wrappers.rs
@@ -1,7 +1,7 @@
 use ::sqlx::{FromRow, Result};
 use atuin_common::record::{EncryptedData, Host, Record};
 use atuin_server_database::models::{History, Session, User};
-use sqlx::{postgres::PgRow, Row};
+use sqlx::{Row, postgres::PgRow};
 use time::PrimitiveDateTime;
 
 pub struct DbUser(pub User);

--- a/crates/atuin-server/Cargo.toml
+++ b/crates/atuin-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "atuin-server"
-edition = "2021"
+edition = "2024"
 description = "server library for atuin"
 
 rust-version = { workspace = true }

--- a/crates/atuin-server/src/handlers/health.rs
+++ b/crates/atuin-server/src/handlers/health.rs
@@ -1,4 +1,4 @@
-use axum::{http, response::IntoResponse, Json};
+use axum::{Json, http, response::IntoResponse};
 
 use serde::Serialize;
 

--- a/crates/atuin-server/src/handlers/history.rs
+++ b/crates/atuin-server/src/handlers/history.rs
@@ -1,9 +1,9 @@
 use std::{collections::HashMap, convert::TryFrom};
 
 use axum::{
+    Json,
     extract::{Path, Query, State},
     http::{HeaderMap, StatusCode},
-    Json,
 };
 use metrics::counter;
 use time::{Month, UtcOffset};
@@ -15,9 +15,9 @@ use crate::{
     utils::client_version_min,
 };
 use atuin_server_database::{
+    Database,
     calendar::{TimePeriod, TimePeriodInfo},
     models::NewHistory,
-    Database,
 };
 
 use atuin_common::api::*;
@@ -223,7 +223,7 @@ pub async fn calendar<DB: Database>(
         "day" => TimePeriod::Day { year, month },
         _ => {
             return Err(ErrorResponse::reply("invalid focus: use year/month/day")
-                .with_status(StatusCode::BAD_REQUEST))
+                .with_status(StatusCode::BAD_REQUEST));
         }
     };
 

--- a/crates/atuin-server/src/handlers/mod.rs
+++ b/crates/atuin-server/src/handlers/mod.rs
@@ -1,6 +1,6 @@
 use atuin_common::api::{ErrorResponse, IndexResponse};
 use atuin_server_database::Database;
-use axum::{extract::State, http, response::IntoResponse, Json};
+use axum::{Json, extract::State, http, response::IntoResponse};
 
 use crate::router::AppState;
 

--- a/crates/atuin-server/src/handlers/record.rs
+++ b/crates/atuin-server/src/handlers/record.rs
@@ -1,4 +1,4 @@
-use axum::{http::StatusCode, response::IntoResponse, Json};
+use axum::{Json, http::StatusCode, response::IntoResponse};
 use serde_json::json;
 use tracing::instrument;
 

--- a/crates/atuin-server/src/handlers/status.rs
+++ b/crates/atuin-server/src/handlers/status.rs
@@ -1,4 +1,4 @@
-use axum::{extract::State, http::StatusCode, Json};
+use axum::{Json, extract::State, http::StatusCode};
 use tracing::instrument;
 
 use super::{ErrorResponse, ErrorResponseStatus, RespExt};
@@ -28,7 +28,7 @@ pub async fn status<DB: Database>(
             Ok(count) => count,
             Err(_) => {
                 return Err(ErrorResponse::reply("failed to query history count")
-                    .with_status(StatusCode::INTERNAL_SERVER_ERROR))
+                    .with_status(StatusCode::INTERNAL_SERVER_ERROR));
             }
         },
     };

--- a/crates/atuin-server/src/handlers/user.rs
+++ b/crates/atuin-server/src/handlers/user.rs
@@ -3,17 +3,17 @@ use std::collections::HashMap;
 use std::time::Duration;
 
 use argon2::{
-    password_hash::SaltString, Algorithm, Argon2, Params, PasswordHash, PasswordHasher,
-    PasswordVerifier, Version,
+    Algorithm, Argon2, Params, PasswordHash, PasswordHasher, PasswordVerifier, Version,
+    password_hash::SaltString,
 };
 use axum::{
+    Json,
     extract::{Path, State},
     http::StatusCode,
-    Json,
 };
 use metrics::counter;
 
-use postmark::{reqwest::PostmarkClient, Query};
+use postmark::{Query, reqwest::PostmarkClient};
 
 use rand::rngs::OsRng;
 use tracing::{debug, error, info, instrument};
@@ -21,8 +21,8 @@ use tracing::{debug, error, info, instrument};
 use super::{ErrorResponse, ErrorResponseStatus, RespExt};
 use crate::router::{AppState, UserAuth};
 use atuin_server_database::{
-    models::{NewSession, NewUser},
     Database, DbError,
+    models::{NewSession, NewUser},
 };
 
 use reqwest::header::CONTENT_TYPE;
@@ -104,7 +104,7 @@ pub async fn register<DB: Database>(
                 return Err(ErrorResponse::reply(
                     "Only alphanumeric and hyphens (-) are allowed in usernames",
                 )
-                .with_status(StatusCode::BAD_REQUEST))
+                .with_status(StatusCode::BAD_REQUEST));
             }
         }
     }
@@ -201,13 +201,14 @@ pub async fn send_verification<DB: Database>(
     }
 
     // TODO: if we ever add another mail provider, can match on them all here.
-    let postmark_token = match settings.mail.postmark.token { Some(token) => {
-        token
-    } _ => {
-        error!("Failed to verify email: got None for postmark token");
-        return Err(ErrorResponse::reply("mail not configured")
-            .with_status(StatusCode::INTERNAL_SERVER_ERROR));
-    }};
+    let postmark_token = match settings.mail.postmark.token {
+        Some(token) => token,
+        _ => {
+            error!("Failed to verify email: got None for postmark token");
+            return Err(ErrorResponse::reply("mail not configured")
+                .with_status(StatusCode::INTERNAL_SERVER_ERROR));
+        }
+    };
 
     let db = &state.0.database;
 

--- a/crates/atuin-server/src/handlers/user.rs
+++ b/crates/atuin-server/src/handlers/user.rs
@@ -201,13 +201,13 @@ pub async fn send_verification<DB: Database>(
     }
 
     // TODO: if we ever add another mail provider, can match on them all here.
-    let postmark_token = if let Some(token) = settings.mail.postmark.token {
+    let postmark_token = match settings.mail.postmark.token { Some(token) => {
         token
-    } else {
+    } _ => {
         error!("Failed to verify email: got None for postmark token");
         return Err(ErrorResponse::reply("mail not configured")
             .with_status(StatusCode::INTERNAL_SERVER_ERROR));
-    };
+    }};
 
     let db = &state.0.database;
 

--- a/crates/atuin-server/src/handlers/v0/record.rs
+++ b/crates/atuin-server/src/handlers/v0/record.rs
@@ -1,4 +1,4 @@
-use axum::{extract::Query, extract::State, http::StatusCode, Json};
+use axum::{Json, extract::Query, extract::State, http::StatusCode};
 use metrics::counter;
 use serde::Deserialize;
 use tracing::{error, instrument};

--- a/crates/atuin-server/src/lib.rs
+++ b/crates/atuin-server/src/lib.rs
@@ -4,18 +4,18 @@ use std::future::Future;
 use std::net::SocketAddr;
 
 use atuin_server_database::Database;
-use axum::{serve, Router};
-use axum_server::tls_rustls::RustlsConfig;
+use axum::{Router, serve};
 use axum_server::Handle;
-use eyre::{eyre, Context, Result};
+use axum_server::tls_rustls::RustlsConfig;
+use eyre::{Context, Result, eyre};
 
 mod handlers;
 mod metrics;
 mod router;
 mod utils;
 
-pub use settings::example_config;
 pub use settings::Settings;
+pub use settings::example_config;
 
 pub mod settings;
 

--- a/crates/atuin-server/src/metrics.rs
+++ b/crates/atuin-server/src/metrics.rs
@@ -28,11 +28,11 @@ pub fn setup_metrics_recorder() -> PrometheusHandle {
 pub async fn track_metrics(req: Request, next: Next) -> impl IntoResponse {
     let start = Instant::now();
 
-    let path = if let Some(matched_path) = req.extensions().get::<MatchedPath>() {
+    let path = match req.extensions().get::<MatchedPath>() { Some(matched_path) => {
         matched_path.as_str().to_owned()
-    } else {
+    } _ => {
         req.uri().path().to_owned()
-    };
+    }};
 
     let method = req.method().clone();
 

--- a/crates/atuin-server/src/metrics.rs
+++ b/crates/atuin-server/src/metrics.rs
@@ -28,11 +28,10 @@ pub fn setup_metrics_recorder() -> PrometheusHandle {
 pub async fn track_metrics(req: Request, next: Next) -> impl IntoResponse {
     let start = Instant::now();
 
-    let path = match req.extensions().get::<MatchedPath>() { Some(matched_path) => {
-        matched_path.as_str().to_owned()
-    } _ => {
-        req.uri().path().to_owned()
-    }};
+    let path = match req.extensions().get::<MatchedPath>() {
+        Some(matched_path) => matched_path.as_str().to_owned(),
+        _ => req.uri().path().to_owned(),
+    };
 
     let method = req.method().clone();
 

--- a/crates/atuin-server/src/router.rs
+++ b/crates/atuin-server/src/router.rs
@@ -1,12 +1,12 @@
 use async_trait::async_trait;
-use atuin_common::api::{ErrorResponse, ATUIN_CARGO_VERSION, ATUIN_HEADER_VERSION};
+use atuin_common::api::{ATUIN_CARGO_VERSION, ATUIN_HEADER_VERSION, ErrorResponse};
 use axum::{
+    Router,
     extract::{FromRequestParts, Request},
     http::{self, request::Parts},
     middleware::Next,
     response::{IntoResponse, Response},
     routing::{delete, get, patch, post},
-    Router,
 };
 use eyre::Result;
 use tower::ServiceBuilder;
@@ -18,7 +18,7 @@ use crate::{
     metrics,
     settings::Settings,
 };
-use atuin_server_database::{models::User, Database, DbError};
+use atuin_server_database::{Database, DbError, models::User};
 
 pub struct UserAuth(pub User);
 

--- a/crates/atuin-server/src/settings.rs
+++ b/crates/atuin-server/src/settings.rs
@@ -1,9 +1,9 @@
 use std::{io::prelude::*, path::PathBuf};
 
 use config::{Config, Environment, File as ConfigFile, FileFormat};
-use eyre::{eyre, Result};
-use fs_err::{create_dir_all, File};
-use serde::{de::DeserializeOwned, Deserialize, Serialize};
+use eyre::{Result, eyre};
+use fs_err::{File, create_dir_all};
+use serde::{Deserialize, Serialize, de::DeserializeOwned};
 
 static EXAMPLE_CONFIG: &str = include_str!("../server.toml");
 

--- a/crates/atuin/Cargo.toml
+++ b/crates/atuin/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "atuin"
-edition = "2021"
+edition = "2024"
 description = "atuin - magical shell history"
 readme = "./README.md"
 

--- a/crates/atuin/src/command/client/account/change_password.rs
+++ b/crates/atuin/src/command/client/account/change_password.rs
@@ -1,5 +1,5 @@
 use clap::Parser;
-use eyre::{bail, Result};
+use eyre::{Result, bail};
 
 use atuin_client::{api_client, settings::Settings};
 use rpassword::prompt_password;

--- a/crates/atuin/src/command/client/account/delete.rs
+++ b/crates/atuin/src/command/client/account/delete.rs
@@ -1,5 +1,5 @@
 use atuin_client::{api_client, settings::Settings};
-use eyre::{bail, Result};
+use eyre::{Result, bail};
 use std::fs::remove_file;
 use std::path::PathBuf;
 

--- a/crates/atuin/src/command/client/account/login.rs
+++ b/crates/atuin/src/command/client/account/login.rs
@@ -75,7 +75,7 @@ impl Cmd {
             match bip39::Mnemonic::from_phrase(&key, bip39::Language::English) {
                 Ok(mnemonic) => encode_key(Key::from_slice(mnemonic.entropy()))?,
                 Err(err) => {
-                    if let Some(err) = err.downcast_ref::<bip39::ErrorKind>() {
+                    match err.downcast_ref::<bip39::ErrorKind>() { Some(err) => {
                         match err {
                             // assume they copied in the base64 key
                             bip39::ErrorKind::InvalidWord => key,
@@ -88,10 +88,10 @@ impl Cmd {
                                 bail!("key was not the correct length")
                             }
                         }
-                    } else {
+                    } _ => {
                         // unknown error. assume they copied the base64 key
                         key
-                    }
+                    }}
                 }
             }
         };

--- a/crates/atuin/src/command/client/account/login.rs
+++ b/crates/atuin/src/command/client/account/login.rs
@@ -1,12 +1,12 @@
 use std::{io, path::PathBuf};
 
 use clap::Parser;
-use eyre::{bail, Context, Result};
+use eyre::{Context, Result, bail};
 use tokio::{fs::File, io::AsyncWriteExt};
 
 use atuin_client::{
     api_client,
-    encryption::{decode_key, encode_key, load_key, Key},
+    encryption::{Key, decode_key, encode_key, load_key},
     record::sqlite_store::SqliteStore,
     record::store::Store,
     settings::Settings,
@@ -56,7 +56,9 @@ impl Cmd {
         let key_path = PathBuf::from(key_path);
 
         println!("IMPORTANT");
-        println!("If you are already logged in on another machine, you must ensure that the key you use here is the same as the key you used there.");
+        println!(
+            "If you are already logged in on another machine, you must ensure that the key you use here is the same as the key you used there."
+        );
         println!("You can find your key by running 'atuin key' on the other machine");
         println!("Do not share this key with anyone");
         println!("\nRead more here: https://docs.atuin.sh/guide/sync/#login \n");
@@ -75,23 +77,26 @@ impl Cmd {
             match bip39::Mnemonic::from_phrase(&key, bip39::Language::English) {
                 Ok(mnemonic) => encode_key(Key::from_slice(mnemonic.entropy()))?,
                 Err(err) => {
-                    match err.downcast_ref::<bip39::ErrorKind>() { Some(err) => {
-                        match err {
-                            // assume they copied in the base64 key
-                            bip39::ErrorKind::InvalidWord => key,
-                            bip39::ErrorKind::InvalidChecksum => {
-                                bail!("key mnemonic was not valid")
-                            }
-                            bip39::ErrorKind::InvalidKeysize(_)
-                            | bip39::ErrorKind::InvalidWordLength(_)
-                            | bip39::ErrorKind::InvalidEntropyLength(_, _) => {
-                                bail!("key was not the correct length")
+                    match err.downcast_ref::<bip39::ErrorKind>() {
+                        Some(err) => {
+                            match err {
+                                // assume they copied in the base64 key
+                                bip39::ErrorKind::InvalidWord => key,
+                                bip39::ErrorKind::InvalidChecksum => {
+                                    bail!("key mnemonic was not valid")
+                                }
+                                bip39::ErrorKind::InvalidKeysize(_)
+                                | bip39::ErrorKind::InvalidWordLength(_)
+                                | bip39::ErrorKind::InvalidEntropyLength(_, _) => {
+                                    bail!("key was not the correct length")
+                                }
                             }
                         }
-                    } _ => {
-                        // unknown error. assume they copied the base64 key
-                        key
-                    }}
+                        _ => {
+                            // unknown error. assume they copied the base64 key
+                            key
+                        }
+                    }
                 }
             }
         };
@@ -106,7 +111,9 @@ impl Cmd {
                     bail!("the key in existing key file was invalid");
                 }
             } else {
-                panic!("No key provided. Please use 'atuin key' on your other machine, or recover your key from a backup.")
+                panic!(
+                    "No key provided. Please use 'atuin key' on your other machine, or recover your key from a backup."
+                )
             }
         } else if !key_path.exists() {
             if decode_key(key.clone()).is_err() {
@@ -184,6 +191,9 @@ mod tests {
             .into_phrase();
         let mnemonic = bip39::Mnemonic::from_phrase(&phrase, bip39::Language::English).unwrap();
         assert_eq!(mnemonic.entropy(), key.as_slice());
-        assert_eq!(phrase, "adapt amused able anxiety mother adapt beef gaze amount else seat alcohol cage lottery avoid scare alcohol cactus school avoid coral adjust catch pink");
+        assert_eq!(
+            phrase,
+            "adapt amused able anxiety mother adapt beef gaze amount else seat alcohol cage lottery avoid scare alcohol cactus school avoid coral adjust catch pink"
+        );
     }
 }

--- a/crates/atuin/src/command/client/account/register.rs
+++ b/crates/atuin/src/command/client/account/register.rs
@@ -1,5 +1,5 @@
 use clap::Parser;
-use eyre::{bail, Result};
+use eyre::{Result, bail};
 use tokio::{fs::File, io::AsyncWriteExt};
 
 use atuin_client::{api_client, settings::Settings};
@@ -51,8 +51,12 @@ pub async fn run(
 
     let _key = atuin_client::encryption::load_key(settings)?;
 
-    println!("Registration successful! Please make a note of your key (run 'atuin key') and keep it safe.");
-    println!("You will need it to log in on other devices, and we cannot help recover it if you lose it.");
+    println!(
+        "Registration successful! Please make a note of your key (run 'atuin key') and keep it safe."
+    );
+    println!(
+        "You will need it to log in on other devices, and we cannot help recover it if you lose it."
+    );
 
     Ok(())
 }

--- a/crates/atuin/src/command/client/account/verify.rs
+++ b/crates/atuin/src/command/client/account/verify.rs
@@ -35,11 +35,15 @@ pub async fn run(settings: &Settings, token: Option<String>) -> Result<()> {
         }
 
         (false, false) => {
-            println!("Your Atuin server does not have mail setup. This is not required, though your account cannot be verified. Speak to your admin.");
+            println!(
+                "Your Atuin server does not have mail setup. This is not required, though your account cannot be verified. Speak to your admin."
+            );
         }
 
         _ => {
-            println!("Invalid email and verification status. This is a bug. Please open an issue: https://github.com/atuinsh/atuin");
+            println!(
+                "Invalid email and verification status. This is a bug. Please open an issue: https://github.com/atuinsh/atuin"
+            );
         }
     }
 

--- a/crates/atuin/src/command/client/doctor.rs
+++ b/crates/atuin/src/command/client/doctor.rs
@@ -3,13 +3,13 @@ use std::{env, path::PathBuf, str::FromStr};
 
 use atuin_client::database::Sqlite;
 use atuin_client::settings::Settings;
-use atuin_common::shell::{shell_name, Shell};
+use atuin_common::shell::{Shell, shell_name};
 use atuin_common::utils;
 use colored::Colorize;
 use eyre::Result;
 use serde::Serialize;
 
-use sysinfo::{get_current_pid, Disks, System};
+use sysinfo::{Disks, System, get_current_pid};
 
 #[derive(Debug, Serialize)]
 struct ShellInfo {
@@ -353,7 +353,7 @@ impl DoctorDump {
 
 fn checks(info: &DoctorDump) {
     println!(); // spacing
-                //
+    //
     let zfs_error = "[Filesystem] ZFS is known to have some issues with SQLite. Atuin uses SQLite heavily. If you are having poor performance, there are some workarounds here: https://github.com/atuinsh/atuin/issues/952".bold().red();
     let bash_plugin_error = "[Shell] If you are using Bash, Atuin requires that either bash-preexec or ble.sh be installed. An older ble.sh may not be detected. so ignore this if you have it set up! Read more here: https://docs.atuin.sh/guide/installation/#bash".bold().red();
     let blesh_integration_error = "[Shell] Atuin and ble.sh seem to be loaded in the session, but the integration does not seem to be working. Please check the setup in .bashrc.".bold().red();

--- a/crates/atuin/src/command/client/dotfiles/alias.rs
+++ b/crates/atuin/src/command/client/dotfiles/alias.rs
@@ -1,5 +1,5 @@
 use clap::Subcommand;
-use eyre::{eyre, Context, Result};
+use eyre::{Context, Result, eyre};
 
 use atuin_client::{encryption, record::sqlite_store::SqliteStore, settings::Settings};
 
@@ -92,7 +92,9 @@ impl Cmd {
 
     pub async fn run(&self, settings: &Settings, store: SqliteStore) -> Result<()> {
         if !settings.dotfiles.enabled {
-            eprintln!("Dotfiles are not enabled. Add\n\n[dotfiles]\nenabled = true\n\nto your configuration file to enable them.\n");
+            eprintln!(
+                "Dotfiles are not enabled. Add\n\n[dotfiles]\nenabled = true\n\nto your configuration file to enable them.\n"
+            );
             eprintln!("The default configuration file is located at ~/.config/atuin/config.toml.");
             return Ok(());
         }

--- a/crates/atuin/src/command/client/dotfiles/var.rs
+++ b/crates/atuin/src/command/client/dotfiles/var.rs
@@ -73,7 +73,9 @@ impl Cmd {
 
     pub async fn run(&self, settings: &Settings, store: SqliteStore) -> Result<()> {
         if !settings.dotfiles.enabled {
-            eprintln!("Dotfiles are not enabled. Add\n\n[dotfiles]\nenabled = true\n\nto your configuration file to enable them.\n");
+            eprintln!(
+                "Dotfiles are not enabled. Add\n\n[dotfiles]\nenabled = true\n\nto your configuration file to enable them.\n"
+            );
             eprintln!("The default configuration file is located at ~/.config/atuin/config.toml.");
             return Ok(());
         }

--- a/crates/atuin/src/command/client/history.rs
+++ b/crates/atuin/src/command/client/history.rs
@@ -11,9 +11,9 @@ use eyre::{Context, Result};
 use runtime_format::{FormatKey, FormatKeyError, ParseSegment, ParsedFmt};
 
 use atuin_client::{
-    database::{current_context, Database, Sqlite},
+    database::{Database, Sqlite, current_context},
     encryption,
-    history::{store::HistoryStore, History},
+    history::{History, store::HistoryStore},
     record::sqlite_store::SqliteStore,
     settings::{
         FilterMode::{Directory, Global, Session},
@@ -25,7 +25,7 @@ use atuin_client::{
 use atuin_client::{record, sync};
 
 use log::{debug, warn};
-use time::{macros::format_description, OffsetDateTime};
+use time::{OffsetDateTime, macros::format_description};
 
 use super::search::format_duration_into;
 
@@ -285,7 +285,9 @@ fn parse_fmt(format: &str) -> ParsedFmt {
         Ok(fmt) => fmt,
         Err(err) => {
             eprintln!("ERROR: History formatting failed with the following error: {err}");
-            println!("If your formatting string contains curly braces (eg: {{var}}) you need to escape them this way: {{{{var}}.");
+            println!(
+                "If your formatting string contains curly braces (eg: {{var}}) you need to escape them this way: {{{{var}}."
+            );
             std::process::exit(1)
         }
     }
@@ -550,11 +552,11 @@ impl Cmd {
         if settings.daemon.enabled {
             match self {
                 Self::Start { command } => {
-                    return Self::handle_daemon_start(settings, &command).await
+                    return Self::handle_daemon_start(settings, &command).await;
                 }
 
                 Self::End { id, exit, duration } => {
-                    return Self::handle_daemon_end(settings, &id, exit, duration).await
+                    return Self::handle_daemon_end(settings, &id, exit, duration).await;
                 }
 
                 _ => {}

--- a/crates/atuin/src/command/client/import.rs
+++ b/crates/atuin/src/command/client/import.rs
@@ -9,8 +9,8 @@ use atuin_client::{
     database::Database,
     history::History,
     import::{
-        bash::Bash, fish::Fish, nu::Nu, nu_histdb::NuHistDb, replxx::Replxx, resh::Resh,
-        xonsh::Xonsh, xonsh_sqlite::XonshSqlite, zsh::Zsh, zsh_histdb::ZshHistDb, Importer, Loader,
+        Importer, Loader, bash::Bash, fish::Fish, nu::Nu, nu_histdb::NuHistDb, replxx::Replxx,
+        resh::Resh, xonsh::Xonsh, xonsh_sqlite::XonshSqlite, zsh::Zsh, zsh_histdb::ZshHistDb,
     },
 };
 
@@ -57,7 +57,9 @@ impl Cmd {
         match self {
             Self::Auto => {
                 if cfg!(windows) {
-                    println!("This feature does not work on windows. Please run atuin import <SHELL>. To view a list of shells, run atuin import.");
+                    println!(
+                        "This feature does not work on windows. Please run atuin import <SHELL>. To view a list of shells, run atuin import."
+                    );
                     return Ok(());
                 }
 

--- a/crates/atuin/src/command/client/init.rs
+++ b/crates/atuin/src/command/client/init.rs
@@ -1,7 +1,7 @@
 use std::path::PathBuf;
 
 use atuin_client::{encryption, record::sqlite_store::SqliteStore, settings::Settings};
-use atuin_dotfiles::store::{var::VarStore, AliasStore};
+use atuin_dotfiles::store::{AliasStore, var::VarStore};
 use clap::{Parser, ValueEnum};
 use eyre::{Result, WrapErr};
 
@@ -160,7 +160,9 @@ $env.config = (
 
     pub async fn run(self, settings: &Settings) -> Result<()> {
         if !settings.paths_ok() {
-            eprintln!("Atuin settings paths are broken. Disabling atuin shell hooks. Run `atuin doctor` to diagnose.");
+            eprintln!(
+                "Atuin settings paths are broken. Disabling atuin shell hooks. Run `atuin doctor` to diagnose."
+            );
             return Ok(());
         }
 

--- a/crates/atuin/src/command/client/init/bash.rs
+++ b/crates/atuin/src/command/client/init/bash.rs
@@ -1,4 +1,4 @@
-use atuin_dotfiles::store::{var::VarStore, AliasStore};
+use atuin_dotfiles::store::{AliasStore, var::VarStore};
 use eyre::Result;
 
 pub fn init_static(disable_up_arrow: bool, disable_ctrl_r: bool) {

--- a/crates/atuin/src/command/client/init/fish.rs
+++ b/crates/atuin/src/command/client/init/fish.rs
@@ -1,4 +1,4 @@
-use atuin_dotfiles::store::{var::VarStore, AliasStore};
+use atuin_dotfiles::store::{AliasStore, var::VarStore};
 use eyre::Result;
 
 pub fn init_static(disable_up_arrow: bool, disable_ctrl_r: bool) {

--- a/crates/atuin/src/command/client/init/xonsh.rs
+++ b/crates/atuin/src/command/client/init/xonsh.rs
@@ -1,4 +1,4 @@
-use atuin_dotfiles::store::{var::VarStore, AliasStore};
+use atuin_dotfiles::store::{AliasStore, var::VarStore};
 use eyre::Result;
 
 pub fn init_static(disable_up_arrow: bool, disable_ctrl_r: bool) {

--- a/crates/atuin/src/command/client/init/zsh.rs
+++ b/crates/atuin/src/command/client/init/zsh.rs
@@ -1,4 +1,4 @@
-use atuin_dotfiles::store::{var::VarStore, AliasStore};
+use atuin_dotfiles::store::{AliasStore, var::VarStore};
 use eyre::Result;
 
 pub fn init_static(disable_up_arrow: bool, disable_ctrl_r: bool) {

--- a/crates/atuin/src/command/client/search.rs
+++ b/crates/atuin/src/command/client/search.rs
@@ -1,4 +1,4 @@
-use std::io::{stderr, IsTerminal as _};
+use std::io::{IsTerminal as _, stderr};
 
 use atuin_common::utils::{self, Escapable as _};
 use clap::Parser;
@@ -6,9 +6,9 @@ use eyre::Result;
 
 use atuin_client::{
     database::Database,
-    database::{current_context, OptFilters},
+    database::{OptFilters, current_context},
     encryption,
-    history::{store::HistoryStore, History},
+    history::{History, store::HistoryStore},
     record::sqlite_store::SqliteStore,
     settings::{FilterMode, KeymapMode, SearchMode, Settings, Timezone},
     theme::Theme,
@@ -165,7 +165,9 @@ impl Cmd {
         }
 
         if self.delete && query.is_empty() {
-            eprintln!("Please specify a query to match the items you wish to delete. If you wish to delete all history, pass --delete-it-all");
+            eprintln!(
+                "Please specify a query to match the items you wish to delete. If you wish to delete all history, pass --delete-it-all"
+            );
             return Ok(());
         }
 

--- a/crates/atuin/src/command/client/search/cursor.rs
+++ b/crates/atuin/src/command/client/search/cursor.rs
@@ -184,11 +184,7 @@ impl Cursor {
     }
 
     pub fn back(&mut self) -> Option<char> {
-        if self.left() {
-            self.remove()
-        } else {
-            None
-        }
+        if self.left() { self.remove() } else { None }
     }
 
     pub fn clear(&mut self) {

--- a/crates/atuin/src/command/client/search/engines/skim.rs
+++ b/crates/atuin/src/command/client/search/engines/skim.rs
@@ -3,7 +3,7 @@ use std::path::Path;
 use async_trait::async_trait;
 use atuin_client::{database::Database, history::History, settings::FilterMode};
 use eyre::Result;
-use fuzzy_matcher::{skim::SkimMatcherV2, FuzzyMatcher};
+use fuzzy_matcher::{FuzzyMatcher, skim::SkimMatcherV2};
 use itertools::Itertools;
 use time::OffsetDateTime;
 use tokio::task::yield_now;

--- a/crates/atuin/src/command/client/search/inspector.rs
+++ b/crates/atuin/src/command/client/search/inspector.rs
@@ -6,12 +6,12 @@ use atuin_client::{
     settings::Settings,
 };
 use ratatui::{
+    Frame,
     crossterm::event::{KeyCode, KeyEvent, KeyModifiers},
     layout::Rect,
     prelude::{Constraint, Direction, Layout},
     style::Style,
     widgets::{Bar, BarChart, BarGroup, Block, Borders, Padding, Paragraph, Row, Table},
-    Frame,
 };
 
 use super::duration::format_duration;
@@ -21,11 +21,7 @@ use super::interactive::{InputAction, State};
 
 #[allow(clippy::cast_sign_loss)]
 fn u64_or_zero(num: i64) -> u64 {
-    if num < 0 {
-        0
-    } else {
-        num as u64
-    }
+    if num < 0 { 0 } else { num as u64 }
 }
 
 pub fn draw_commands(

--- a/crates/atuin/src/command/client/search/interactive.rs
+++ b/crates/atuin/src/command/client/search/interactive.rs
@@ -1,5 +1,5 @@
 use std::{
-    io::{stdout, Write},
+    io::{Write, stdout},
     time::Duration,
 };
 
@@ -11,8 +11,8 @@ use time::OffsetDateTime;
 use unicode_width::UnicodeWidthStr;
 
 use atuin_client::{
-    database::{current_context, Database},
-    history::{store::HistoryStore, History, HistoryStats},
+    database::{Database, current_context},
+    history::{History, HistoryStats, store::HistoryStore},
     settings::{
         CursorStyle, ExitMode, FilterMode, KeymapMode, PreviewStrategy, SearchMode, Settings,
     },
@@ -25,9 +25,10 @@ use super::{
 };
 
 use crate::command::client::theme::{Meaning, Theme};
-use crate::{command::client::search::engines, VERSION};
+use crate::{VERSION, command::client::search::engines};
 
 use ratatui::{
+    Frame, Terminal, TerminalOptions, Viewport,
     backend::CrosstermBackend,
     crossterm::{
         cursor::SetCursorStyle,
@@ -42,8 +43,7 @@ use ratatui::{
     prelude::*,
     style::{Modifier, Style},
     text::{Line, Span, Text},
-    widgets::{block::Title, Block, BorderType, Borders, Padding, Paragraph, Tabs},
-    Frame, Terminal, TerminalOptions, Viewport,
+    widgets::{Block, BorderType, Borders, Padding, Paragraph, Tabs, block::Title},
 };
 
 const TAB_TITLES: [&str; 2] = ["Search", "Inspect"];
@@ -390,7 +390,7 @@ impl State {
             KeyCode::Char(c @ '1'..='9') if modfr => {
                 return c.to_digit(10).map_or(InputAction::Continue, |c| {
                     InputAction::Accept(self.results_state.selected() + c as usize)
-                })
+                });
             }
             KeyCode::Left if ctrl => self
                 .search
@@ -763,7 +763,9 @@ impl State {
 
                 // HACK: I'm following up with abstracting this into the UI container, with a
                 // sub-widget for search + for inspector
-                let feedback = Paragraph::new("The inspector is new - please give feedback (good, or bad) at https://forum.atuin.sh");
+                let feedback = Paragraph::new(
+                    "The inspector is new - please give feedback (good, or bad) at https://forum.atuin.sh",
+                );
                 f.render_widget(feedback, input_chunk);
 
                 return;

--- a/crates/atuin/src/command/client/stats.rs
+++ b/crates/atuin/src/command/client/stats.rs
@@ -4,7 +4,7 @@ use interim::parse_date_string;
 use time::{Duration, OffsetDateTime, Time};
 
 use atuin_client::{
-    database::{current_context, Database},
+    database::{Database, current_context},
     settings::Settings,
     theme::Theme,
 };

--- a/crates/atuin/src/command/client/store/rebuild.rs
+++ b/crates/atuin/src/command/client/store/rebuild.rs
@@ -1,6 +1,6 @@
-use atuin_dotfiles::store::{var::VarStore, AliasStore};
+use atuin_dotfiles::store::{AliasStore, var::VarStore};
 use clap::Args;
-use eyre::{bail, Result};
+use eyre::{Result, bail};
 
 use atuin_client::{
     database::Database, encryption, history::store::HistoryStore,

--- a/crates/atuin/src/command/client/store/rekey.rs
+++ b/crates/atuin/src/command/client/store/rekey.rs
@@ -1,9 +1,9 @@
 use clap::Args;
-use eyre::{bail, Result};
+use eyre::{Result, bail};
 use tokio::{fs::File, io::AsyncWriteExt};
 
 use atuin_client::{
-    encryption::{decode_key, encode_key, generate_encoded_key, load_key, Key},
+    encryption::{Key, decode_key, encode_key, generate_encoded_key, load_key},
     record::sqlite_store::SqliteStore,
     record::store::Store,
     settings::Settings,
@@ -23,23 +23,26 @@ impl Rekey {
             let key = match bip39::Mnemonic::from_phrase(&key, bip39::Language::English) {
                 Ok(mnemonic) => encode_key(Key::from_slice(mnemonic.entropy()))?,
                 Err(err) => {
-                    match err.downcast_ref::<bip39::ErrorKind>() { Some(err) => {
-                        match err {
-                            // assume they copied in the base64 key
-                            bip39::ErrorKind::InvalidWord => key,
-                            bip39::ErrorKind::InvalidChecksum => {
-                                bail!("key mnemonic was not valid")
-                            }
-                            bip39::ErrorKind::InvalidKeysize(_)
-                            | bip39::ErrorKind::InvalidWordLength(_)
-                            | bip39::ErrorKind::InvalidEntropyLength(_, _) => {
-                                bail!("key was not the correct length")
+                    match err.downcast_ref::<bip39::ErrorKind>() {
+                        Some(err) => {
+                            match err {
+                                // assume they copied in the base64 key
+                                bip39::ErrorKind::InvalidWord => key,
+                                bip39::ErrorKind::InvalidChecksum => {
+                                    bail!("key mnemonic was not valid")
+                                }
+                                bip39::ErrorKind::InvalidKeysize(_)
+                                | bip39::ErrorKind::InvalidWordLength(_)
+                                | bip39::ErrorKind::InvalidEntropyLength(_, _) => {
+                                    bail!("key was not the correct length")
+                                }
                             }
                         }
-                    } _ => {
-                        // unknown error. assume they copied the base64 key
-                        key
-                    }}
+                        _ => {
+                            // unknown error. assume they copied the base64 key
+                            key
+                        }
+                    }
                 }
             };
 

--- a/crates/atuin/src/command/client/store/rekey.rs
+++ b/crates/atuin/src/command/client/store/rekey.rs
@@ -23,7 +23,7 @@ impl Rekey {
             let key = match bip39::Mnemonic::from_phrase(&key, bip39::Language::English) {
                 Ok(mnemonic) => encode_key(Key::from_slice(mnemonic.entropy()))?,
                 Err(err) => {
-                    if let Some(err) = err.downcast_ref::<bip39::ErrorKind>() {
+                    match err.downcast_ref::<bip39::ErrorKind>() { Some(err) => {
                         match err {
                             // assume they copied in the base64 key
                             bip39::ErrorKind::InvalidWord => key,
@@ -36,10 +36,10 @@ impl Rekey {
                                 bail!("key was not the correct length")
                             }
                         }
-                    } else {
+                    } _ => {
                         // unknown error. assume they copied the base64 key
                         key
-                    }
+                    }}
                 }
             };
 

--- a/crates/atuin/src/command/client/wrapped.rs
+++ b/crates/atuin/src/command/client/wrapped.rs
@@ -5,7 +5,7 @@ use time::{Date, Duration, Month, OffsetDateTime, Time};
 
 use atuin_client::{database::Database, settings::Settings, theme::Theme};
 
-use atuin_history::stats::{compute, Stats};
+use atuin_history::stats::{Stats, compute};
 
 #[derive(Debug)]
 struct WrappedStats {
@@ -293,7 +293,9 @@ pub async fn run(
 
     let history = db.range(start, end).await?;
     if history.is_empty() {
-        println!("Your history for {year} is empty!\nMaybe 'atuin import' could help you import your previous history 🪄");
+        println!(
+            "Your history for {year} is empty!\nMaybe 'atuin import' could help you import your previous history 🪄"
+        );
         return Ok(());
     }
 

--- a/crates/atuin/src/command/gen_completions.rs
+++ b/crates/atuin/src/command/gen_completions.rs
@@ -1,5 +1,5 @@
 use clap::{CommandFactory, Parser, ValueEnum};
-use clap_complete::{generate, generate_to, Generator, Shell};
+use clap_complete::{Generator, Shell, generate, generate_to};
 use clap_complete_nushell::Nushell;
 use eyre::Result;
 

--- a/crates/atuin/src/command/server.rs
+++ b/crates/atuin/src/command/server.rs
@@ -1,12 +1,12 @@
 use std::net::SocketAddr;
 
 use atuin_server_postgres::Postgres;
-use tracing_subscriber::{fmt, prelude::*, EnvFilter};
+use tracing_subscriber::{EnvFilter, fmt, prelude::*};
 
 use clap::Parser;
 use eyre::{Context, Result};
 
-use atuin_server::{example_config, launch, launch_metrics_server, Settings};
+use atuin_server::{Settings, example_config, launch, launch_metrics_server};
 
 #[derive(Parser, Debug)]
 #[clap(infer_subcommands = true)]

--- a/crates/atuin/src/sync.rs
+++ b/crates/atuin/src/sync.rs
@@ -1,4 +1,4 @@
-use atuin_dotfiles::store::{var::VarStore, AliasStore};
+use atuin_dotfiles::store::{AliasStore, var::VarStore};
 use eyre::{Context, Result};
 
 use atuin_client::{

--- a/crates/atuin/tests/common/mod.rs
+++ b/crates/atuin/tests/common/mod.rs
@@ -2,12 +2,12 @@ use std::{env, time::Duration};
 
 use atuin_client::api_client;
 use atuin_common::utils::uuid_v7;
-use atuin_server::{launch_with_tcp_listener, Settings as ServerSettings};
+use atuin_server::{Settings as ServerSettings, launch_with_tcp_listener};
 use atuin_server_postgres::{Postgres, PostgresSettings};
 use futures_util::TryFutureExt;
 use tokio::{net::TcpListener, sync::oneshot, task::JoinHandle};
-use tracing::{dispatcher, Dispatch};
-use tracing_subscriber::{layer::SubscriberExt, EnvFilter};
+use tracing::{Dispatch, dispatcher};
+use tracing_subscriber::{EnvFilter, layer::SubscriberExt};
 
 pub async fn start_server(path: &str) -> (String, oneshot::Sender<()>, JoinHandle<()>) {
     let formatting_layer = tracing_tree::HierarchicalLayer::default()

--- a/flake.nix
+++ b/flake.nix
@@ -32,7 +32,7 @@
                 fenix.packages.${system}.fromToolchainFile
                   {
                     file = ./rust-toolchain.toml;
-                    sha256 = "sha256-AJ6LX/Q/Er9kS15bn9iflkUwcgYqRQxiOIL2ToVAXaU=";
+                    sha256 = "sha256-Hn2uaQzRLidAWpfmRwSRdImifGUCAb9HeAqTYFXWeQk=";
                   };
             in
             pkgs.makeRustPlatform {


### PR DESCRIPTION
This introduces some unsafe code :( I am sorry!

Small caveat though. The code has ALWAYS been unsafe, just as of 2024 env operations are actually marked as such. Our usage is entirely in tests, so I feel much less bad about it.

## Checks
- [ ] I am happy for maintainers to push small adjustments to this PR, to speed up the review cycle
- [ ] I have checked that there are no existing pull requests for the same thing
