### PR TITLE
fix: add redundant clones to clippy and cleanup instances of it

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -212,7 +212,7 @@ jobs:
           key: ${{ runner.os }}-cargo-debug-${{ hashFiles('**/Cargo.lock') }}
 
       - name: Run clippy
-        run: cargo clippy -- -D warnings
+        run: cargo clippy -- -D warnings -D clippy::redundant_clone
 
   format:
     runs-on: ubuntu-latest

--- a/crates/atuin-dotfiles/src/shell.rs
+++ b/crates/atuin-dotfiles/src/shell.rs
@@ -98,12 +98,12 @@ pub fn parse_alias(line: &str) -> Option<Alias> {
 
     let mut parts = parts.iter().map(|s| s.to_string());
 
-    let name = parts.next().unwrap().to_string();
+    let name = parts.next().unwrap();
 
     let remaining = if is_fish {
-        parts.collect::<Vec<String>>().join(" ").to_string()
+        parts.collect::<Vec<String>>().join(" ")
     } else {
-        parts.collect::<Vec<String>>().join("=").to_string()
+        parts.collect::<Vec<String>>().join("=")
     };
 
     Some(Alias {


### PR DESCRIPTION
clippy::redundant_clone is pretty safe and helps cleanup some useless code, found a few instances of it in the codebase so though its worth adding to CI

## Checks
- [x] I am happy for maintainers to push small adjustments to this PR, to speed up the review cycle
- [x] I have checked that there are no existing pull requests for the same thing
