### PR TITLE
feat(stats): add jj to default common subcommands

### DIFF
--- a/crates/atuin-client/config.toml
+++ b/crates/atuin-client/config.toml
@@ -183,6 +183,7 @@ enter_accept = true
 #   "git",
 #   "go",
 #   "ip",
+#   "jj",
 #   "kubectl",
 #   "nix",
 #   "nmcli",

--- a/crates/atuin-client/src/settings.rs
+++ b/crates/atuin-client/src/settings.rs
@@ -293,6 +293,7 @@ impl Stats {
             "git",
             "go",
             "ip",
+            "jj",
             "kubectl",
             "nix",
             "nmcli",


### PR DESCRIPTION
This PR adds `jj`, the CLI for the [Jujutsu VCS](https://jj-vcs.github.io), to the default list of `common_subcommands`. As with `git`, `jj` makes extensive use of subcommands.

<!-- Thank you for making a PR! Bug fixes are always welcome, but if you're adding a new feature or changing an existing one, we'd really appreciate if you open an issue, post on the forum, or drop in on Discord -->

## Checks
- [x] I am happy for maintainers to push small adjustments to this PR, to speed up the review cycle
- [x] I have checked that there are no existing pull requests for the same thing
