### PR TITLE
Feature csv import

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -275,6 +275,7 @@ dependencies = [
  "config",
  "crossterm",
  "crypto_secretbox",
+ "csv",
  "directories",
  "eyre",
  "fs-err 2.11.0",
@@ -308,6 +309,7 @@ dependencies = [
  "sqlx",
  "strum",
  "strum_macros",
+ "tempfile",
  "testing_logger",
  "thiserror 1.0.69",
  "time",
@@ -1032,6 +1034,27 @@ dependencies = [
  "salsa20",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "csv"
+version = "1.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acdc4883a9c96732e4733212c01447ebd805833b7275a73ca3ee080fd77afdaf"
+dependencies = [
+ "csv-core",
+ "itoa",
+ "ryu",
+ "serde",
+]
+
+[[package]]
+name = "csv-core"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d02f3b0da4c6504f86e9cd789d8dbafab48c2321be74e9987593de5a894d93d"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]

--- a/crates/atuin-client/Cargo.toml
+++ b/crates/atuin-client/Cargo.toml
@@ -54,6 +54,7 @@ futures = "0.3"
 crypto_secretbox = "0.1.1"
 generic-array = { version = "0.14", features = ["serde"] }
 serde_with = "3.8.1"
+csv = "1.1"
 
 # encryption
 rusty_paseto = { version = "0.7.0", default-features = false }
@@ -78,3 +79,4 @@ strum = { version = "0.26.2", features = ["strum_macros"] }
 tokio = { version = "1", features = ["full"] }
 pretty_assertions = { workspace = true }
 testing_logger = "0.1.1"
+tempfile ="3.3"

--- a/crates/atuin-client/src/import/csv_history.rs
+++ b/crates/atuin-client/src/import/csv_history.rs
@@ -1,11 +1,11 @@
-use std::path::PathBuf;
 use std::fs::File;
-use std::io::{BufReader, BufRead};
+use std::io::{BufRead, BufReader};
+use std::path::PathBuf;
 
 use async_trait::async_trait;
+use csv::Reader;
 use eyre::{Result, eyre};
 use time::OffsetDateTime;
-use csv::Reader;
 
 use super::{Importer, Loader};
 use crate::history::History;
@@ -20,7 +20,9 @@ fn default_histpath() -> Result<PathBuf> {
     if histpath.exists() {
         Ok(histpath)
     } else {
-        Err(eyre!("Could not find history file. Please create 'history.csv' in the current directory."))
+        Err(eyre!(
+            "Could not find history file. Please create 'history.csv' in the current directory."
+        ))
     }
 }
 
@@ -45,8 +47,12 @@ impl Importer for CsvHistoryImporter {
 
         for result in reader.records() {
             let record = result?;
-            if let (Some(timestamp), Some(duration), Some(command)) = (record.get(0), record.get(1), record.get(2)) {
-                let timestamp = timestamp.parse::<i64>().ok()
+            if let (Some(timestamp), Some(duration), Some(command)) =
+                (record.get(0), record.get(1), record.get(2))
+            {
+                let timestamp = timestamp
+                    .parse::<i64>()
+                    .ok()
                     .and_then(|t| OffsetDateTime::from_unix_timestamp(t).ok())
                     .unwrap_or_else(OffsetDateTime::now_utc);
                 let duration = duration.parse::<i64>().map_or(-1, |t| t * 1_000_000_000);
@@ -67,10 +73,10 @@ impl Importer for CsvHistoryImporter {
 mod test {
     use super::*;
     use crate::import::tests::TestLoader;
-    use std::io::Write;
-    use std::fs;
-    use tempfile::NamedTempFile;
     use itertools::assert_equal;
+    use std::fs;
+    use std::io::Write;
+    use tempfile::NamedTempFile;
 
     #[tokio::test]
     async fn test_parse_file() {

--- a/crates/atuin-client/src/import/csv_history.rs
+++ b/crates/atuin-client/src/import/csv_history.rs
@@ -1,0 +1,99 @@
+use std::path::PathBuf;
+use std::fs::File;
+use std::io::{BufReader, BufRead};
+
+use async_trait::async_trait;
+use eyre::{Result, eyre};
+use time::OffsetDateTime;
+use csv::Reader;
+
+use super::{Importer, Loader};
+use crate::history::History;
+
+const HISTORY_FILE: &str = "history.csv"; // Global constant for history file
+
+#[derive(Debug)]
+pub struct CsvHistoryImporter;
+
+fn default_histpath() -> Result<PathBuf> {
+    let histpath = PathBuf::from(HISTORY_FILE);
+    if histpath.exists() {
+        Ok(histpath)
+    } else {
+        Err(eyre!("Could not find history file. Please create 'history.csv' in the current directory."))
+    }
+}
+
+#[async_trait]
+impl Importer for CsvHistoryImporter {
+    const NAME: &'static str = "csv_history";
+
+    async fn new() -> Result<Self> {
+        let _ = default_histpath()?; // Ensure the file exists
+        Ok(Self)
+    }
+
+    async fn entries(&mut self) -> Result<usize> {
+        let file = File::open(default_histpath()?)?;
+        let reader = BufReader::new(file);
+        Ok(reader.lines().count() - 1) // Exclude header row
+    }
+
+    async fn load(self, h: &mut impl Loader) -> Result<()> {
+        let file = File::open(default_histpath()?)?;
+        let mut reader = Reader::from_reader(file);
+
+        for result in reader.records() {
+            let record = result?;
+            if let (Some(timestamp), Some(duration), Some(command)) = (record.get(0), record.get(1), record.get(2)) {
+                let timestamp = timestamp.parse::<i64>().ok()
+                    .and_then(|t| OffsetDateTime::from_unix_timestamp(t).ok())
+                    .unwrap_or_else(OffsetDateTime::now_utc);
+                let duration = duration.parse::<i64>().map_or(-1, |t| t * 1_000_000_000);
+
+                let imported = History::import()
+                    .timestamp(timestamp)
+                    .command(command.trim().to_string())
+                    .duration(duration);
+
+                h.push(imported.build().into()).await?;
+            }
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::import::tests::TestLoader;
+    use std::io::Write;
+    use std::fs;
+    use tempfile::NamedTempFile;
+    use itertools::assert_equal;
+
+    #[tokio::test]
+    async fn test_parse_file() {
+        let mut file = NamedTempFile::new().unwrap();
+        writeln!(file, "timestamp,duration,command").unwrap();
+        writeln!(file, "1613322469,10,cargo install atuin").unwrap();
+        writeln!(file, "1613322470,5,ls -la").unwrap();
+        writeln!(file, "1613322471,3,git status").unwrap();
+
+        let path = file.path().to_path_buf();
+        fs::copy(&path, HISTORY_FILE).unwrap();
+
+        let mut importer = CsvHistoryImporter::new().await.unwrap();
+        assert_eq!(importer.entries().await.unwrap(), 3);
+
+        let mut loader = TestLoader::default();
+        importer.load(&mut loader).await.unwrap();
+
+        assert_equal(
+            loader.buf.iter().map(|h| h.command.as_str()),
+            ["cargo install atuin", "ls -la", "git status"],
+        );
+
+        fs::remove_file(HISTORY_FILE).unwrap();
+    }
+}

--- a/crates/atuin-client/src/import/mod.rs
+++ b/crates/atuin-client/src/import/mod.rs
@@ -9,6 +9,7 @@ use memchr::Memchr;
 use crate::history::History;
 
 pub mod bash;
+pub mod csv_history;
 pub mod fish;
 pub mod nu;
 pub mod nu_histdb;

--- a/crates/atuin/src/command/client/import.rs
+++ b/crates/atuin/src/command/client/import.rs
@@ -9,8 +9,9 @@ use atuin_client::{
     database::Database,
     history::History,
     import::{
-        Importer, Loader, bash::Bash, fish::Fish, nu::Nu, nu_histdb::NuHistDb, replxx::Replxx,
-        resh::Resh, xonsh::Xonsh, xonsh_sqlite::XonshSqlite, zsh::Zsh, zsh_histdb::ZshHistDb,
+        Importer, Loader, bash::Bash, csv_history::CsvHistoryImporter, fish::Fish, nu::Nu,
+        nu_histdb::NuHistDb, replxx::Replxx, resh::Resh, xonsh::Xonsh, xonsh_sqlite::XonshSqlite,
+        zsh::Zsh, zsh_histdb::ZshHistDb,
     },
 };
 
@@ -26,6 +27,8 @@ pub enum Cmd {
     ZshHistDb,
     /// Import history from the bash history file
     Bash,
+    /// Import history from user csv history file
+    CsvHistoryImporter,
     /// Import history from the replxx history file
     Replxx,
     /// Import history from the resh history file
@@ -111,6 +114,7 @@ impl Cmd {
             Self::Zsh => import::<Zsh, DB>(db).await,
             Self::ZshHistDb => import::<ZshHistDb, DB>(db).await,
             Self::Bash => import::<Bash, DB>(db).await,
+            Self::CsvHistoryImporter => import::<CsvHistoryImporter, DB>(db).await,
             Self::Replxx => import::<Replxx, DB>(db).await,
             Self::Resh => import::<Resh, DB>(db).await,
             Self::Fish => import::<Fish, DB>(db).await,


### PR DESCRIPTION
<!-- Thank you for making a PR! Bug fixes are always welcome, but if you're adding a new feature or changing an existing one, we'd really appreciate if you open an issue, post on the forum, or drop in on Discord -->

this provides a simple csv file import. after reviewing #2556 and #2431, it never seemed like there was an answer to this, so here's my take at a first cut. i will apologize in advance that i'm not super familiar with rust, so feedback is appreciated.

in keeping with the way other parts of the tool operate, we look for a `history.csv` file with the format of:

```csv
timestamp,duration,command
1613322469,10,cargo install atuin
..., ..., ...
```

the test provides an example. note that the class/module is called `csv_importer`, `CsvHistroyImporter` because I ran into conflicts with `csv` and the crate it belongs to, happy to take suggestions.

## Checks
- [x] I am happy for maintainers to push small adjustments to this PR, to speed up the review cycle
- [x] I have checked that there are no existing pull requests for the same thing
