### PR TITLE
[Project Fluent] Basic internationalization support (would close PR #2553)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1800,70 +1800,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
 
 [[package]]
-name = "encoding"
-version = "0.2.33"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b0d943856b990d12d3b55b359144ff341533e516d94098b1d3fc1ac666d36ec"
-dependencies = [
- "encoding-index-japanese",
- "encoding-index-korean",
- "encoding-index-simpchinese",
- "encoding-index-singlebyte",
- "encoding-index-tradchinese",
-]
-
-[[package]]
-name = "encoding-index-japanese"
-version = "1.20141219.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04e8b2ff42e9a05335dbf8b5c6f7567e5591d0d916ccef4e0b1710d32a0d0c91"
-dependencies = [
- "encoding_index_tests",
-]
-
-[[package]]
-name = "encoding-index-korean"
-version = "1.20141219.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4dc33fb8e6bcba213fe2f14275f0963fd16f0a02c878e3095ecfdf5bee529d81"
-dependencies = [
- "encoding_index_tests",
-]
-
-[[package]]
-name = "encoding-index-simpchinese"
-version = "1.20141219.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d87a7194909b9118fc707194baa434a4e3b0fb6a5a757c73c3adb07aa25031f7"
-dependencies = [
- "encoding_index_tests",
-]
-
-[[package]]
-name = "encoding-index-singlebyte"
-version = "1.20141219.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3351d5acffb224af9ca265f435b859c7c01537c0849754d3db3fdf2bfe2ae84a"
-dependencies = [
- "encoding_index_tests",
-]
-
-[[package]]
-name = "encoding-index-tradchinese"
-version = "1.20141219.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd0e20d5688ce3cab59eb3ef3a2083a5c77bf496cb798dc6fcdb75f323890c18"
-dependencies = [
- "encoding_index_tests",
-]
-
-[[package]]
-name = "encoding_index_tests"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a246d82be1c9d791c5dfde9a2bd045fc3cbba3fa2b11ad558f27d01712f00569"
-
-[[package]]
 name = "encoding_rs"
 version = "0.8.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2362,16 +2298,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "gettext"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ebb594e753d5997e4be036e5a8cf048ab9414352870fb45c779557bbc9ba971"
-dependencies = [
- "byteorder",
- "encoding",
-]
-
-[[package]]
 name = "glob"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2662,12 +2588,10 @@ dependencies = [
  "fluent",
  "fluent-langneg",
  "fluent-syntax",
- "gettext",
  "i18n-embed-impl",
  "intl-memoizer",
  "locale_config",
  "log",
- "notify",
  "parking_lot",
  "rust-embed",
  "thiserror 1.0.69",
@@ -6265,9 +6189,6 @@ name = "tr"
 version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "79d30c7e79732253d80e9d619007002c8f3a362b0816e37340af648d4e2c6092"
-dependencies = [
- "gettext",
-]
 
 [[package]]
 name = "tracing"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -132,6 +132,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "arc-swap"
+version = "1.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c049c0be4daef0b145cb3555416b3b8ef5b7888a38aea1a3a155801fe7b0810b"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
 name = "argon2"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -241,6 +250,8 @@ dependencies = [
  "frizbee",
  "fs-err",
  "futures-util",
+ "i18n-embed",
+ "i18n-embed-fl",
  "indicatif",
  "interim",
  "itertools",
@@ -252,6 +263,7 @@ dependencies = [
  "rpassword",
  "rstest",
  "runtime-format",
+ "rust-embed",
  "rustix",
  "semver",
  "serde",
@@ -317,7 +329,7 @@ dependencies = [
  "thiserror 2.0.18",
  "time",
  "tokio",
- "toml",
+ "toml 1.1.2+spec-1.1.0",
  "toml_edit",
  "tracing",
  "tracing-appender",
@@ -384,7 +396,7 @@ dependencies = [
  "time",
  "tiny-bip39",
  "tokio",
- "toml",
+ "toml 1.1.2+spec-1.1.0",
  "tracing",
  "typed-builder",
  "url",
@@ -396,18 +408,26 @@ dependencies = [
 name = "atuin-common"
 version = "18.19.0-beta.3"
 dependencies = [
+ "atuin-macro",
  "base64",
  "derive_more",
  "directories",
  "eyre",
  "getrandom 0.4.3",
+ "i18n-embed",
+ "i18n-embed-fl",
  "itertools",
+ "lazy_static",
+ "paste",
  "pretty_assertions",
  "proptest",
  "rstest",
+ "rust-embed",
  "serde",
  "serde_json",
  "serde_with",
+ "slugify",
+ "sys-locale",
  "sysinfo",
  "thiserror 2.0.18",
  "time",
@@ -522,6 +542,34 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "typed-builder",
+]
+
+[[package]]
+name = "atuin-macro"
+version = "18.19.0-beta.3"
+dependencies = [
+ "base64",
+ "directories",
+ "eyre",
+ "getrandom 0.2.17",
+ "i18n-embed",
+ "i18n-embed-fl",
+ "lazy_static",
+ "paste",
+ "proc-macro2",
+ "quote",
+ "rust-embed",
+ "semver",
+ "serde",
+ "slugify",
+ "sqlx",
+ "syn 2.0.119",
+ "sys-locale",
+ "sysinfo",
+ "thiserror 2.0.18",
+ "time",
+ "typed-builder",
+ "uuid",
 ]
 
 [[package]]
@@ -807,6 +855,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
+name = "basic-toml"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba62675e8242a4c4e806d12f11d136e626e6c8361d6b829310732241652a178a"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "beef"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -865,6 +922,12 @@ checksum = "46502ad458c9a52b69d4d4d32775c788b7a1b85e8bc9d482d92250fc0e3f8efe"
 dependencies = [
  "digest 0.10.7",
 ]
+
+[[package]]
+name = "block"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d8c1fef690941d3e7788d328517591fecc684c084084702d6ff1641e993699a"
 
 [[package]]
 name = "block-buffer"
@@ -1228,7 +1291,7 @@ checksum = "b85f248a4de22d204ceabc6299d89d2c70fbd7f09fea53c06c852369652d8139"
 dependencies = [
  "pathdiff",
  "serde_core",
- "toml",
+ "toml 1.1.2+spec-1.1.0",
  "winnow",
 ]
 
@@ -1249,6 +1312,12 @@ name = "const-oid"
 version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
+
+[[package]]
+name = "const-oid"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
 
 [[package]]
 name = "convert_case"
@@ -1531,7 +1600,7 @@ version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
 dependencies = [
- "const-oid",
+ "const-oid 0.9.6",
  "zeroize",
 ]
 
@@ -1597,6 +1666,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
 dependencies = [
  "block-buffer 0.12.1",
+ "const-oid 0.10.2",
  "crypto-common 0.2.2",
  "ctutils",
 ]
@@ -1728,6 +1798,70 @@ name = "encode_unicode"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
+
+[[package]]
+name = "encoding"
+version = "0.2.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b0d943856b990d12d3b55b359144ff341533e516d94098b1d3fc1ac666d36ec"
+dependencies = [
+ "encoding-index-japanese",
+ "encoding-index-korean",
+ "encoding-index-simpchinese",
+ "encoding-index-singlebyte",
+ "encoding-index-tradchinese",
+]
+
+[[package]]
+name = "encoding-index-japanese"
+version = "1.20141219.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04e8b2ff42e9a05335dbf8b5c6f7567e5591d0d916ccef4e0b1710d32a0d0c91"
+dependencies = [
+ "encoding_index_tests",
+]
+
+[[package]]
+name = "encoding-index-korean"
+version = "1.20141219.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4dc33fb8e6bcba213fe2f14275f0963fd16f0a02c878e3095ecfdf5bee529d81"
+dependencies = [
+ "encoding_index_tests",
+]
+
+[[package]]
+name = "encoding-index-simpchinese"
+version = "1.20141219.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d87a7194909b9118fc707194baa434a4e3b0fb6a5a757c73c3adb07aa25031f7"
+dependencies = [
+ "encoding_index_tests",
+]
+
+[[package]]
+name = "encoding-index-singlebyte"
+version = "1.20141219.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3351d5acffb224af9ca265f435b859c7c01537c0849754d3db3fdf2bfe2ae84a"
+dependencies = [
+ "encoding_index_tests",
+]
+
+[[package]]
+name = "encoding-index-tradchinese"
+version = "1.20141219.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd0e20d5688ce3cab59eb3ef3a2083a5c77bf496cb798dc6fcdb75f323890c18"
+dependencies = [
+ "encoding_index_tests",
+]
+
+[[package]]
+name = "encoding_index_tests"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a246d82be1c9d791c5dfde9a2bd045fc3cbba3fa2b11ad558f27d01712f00569"
 
 [[package]]
 name = "encoding_rs"
@@ -1904,6 +2038,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "find-crate"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59a98bbaacea1c0eb6a0876280051b892eb73594fd90cf3b20e9c817029c57d2"
+dependencies = [
+ "toml 0.5.11",
+]
+
+[[package]]
 name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1926,6 +2069,50 @@ name = "fixedbitset"
 version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
+
+[[package]]
+name = "fluent"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb74634707bebd0ce645a981148e8fb8c7bccd4c33c652aeffd28bf2f96d555a"
+dependencies = [
+ "fluent-bundle",
+ "unic-langid",
+]
+
+[[package]]
+name = "fluent-bundle"
+version = "0.15.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fe0a21ee80050c678013f82edf4b705fe2f26f1f9877593d13198612503f493"
+dependencies = [
+ "fluent-langneg",
+ "fluent-syntax",
+ "intl-memoizer",
+ "intl_pluralrules",
+ "rustc-hash 1.1.0",
+ "self_cell 0.10.3",
+ "smallvec",
+ "unic-langid",
+]
+
+[[package]]
+name = "fluent-langneg"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7eebbe59450baee8282d71676f3bfed5689aeab00b27545e83e5f14b1195e8b0"
+dependencies = [
+ "unic-langid",
+]
+
+[[package]]
+name = "fluent-syntax"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a530c4694a6a8d528794ee9bbd8ba0122e779629ac908d15ad5a7ae7763a33d"
+dependencies = [
+ "thiserror 1.0.69",
+]
 
 [[package]]
 name = "flume"
@@ -2172,6 +2359,16 @@ dependencies = [
  "libc",
  "r-efi 6.0.0",
  "rand_core 0.10.1",
+]
+
+[[package]]
+name = "gettext"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ebb594e753d5997e4be036e5a8cf048ab9414352870fb45c779557bbc9ba971"
+dependencies = [
+ "byteorder",
+ "encoding",
 ]
 
 [[package]]
@@ -2442,6 +2639,76 @@ dependencies = [
 ]
 
 [[package]]
+name = "i18n-config"
+version = "0.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e06b90c8a0d252e203c94344b21e35a30f3a3a85dc7db5af8f8df9f3e0c63ef"
+dependencies = [
+ "basic-toml",
+ "log",
+ "serde",
+ "serde_derive",
+ "thiserror 1.0.69",
+ "unic-langid",
+]
+
+[[package]]
+name = "i18n-embed"
+version = "0.15.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "669ffc2c93f97e6ddf06ddbe999fcd6782e3342978bb85f7d3c087c7978404c4"
+dependencies = [
+ "arc-swap",
+ "fluent",
+ "fluent-langneg",
+ "fluent-syntax",
+ "gettext",
+ "i18n-embed-impl",
+ "intl-memoizer",
+ "locale_config",
+ "log",
+ "notify",
+ "parking_lot",
+ "rust-embed",
+ "thiserror 1.0.69",
+ "tr",
+ "unic-langid",
+ "walkdir",
+]
+
+[[package]]
+name = "i18n-embed-fl"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04b2969d0b3fc6143776c535184c19722032b43e6a642d710fa3f88faec53c2d"
+dependencies = [
+ "find-crate",
+ "fluent",
+ "fluent-syntax",
+ "i18n-config",
+ "i18n-embed",
+ "proc-macro-error2",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn 2.0.119",
+ "unic-langid",
+]
+
+[[package]]
+name = "i18n-embed-impl"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f2cc0e0523d1fe6fc2c6f66e5038624ea8091b3e7748b5e8e0c84b1698db6c2"
+dependencies = [
+ "find-crate",
+ "i18n-config",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
 name = "iana-time-zone"
 version = "0.1.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2700,6 +2967,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "intl-memoizer"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "310da2e345f5eb861e7a07ee182262e94975051db9e4223e909ba90f392f163f"
+dependencies = [
+ "type-map",
+ "unic-langid",
+]
+
+[[package]]
+name = "intl_pluralrules"
+version = "7.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "078ea7b7c29a2b4df841a7f6ac8775ff6074020c6776d48491ce2268e068f972"
+dependencies = [
+ "unic-langid",
+]
+
+[[package]]
 name = "ipnet"
 version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2883,6 +3169,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "11d3d7f243d5c5a8b9bb5d6dd2b1602c0cb0b9db1621bafc7ed66e35ff9fe092"
 
 [[package]]
+name = "locale_config"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08d2c35b16f4483f6c26f0e4e9550717a2f6575bcd6f12a53ff0c490a94a6934"
+dependencies = [
+ "lazy_static",
+ "objc",
+ "objc-foundation",
+ "regex",
+ "winapi",
+]
+
+[[package]]
 name = "lock_api"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2948,6 +3247,15 @@ checksum = "c0aeb26bf5e836cc1c341c8106051b573f1766dfa05aa87f0b98be5e51b02303"
 dependencies = [
  "nix 0.29.0",
  "winapi",
+]
+
+[[package]]
+name = "malloc_buf"
+version = "0.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62bb907fe88d54d8d9ce32a3cceab4218ed2f6b7d35617cafe9adf84e43919cb"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -3069,6 +3377,16 @@ name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
+
+[[package]]
+name = "mime_guess"
+version = "2.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7c44f8e672c00fe5308fa235f821cb4198414e1c77935c1ab6948d3fd78550e"
+dependencies = [
+ "mime",
+ "unicase",
+]
 
 [[package]]
 name = "minijinja"
@@ -3295,6 +3613,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "915b1b472bc21c53464d6c8461c9d3af805ba1ef837e1cac254428f4a77177b1"
+dependencies = [
+ "malloc_buf",
+]
+
+[[package]]
+name = "objc-foundation"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1add1b659e36c9607c7aab864a76c7a4c2760cd0cd2e120f3fb8b952c7e22bf9"
+dependencies = [
+ "block",
+ "objc",
+ "objc_id",
+]
+
+[[package]]
 name = "objc2"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3374,6 +3712,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7216bd11cbda54ccabcab84d523dc93b858ec75ecfb3a7d89513fa22464da396"
 dependencies = [
  "objc2-core-foundation",
+]
+
+[[package]]
+name = "objc_id"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c92d4ddb4bd7b50d730c215ff871754d0da6b2178849f8a2a2ab69712d0c073b"
+dependencies = [
+ "objc",
 ]
 
 [[package]]
@@ -3547,6 +3894,12 @@ dependencies = [
  "rand_core 0.6.4",
  "subtle",
 ]
+
+[[package]]
+name = "paste"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "pastey"
@@ -3813,6 +4166,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
 dependencies = [
  "toml_edit",
+]
+
+[[package]]
+name = "proc-macro-error-attr2"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96de42df36bb9bba5542fe9f1a054b8cc87e172759a1868aa05c1f3acc89dfc5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+]
+
+[[package]]
+name = "proc-macro-error2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11ec05c52be0a07b08061f7dd003e7d7092e0472bc731b4af7bb1ef876109802"
+dependencies = [
+ "proc-macro-error-attr2",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -4450,10 +4825,51 @@ dependencies = [
 ]
 
 [[package]]
+name = "rust-embed"
+version = "8.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9e7760e252aaba7b09f4be00e36476cf585bdb68a53552ac954cdf504ab4bc9"
+dependencies = [
+ "rust-embed-impl",
+ "rust-embed-utils",
+ "walkdir",
+]
+
+[[package]]
+name = "rust-embed-impl"
+version = "8.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3bcfc4d6f53af43755f7a723e4b6b8794fcce052a178dd8c6c1dadc5f5343097"
+dependencies = [
+ "mime_guess",
+ "proc-macro2",
+ "quote",
+ "rust-embed-utils",
+ "syn 2.0.119",
+ "walkdir",
+]
+
+[[package]]
+name = "rust-embed-utils"
+version = "8.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42ffa149f6aa81b58a5b3011d01a857c4ed12c7a732d2c51947a4c7c692185f0"
+dependencies = [
+ "sha2 0.11.0",
+ "walkdir",
+]
+
+[[package]]
 name = "rustc-hash"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
+
+[[package]]
+name = "rustc-hash"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b1e7f9a428571be2dc5bc0505c13fb6bf936822b894ec87abf8a08a4e51742d"
 
 [[package]]
 name = "rustc_version"
@@ -4658,6 +5074,21 @@ dependencies = [
  "tempfile",
  "windows-sys 0.52.0",
 ]
+
+[[package]]
+name = "self_cell"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e14e4d63b804dc0c7ec4a1e52bcb63f02c7ac94476755aa579edac21e01f915d"
+dependencies = [
+ "self_cell 1.3.0",
+]
+
+[[package]]
+name = "self_cell"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ab42ca02749e120097e328d91d415325bdf43b1c72c4c8badf37375fe40a813"
 
 [[package]]
 name = "semver"
@@ -4941,6 +5372,15 @@ name = "slab"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
+
+[[package]]
+name = "slugify"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6b8cf203d2088b831d7558f8e5151bfa420c57a34240b28cee29d0ae5f2ac8b"
+dependencies = [
+ "unidecode",
+]
 
 [[package]]
 name = "smallvec"
@@ -5309,6 +5749,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "sys-locale"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8eab9a99a024a169fe8a903cf9d4a3b3601109bcc13bd9e3c6fff259138626c4"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "sysinfo"
 version = "0.30.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5525,7 +5974,7 @@ dependencies = [
  "once_cell",
  "pbkdf2",
  "rand 0.8.7",
- "rustc-hash",
+ "rustc-hash 1.1.0",
  "sha2 0.10.9",
  "thiserror 1.0.69",
  "unicode-normalization",
@@ -5540,6 +5989,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
 dependencies = [
  "displaydoc",
+ "serde_core",
  "zerovec",
 ]
 
@@ -5618,6 +6068,15 @@ dependencies = [
  "futures-sink",
  "pin-project-lite",
  "tokio",
+]
+
+[[package]]
+name = "toml"
+version = "0.5.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4f7f0dd8d50a853a531c426359045b1998f04219d88799810762cd4ad314234"
+dependencies = [
+ "serde",
 ]
 
 [[package]]
@@ -5802,6 +6261,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
 
 [[package]]
+name = "tr"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79d30c7e79732253d80e9d619007002c8f3a362b0816e37340af648d4e2c6092"
+dependencies = [
+ "gettext",
+]
+
+[[package]]
 name = "tracing"
 version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5973,6 +6441,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "type-map"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb30dbbd9036155e74adad6812e9898d03ec374946234fbcebd5dfc7b9187b90"
+dependencies = [
+ "rustc-hash 2.1.3",
+]
+
+[[package]]
 name = "typed-builder"
 version = "0.23.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6009,6 +6486,25 @@ name = "unarray"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
+
+[[package]]
+name = "unic-langid"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a28ba52c9b05311f4f6e62d5d9d46f094bd6e84cb8df7b3ef952748d752a7d05"
+dependencies = [
+ "unic-langid-impl",
+]
+
+[[package]]
+name = "unic-langid-impl"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dce1bf08044d4b7a94028c93786f8566047edc11110595914de93362559bc658"
+dependencies = [
+ "serde",
+ "tinystr",
+]
 
 [[package]]
 name = "unicase"
@@ -6077,6 +6573,12 @@ name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
+name = "unidecode"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "402bb19d8e03f1d1a7450e2bd613980869438e0666331be3e073089124aa1adc"
 
 [[package]]
 name = "unit-prefix"
@@ -7048,6 +7550,7 @@ version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239"
 dependencies = [
+ "serde",
  "yoke",
  "zerofrom",
  "zerovec-derive",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -433,6 +433,7 @@ dependencies = [
  "time",
  "tracing",
  "tracing-subscriber",
+ "unic-langid",
  "unicode-segmentation",
  "unicode-width 0.2.2",
  "url",

--- a/crates/atuin-common/Cargo.toml
+++ b/crates/atuin-common/Cargo.toml
@@ -46,11 +46,12 @@ itertools = { workspace = true }
 sys-locale = "0.3.2"
 
 lazy_static = "1.4.0"
-i18n-embed = { version = "0.15.3", features = ["fluent", "fluent-system", "tr", "locale_config", "walkdir", "filesystem-assets"] }
+i18n-embed = { version = "0.15.3", features = ["fluent", "fluent-system", "tr", "locale_config", "desktop-requester", "walkdir", "filesystem-assets"] }
 rust-embed = "8"
 i18n-embed-fl = "0.9.3"
 slugify = "0.1.0"
 paste = "1.0.15"
+unic-langid = "0.9.5"
 
 [dev-dependencies]
 pretty_assertions = { workspace = true }

--- a/crates/atuin-common/Cargo.toml
+++ b/crates/atuin-common/Cargo.toml
@@ -46,7 +46,7 @@ itertools = { workspace = true }
 sys-locale = "0.3.2"
 
 lazy_static = "1.4.0"
-i18n-embed = { version = "0.15.3", features = ["fluent", "fluent-system", "tr", "locale_config", "desktop-requester", "walkdir", "gettext-system", "autoreload", "filesystem-assets", "notify"] }
+i18n-embed = { version = "0.15.3", features = ["fluent", "fluent-system", "tr", "locale_config", "walkdir", "filesystem-assets"] }
 rust-embed = "8"
 i18n-embed-fl = "0.9.3"
 slugify = "0.1.0"

--- a/crates/atuin-common/Cargo.toml
+++ b/crates/atuin-common/Cargo.toml
@@ -24,6 +24,7 @@ unicode = ["dep:unicode-width", "dep:unicode-segmentation"]
 ansi = ["dep:vt100"]
 
 [dependencies]
+atuin-macro = { path = "../atuin-macro" }
 derive_more = { workspace = true }
 time = { workspace = true, features = ["formatting", "parsing"] }
 serde = { workspace = true }
@@ -42,6 +43,14 @@ unicode-width = { version = "0.2", optional = true }
 unicode-segmentation = { version = "1.11.0", optional = true }
 vt100 = { workspace = true, optional = true }
 itertools = { workspace = true }
+sys-locale = "0.3.2"
+
+lazy_static = "1.4.0"
+i18n-embed = { version = "0.15.3", features = ["fluent", "fluent-system", "tr", "locale_config", "desktop-requester", "walkdir", "gettext-system", "autoreload", "filesystem-assets", "notify"] }
+rust-embed = "8"
+i18n-embed-fl = "0.9.3"
+slugify = "0.1.0"
+paste = "1.0.15"
 
 [dev-dependencies]
 pretty_assertions = { workspace = true }

--- a/crates/atuin-common/i18n.toml
+++ b/crates/atuin-common/i18n.toml
@@ -2,7 +2,7 @@
 # source code for gettext system, and the primary fallback language
 # (for which all strings must be present) when using the fluent
 # system.
-fallback_language = "en-US"
+fallback_language = "en-GB"
 
 # Use the fluent localization system.
 [fluent]

--- a/crates/atuin-common/i18n.toml
+++ b/crates/atuin-common/i18n.toml
@@ -1,0 +1,13 @@
+# (Required) The language identifier of the language used in the
+# source code for gettext system, and the primary fallback language
+# (for which all strings must be present) when using the fluent
+# system.
+fallback_language = "en-US"
+
+# Use the fluent localization system.
+[fluent]
+domain = "atuin"
+# (Required) The path to the assets directory.
+# The paths inside the assets directory should be structured like so:
+# `assets_dir/{language}/{domain}.ftl`
+assets_dir = "../../i18n"

--- a/crates/atuin-common/src/i18n.rs
+++ b/crates/atuin-common/src/i18n.rs
@@ -13,6 +13,8 @@ pub use atuin_macro::tl;
 use lazy_static::lazy_static;
 
 lazy_static! {
+    // We assume that one LOADER is sufficient. Fluent provides more
+    // flexibility, but for now, this simplifies integration.
     pub static ref LOADER: FluentLanguageLoader = {
         // Load languages from central internationalization folder.
         let language_loader: FluentLanguageLoader = fluent_language_loader!();
@@ -26,10 +28,12 @@ lazy_static! {
 
 #[macro_export]
 macro_rules! t {
+    // Case that t!("foo bar") is called with no runtime parameters to interpolate.
     ($message_id:literal) => {
         $crate::i18n::tl!($crate::i18n::fl, $crate::i18n::LOADER, $message_id)
     };
 
+    // Case that t!("foo %{bar}", bar=baz.to_string()) is called with runtime parameters to interpolate.
     ($message_id:literal, $($args:expr),*) => {{
         $crate::i18n::tl!($crate::i18n::fl, $crate::i18n::LOADER, $message_id, $($args), *)
     }};

--- a/crates/atuin-common/src/i18n.rs
+++ b/crates/atuin-common/src/i18n.rs
@@ -1,15 +1,16 @@
-use i18n_embed::{DesktopLanguageRequester, fluent::{
-    FluentLanguageLoader, fluent_language_loader
-}};
-use rust_embed::RustEmbed;
+use i18n_embed::{
+    DesktopLanguageRequester,
+    fluent::{FluentLanguageLoader, fluent_language_loader},
+};
 pub use i18n_embed_fl::fl;
+use rust_embed::RustEmbed;
 
 #[derive(RustEmbed)]
 #[folder = "../../i18n"] // path to the compiled localization resources
 struct Localizations;
 
-use lazy_static::lazy_static;
 pub use atuin_macro::tl;
+use lazy_static::lazy_static;
 
 lazy_static! {
     pub static ref LOADER: FluentLanguageLoader = {

--- a/crates/atuin-common/src/i18n.rs
+++ b/crates/atuin-common/src/i18n.rs
@@ -1,0 +1,37 @@
+use i18n_embed::{DesktopLanguageRequester, fluent::{
+    FluentLanguageLoader, fluent_language_loader
+}};
+use rust_embed::RustEmbed;
+pub use i18n_embed_fl::fl;
+
+#[derive(RustEmbed)]
+#[folder = "../../i18n"] // path to the compiled localization resources
+struct Localizations;
+
+use lazy_static::lazy_static;
+pub use atuin_macro::tl;
+
+lazy_static! {
+    pub static ref LOADER: FluentLanguageLoader = {
+        // Load languages from central internationalization folder.
+        let language_loader: FluentLanguageLoader = fluent_language_loader!();
+        let requested_languages = DesktopLanguageRequester::requested_languages();
+
+        let _result = i18n_embed::select(
+            &language_loader, &Localizations, &requested_languages);
+        language_loader
+    };
+}
+
+#[macro_export]
+macro_rules! t {
+    ($message_id:literal) => {
+        $crate::i18n::tl!($crate::i18n::fl, $crate::i18n::LOADER, $message_id)
+    };
+
+    ($message_id:literal, $($args:expr),*) => {{
+        $crate::i18n::tl!($crate::i18n::fl, $crate::i18n::LOADER, $message_id, $($args), *)
+    }};
+}
+
+pub use t;

--- a/crates/atuin-common/src/lib.rs
+++ b/crates/atuin-common/src/lib.rs
@@ -4,6 +4,7 @@
 pub mod ansi;
 pub mod docs;
 pub mod filter;
+pub mod i18n;
 pub mod logs;
 pub mod path;
 pub mod shell;
@@ -14,4 +15,3 @@ pub mod test_utils;
 pub mod time;
 pub mod url;
 pub mod utils;
-pub mod i18n;

--- a/crates/atuin-common/src/lib.rs
+++ b/crates/atuin-common/src/lib.rs
@@ -14,3 +14,4 @@ pub mod test_utils;
 pub mod time;
 pub mod url;
 pub mod utils;
+pub mod i18n;

--- a/crates/atuin-macro/Cargo.toml
+++ b/crates/atuin-macro/Cargo.toml
@@ -31,7 +31,7 @@ getrandom = "0.2"
 sys-locale = "0.3.2"
 
 lazy_static = "1.4.0"
-i18n-embed = { version = "0.15.3", features = ["fluent", "fluent-system", "tr", "locale_config", "walkdir", "filesystem-assets"] }
+i18n-embed = { version = "0.15.3", features = ["fluent", "fluent-system", "tr", "locale_config", "desktop-requester", "walkdir", "filesystem-assets"] }
 rust-embed = "8"
 i18n-embed-fl = "0.9.3"
 slugify = "0.1.0"

--- a/crates/atuin-macro/Cargo.toml
+++ b/crates/atuin-macro/Cargo.toml
@@ -31,7 +31,7 @@ getrandom = "0.2"
 sys-locale = "0.3.2"
 
 lazy_static = "1.4.0"
-i18n-embed = { version = "0.15.3", features = ["fluent", "fluent-system", "tr", "locale_config", "desktop-requester", "walkdir", "gettext-system", "autoreload", "filesystem-assets", "notify"] }
+i18n-embed = { version = "0.15.3", features = ["fluent", "fluent-system", "tr", "locale_config", "walkdir", "filesystem-assets"] }
 rust-embed = "8"
 i18n-embed-fl = "0.9.3"
 slugify = "0.1.0"

--- a/crates/atuin-macro/Cargo.toml
+++ b/crates/atuin-macro/Cargo.toml
@@ -1,0 +1,41 @@
+[package]
+name = "atuin-macro"
+edition = "2021"
+description = "macro library for atuin"
+
+rust-version = { workspace = true }
+version = { workspace = true }
+authors = { workspace = true }
+license = { workspace = true }
+homepage = { workspace = true }
+repository = { workspace = true }
+
+[lib]
+proc-macro = true
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+time = { workspace = true }
+serde = { workspace = true }
+uuid = { workspace = true }
+typed-builder = { workspace = true }
+eyre = { workspace = true }
+sqlx = { workspace = true }
+semver = { workspace = true }
+thiserror = { workspace = true }
+directories = { workspace = true }
+sysinfo = "0.30.7"
+base64 = { workspace = true }
+getrandom = "0.2"
+sys-locale = "0.3.2"
+
+lazy_static = "1.4.0"
+i18n-embed = { version = "0.15.3", features = ["fluent", "fluent-system", "tr", "locale_config", "desktop-requester", "walkdir", "gettext-system", "autoreload", "filesystem-assets", "notify"] }
+rust-embed = "8"
+i18n-embed-fl = "0.9.3"
+slugify = "0.1.0"
+paste = "1.0.15"
+syn = "2.0.96"
+quote = "1.0.38"
+proc-macro2 = "1.0.93"

--- a/crates/atuin-macro/i18n.toml
+++ b/crates/atuin-macro/i18n.toml
@@ -1,0 +1,13 @@
+# (Required) The language identifier of the language used in the
+# source code for gettext system, and the primary fallback language
+# (for which all strings must be present) when using the fluent
+# system.
+fallback_language = "en-GB"
+
+# Use the fluent localization system.
+[fluent]
+domain = "atuin"
+# (Required) The path to the assets directory.
+# The paths inside the assets directory should be structured like so:
+# `assets_dir/{language}/{domain}.ftl`
+assets_dir = "./tests/i18n"

--- a/crates/atuin-macro/src/lib.rs
+++ b/crates/atuin-macro/src/lib.rs
@@ -2,42 +2,68 @@
 extern crate proc_macro;
 
 use proc_macro::TokenStream;
+use proc_macro2::TokenStream as TokenStream2;
 use quote::quote;
 use slugify::slugify;
 use syn::parse::Parser;
 
+fn literal_to_slug(literal: &syn::ExprLit) -> TokenStream2 {
+    // We pull out the actual text from the literal string expression.
+    let quoted: String = match &literal.lit {
+        syn::Lit::Str(message_id) => message_id.value(),
+        _ => panic!("Message ID must be a literal string"),
+    };
+    // ...and pass it to slugify,
+    let slug = slugify!(quoted.as_str());
+    // ...then turn it back into a literal string.
+    quote!(#slug)
+}
+
 #[proc_macro]
 pub fn tl(tokens: TokenStream) -> TokenStream {
+    // Begin by getting the individual arguments to tl!
     let args = syn::punctuated::Punctuated::<syn::Expr, syn::Token![,]>::parse_terminated
         .parse(tokens)
         .unwrap();
+
     let mut arg_iter = args.iter();
+
+    // The first should always be the fl! macro for fluent (cf. atuin-common/src/i18n.rs)
     let fl = arg_iter.next().unwrap();
+    // atuin-common will send the universal loader as the second argument. This avoids
+    // every translation string having to explicitly pass it.
     let loader = arg_iter.next().unwrap();
+
+    // The third argument should be the message ID. This logic takes the human-readable
+    // string and slugifies it. One of the main benefits of Fluent is that English-language
+    // ASCII is not the de facto reference (and things like gender and plurality can be
+    // encoded even where English makes no grammatical distinction). However, this approach
+    // still allows the `fl!` macro to be used directly, but saves having to switch all
+    // strings to slugs throughout the codebase just to make them translatable at all.
+
+    // It is possible that the string literal representing the message (e.g. "Danger, Bill Bobinson")
+    // appears wrapped in a group or not, so we handle both possibilities.
+    // We use literal_to_slug to turn it to a slug, e.g. "danger-bill-bobinson"
     let message_id: proc_macro2::TokenStream = match arg_iter.next() {
         Some(syn::Expr::Group(arg)) => match *arg.expr.clone() {
-            syn::Expr::Lit(arg) => {
-                let quoted: String = match &arg.lit {
-                    syn::Lit::Str(message_id) => message_id.value(),
-                    _ => panic!("Message ID must be a literal string"),
-                };
-                let slug = slugify!(quoted.as_str());
-                quote!(#slug)
-            }
+            syn::Expr::Lit(arg) => literal_to_slug(&arg),
             arg => panic!("Message ID {:?} must be a literal", arg),
         },
-        Some(syn::Expr::Lit(arg)) => {
-            let quoted: String = match &arg.lit {
-                syn::Lit::Str(message_id) => message_id.value(),
-                _ => panic!("Message ID must be a literal string"),
-            };
-            let slug = slugify!(quoted.as_str());
-            quote!(#slug)
-        }
+        Some(syn::Expr::Lit(arg)) => literal_to_slug(arg),
         arg => panic!("Message ID {:?} must be a literal", arg),
     };
+
+    // Reconstruct the arguments that we initially had, and pull in any extra ones
+    // that should go right through to Fluent. For example:
+    //     t!("Danger ${name}", name="Bill Bobinson")
+    //     -> tr!(fl, LOADER, "Danger ${name}", name="Bill Bobinson")
+    //     -> fl!(LOADER, "danger-name", name="Bill Bobinson")
+    // `danger-name` is then searched for in the i18n/ folder, and should map
+    // to a template like `Danger, { $name }` that Fluent can insert the parameter into.
     let args: Vec<_> = arg_iter.collect();
 
+    // If there are no parameters, then Fluent can do this entirely statically.
+    // Otherwise, it will require runtime interpolation.
     if args.is_empty() {
         TokenStream::from(quote!(
             #fl!(#loader, #message_id)

--- a/crates/atuin-macro/src/lib.rs
+++ b/crates/atuin-macro/src/lib.rs
@@ -1,0 +1,52 @@
+#![forbid(unsafe_code)]
+extern crate proc_macro;
+
+use proc_macro::TokenStream;
+use quote::quote;
+use syn;
+use syn::parse::Parser;
+use slugify::slugify;
+
+#[proc_macro]
+pub fn tl(tokens: TokenStream) -> TokenStream {
+    let args = syn::punctuated::Punctuated::<syn::Expr, syn::Token![,]>::parse_terminated.parse(tokens).unwrap();
+    let mut arg_iter = args.iter();
+    let fl = arg_iter.next().unwrap();
+    let loader = arg_iter.next().unwrap();
+    let message_id: proc_macro2::TokenStream = match arg_iter.next() {
+        Some(syn::Expr::Group(arg)) => {
+            match *arg.expr.clone() {
+                syn::Expr::Lit(arg) => {
+                    let quoted: String = match arg.lit.clone() {
+                        syn::Lit::Str(message_id) => message_id.value(),
+                        _ => panic!("Message ID must be a literal string")
+                    };
+                    let slug = slugify!(quoted.as_str());
+                    quote!(#slug)
+                },
+                arg => panic!("Message ID {:?} must be a literal", arg)
+            }
+        },
+        Some(syn::Expr::Lit(arg)) => {
+            let quoted: String = match arg.lit.clone() {
+                syn::Lit::Str(message_id) => message_id.value(),
+                _ => panic!("Message ID must be a literal string")
+            };
+            let slug = slugify!(quoted.as_str());
+            quote!(#slug)
+        },
+        arg => panic!("Message ID {:?} must be a literal", arg)
+    };
+    let args: Vec<_> = arg_iter.collect();
+
+    if args.is_empty() {
+        TokenStream::from(quote!(
+            #fl!(#loader, #message_id)
+        ))
+    } else {
+        TokenStream::from(quote!(
+            #fl!(#loader, #message_id, #(#args),*)
+        ))
+    }
+}
+

--- a/crates/atuin-macro/src/lib.rs
+++ b/crates/atuin-macro/src/lib.rs
@@ -3,38 +3,38 @@ extern crate proc_macro;
 
 use proc_macro::TokenStream;
 use quote::quote;
-use syn::parse::Parser;
 use slugify::slugify;
+use syn::parse::Parser;
 
 #[proc_macro]
 pub fn tl(tokens: TokenStream) -> TokenStream {
-    let args = syn::punctuated::Punctuated::<syn::Expr, syn::Token![,]>::parse_terminated.parse(tokens).unwrap();
+    let args = syn::punctuated::Punctuated::<syn::Expr, syn::Token![,]>::parse_terminated
+        .parse(tokens)
+        .unwrap();
     let mut arg_iter = args.iter();
     let fl = arg_iter.next().unwrap();
     let loader = arg_iter.next().unwrap();
     let message_id: proc_macro2::TokenStream = match arg_iter.next() {
-        Some(syn::Expr::Group(arg)) => {
-            match *arg.expr.clone() {
-                syn::Expr::Lit(arg) => {
-                    let quoted: String = match &arg.lit {
-                        syn::Lit::Str(message_id) => message_id.value(),
-                        _ => panic!("Message ID must be a literal string")
-                    };
-                    let slug = slugify!(quoted.as_str());
-                    quote!(#slug)
-                },
-                arg => panic!("Message ID {:?} must be a literal", arg)
+        Some(syn::Expr::Group(arg)) => match *arg.expr.clone() {
+            syn::Expr::Lit(arg) => {
+                let quoted: String = match &arg.lit {
+                    syn::Lit::Str(message_id) => message_id.value(),
+                    _ => panic!("Message ID must be a literal string"),
+                };
+                let slug = slugify!(quoted.as_str());
+                quote!(#slug)
             }
+            arg => panic!("Message ID {:?} must be a literal", arg),
         },
         Some(syn::Expr::Lit(arg)) => {
             let quoted: String = match &arg.lit {
                 syn::Lit::Str(message_id) => message_id.value(),
-                _ => panic!("Message ID must be a literal string")
+                _ => panic!("Message ID must be a literal string"),
             };
             let slug = slugify!(quoted.as_str());
             quote!(#slug)
-        },
-        arg => panic!("Message ID {:?} must be a literal", arg)
+        }
+        arg => panic!("Message ID {:?} must be a literal", arg),
     };
     let args: Vec<_> = arg_iter.collect();
 
@@ -48,4 +48,3 @@ pub fn tl(tokens: TokenStream) -> TokenStream {
         ))
     }
 }
-

--- a/crates/atuin-macro/src/lib.rs
+++ b/crates/atuin-macro/src/lib.rs
@@ -3,7 +3,6 @@ extern crate proc_macro;
 
 use proc_macro::TokenStream;
 use quote::quote;
-use syn;
 use syn::parse::Parser;
 use slugify::slugify;
 
@@ -17,7 +16,7 @@ pub fn tl(tokens: TokenStream) -> TokenStream {
         Some(syn::Expr::Group(arg)) => {
             match *arg.expr.clone() {
                 syn::Expr::Lit(arg) => {
-                    let quoted: String = match arg.lit.clone() {
+                    let quoted: String = match &arg.lit {
                         syn::Lit::Str(message_id) => message_id.value(),
                         _ => panic!("Message ID must be a literal string")
                     };
@@ -28,7 +27,7 @@ pub fn tl(tokens: TokenStream) -> TokenStream {
             }
         },
         Some(syn::Expr::Lit(arg)) => {
-            let quoted: String = match arg.lit.clone() {
+            let quoted: String = match &arg.lit {
                 syn::Lit::Str(message_id) => message_id.value(),
                 _ => panic!("Message ID must be a literal string")
             };

--- a/crates/atuin-macro/tests/basic.rs
+++ b/crates/atuin-macro/tests/basic.rs
@@ -24,7 +24,7 @@ lazy_static! {
 }
 
 #[test]
-fn basic_tr_without_parameter() {
+fn basic_tl_without_parameter() {
     assert_eq!(
         tl!(fl, LOADER, "Danger, Bill Bobinson"),
         "Danger, William of Bobinson"
@@ -32,7 +32,7 @@ fn basic_tr_without_parameter() {
 }
 
 #[test]
-fn basic_tr_with_parameter() {
+fn basic_tl_with_parameter() {
     assert_eq!(
         tl!(
             fl,
@@ -45,7 +45,7 @@ fn basic_tr_with_parameter() {
 }
 
 #[test]
-fn tr_with_non_en_range_without_parameter() {
+fn tl_with_non_en_range_without_parameter() {
     let language_loader: FluentLanguageLoader = fluent_language_loader!();
     let requested_languages = vec!["ga-IE".parse().unwrap()];
 
@@ -58,7 +58,7 @@ fn tr_with_non_en_range_without_parameter() {
 }
 
 #[test]
-fn tr_with_non_en_range_with_parameter() {
+fn tl_with_non_en_range_with_parameter() {
     let language_loader: FluentLanguageLoader = fluent_language_loader!();
     let requested_languages = vec!["hi-IN".parse().unwrap()];
 
@@ -76,7 +76,7 @@ fn tr_with_non_en_range_with_parameter() {
 }
 
 #[test]
-fn tr_with_selector_irrelevant() {
+fn tl_with_selector_parameter() {
     let language_loader: FluentLanguageLoader = fluent_language_loader!();
 
     let _result = i18n_embed::select(&language_loader, &Localizations, &vec!["en-GB".parse().unwrap()]);

--- a/crates/atuin-macro/tests/basic.rs
+++ b/crates/atuin-macro/tests/basic.rs
@@ -1,4 +1,4 @@
-use i18n_embed::fluent::{FluentLanguageLoader, fluent_language_loader};
+use i18n_embed::fluent::{fluent_language_loader, FluentLanguageLoader};
 pub use i18n_embed_fl::fl;
 use lazy_static::lazy_static;
 use rust_embed::RustEmbed;

--- a/crates/atuin-macro/tests/basic.rs
+++ b/crates/atuin-macro/tests/basic.rs
@@ -1,4 +1,4 @@
-use i18n_embed::fluent::{fluent_language_loader, FluentLanguageLoader};
+use i18n_embed::fluent::{FluentLanguageLoader, fluent_language_loader};
 pub use i18n_embed_fl::fl;
 use lazy_static::lazy_static;
 use rust_embed::RustEmbed;
@@ -79,7 +79,11 @@ fn tl_with_non_en_range_with_parameter() {
 fn tl_with_selector_parameter() {
     let language_loader: FluentLanguageLoader = fluent_language_loader!();
 
-    let _result = i18n_embed::select(&language_loader, &Localizations, &vec!["en-GB".parse().unwrap()]);
+    let _result = i18n_embed::select(
+        &language_loader,
+        &Localizations,
+        &vec!["en-GB".parse().unwrap()],
+    );
 
     assert_eq!(
         tl!(fl, language_loader, "the user that has files", gender = "f"),
@@ -91,7 +95,11 @@ fn tl_with_selector_parameter() {
         "the user that has files"
     );
 
-    let _result = i18n_embed::select(&language_loader, &Localizations, &vec!["ga-IE".parse().unwrap()]);
+    let _result = i18n_embed::select(
+        &language_loader,
+        &Localizations,
+        &vec!["ga-IE".parse().unwrap()],
+    );
 
     assert_eq!(
         tl!(fl, language_loader, "the user that has files", gender = "f"),

--- a/crates/atuin-macro/tests/basic.rs
+++ b/crates/atuin-macro/tests/basic.rs
@@ -95,6 +95,11 @@ fn tl_with_selector_parameter() {
         "the user that has files"
     );
 
+    assert_eq!(
+        tl!(fl, language_loader, "the user that has files", gender = "o"),
+        "the user that has files"
+    );
+
     let _result = i18n_embed::select(
         &language_loader,
         &Localizations,
@@ -109,5 +114,10 @@ fn tl_with_selector_parameter() {
     assert_eq!(
         tl!(fl, language_loader, "the user that has files", gender = "m"),
         "an t-úsáideoir a bhfuil comhaid aige"
+    );
+
+    assert_eq!(
+        tl!(fl, language_loader, "the user that has files", gender = "o"),
+        "an t-úsáideoir a bhfuil comhaid acu"
     );
 }

--- a/crates/atuin-macro/tests/basic.rs
+++ b/crates/atuin-macro/tests/basic.rs
@@ -74,3 +74,32 @@ fn tr_with_non_en_range_with_parameter() {
         "नमस्ते, मेरा नाम \u{2068}रीमा\u{2069} है।"
     );
 }
+
+#[test]
+fn tr_with_selector_irrelevant() {
+    let language_loader: FluentLanguageLoader = fluent_language_loader!();
+
+    let _result = i18n_embed::select(&language_loader, &Localizations, &vec!["en-GB".parse().unwrap()]);
+
+    assert_eq!(
+        tl!(fl, language_loader, "the user that has files", gender = "f"),
+        "the user that has files"
+    );
+
+    assert_eq!(
+        tl!(fl, language_loader, "the user that has files", gender = "m"),
+        "the user that has files"
+    );
+
+    let _result = i18n_embed::select(&language_loader, &Localizations, &vec!["ga-IE".parse().unwrap()]);
+
+    assert_eq!(
+        tl!(fl, language_loader, "the user that has files", gender = "f"),
+        "an t-úsáideoir a bhfuil comhaid aici"
+    );
+
+    assert_eq!(
+        tl!(fl, language_loader, "the user that has files", gender = "m"),
+        "an t-úsáideoir a bhfuil comhaid aige"
+    );
+}

--- a/crates/atuin-macro/tests/basic.rs
+++ b/crates/atuin-macro/tests/basic.rs
@@ -1,8 +1,6 @@
-use i18n_embed::{
-    fluent::{FluentLanguageLoader, fluent_language_loader},
-};
-use lazy_static::lazy_static;
+use i18n_embed::fluent::{fluent_language_loader, FluentLanguageLoader};
 pub use i18n_embed_fl::fl;
+use lazy_static::lazy_static;
 use rust_embed::RustEmbed;
 
 #[derive(RustEmbed)]
@@ -36,7 +34,12 @@ fn basic_tr_without_parameter() {
 #[test]
 fn basic_tr_with_parameter() {
     assert_eq!(
-        tl!(fl, LOADER, "unrecognized subcommand '%{subcommand}'", subcommand = "SUB"),
+        tl!(
+            fl,
+            LOADER,
+            "unrecognized subcommand '%{subcommand}'",
+            subcommand = "SUB"
+        ),
         "unrecognised subcommand '\u{2068}SUB\u{2069}'"
     );
 }
@@ -62,7 +65,12 @@ fn tr_with_non_en_range_with_parameter() {
     let _result = i18n_embed::select(&language_loader, &Localizations, &requested_languages);
 
     assert_eq!(
-        tl!(fl, language_loader, "Hello, my name is %{name}", name = "रीमा"),
+        tl!(
+            fl,
+            language_loader,
+            "Hello, my name is %{name}",
+            name = "रीमा"
+        ),
         "नमस्ते, मेरा नाम \u{2068}रीमा\u{2069} है।"
     );
 }

--- a/crates/atuin-macro/tests/basic.rs
+++ b/crates/atuin-macro/tests/basic.rs
@@ -1,0 +1,68 @@
+use i18n_embed::{
+    fluent::{FluentLanguageLoader, fluent_language_loader},
+};
+use lazy_static::lazy_static;
+pub use i18n_embed_fl::fl;
+use rust_embed::RustEmbed;
+
+#[derive(RustEmbed)]
+#[folder = "tests/i18n"] // path to the compiled localization resources
+struct Localizations;
+
+pub use atuin_macro::tl;
+
+lazy_static! {
+    // We assume that one LOADER is sufficient. Fluent provides more
+    // flexibility, but for now, this simplifies integration.
+    pub static ref LOADER: FluentLanguageLoader = {
+        // Load languages from central internationalization folder.
+        let language_loader: FluentLanguageLoader = fluent_language_loader!();
+        let requested_languages = vec!["en-GB".parse().unwrap()];
+
+        let _result = i18n_embed::select(
+            &language_loader, &Localizations, &requested_languages);
+        language_loader
+    };
+}
+
+#[test]
+fn basic_tr_without_parameter() {
+    assert_eq!(
+        tl!(fl, LOADER, "Danger, Bill Bobinson"),
+        "Danger, William of Bobinson"
+    );
+}
+
+#[test]
+fn basic_tr_with_parameter() {
+    assert_eq!(
+        tl!(fl, LOADER, "unrecognized subcommand '%{subcommand}'", subcommand = "SUB"),
+        "unrecognised subcommand '\u{2068}SUB\u{2069}'"
+    );
+}
+
+#[test]
+fn tr_with_non_en_range_without_parameter() {
+    let language_loader: FluentLanguageLoader = fluent_language_loader!();
+    let requested_languages = vec!["ga-IE".parse().unwrap()];
+
+    let _result = i18n_embed::select(&language_loader, &Localizations, &requested_languages);
+
+    assert_eq!(
+        tl!(fl, language_loader, "Danger, Bill Bobinson"),
+        "Contúirt, a Uilliam Mac Bhoboin"
+    );
+}
+
+#[test]
+fn tr_with_non_en_range_with_parameter() {
+    let language_loader: FluentLanguageLoader = fluent_language_loader!();
+    let requested_languages = vec!["hi-IN".parse().unwrap()];
+
+    let _result = i18n_embed::select(&language_loader, &Localizations, &requested_languages);
+
+    assert_eq!(
+        tl!(fl, language_loader, "Hello, my name is %{name}", name = "रीमा"),
+        "नमस्ते, मेरा नाम \u{2068}रीमा\u{2069} है।"
+    );
+}

--- a/crates/atuin-macro/tests/basic.rs
+++ b/crates/atuin-macro/tests/basic.rs
@@ -82,7 +82,7 @@ fn tl_with_selector_parameter() {
     let _result = i18n_embed::select(
         &language_loader,
         &Localizations,
-        &vec!["en-GB".parse().unwrap()],
+        &["en-GB".parse().unwrap()],
     );
 
     assert_eq!(
@@ -103,7 +103,7 @@ fn tl_with_selector_parameter() {
     let _result = i18n_embed::select(
         &language_loader,
         &Localizations,
-        &vec!["ga-IE".parse().unwrap()],
+        &["ga-IE".parse().unwrap()],
     );
 
     assert_eq!(

--- a/crates/atuin-macro/tests/i18n/en-GB/atuin.ftl
+++ b/crates/atuin-macro/tests/i18n/en-GB/atuin.ftl
@@ -4,3 +4,7 @@ danger-bill-bobinson =
   Danger, William of Bobinson
 hello-my-name-is-name =
   Hello, my name is { $name }
+the-user-that-has-files =
+  { $gender ->
+    *[other] the user that has files
+  }

--- a/crates/atuin-macro/tests/i18n/en-GB/atuin.ftl
+++ b/crates/atuin-macro/tests/i18n/en-GB/atuin.ftl
@@ -1,0 +1,6 @@
+unrecognized-subcommand-subcommand =
+  unrecognised subcommand '{ $subcommand }'
+danger-bill-bobinson =
+  Danger, William of Bobinson
+hello-my-name-is-name =
+  Hello, my name is { $name }

--- a/crates/atuin-macro/tests/i18n/ga-IE/atuin.ftl
+++ b/crates/atuin-macro/tests/i18n/ga-IE/atuin.ftl
@@ -1,2 +1,8 @@
 danger-bill-bobinson =
   Contúirt, a Uilliam Mac Bhoboin
+the-user-that-has-files =
+  { $gender ->
+    [f] an t-úsáideoir a bhfuil comhaid aici
+    [m] an t-úsáideoir a bhfuil comhaid aige
+    *[other] an t-úsáideoir a bhfuil comhaid acu
+  }

--- a/crates/atuin-macro/tests/i18n/ga-IE/atuin.ftl
+++ b/crates/atuin-macro/tests/i18n/ga-IE/atuin.ftl
@@ -1,0 +1,2 @@
+danger-bill-bobinson =
+  Contúirt, a Uilliam Mac Bhoboin

--- a/crates/atuin-macro/tests/i18n/hi-IN/atuin.ftl
+++ b/crates/atuin-macro/tests/i18n/hi-IN/atuin.ftl
@@ -1,0 +1,2 @@
+hello-my-name-is-name =
+    नमस्ते, मेरा नाम { $name } है।

--- a/crates/atuin/Cargo.toml
+++ b/crates/atuin/Cargo.toml
@@ -5,7 +5,7 @@ description = "atuin - magical shell history"
 readme = "./README.md"
 
 rust-version = { workspace = true }
-version = "18.5.0-beta.2"
+version = { workspace = true }
 authors = { workspace = true }
 license = { workspace = true }
 homepage = { workspace = true }

--- a/crates/atuin/Cargo.toml
+++ b/crates/atuin/Cargo.toml
@@ -5,7 +5,7 @@ description = "atuin - magical shell history"
 readme = "./README.md"
 
 rust-version = { workspace = true }
-version = { workspace = true }
+version = "18.5.0-beta.2"
 authors = { workspace = true }
 license = { workspace = true }
 homepage = { workspace = true }
@@ -120,6 +120,11 @@ thiserror = { workspace = true }
 
 # settings editor with comment and relative ordering preservation
 toml_edit = { workspace = true }
+
+# internationalization (Project Fluent)
+i18n-embed = { version = "0.15.3", features = ["fluent", "fluent-system", "tr", "locale_config", "desktop-requester", "walkdir", "gettext-system", "autoreload", "filesystem-assets", "notify"] }
+rust-embed = "8"
+i18n-embed-fl = "0.9.3"
 
 [target.'cfg(any(target_os = "windows", target_os = "macos"))'.dependencies]
 arboard = { version = "3.4", optional = true, default-features = false }

--- a/crates/atuin/Cargo.toml
+++ b/crates/atuin/Cargo.toml
@@ -122,7 +122,7 @@ thiserror = { workspace = true }
 toml_edit = { workspace = true }
 
 # internationalization (Project Fluent)
-i18n-embed = { version = "0.15.3", features = ["fluent", "fluent-system", "tr", "locale_config", "desktop-requester", "walkdir", "gettext-system", "autoreload", "filesystem-assets", "notify"] }
+i18n-embed = { version = "0.15.3", features = ["fluent", "fluent-system", "tr", "locale_config", "walkdir", "filesystem-assets"] }
 rust-embed = "8"
 i18n-embed-fl = "0.9.3"
 

--- a/crates/atuin/i18n.toml
+++ b/crates/atuin/i18n.toml
@@ -1,0 +1,14 @@
+# (Required) The language identifier of the language used in the
+# source code for gettext system, and the primary fallback language
+# (for which all strings must be present) when using the fluent
+# system.
+fallback_language = "en-US"
+
+# Use the fluent localization system.
+[fluent]
+domain = "atuin"
+
+# (Required) The path to the assets directory.
+# The paths inside the assets directory should be structured like so:
+# `assets_dir/{language}/{domain}.ftl`
+assets_dir = "../../i18n"

--- a/crates/atuin/i18n.toml
+++ b/crates/atuin/i18n.toml
@@ -2,12 +2,11 @@
 # source code for gettext system, and the primary fallback language
 # (for which all strings must be present) when using the fluent
 # system.
-fallback_language = "en-US"
+fallback_language = "en-GB"
 
 # Use the fluent localization system.
 [fluent]
 domain = "atuin"
-
 # (Required) The path to the assets directory.
 # The paths inside the assets directory should be structured like so:
 # `assets_dir/{language}/{domain}.ftl`

--- a/crates/atuin/src/command/external.rs
+++ b/crates/atuin/src/command/external.rs
@@ -84,7 +84,11 @@ fn render_not_found(subcommand: &str, bin: &str) -> StyledStr {
     let _ = write!(output, "{error}error:{error:#} ");
     let _ = write!(
         output,
-        "unrecognized subcommand '{invalid}{subcommand}{invalid:#}' "
+        "{} ",
+        t!(
+            "unrecognized subcommand '%{subcommand}'",
+            subcommand = format!("{invalid}{subcommand}{invalid:#}")
+        )
     );
     let _ = write!(
         output,

--- a/crates/atuin/src/main.rs
+++ b/crates/atuin/src/main.rs
@@ -1,5 +1,7 @@
 #![warn(clippy::pedantic, clippy::nursery)]
 #![allow(clippy::use_self, clippy::missing_const_for_fn)] // not 100% reliable
+#[macro_use]
+extern crate atuin_common;
 
 use clap::Parser;
 use clap::builder::Styles;

--- a/i18n/en-GB/atuin.ftl
+++ b/i18n/en-GB/atuin.ftl
@@ -1,0 +1,2 @@
+unrecognized-subcommand-subcommand =
+  unrecognised subcommand '{ $subcommand }'

--- a/i18n/en-US/atuin.ftl
+++ b/i18n/en-US/atuin.ftl
@@ -1,0 +1,2 @@
+unrecognized-subcommand-subcommand =
+  unrecognized subcommand '{ $subcommand }'

--- a/i18n/ga-IE/atuin.ftl
+++ b/i18n/ga-IE/atuin.ftl
@@ -1,0 +1,2 @@
+unrecognized-subcommand-subcommand =
+  ordú neamhaitheanta '{ $subcommand }'


### PR DESCRIPTION
Alternative approach to #2553. Not closing that just yet, but keen for feedback either way.

After thinking about the discussion on the [Forum](https://forum.atuin.sh/t/internationalization/733), the biggest challenge is that a lot of small changes brings risk. This is a suggestion:

1. finalize this PR that _only_ adds the machinery for Fluent (and an single "canary" string)
2. this [change](https://github.com/atuinsh/atuin/commit/697001768601d31c5ff4dfce3f281e865b18792d) sits on top to add give MVP coverage of translatable strings (feature/i18n-support-fluent-basic)
3. a much bigger set is here https://github.com/philtweir/fork-atuin/tree/feature/i18n-support-fluent

**Suggestion:** tidy-up, PR and merge this to provide i18n support. Once that is in a release and there is no negative feedback and folks confirm that the single example works OK, then PR 2., which is roughly the minimal set of common translatable strings. Less than that, and there's too much English leaking through to get buy-in, any more and the PR is oversized.

NB: there is a commit in 2. with English translations - note that it covers the full set of changes in 3.  so most of them can be ignored in the near-term (happy to split it in two parts - one for 2. and one for 3.).

*This PR does not add any translatable strings except one*. Changes 2. and 3. only translate the crates `atuin-common` and `atuin-client`, plus `inspector.rs` and `interactive.rs` in the `atuin` crate.

### How to test

This PR has only one translatable string, to make sure it works and breaks nothing, as the main challenge is to get the machinery in without regressions. However, using https://github.com/philtweir/fork-atuin/tree/feature/i18n-support-fluent-basic, you can build and take the interactive search as a minimal test.

In this PR, the only visible change should be:

```
$ LANG=en-US atuin asdf
error: unrecognized subcommand '⁨asdf⁩' and no executable named 'atuin-asdf' found in your PATH

Usage: atuin <COMMAND>

For more information, try '--help'.
```

vs

```
$ LANG=en-GB atuin asdf
error: unrecognised subcommand '⁨asdf⁩' and no executable named 'atuin-asdf' found in your PATH

Usage: atuin <COMMAND>

For more information, try '--help'.
```

### How translatability is implemented

Adding `t!(...)` everywhere appropriate, in some places accounting for static return values, and then progressively adding translations to `*.flt` files as people wish to (separately) PR.

## Notes

* as `t!(...)` can take arguments (e.g. translate `%{time} ago`) it does not return `&'static str`   so, for FilterMode, I used `lazy_static` and elsewhere, switched to `String` or otherwise worked-around.
* originally I leaned to rust-i18n as Project Fluent wants slug-like keys, and that would make PRs much bigger and hard to review, but this approach creates a more traditional gettext-like macro, which is less invasive (as recommended in the `cargo-i18n` docs) - **this means a new `atuin_macro` package** (if this is a hard no, please say and I will try new ideas!)
* I had some difficulty getting the crates to behave consistently independently (which was not previously an issue) but I have now centralized translation strings in a top-level `./i18n` folder (this has a side-benefit/downside that the same string will be translated the same way in all crates)

## Checks
- [x] I am happy for maintainers to push small adjustments to this PR, to speed up the review cycle
- [x] I have checked that there are no existing pull requests for the same thing
