### PR TITLE
fix: More thorough search through search.filters w/ workspaces

### DIFF
--- a/crates/atuin-client/src/settings.rs
+++ b/crates/atuin-client/src/settings.rs
@@ -719,10 +719,20 @@ impl Settings {
         None
     }
 
-    pub fn default_filter_mode(&self) -> FilterMode {
+    pub fn default_filter_mode(&self, git_root: bool) -> FilterMode {
         self.filter_mode
             .filter(|x| self.search.filters.contains(x))
-            .or(self.search.filters.first().copied())
+            .or_else(|| {
+                self.search
+                    .filters
+                    .iter()
+                    .find(|x| match (x, git_root, self.workspaces) {
+                        (FilterMode::Workspace, true, true) => true,
+                        (FilterMode::Workspace, _, _) => false,
+                        (_, _, _) => true,
+                    })
+                    .copied()
+            })
             .unwrap_or(FilterMode::Global)
     }
 
@@ -944,6 +954,60 @@ mod tests {
         // require a leading sign for clarity
         assert!(Timezone::from_str("5").is_err());
         assert!(Timezone::from_str("10:30").is_err());
+
+        Ok(())
+    }
+
+    #[test]
+    fn can_choose_workspace_filters_when_in_git_context() -> Result<()> {
+        let mut settings = super::Settings::default();
+        settings.search.filters = vec![
+            super::FilterMode::Workspace,
+            super::FilterMode::Host,
+            super::FilterMode::Directory,
+            super::FilterMode::Session,
+            super::FilterMode::Global,
+        ];
+        settings.workspaces = true;
+
+        assert_eq!(
+            settings.default_filter_mode(true),
+            super::FilterMode::Workspace,
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn wont_choose_workspace_filters_when_not_in_git_context() -> Result<()> {
+        let mut settings = super::Settings::default();
+        settings.search.filters = vec![
+            super::FilterMode::Workspace,
+            super::FilterMode::Host,
+            super::FilterMode::Directory,
+            super::FilterMode::Session,
+            super::FilterMode::Global,
+        ];
+        settings.workspaces = true;
+
+        assert_eq!(settings.default_filter_mode(false), super::FilterMode::Host,);
+
+        Ok(())
+    }
+
+    #[test]
+    fn wont_choose_workspace_filters_when_workspaces_disabled() -> Result<()> {
+        let mut settings = super::Settings::default();
+        settings.search.filters = vec![
+            super::FilterMode::Workspace,
+            super::FilterMode::Host,
+            super::FilterMode::Directory,
+            super::FilterMode::Session,
+            super::FilterMode::Global,
+        ];
+        settings.workspaces = false;
+
+        assert_eq!(settings.default_filter_mode(true), super::FilterMode::Host,);
 
         Ok(())
     }

--- a/crates/atuin/src/command/client/history.rs
+++ b/crates/atuin/src/command/client/history.rs
@@ -468,7 +468,10 @@ impl Cmd {
             (true, true) => [Session, Directory],
             (true, false) => [Session, Global],
             (false, true) => [Global, Directory],
-            (false, false) => [settings.default_filter_mode(), Global],
+            (false, false) => [
+                settings.default_filter_mode(context.git_root.is_some()),
+                Global,
+            ],
         };
 
         let history = db

--- a/crates/atuin/src/command/client/scripts.rs
+++ b/crates/atuin/src/command/client/scripts.rs
@@ -221,7 +221,7 @@ impl Cmd {
             let context = atuin_client::database::current_context();
 
             // Get the last N+1 commands, filtering by the default mode
-            let filters = [settings.default_filter_mode()];
+            let filters = [settings.default_filter_mode(context.git_root.is_some())];
 
             let mut history = history_db
                 .list(&filters, &context, Some(count), false, false)

--- a/crates/atuin/src/command/client/search.rs
+++ b/crates/atuin/src/command/client/search.rs
@@ -305,7 +305,7 @@ async fn run_non_interactive(
         ..filter_options
     };
 
-    let filter_mode = settings.default_filter_mode();
+    let filter_mode = settings.default_filter_mode(context.git_root.is_some());
 
     let results = db
         .search(

--- a/crates/atuin/src/command/client/search/interactive.rs
+++ b/crates/atuin/src/command/client/search/interactive.rs
@@ -13,9 +13,7 @@ use unicode_width::UnicodeWidthStr;
 use atuin_client::{
     database::{Database, current_context},
     history::{History, HistoryStats, store::HistoryStore},
-    settings::{
-        CursorStyle, ExitMode, FilterMode, KeymapMode, PreviewStrategy, SearchMode, Settings,
-    },
+    settings::{CursorStyle, ExitMode, KeymapMode, PreviewStrategy, SearchMode, Settings},
 };
 
 use super::{
@@ -1096,9 +1094,7 @@ pub async fn history(
             filter_mode: settings
                 .filter_mode_shell_up_key_binding
                 .filter(|_| settings.shell_up_key_binding)
-                .or_else(|| Some(settings.default_filter_mode()))
-                .filter(|&x| x != FilterMode::Workspace || context.git_root.is_some())
-                .unwrap_or(FilterMode::Global),
+                .unwrap_or_else(|| settings.default_filter_mode(context.git_root.is_some())),
             context,
         },
         engine: engines::engine(search_mode),


### PR DESCRIPTION
Do not just pick first from search.filters, consider all options, filtering based on git-root and workspaces config

atuinsh/atuin#2700

Wrote a few simple unit tests, and tried it by running the client locally. Not sure about which of "[search] filters" vs "workspaces" should be more respected, so i made it so if workspaces = false, regardless of whats in "[search] filters" workspace gets filtered out.

First time looking at atuins code, let me know if this needs any changes.

<!-- Thank you for making a PR! Bug fixes are always welcome, but if you're adding a new feature or changing an existing one, we'd really appreciate if you open an issue, post on the forum, or drop in on Discord -->

## Checks
- [X] I am happy for maintainers to push small adjustments to this PR, to speed up the review cycle
- [X] I have checked that there are no existing pull requests for the same thing
  - #1655 might be related, but it seems to also implement code that is already merged, and has been open for over a year, hope its ok to suggest this
