### PR TITLE
fix(zsh): fix an error introduced earilier with support for bracketed paste mode

### DIFF
--- a/crates/atuin/src/shell/atuin.zsh
+++ b/crates/atuin/src/shell/atuin.zsh
@@ -61,7 +61,7 @@ _atuin_search() {
     zle reset-prompt
     # re-enable bracketed paste
     # shellcheck disable=SC2154
-    echo ${zle_bracketed_paste[1]} >/dev/tty
+    echo -n ${zle_bracketed_paste[1]} >/dev/tty
 
     if [[ -n $output ]]; then
         RBUFFER=""


### PR DESCRIPTION
An extra newline was written to the terminal and caused issues. See https://github.com/atuinsh/atuin/pull/2646#issuecomment-2757157442.

<!-- Thank you for making a PR! Bug fixes are always welcome, but if you're adding a new feature or changing an existing one, we'd really appreciate if you open an issue, post on the forum, or drop in on Discord -->

## Checks
- [x] I am happy for maintainers to push small adjustments to this PR, to speed up the review cycle
- [x] I have checked that there are no existing pull requests for the same thing
