### PR TITLE
chore: Allow setting script DB path

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,9 +13,10 @@ Before working on anything, we suggest taking a copy of your Atuin data director
 While data directory backups are always a good idea, you can instruct Atuin to use custom path using the following environment variables:
 
 ```shell
+export ATUIN_RECORD_STORE_PATH=/tmp/atuin_records.db
 export ATUIN_DB_PATH=/tmp/atuin_dev.db
 export ATUIN_KV__DB_PATH=/tmp/atuin_kv.db
-export ATUIN_RECORD_STORE_PATH=/tmp/atuin_records.db
+export ATUIN_SCRIPTS__DB_PATH=/tmp/atuin_scripts.db
 ```
 
 It is also recommended to update your `$PATH` so that the pre-exec scripts would use the locally built version:
@@ -24,7 +25,7 @@ It is also recommended to update your `$PATH` so that the pre-exec scripts would
 export PATH="./target/release:$PATH"
 ```
 
-These 4 variables can be added in a local `.envrc` file, read by [direnv](https://direnv.net/).
+These 5 variables can be added in a local `.envrc` file, read by [direnv](https://direnv.net/).
 
 ## PRs 
 

--- a/crates/atuin-client/src/settings.rs
+++ b/crates/atuin-client/src/settings.rs
@@ -741,6 +741,7 @@ impl Settings {
         let db_path = data_dir.join("history.db");
         let record_store_path = data_dir.join("records.db");
         let kv_path = data_dir.join("kv.db");
+        let scripts_path = data_dir.join("scripts.db");
         let socket_path = atuin_common::utils::runtime_dir().join("atuin.sock");
 
         let key_path = data_dir.join("key");
@@ -805,6 +806,7 @@ impl Settings {
             .set_default("daemon.systemd_socket", false)?
             .set_default("daemon.tcp_port", 8889)?
             .set_default("kv.db_path", kv_path.to_str())?
+            .set_default("scripts.db_path", scripts_path.to_str())?
             .set_default(
                 "search.filters",
                 vec!["global", "host", "session", "workspace", "directory"],

--- a/crates/atuin-client/src/settings/scripts.rs
+++ b/crates/atuin-client/src/settings/scripts.rs
@@ -2,7 +2,7 @@ use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct Settings {
-    pub database_path: String,
+    pub db_path: String,
 }
 
 impl Default for Settings {
@@ -11,7 +11,7 @@ impl Default for Settings {
         let path = dir.join("scripts.db");
 
         Self {
-            database_path: path.to_string_lossy().to_string(),
+            db_path: path.to_string_lossy().to_string(),
         }
     }
 }

--- a/crates/atuin/src/command/client/scripts.rs
+++ b/crates/atuin/src/command/client/scripts.rs
@@ -561,8 +561,7 @@ impl Cmd {
 
         let script_store = ScriptStore::new(store, host_id, encryption_key);
         let script_db =
-            atuin_scripts::database::Database::new(settings.scripts.database_path.clone(), 1.0)
-                .await?;
+            atuin_scripts::database::Database::new(settings.scripts.db_path.clone(), 1.0).await?;
 
         match self {
             Self::New(new_script) => {

--- a/crates/atuin/src/command/client/store/rebuild.rs
+++ b/crates/atuin/src/command/client/store/rebuild.rs
@@ -79,8 +79,7 @@ impl Rebuild {
         let host_id = Settings::host_id().expect("failed to get host_id");
         let script_store = ScriptStore::new(store, host_id, encryption_key);
         let database =
-            atuin_scripts::database::Database::new(settings.scripts.database_path.clone(), 1.0)
-                .await?;
+            atuin_scripts::database::Database::new(settings.scripts.db_path.clone(), 1.0).await?;
 
         script_store.build(database).await?;
 

--- a/crates/atuin/src/sync.rs
+++ b/crates/atuin/src/sync.rs
@@ -44,7 +44,7 @@ pub async fn build(
     kv_store.build().await?;
 
     let script_db =
-        atuin_scripts::database::Database::new(settings.scripts.database_path.clone(), 1.0).await?;
+        atuin_scripts::database::Database::new(settings.scripts.db_path.clone(), 1.0).await?;
     script_store.build(script_db).await?;
     Ok(())
 }


### PR DESCRIPTION
This PR allows setting the Atuin scripts DB path for development, similar to the KV and history DB path overrides.

## Checks
- [x] I am happy for maintainers to push small adjustments to this PR, to speed up the review cycle
- [x] I have checked that there are no existing pull requests for the same thing
