### PR TITLE
Don't print errors in `zsh_autosuggest` helper

### DIFF
--- a/crates/atuin/src/shell/atuin.zsh
+++ b/crates/atuin/src/shell/atuin.zsh
@@ -15,7 +15,8 @@ zmodload zsh/datetime 2>/dev/null
 # you'd like to override this, then add your config after the $(atuin init zsh)
 # in your .zshrc
 _zsh_autosuggest_strategy_atuin() {
-    suggestion=$(ATUIN_QUERY="$1" atuin search --cmd-only --limit 1 --search-mode prefix)
+    # silence errors, since we don't want to spam the terminal prompt while typing.
+    suggestion=$(ATUIN_QUERY="$1" atuin search --cmd-only --limit 1 --search-mode prefix 2>/dev/null)
 }
 
 if [ -n "${ZSH_AUTOSUGGEST_STRATEGY:-}" ]; then


### PR DESCRIPTION
Previously, this would result in long multi-line errors when typing, making it hard to see the shell prompt:
```
$  Error: could not load client settings

Caused by:
   0: could not create config file
   1: failed to create file `/home/jyn/.config/atuin/config.toml`
   2: Required key not available (os error 126)

Location:
    atuin-client/src/settings.rs:675:54
 fError: could not load client settings

Caused by:
   0: could not create config file
   1: failed to create file `/home/jyn/.config/atuin/config.toml`
   2: Required key not available (os error 126)

Location:
    atuin-client/src/settings.rs:675:54
 faError: could not load client settings
```

Silence these in autosuggestions, such that they only show up when explicitly invoking atuin.

<!-- Thank you for making a PR! Bug fixes are always welcome, but if you're adding a new feature or changing an existing one, we'd really appreciate if you open an issue, post on the forum, or drop in on Discord -->

Fixes https://github.com/atuinsh/atuin/issues/2779

## Checks
- [x] I am happy for maintainers to push small adjustments to this PR, to speed up the review cycle
- [x] I have checked that there are no existing pull requests for the same thing
