### PR TITLE
feat: support multiple concurrent data stores

### DIFF
--- a/crates/atuin/src/command/client/info.rs
+++ b/crates/atuin/src/command/client/info.rs
@@ -19,8 +19,9 @@ pub fn run(settings: &Settings) {
     );
 
     let env_vars = format!(
-        "Env Vars:\nATUIN_CONFIG_DIR = {:?}",
-        std::env::var("ATUIN_CONFIG_DIR").unwrap_or_else(|_| "None".into())
+        "Env Vars:\nATUIN_CONFIG_DIR = {:?}\nATUIN_DIR_SUFFIX = {:?}",
+        std::env::var("ATUIN_CONFIG_DIR").unwrap_or_else(|_| "None".into()),
+        std::env::var("ATUIN_DIR_SUFFIX").unwrap_or_else(|_| "None".into())
     );
 
     let general_info = format!("Version info:\nversion: {VERSION}");


### PR DESCRIPTION
This PR enables atuin to use multiple isolated configuration/data stores on the same host.
The main reason someone would want to is to keep histories for different shells separate.
Better ideas for solving this are covered in #608 so I'm not sure if this is an acceptable stopgap.
Closes: #2540

It works by introducing a new ENV Var `ATUIN_DIR_SUFFIX`. When provided the config and data directory names are appended with the suffix allowing someone to customize those directories to their needs.

## Checks
- [x] I am happy for maintainers to push small adjustments to this PR, to speed up the review cycle
- [x] I have checked that there are no existing pull requests for the same thing
