### PR TITLE
feat(zsh): re-enable bracketed paste

### DIFF
--- a/crates/atuin/src/shell/atuin.zsh
+++ b/crates/atuin/src/shell/atuin.zsh
@@ -59,6 +59,8 @@ _atuin_search() {
     output=$(ATUIN_SHELL_ZSH=t ATUIN_LOG=error ATUIN_QUERY=$BUFFER atuin search $* -i 3>&1 1>&2 2>&3)
 
     zle reset-prompt
+    # re-enable bracketed paste
+    echo $zle_bracketed_paste[1] >/dev/tty
 
     if [[ -n $output ]]; then
         RBUFFER=""

--- a/crates/atuin/src/shell/atuin.zsh
+++ b/crates/atuin/src/shell/atuin.zsh
@@ -60,7 +60,8 @@ _atuin_search() {
 
     zle reset-prompt
     # re-enable bracketed paste
-    echo $zle_bracketed_paste[1] >/dev/tty
+    # shellcheck disable=SC2154
+    echo ${zle_bracketed_paste[1]} >/dev/tty
 
     if [[ -n $output ]]; then
         RBUFFER=""


### PR DESCRIPTION
atuin will reset it so after exiting atuin without executing a command, bracketed paste mode is disabled until a command is executed. This breaks e.g. the bracketed-paste-url-magic widget.

This change will re-enable it if it's enabled; when it's disabled or unavailable, $zle_bracketed_paste[1] will be empty string.

<!-- Thank you for making a PR! Bug fixes are always welcome, but if you're adding a new feature or changing an existing one, we'd really appreciate if you open an issue, post on the forum, or drop in on Discord -->

## Checks
- [x] I am happy for maintainers to push small adjustments to this PR, to speed up the review cycle
- [x] I have checked that there are no existing pull requests for the same thing
