### PR TITLE
fix: typeerror in client sync code

### DIFF
--- a/crates/atuin-client/src/sync.rs
+++ b/crates/atuin-client/src/sync.rs
@@ -85,8 +85,9 @@ async fn sync_download(
         db.save_bulk(&history).await?;
 
         local_count = db.history_count(true).await?;
+        let remote_page_size = std::cmp::max(remote_status.page_size, 0) as usize;
 
-        if history.len() < remote_status.page_size.try_into().unwrap() {
+        if history.len() < remote_page_size {
             break;
         }
 

--- a/crates/atuin-client/src/sync.rs
+++ b/crates/atuin-client/src/sync.rs
@@ -1,5 +1,4 @@
 use std::collections::HashSet;
-use std::convert::TryInto;
 use std::iter::FromIterator;
 
 use eyre::Result;


### PR DESCRIPTION
Fixes #2645

This is really weird

1. I have not touched this code in _years_. It has not changed. In recent rust versions, it has a typeerror (see linked issue)
2. This does not occur when running `cargo build`, in release mode or otherwise. It only occurs with `cargo install`
3. I can't find any other occurences of this typeerror online - unsure if it is a compiler regression? The code here is not very complex at all.

<!-- Thank you for making a PR! Bug fixes are always welcome, but if you're adding a new feature or changing an existing one, we'd really appreciate if you open an issue, post on the forum, or drop in on Discord -->

## Checks
- [ ] I am happy for maintainers to push small adjustments to this PR, to speed up the review cycle
- [ ] I have checked that there are no existing pull requests for the same thing
