### PR TITLE
[Temporary on v18.4.0 tag]: using tracing for theming debug

### DIFF
--- a/crates/atuin-client/Cargo.toml
+++ b/crates/atuin-client/Cargo.toml
@@ -76,6 +76,7 @@ palette = { version = "0.7.5", features = ["serializing"] }
 lazy_static = "1.4.0"
 strum_macros = "0.26.3"
 strum = { version = "0.26.2", features = ["strum_macros"] }
+tracing.workspace = true
 
 [dev-dependencies]
 tokio = { version = "1", features = ["full"] }


### PR DESCRIPTION
Improving alignment of the debug within theming with the rest of atuin.

Originally, I had just added `log` as I was not sure how best to link in, but this uses `tracing`, which is present elsewhere.

As such, you can see theming-related logging by using:

```
ATUIN_LOG=1 atuin search -i
```

For example:

![Screenshot From 2025-04-06 18-53-42](https://github.com/user-attachments/assets/8594446f-a668-4fb9-9940-ed95c00639a1)

Unfortunately, it is a bit hard to read on top of an interactive prompt, so if there is a simple workaround I am missing, please say.

## Checks
- [x] I am happy for maintainers to push small adjustments to this PR, to speed up the review cycle
- [x] I have checked that there are no existing pull requests for the same thing
