### PR TITLE
fix: fish up binding bug

### DIFF
--- a/crates/atuin/src/command/client/init/fish.rs
+++ b/crates/atuin/src/command/client/init/fish.rs
@@ -10,20 +10,30 @@ pub fn init_static(disable_up_arrow: bool, disable_ctrl_r: bool) {
     // We keep it for compatibility with fish 3.x
     if std::env::var("ATUIN_NOBIND").is_err() {
         const BIND_CTRL_R: &str = r"bind \cr _atuin_search";
-        const BIND_UP_ARROW: &str = r"bind -k up _atuin_bind_up
-bind up _atuin_bind_up
-bind \eOA _atuin_bind_up
-bind \e\[A _atuin_bind_up";
         const BIND_CTRL_R_INS: &str = r"bind -M insert \cr _atuin_search";
         const BIND_UP_ARROW_INS: &str = r"bind -M insert -k up _atuin_bind_up
 bind -M insert \eOA _atuin_bind_up
 bind -M insert \e\[A _atuin_bind_up";
 
+        let bind_up_arrow = match std::env::var("FISH_VERSION") {
+            Ok(ref version) if version.starts_with("4.") => r"bind up _atuin_bind_up",
+            Ok(_) => r"bind -k up _atuin_bind_up",
+
+            // do nothing - we can't panic or error as this could be in use in
+            // non-fish pipelines
+            _ => "",
+        }
+        .to_string();
+
         if !disable_ctrl_r {
             println!("{BIND_CTRL_R}");
         }
         if !disable_up_arrow {
-            println!("{BIND_UP_ARROW}");
+            println!(
+                r"{bind_up_arrow}
+bind \eOA _atuin_bind_up
+bind \e\[A _atuin_bind_up"
+            );
         }
 
         println!("if bind -M insert > /dev/null 2>&1");


### PR DESCRIPTION
Closes: #2672

I think this was introduced in #2616 - typing the literally characters `u p` lead to opening the TUI, as we were still executing the fish 4 bindings on fish 3.7.

<!-- Thank you for making a PR! Bug fixes are always welcome, but if you're adding a new feature or changing an existing one, we'd really appreciate if you open an issue, post on the forum, or drop in on Discord -->

## Checks
- [ ] I am happy for maintainers to push small adjustments to this PR, to speed up the review cycle
- [ ] I have checked that there are no existing pull requests for the same thing
