### PR TITLE
fix(zsh): avoid calling user-defined widgets when searching for history position

### DIFF
--- a/crates/atuin/src/shell/atuin.zsh
+++ b/crates/atuin/src/shell/atuin.zsh
@@ -72,7 +72,7 @@ _atuin_search() {
             LBUFFER=${LBUFFER#__atuin_accept__:}
             zle accept-line
         else
-            zle infer-next-history && zle up-history
+            zle .infer-next-history && zle .up-history
         fi
     fi
 }


### PR DESCRIPTION
Or those widgets may behave badly when calling them too quickly. We don't need calling them anyway as this is not considered to be user action, and if our calls fail, the history position is unchanged.

Issue introduced in #1469.

## Checks
- [x] I am happy for maintainers to push small adjustments to this PR, to speed up the review cycle
- [x] I have checked that there are no existing pull requests for the same thing
