### PR TITLE
feat: Add 'atuin scripts rm' and 'atuin scripts ls' aliases; allow reading from stdin

### DIFF
--- a/crates/atuin/src/command/client/scripts.rs
+++ b/crates/atuin/src/command/client/scripts.rs
@@ -1,5 +1,7 @@
 use std::collections::HashMap;
 use std::collections::HashSet;
+use std::io::IsTerminal;
+use std::io::Read;
 use std::path::PathBuf;
 
 use atuin_scripts::execution::template_script;
@@ -212,6 +214,7 @@ impl Cmd {
         script_db: atuin_scripts::database::Database,
         history_db: &impl Database,
     ) -> Result<()> {
+        let mut stdin = std::io::stdin();
         let script_content = if let Some(count_opt) = new_script.last {
             // Get the last N commands from history, plus 1 to exclude the command that runs this script
             let count = count_opt.unwrap_or(1) + 1; // Add 1 to the count to exclude the current command
@@ -251,6 +254,10 @@ impl Cmd {
         } else if let Some(script_path) = new_script.script {
             let script_content = std::fs::read_to_string(script_path)?;
             Some(script_content)
+        } else if !stdin.is_terminal() {
+            let mut buffer = String::new();
+            stdin.read_to_string(&mut buffer)?;
+            Some(buffer)
         } else {
             // Open editor with empty file
             Some(Self::open_editor(None)?)

--- a/crates/atuin/src/command/client/scripts.rs
+++ b/crates/atuin/src/command/client/scripts.rs
@@ -107,10 +107,12 @@ pub struct Delete {
 pub enum Cmd {
     New(NewScript),
     Run(Run),
+    #[command(alias = "ls")]
     List(List),
 
     Get(Get),
     Edit(Edit),
+    #[command(alias = "rm")]
     Delete(Delete),
 }
 


### PR DESCRIPTION
* Adds `atuin scripts ls` and `atuin scripts rm` as aliases for `atuin scripts list` and `atuin scripts delete`
* Allows piping from stdin when stdin [isn't a terminal](https://doc.rust-lang.org/beta/std/io/trait.IsTerminal.html)

<img width="700" alt="image" src="https://github.com/user-attachments/assets/33a954b5-600e-4d0b-bcfa-6805fca0eaf4" />

## Checks
- [x] I am happy for maintainers to push small adjustments to this PR, to speed up the review cycle
- [x] I have checked that there are no existing pull requests for the same thing
