### PR TITLE
fix(kv): Filter deleted keys from `kv list`

### DIFF
--- a/crates/atuin/src/command/client/kv.rs
+++ b/crates/atuin/src/command/client/kv.rs
@@ -92,16 +92,20 @@ impl Cmd {
                 // slower, but sorting is probably useful
                 if *all_namespaces {
                     for (ns, kv) in &map {
-                        for k in kv.keys() {
-                            println!("{ns}.{k}");
+                        for (k, v) in kv.iter() {
+                            if let Some(_) = v.value {
+                                println!("{ns}.{k}");
+                            }
                         }
                     }
                 } else {
                     let ns = map.get(namespace);
 
                     if let Some(ns) = ns {
-                        for k in ns.keys() {
-                            println!("{k}");
+                        for (k, v) in ns.iter() {
+                            if let Some(_) = v.value {
+                                println!("{k}");
+                            }
                         }
                     }
                 }

--- a/crates/atuin/src/command/client/kv.rs
+++ b/crates/atuin/src/command/client/kv.rs
@@ -92,8 +92,8 @@ impl Cmd {
                 // slower, but sorting is probably useful
                 if *all_namespaces {
                     for (ns, kv) in &map {
-                        for (k, v) in kv.iter() {
-                            if let Some(_) = v.value {
+                        for (k, v) in kv {
+                            if v.value.is_some() {
                                 println!("{ns}.{k}");
                             }
                         }
@@ -102,8 +102,8 @@ impl Cmd {
                     let ns = map.get(namespace);
 
                     if let Some(ns) = ns {
-                        for (k, v) in ns.iter() {
-                            if let Some(_) = v.value {
+                        for (k, v) in ns {
+                            if v.value.is_some() {
                                 println!("{k}");
                             }
                         }


### PR DESCRIPTION
Something got lost between #2660 and the paging PR, and deleted keys show up in `kv list` — this PR fixes that.

## Checks
- [x] I am happy for maintainers to push small adjustments to this PR, to speed up the review cycle
- [x] I have checked that there are no existing pull requests for the same thing
