### PR TITLE
fix(stats): Ignore leading environment variables when calculating stats

### DIFF
--- a/crates/atuin-history/src/stats.rs
+++ b/crates/atuin-history/src/stats.rs
@@ -350,7 +350,6 @@ mod tests {
             .into();
 
         let stats = compute(&settings, &[history], 10, 1).expect("failed to compute stats");
-        println!("{:?}", stats);
         assert_eq!(stats.top.get(0).unwrap().0, vec!["echo"]);
     }
 

--- a/crates/atuin-history/src/stats.rs
+++ b/crates/atuin-history/src/stats.rs
@@ -109,6 +109,91 @@ fn split_at_pipe(command: &str) -> Vec<&str> {
     result
 }
 
+fn strip_leading_env_vars(command: &str) -> &str {
+    // fast path: no equals sign, no environment variable
+    if !command.contains('=') {
+        return command;
+    }
+
+    let cmd_len = command.len();
+    // [(token, is_env_var, start_index)]
+    let mut tokens = Vec::<(String, bool, usize)>::new();
+    let mut current_token = Some(String::with_capacity(cmd_len));
+    let mut token_start_pos = 0;
+    let mut in_single_quotes = false;
+    let mut in_double_quotes = false;
+    let mut escape_next = false;
+    let mut has_equals_outside_quotes = false;
+
+    for (i, g) in UnicodeSegmentation::grapheme_indices(command, true) {
+        if escape_next {
+            current_token.as_mut().unwrap().push_str(g);
+            escape_next = false;
+            continue;
+        }
+
+        if current_token.as_ref().unwrap().is_empty() {
+            token_start_pos = i;
+        }
+
+        match g {
+            "\\" => {
+                escape_next = true;
+                current_token.as_mut().unwrap().push_str(g);
+            }
+            "'" if !in_double_quotes => {
+                in_single_quotes = !in_single_quotes;
+                current_token.as_mut().unwrap().push_str(g);
+            }
+            "\"" if !in_single_quotes => {
+                in_double_quotes = !in_double_quotes;
+                current_token.as_mut().unwrap().push_str(g);
+            }
+            "=" if !in_single_quotes && !in_double_quotes => {
+                has_equals_outside_quotes = true;
+                current_token.as_mut().unwrap().push_str(g);
+            }
+            " " | "\t" if !in_single_quotes && !in_double_quotes => {
+                if !current_token.as_ref().unwrap().is_empty() {
+                    tokens.push((
+                        current_token.take().unwrap(),
+                        has_equals_outside_quotes,
+                        token_start_pos,
+                    ));
+                    if !has_equals_outside_quotes {
+                        // if we're not in an env var, we can break early
+                        break;
+                    }
+                    current_token = Some(String::with_capacity(cmd_len - i));
+                    has_equals_outside_quotes = false;
+                }
+            }
+            _ => {
+                current_token.as_mut().unwrap().push_str(g);
+            }
+        }
+    }
+
+    // make sure we don't lose the last token if we never found an env var
+    if let Some(token) = current_token {
+        tokens.push((token, has_equals_outside_quotes, token_start_pos));
+    }
+
+    // find the first non-env-var token
+    let first_command_idx = tokens
+        .iter()
+        .position(|(_, is_env_var, _)| !is_env_var)
+        .unwrap_or(tokens.len());
+
+    if first_command_idx >= tokens.len() {
+        // oops, all env vars
+        return "";
+    }
+
+    let start_pos = tokens[first_command_idx].2;
+    &command[start_pos..].trim()
+}
+
 pub fn pretty_print(stats: Stats, ngram_size: usize, theme: &Theme) {
     let max = stats.top.iter().map(|x| x.1).max().unwrap();
     let num_pad = max.ilog10() as usize + 1;
@@ -198,7 +283,7 @@ pub fn compute(
 
     for i in history {
         // just in case it somehow has a leading tab or space or something (legacy atuin didn't ignore space prefixes)
-        let command = i.command.trim();
+        let command = strip_leading_env_vars(i.command.trim());
         let prefix = interesting_command(settings, command);
 
         if settings.stats.ignored_commands.iter().any(|c| c == prefix) {
@@ -208,7 +293,7 @@ pub fn compute(
         total_unignored += 1;
         commands.insert(command);
 
-        split_at_pipe(i.command.trim())
+        split_at_pipe(command)
             .iter()
             .map(|l| {
                 let command = l.trim();
@@ -251,7 +336,23 @@ mod tests {
     use time::OffsetDateTime;
 
     use super::compute;
-    use super::{interesting_command, split_at_pipe};
+    use super::{interesting_command, split_at_pipe, strip_leading_env_vars};
+
+    #[test]
+    fn ignored_env_vars() {
+        let settings = Settings::utc();
+
+        let history: History = History::capture()
+            .timestamp(time::OffsetDateTime::now_utc())
+            .command("FOO='BAR=🚀' echo foo")
+            .cwd("/")
+            .build()
+            .into();
+
+        let stats = compute(&settings, &[history], 10, 1).expect("failed to compute stats");
+        println!("{:?}", stats);
+        assert_eq!(stats.top.get(0).unwrap().0, vec!["echo"]);
+    }
 
     #[test]
     fn ignored_commands() {
@@ -434,5 +535,47 @@ mod tests {
             split_at_pipe("  | sed 's/[0-9a-f]//g'"),
             ["  ", " sed 's/[0-9a-f]//g'"]
         );
+    }
+
+    #[test]
+    fn strip_leading_env_vars_simple() {
+        assert_eq!(
+            strip_leading_env_vars("FOO=bar BAZ=quux echo foo"),
+            "echo foo"
+        );
+    }
+
+    #[test]
+    fn strip_leading_env_vars_quoted_single() {
+        assert_eq!(strip_leading_env_vars("FOO='BAR=baz' echo foo"), "echo foo");
+    }
+
+    #[test]
+    fn strip_leading_env_vars_quoted_double() {
+        assert_eq!(
+            strip_leading_env_vars("FOO=\"BAR=baz\" echo foo"),
+            "echo foo"
+        );
+    }
+
+    #[test]
+    fn strip_leading_env_vars_quoted_single_and_double() {
+        assert_eq!(
+            strip_leading_env_vars("FOO='BAR=\"baz\"' echo foo \"BAR=quux\""),
+            "echo foo \"BAR=quux\""
+        );
+    }
+
+    #[test]
+    fn strip_leading_env_vars_emojis() {
+        assert_eq!(
+            strip_leading_env_vars("FOO='BAR=🚀' echo foo \"BAR=quux\" foo"),
+            "echo foo \"BAR=quux\" foo"
+        );
+    }
+
+    #[test]
+    fn strip_leading_env_vars_name_same_as_command() {
+        assert_eq!(strip_leading_env_vars("FOO='bar' bar baz"), "bar baz");
     }
 }

--- a/crates/atuin-history/src/stats.rs
+++ b/crates/atuin-history/src/stats.rs
@@ -191,7 +191,7 @@ fn strip_leading_env_vars(command: &str) -> &str {
     }
 
     let start_pos = tokens[first_command_idx].2;
-    &command[start_pos..].trim()
+    command[start_pos..].trim()
 }
 
 pub fn pretty_print(stats: Stats, ngram_size: usize, theme: &Theme) {


### PR DESCRIPTION
This PR updates `atuin_history::stats::compute` so that it makes a best attempt at ignoring leading environment variables when calculating the stats. This includes a new helper function `strip_leading_env_vars` that has a few tests at the bottom of the file.

Closes #2594

## Checks
- [x] I am happy for maintainers to push small adjustments to this PR, to speed up the review cycle
- [x] I have checked that there are no existing pull requests for the same thing
