### PR TITLE
fix(build): change atuin-daemon build script .proto paths

### DIFF
--- a/crates/atuin-daemon/build.rs
+++ b/crates/atuin-daemon/build.rs
@@ -3,7 +3,10 @@ use std::{env, fs, path::PathBuf};
 use protox::prost::Message;
 
 fn main() -> std::io::Result<()> {
-    let file_descriptors = protox::compile(["history.proto"], ["./proto/"]).unwrap();
+    let proto_paths = ["proto/history.proto"];
+    let proto_include_dirs = ["proto"];
+
+    let file_descriptors = protox::compile(proto_paths, proto_include_dirs).unwrap();
 
     let file_descriptor_path = PathBuf::from(env::var_os("OUT_DIR").expect("OUT_DIR not set"))
         .join("file_descriptor_set.bin");
@@ -13,5 +16,5 @@ fn main() -> std::io::Result<()> {
         .build_server(true)
         .file_descriptor_set_path(&file_descriptor_path)
         .skip_protoc_run()
-        .compile_protos(&["history.proto"], &["."])
+        .compile_protos(&proto_paths, &proto_include_dirs)
 }


### PR DESCRIPTION
Modify paths specified in the atuin-daemon build script to make tonic-build print the correct cargo:rerun-if-changed paths when the build script is run.

Fixes the atuin-daemon crate being rebuilt unconditionally, even if .proto files are unchanged.

<!-- Thank you for making a PR! Bug fixes are always welcome, but if you're adding a new feature or changing an existing one, we'd really appreciate if you open an issue, post on the forum, or drop in on Discord -->

## Checks
- [x] I am happy for maintainers to push small adjustments to this PR, to speed up the review cycle
- [x] I have checked that there are no existing pull requests for the same thing
