### PR TITLE
fix: zsh + omz selecting the wrong item from history

### DIFF
--- a/crates/atuin/src/shell/atuin.zsh
+++ b/crates/atuin/src/shell/atuin.zsh
@@ -71,8 +71,6 @@ _atuin_search() {
         then
             LBUFFER=${LBUFFER#__atuin_accept__:}
             zle accept-line
-        else
-            zle .infer-next-history && zle .up-history
         fi
     fi
 }


### PR DESCRIPTION
Resolves #2704 

After seeing a reproduction case that @BinaryMuse found, it seems like the error is occurring in the shell. Opening a new shell stops it from happening

This change reverts all changes to atuin.zsh since 18.3.0

## Checks
- [ ] I am happy for maintainers to push small adjustments to this PR, to speed up the review cycle
- [ ] I have checked that there are no existing pull requests for the same thing
