### PR TITLE
fix: selection vs render issue

### DIFF
--- a/crates/atuin/src/command/client/search/interactive.rs
+++ b/crates/atuin/src/command/client/search/interactive.rs
@@ -199,7 +199,12 @@ impl State {
         }
     }
 
-    fn handle_key_input(&mut self, settings: &Settings, input: &KeyEvent, results: &[History]) -> InputAction {
+    fn handle_key_input(
+        &mut self,
+        settings: &Settings,
+        input: &KeyEvent,
+        results: &[History],
+    ) -> InputAction {
         if input.kind == event::KeyEventKind::Release {
             return InputAction::Continue;
         }
@@ -231,7 +236,7 @@ impl State {
                 } else {
                     Some(InputAction::ReturnQuery)
                 }
-            },
+            }
             KeyCode::Right if cursor_at_end_of_line => {
                 let selected = self.results_state.selected();
                 if !results.is_empty() && selected < results.len() {
@@ -239,7 +244,7 @@ impl State {
                 } else {
                     Some(InputAction::ReturnQuery)
                 }
-            },
+            }
             KeyCode::Left if cursor_at_start_of_line => Some(Self::handle_key_exit(settings)),
             KeyCode::Char('o') if ctrl => {
                 self.tab_index = (self.tab_index + 1) % TAB_TITLES.len();
@@ -307,7 +312,12 @@ impl State {
 
     #[allow(clippy::too_many_lines)]
     #[allow(clippy::cognitive_complexity)]
-    fn handle_search_input(&mut self, settings: &Settings, input: &KeyEvent, results: &[History]) -> InputAction {
+    fn handle_search_input(
+        &mut self,
+        settings: &Settings,
+        input: &KeyEvent,
+        results: &[History],
+    ) -> InputAction {
         let ctrl = input.modifiers.contains(KeyModifiers::CONTROL);
         let alt = input.modifiers.contains(KeyModifiers::ALT);
 
@@ -1256,9 +1266,7 @@ pub async fn history(
             }
             Ok(String::new())
         }
-        InputAction::ReturnQuery => {
-            Ok(app.search.input.into_inner())
-        }
+        InputAction::ReturnQuery => Ok(app.search.input.into_inner()),
         InputAction::Continue | InputAction::Redraw | InputAction::Delete(_) => {
             unreachable!("should have been handled!")
         }

--- a/crates/atuin/src/command/client/search/interactive.rs
+++ b/crates/atuin/src/command/client/search/interactive.rs
@@ -1164,7 +1164,10 @@ pub async fn history(
                 if event_ready?? {
                     loop {
                         match app.handle_input(settings, &event::read()?, &mut std::io::stdout(), &results)? {
-                            InputAction::Continue => {},
+                            InputAction::Continue => {
+                                // Redraw the UI to keep it in sync with the selection state
+                                terminal.draw(|f| app.draw(f, &results, stats.clone(), settings, theme))?;
+                            },
                             InputAction::Delete(index) => {
                                 if results.is_empty() {
                                     break;

--- a/crates/atuin/src/command/client/search/interactive.rs
+++ b/crates/atuin/src/command/client/search/interactive.rs
@@ -49,7 +49,7 @@ use ratatui::{
 const TAB_TITLES: [&str; 2] = ["Search", "Inspect"];
 
 pub enum InputAction {
-    Accept(usize, History),
+    Accept(History),
     Copy(usize),
     Delete(usize),
     ReturnOriginal,
@@ -227,7 +227,7 @@ impl State {
             KeyCode::Tab => {
                 let selected = self.results_state.selected();
                 if !results.is_empty() && selected < results.len() {
-                    Some(InputAction::Accept(selected, results[selected].clone()))
+                    Some(InputAction::Accept(results[selected].clone()))
                 } else {
                     Some(InputAction::ReturnQuery)
                 }
@@ -235,7 +235,7 @@ impl State {
             KeyCode::Right if cursor_at_end_of_line => {
                 let selected = self.results_state.selected();
                 if !results.is_empty() && selected < results.len() {
-                    Some(InputAction::Accept(selected, results[selected].clone()))
+                    Some(InputAction::Accept(results[selected].clone()))
                 } else {
                     Some(InputAction::ReturnQuery)
                 }
@@ -299,7 +299,7 @@ impl State {
         }
         let selected = self.results_state.selected();
         if !results.is_empty() && selected < results.len() {
-            InputAction::Accept(selected, results[selected].clone())
+            InputAction::Accept(results[selected].clone())
         } else {
             InputAction::ReturnQuery
         }
@@ -408,7 +408,7 @@ impl State {
                 return c.to_digit(10).map_or(InputAction::Continue, |c| {
                     let new_index = selected + c as usize;
                     if !results.is_empty() && new_index < results.len() {
-                        InputAction::Accept(new_index, results[new_index].clone())
+                        InputAction::Accept(results[new_index].clone())
                     } else {
                         InputAction::ReturnQuery
                     }
@@ -1237,7 +1237,7 @@ pub async fn history(
     }
 
     match result {
-        InputAction::Accept(_, history) => {
+        InputAction::Accept(history) => {
             let mut command = history.command;
             if accept
                 && (utils::is_zsh() || utils::is_fish() || utils::is_bash() || utils::is_xonsh())


### PR DESCRIPTION
Edit: after testing, I don't think this resolves the issue. HOWEVER I would like to make this change regardless

I can't replicate that issue just yet so i have _no idea_

It could be a classic race condition. When the UI selects an entry, it only stores the index of the selected item, not the actual entry itself. Then later, when it comes time to actually return the command, it goes back to the results array and grabs whatever is at that index. This is fine most of the time...

BUT - if anything changed the results array between selection and execution (like a new search query being processed), the index would still point to the same position, but that position might now contain a completely different history entry! 🫠

There's another potential cause too. We have the main loop, that handles calling draw + also updating the results when needed. But an inner loop, that processes all input events received. If a user sends a lot of events (maybe holds the arrow key?), then there could be a discrepancy between the selected state and the currently rendered state. Ensure we also call draw when we process the Continue event.

## Checks
- [ ] I am happy for maintainers to push small adjustments to this PR, to speed up the review cycle
- [ ] I have checked that there are no existing pull requests for the same thing
