### PR TITLE
chore: don't panic if clipboard cannot be accessed

### DIFF
--- a/crates/atuin/src/command/client/search/interactive.rs
+++ b/crates/atuin/src/command/client/search/interactive.rs
@@ -1244,10 +1244,12 @@ pub async fn history(
     any(target_os = "windows", target_os = "macos", target_os = "linux")
 ))]
 fn set_clipboard(s: String) {
-    let mut ctx = arboard::Clipboard::new().unwrap();
-    ctx.set_text(s).unwrap();
-    // Use the clipboard context to make sure it is saved
-    ctx.get_text().unwrap();
+    // Do nothing if clipboard cannot be accessed
+    if let Ok(mut ctx) = arboard::Clipboard::new() {
+        ctx.set_text(s).unwrap();
+        // Use the clipboard context to make sure it is saved
+        ctx.get_text().unwrap();
+    }
 }
 
 #[cfg(not(all(

--- a/crates/atuin/src/command/client/search/interactive.rs
+++ b/crates/atuin/src/command/client/search/interactive.rs
@@ -1222,7 +1222,9 @@ pub async fn history(
         InputAction::ReturnOriginal => Ok(String::new()),
         InputAction::Copy(index) => {
             let cmd = results.swap_remove(index).command;
-            set_clipboard(cmd);
+            if let Err(e) = set_clipboard(cmd) {
+                tracing::warn!(?e, "failed to copy to clipboard");
+            }
             Ok(String::new())
         }
         InputAction::ReturnQuery | InputAction::Accept(_) => {
@@ -1243,20 +1245,21 @@ pub async fn history(
     feature = "clipboard",
     any(target_os = "windows", target_os = "macos", target_os = "linux")
 ))]
-fn set_clipboard(s: String) {
-    // Do nothing if clipboard cannot be accessed
-    if let Ok(mut ctx) = arboard::Clipboard::new() {
-        ctx.set_text(s).unwrap();
-        // Use the clipboard context to make sure it is saved
-        ctx.get_text().unwrap();
-    }
+fn set_clipboard(s: String) -> Result<(), arboard::Error> {
+    let mut ctx = arboard::Clipboard::new()?;
+    ctx.set_text(s)?;
+    // Use the clipboard context to make sure it is saved
+    ctx.get_text()?;
+    Ok(())
 }
 
 #[cfg(not(all(
     feature = "clipboard",
     any(target_os = "windows", target_os = "macos", target_os = "linux")
 )))]
-fn set_clipboard(_s: String) {}
+fn set_clipboard(_s: String) -> Result<(), std::convert::Infallible> {
+    Ok(())
+}
 
 #[cfg(test)]
 mod tests {


### PR DESCRIPTION
<!-- Thank you for making a PR! Bug fixes are always welcome, but if you're adding a new feature or changing an existing one, we'd really appreciate if you open an issue, post on the forum, or drop in on Discord -->

Fixes https://github.com/atuinsh/atuin/issues/1707.

Summary
---

`atuin` doesn't panic if the system clipboard cannot be accessed for any reason.

Questions
---

- Do we also want to stop panicking if setting text to the clipboard fails?
- Do we also want to stop panicking if the follow up check to see if the value was set fails?
- Should we add an error message to the TUI if any of the steps involved fail?

## Checks
- [x] I am happy for maintainers to push small adjustments to this PR, to speed up the review cycle
- [x] I have checked that there are no existing pull requests for the same thing
