### PR TITLE
Reimplement execute_script to allow usage of interactive TUI programs…

### DIFF
--- a/crates/atuin-scripts/src/execution.rs
+++ b/crates/atuin-scripts/src/execution.rs
@@ -2,11 +2,8 @@ use crate::store::script::Script;
 use eyre::Result;
 use std::collections::{HashMap, HashSet};
 use std::fs;
-use std::process::Stdio;
 use tempfile::NamedTempFile;
-use tokio::io::{AsyncReadExt, AsyncWriteExt, BufReader};
 use tokio::sync::mpsc;
-use tokio::task;
 use tracing::debug;
 
 // Helper function to build a complete script with shebang
@@ -23,18 +20,17 @@ pub fn build_executable_script(script: String, shebang: String) -> String {
 
 /// Represents the communication channels for an interactive script
 pub struct ScriptSession {
-    /// Channel to send input to the script
-    pub stdin_tx: mpsc::Sender<String>,
+    /// Indicate that parent is being killed
+    pub killer_tx: mpsc::Sender<bool>,
     /// Exit code of the process once it completes
     pub exit_code_rx: mpsc::Receiver<i32>,
 }
 
 impl ScriptSession {
-    /// Send input to the running script
-    pub async fn send_input(&self, input: String) -> Result<(), mpsc::error::SendError<String>> {
-        self.stdin_tx.send(input).await
+    // return the sender for the canceler
+    pub async fn get_canceler(&mut self) -> mpsc::Sender<bool> {
+        self.killer_tx.clone()
     }
-
     /// Wait for the script to complete and get the exit code
     pub async fn wait_for_exit(&mut self) -> Option<i32> {
         self.exit_code_rx.recv().await
@@ -108,11 +104,7 @@ pub async fn execute_script_interactive(
     let _keep_temp_file = temp_file;
 
     debug!("attempting direct script execution");
-    let mut child_result = tokio::process::Command::new(temp_path.to_str().unwrap())
-        .stdin(Stdio::piped())
-        .stdout(Stdio::piped())
-        .stderr(Stdio::piped())
-        .spawn();
+    let mut child_result = tokio::process::Command::new(temp_path.to_str().unwrap()).spawn();
 
     // If direct execution fails, try using the interpreter
     if let Err(e) = &child_result {
@@ -137,11 +129,7 @@ pub async fn execute_script_interactive(
             cmd.arg(temp_path.to_str().unwrap());
 
             // Try with the interpreter
-            child_result = cmd
-                .stdin(Stdio::piped())
-                .stdout(Stdio::piped())
-                .stderr(Stdio::piped())
-                .spawn();
+            child_result = cmd.spawn();
         }
     }
 
@@ -153,125 +141,51 @@ pub async fn execute_script_interactive(
         }
     };
 
-    // Get handles to stdin, stdout, stderr
-    let mut stdin = child
-        .stdin
-        .take()
-        .ok_or_else(|| "Failed to open child process stdin".to_string())?;
-    let stdout = child
-        .stdout
-        .take()
-        .ok_or_else(|| "Failed to open child process stdout".to_string())?;
-    let stderr = child
-        .stderr
-        .take()
-        .ok_or_else(|| "Failed to open child process stderr".to_string())?;
-
     // Create channels for the interactive session
-    let (stdin_tx, mut stdin_rx) = mpsc::channel::<String>(32);
+    let (killer_tx, mut killer_rx) = mpsc::channel::<bool>(1);
     let (exit_code_tx, exit_code_rx) = mpsc::channel::<i32>(1);
-
-    // handle user stdin
-    debug!("spawning stdin handler");
-    tokio::spawn(async move {
-        while let Some(input) = stdin_rx.recv().await {
-            if let Err(e) = stdin.write_all(input.as_bytes()).await {
-                eprintln!("Error writing to stdin: {}", e);
-                break;
-            }
-            if let Err(e) = stdin.flush().await {
-                eprintln!("Error flushing stdin: {}", e);
-                break;
-            }
-        }
-        // when the channel closes (sender dropped), we let stdin close naturally
-    });
-
-    // handle stdout
-    debug!("spawning stdout handler");
-    let stdout_handle = task::spawn(async move {
-        let mut stdout_reader = BufReader::new(stdout);
-        let mut buffer = [0u8; 1024];
-        let mut stdout_writer = tokio::io::stdout();
-
-        loop {
-            match stdout_reader.read(&mut buffer).await {
-                Ok(0) => break, // End of stdout
-                Ok(n) => {
-                    if let Err(e) = stdout_writer.write_all(&buffer[0..n]).await {
-                        eprintln!("Error writing to stdout: {}", e);
-                        break;
-                    }
-                    if let Err(e) = stdout_writer.flush().await {
-                        eprintln!("Error flushing stdout: {}", e);
-                        break;
-                    }
-                }
-                Err(e) => {
-                    eprintln!("Error reading from process stdout: {}", e);
-                    break;
-                }
-            }
-        }
-    });
-
-    // Process stderr in a separate task
-    debug!("spawning stderr handler");
-    let stderr_handle = task::spawn(async move {
-        let mut stderr_reader = BufReader::new(stderr);
-        let mut buffer = [0u8; 1024];
-        let mut stderr_writer = tokio::io::stderr();
-
-        loop {
-            match stderr_reader.read(&mut buffer).await {
-                Ok(0) => break, // End of stderr
-                Ok(n) => {
-                    if let Err(e) = stderr_writer.write_all(&buffer[0..n]).await {
-                        eprintln!("Error writing to stderr: {}", e);
-                        break;
-                    }
-                    if let Err(e) = stderr_writer.flush().await {
-                        eprintln!("Error flushing stderr: {}", e);
-                        break;
-                    }
-                }
-                Err(e) => {
-                    eprintln!("Error reading from process stderr: {}", e);
-                    break;
-                }
-            }
-        }
-    });
 
     // Spawn a task to wait for the child process to complete
     debug!("spawning exit code handler");
     let _keep_temp_file_clone = _keep_temp_file;
     tokio::spawn(async move {
+        use tokio::select;
+
         // Keep the temp file alive until the process completes
         let _temp_file_ref = _keep_temp_file_clone;
 
-        // Wait for the child process to complete
-        let status = match child.wait().await {
-            Ok(status) => {
-                debug!("Process exited with status: {:?}", status);
-                status
+        // wait for child process to end or parent to receive Ctrl-C
+        let status = select! {
+            // check if the child process has exited
+            status = child.wait() => {
+                debug!("Child process exited");
+                match status {
+                    Ok(status) => {
+                        debug!("Child process exited with status: {:?}", status);
+                        status
+                    }
+                    Err(e) => {
+                        eprintln!("Error waiting for child process: {}", e);
+                        let _ = exit_code_tx.send(-1).await;
+                        return;
+                    }
+                }
             }
-            Err(e) => {
-                eprintln!("Error waiting for child process: {}", e);
-                // Send a default error code
+            // Check if parent it being terminated
+            _ = killer_rx.recv() => {
+                debug!("Received killer signal, terminating child process");
+                match child.kill().await {
+                    Ok(_) => {
+                        debug!("Child process was killed");
+                    }
+                    Err(e) => {
+                        eprintln!("Error killing child process: {}", e);
+                    }
+                }
                 let _ = exit_code_tx.send(-1).await;
                 return;
             }
         };
-
-        // Wait for stdout/stderr tasks to complete
-        if let Err(e) = stdout_handle.await {
-            eprintln!("Error joining stdout task: {}", e);
-        }
-
-        if let Err(e) = stderr_handle.await {
-            eprintln!("Error joining stderr task: {}", e);
-        }
 
         // Send the exit code
         let exit_code = status.code().unwrap_or(-1);
@@ -281,7 +195,7 @@ pub async fn execute_script_interactive(
 
     // Return the communication channels as a ScriptSession
     Ok(ScriptSession {
-        stdin_tx,
+        killer_tx,
         exit_code_rx,
     })
 }

--- a/crates/atuin/src/command/client/scripts.rs
+++ b/crates/atuin/src/command/client/scripts.rs
@@ -3,6 +3,7 @@ use std::collections::HashSet;
 use std::io::IsTerminal;
 use std::io::Read;
 use std::path::PathBuf;
+use tokio::process::Command;
 
 use atuin_scripts::execution::template_script;
 use atuin_scripts::{
@@ -118,6 +119,39 @@ pub enum Cmd {
     Delete(Delete),
 }
 
+#[cfg(unix)]
+pub async fn save_terminal_state() -> Option<String> {
+    let output = Command::new("stty")
+        .arg("-g")
+        .output()
+        .await
+        .ok()?;
+
+    let settings = String::from_utf8(output.stdout).ok()?;
+    // Remove newline and any surrounding whitespace
+    Some(settings.trim().to_string())
+}
+
+#[cfg(unix)]
+pub async fn restore_terminal_state(settings: &str) -> bool {
+    Command::new("stty")
+        .arg(settings)
+        .status()
+        .await
+        .map(|status| status.success())
+        .unwrap_or(false)
+}
+
+#[cfg(not(unix))]
+pub async fn save_terminal_state() -> Option<String> {
+    None
+}
+
+#[cfg(not(unix))]
+pub async fn restore_terminal_state(settings: &str) -> bool {
+   false
+}
+
 impl Cmd {
     // Helper function to open an editor with optional initial content
     fn open_editor(initial_content: Option<&str>) -> Result<String> {
@@ -144,64 +178,36 @@ impl Cmd {
         Ok(content)
     }
 
-    // Helper function to execute a script and manage stdin/stdout/stderr
+    // Helper function to execute a script and manage signals and terminal state
     async fn execute_script(script_content: String, shebang: String) -> Result<i32> {
+
+        // NOTE: save terminal state to be restored after script run
+        // sometimes interactive scripts mess with terminal and
+        // often if script is interrupted by signal it leaves terminal in
+        // undesired state.
+        let terminal_state = save_terminal_state().await;
+
         let mut session = execute_script_interactive(script_content, shebang)
             .await
             .expect("failed to execute script");
+        let cancel = session.get_canceler().await;
 
-        // Create a channel to signal when the process exits
-        let (exit_tx, mut exit_rx) = tokio::sync::oneshot::channel();
-
-        // Set up a task to read from stdin and forward to the script
-        let sender = session.stdin_tx.clone();
-        let stdin_task = tokio::spawn(async move {
-            use tokio::io::AsyncReadExt;
-            use tokio::select;
-
-            let stdin = tokio::io::stdin();
-            let mut reader = tokio::io::BufReader::new(stdin);
-            let mut buffer = vec![0u8; 1024]; // Read in chunks for efficiency
-
-            loop {
-                // Use select to either read from stdin or detect when the process exits
-                select! {
-                    // Check if the script process has exited
-                    _ = &mut exit_rx => {
-                        break;
-                    }
-                    // Try to read from stdin
-                    read_result = reader.read(&mut buffer) => {
-                        match read_result {
-                            Ok(0) => break, // EOF
-                            Ok(n) => {
-                                // Convert the bytes to a string and forward to script
-                                let input = String::from_utf8_lossy(&buffer[0..n]).to_string();
-                                if let Err(e) = sender.send(input).await {
-                                    eprintln!("Error sending input to script: {e}");
-                                    break;
-                                }
-                            },
-                            Err(e) => {
-                                eprintln!("Error reading from stdin: {e}");
-                                break;
-                            }
-                        }
-                    }
-                }
-            }
+        tokio::spawn(async move {
+            tokio::signal::ctrl_c().await.unwrap();
+            let _ = cancel.send(true).await;
         });
 
-        // Wait for the script to complete
+        // Wait for the script to completed
         let exit_code = session.wait_for_exit().await;
-
-        // Signal the stdin task to stop
-        let _ = exit_tx.send(());
-        let _ = stdin_task.await;
 
         let code = exit_code.unwrap_or(-1);
         if code != 0 {
             eprintln!("Script exited with code {code}");
+        }
+
+        // Restore terminal state if it was saved
+        if let Some(state) = terminal_state {
+            let _ = restore_terminal_state(&state).await;
         }
 
         Ok(code)


### PR DESCRIPTION
… in scripts snippets.

<!-- Thank you for making a PR! Bug fixes are always welcome, but if you're adding a new feature or changing an existing one, we'd really appreciate if you open an issue, post on the forum, or drop in on Discord -->

## Checks
- [ X] I am happy for maintainers to push small adjustments to this PR, to speed up the review cycle
- [ X] I have checked that there are no existing pull requests for the same thing

Attempt to run scripts using parents stdin, stdout and stderr so "atuin script run" behaves similar to "pet" allowing psql or mycli (for example) to be used as part of the scripts. 