### PR TITLE
fix: clarify that HISTFILE, if used, must be exported

### DIFF
--- a/crates/atuin-client/src/import/mod.rs
+++ b/crates/atuin-client/src/import/mod.rs
@@ -103,7 +103,7 @@ fn is_file(p: PathBuf) -> Result<PathBuf> {
     if p.is_file() {
         Ok(p)
     } else {
-        bail!("Could not find history file {:?}. Try setting $HISTFILE", p)
+        bail!("Could not find history file {:?}. Try setting and exporting $HISTFILE", p)
     }
 }
 fn is_dir(p: PathBuf) -> Result<PathBuf> {
@@ -111,7 +111,7 @@ fn is_dir(p: PathBuf) -> Result<PathBuf> {
         Ok(p)
     } else {
         bail!(
-            "Could not find history directory {:?}. Try setting $HISTFILE",
+            "Could not find history directory {:?}. Try setting and exporting $HISTFILE",
             p
         )
     }


### PR DESCRIPTION
I tripped over this when installing atuin. A small change in the error message might help someone in the future.

My history file is in a nonstandard location. `atuin import bash` couldn't find it and said `Try setting $HISTFILE`. The problem is, my `HISTFILE` *is* set:

~~~
% atuin import bash
        Atuin         
======================
          🌍          
       🐘🐘🐘🐘       
          🐢          
======================
Importing history...
Importing history from bash
Error: Could not find history file "/home/kosak/.bash_history". Try setting $HISTFILE

Location:
    crates/atuin-client/src/import/mod.rs:106:9
% echo $HISTFILE && ls -l $HISTFILE
/home/kosak/.bash_history_kosak
-rw------- 1 kosak kosak 891140 May 14 18:30 /home/kosak/.bash_history_kosak
~~~

The problem is, setting it isn't enough. It needs to be set and exported. That is

.bashrc:
```
HISTFILE=~/.bash_history_kosak  # no
export HISTFILE=~/.bash_history_kosak   # yes
```

But, exporting is not normal for `HIST*` variables in .bashrc. These entries are in the default `.bashrc` for Ubuntu 24.04, and they're not exported. So there's no reason (outside of atuin) that HISTFILE should be exported either.
```
...
HISTCONTROL=ignoreboth
HISTSIZE=1000
HISTFILESIZE=2000
...
```

But, that's the only way atuin will see it, so this PR changes the message to nudge people to export `HISTFILE` if needed.

## Checks
- [X] I am happy for maintainers to push small adjustments to this PR, to speed up the review cycle
- [X] I have checked that there are no existing pull requests for the same thing
