### PR TITLE
feat: nushell init script enchancements

### DIFF
--- a/crates/atuin/src/shell/atuin.nu
+++ b/crates/atuin/src/shell/atuin.nu
@@ -1,5 +1,14 @@
 # Source this in your ~/.config/nushell/config.nu
-$env.ATUIN_SESSION = (atuin uuid)
+# minimum supported version = 0.93.0
+module compat {
+  export def --wrapped "random uuid -v 7" [...rest] { atuin uuid }
+}
+use (if not (
+    (version).major > 0 or
+    (version).minor >= 103
+) { "compat" }) *
+
+$env.ATUIN_SESSION = (random uuid -v 7 | str replace -a "-" "")
 hide-env -i ATUIN_HISTORY_ID
 
 # Magic token to make sure we don't record commands run by keybindings
@@ -24,32 +33,27 @@ let _atuin_pre_prompt = {||
         return
     }
     with-env { ATUIN_LOG: error } {
-        do { atuin history end $'--exit=($last_exit)' -- $env.ATUIN_HISTORY_ID } | complete
+        if (version).minor >= 104 or (version).major > 0 {
+            job spawn -t atuin {
+                ^atuin history end $'--exit=($env.LAST_EXIT_CODE)' -- $env.ATUIN_HISTORY_ID | complete
+            } | ignore
+        } else {
+            do { atuin history end $'--exit=($last_exit)' -- $env.ATUIN_HISTORY_ID } | complete
+        }
 
     }
     hide-env ATUIN_HISTORY_ID
 }
 
 def _atuin_search_cmd [...flags: string] {
-    let nu_version = do {
-        let version = version
-        let major = $version.major?
-        if $major != null {
-            # These members are only available in versions > 0.92.2
-            [$major $version.minor $version.patch]
-        } else {
-            # So fall back to the slower parsing when they're missing
-            $version.version | split row '.' | into int
-        }
-    }
     [
         $ATUIN_KEYBINDING_TOKEN,
         ([
             `with-env { ATUIN_LOG: error, ATUIN_QUERY: (commandline) } {`,
-                (if $nu_version.0 <= 0 and $nu_version.1 <= 90 { 'commandline' } else { 'commandline edit' }),
-                (if $nu_version.1 >= 92 { '(run-external atuin search' } else { '(run-external --redirect-stderr atuin search' }),
+                'commandline edit',
+                '(run-external atuin search',
                     ($flags | append [--interactive] | each {|e| $'"($e)"'}),
-                (if $nu_version.1 >= 92 { ' e>| str trim)' } else {' | complete | $in.stderr | str substring ..-1)'}),
+                ' e>| str trim)',
             `}`,
         ] | flatten | str join ' '),
     ] | str join "\n"


### PR DESCRIPTION
<!-- Thank you for making a PR! Bug fixes are always welcome, but if you're adding a new feature or changing an existing one, we'd really appreciate if you open an issue, post on the forum, or drop in on Discord -->
Some improvements to the atuin init script for nushell
- Minimum supported version bumped to `0.93.0` (Released `2024-5-1`)
Following #1963, this nushell release is more than a year old and enables doing `if (version).major > ...` without more complications (having to check the version to see if you can check the version more ergonomically is kind of ridiculous). For a program like nushell, I don't think it makes much sense to support even older releases. I have tested this script in both `0.93.0` and latest (`0.104.2`).

- Use `random uuid -v 7` if available.
Nushell has a command for creating uuids in the core library, and it is considerably faster than calling the external `atuin uuid`, saving precious milliseconds at startup. Includes module magic to make it compatible with older versions thanks to @132ikl.
![image](https://github.com/user-attachments/assets/d0efdfc5-8a63-4557-9a4e-96b992956d90)

- Use `job spawn` for `atuin history end`
Should improve performance of #2208. `atuin history end` can easily be invoked in a job so that it doesn't block the main thread, `atuin history start` is trickier since it needs to be assigned to an `$env`.


## Checks
- [X] I am happy for maintainers to push small adjustments to this PR, to speed up the review cycle
- [X] I have checked that there are no existing pull requests for the same thing
