### PR TITLE
Nix: various improvements

### DIFF
--- a/atuin.nix
+++ b/atuin.nix
@@ -10,7 +10,7 @@
   installShellFiles,
   rustPlatform,
   libiconv,
-  gitRev ? "dirty",
+  gitRev,
 }:
 let
   fs = lib.fileset;
@@ -28,7 +28,7 @@ let
 
 in
 rustPlatform.buildRustPackage {
-  name = "atuin";
+  pname = "atuin";
   version = "${packageVersion}-unstable-${gitRev}";
 
   src = fs.toSource {

--- a/atuin.nix
+++ b/atuin.nix
@@ -1,7 +1,7 @@
 # Atuin package definition
 #
 # This file will be similar to the package definition in nixpkgs:
-#     https://github.com/NixOS/nixpkgs/blob/master/pkgs/by-name/at/atuin/package.nix
+# https://github.com/NixOS/nixpkgs/blob/master/pkgs/by-name/at/atuin/package.nix
 #
 # Helpful documentation: https://github.com/NixOS/nixpkgs/blob/master/doc/languages-frameworks/rust.section.md
 {
@@ -10,11 +10,31 @@
   installShellFiles,
   rustPlatform,
   libiconv,
+  gitRev ? "dirty",
 }:
+let
+  fs = lib.fileset;
+  src = fs.difference (fs.gitTracked ./.) (
+    fs.unions [
+      ./demo.gif
+      ./flake.lock
+      (fs.fileFilter (file: lib.strings.hasInfix ".git" file.name) ./.)
+      (fs.fileFilter (file: file.hasExt "svg") ./.)
+      (fs.fileFilter (file: file.hasExt "md") ./.)
+      (fs.fileFilter (file: file.hasExt "nix") ./.)
+    ]
+  );
+  packageVersion = (builtins.fromTOML (builtins.readFile ./Cargo.toml)).workspace.package.version;
+
+in
 rustPlatform.buildRustPackage {
   name = "atuin";
+  version = "${packageVersion}-unstable-${gitRev}";
 
-  src = lib.cleanSource ./.;
+  src = fs.toSource {
+    root = ./.;
+    fileset = src;
+  };
 
   cargoLock = {
     lockFile = ./Cargo.lock;
@@ -22,9 +42,11 @@ rustPlatform.buildRustPackage {
     allowBuiltinFetchGit = true;
   };
 
-  nativeBuildInputs = [installShellFiles];
+  nativeBuildInputs = [ installShellFiles ];
 
-  buildInputs = lib.optionals stdenv.isDarwin [libiconv];
+  buildInputs = lib.optionals stdenv.isDarwin [
+    libiconv
+  ];
 
   postInstall = ''
     installShellCompletion --cmd atuin \
@@ -35,10 +57,10 @@ rustPlatform.buildRustPackage {
 
   doCheck = false;
 
-  meta = with lib; {
+  meta = {
     description = "Replacement for a shell history which records additional commands context with optional encrypted synchronization between machines";
     homepage = "https://github.com/atuinsh/atuin";
-    license = licenses.mit;
+    license = lib.licenses.mit;
     mainProgram = "atuin";
   };
 }

--- a/flake.lock
+++ b/flake.lock
@@ -37,24 +37,6 @@
         "type": "github"
       }
     },
-    "flake-utils": {
-      "inputs": {
-        "systems": "systems"
-      },
-      "locked": {
-        "lastModified": 1731533236,
-        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "type": "github"
-      }
-    },
     "nixpkgs": {
       "locked": {
         "lastModified": 1758446476,
@@ -75,7 +57,6 @@
       "inputs": {
         "fenix": "fenix",
         "flake-compat": "flake-compat",
-        "flake-utils": "flake-utils",
         "nixpkgs": "nixpkgs"
       }
     },
@@ -93,21 +74,6 @@
         "owner": "rust-lang",
         "ref": "nightly",
         "repo": "rust-analyzer",
-        "type": "github"
-      }
-    },
-    "systems": {
-      "locked": {
-        "lastModified": 1681028828,
-        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
-        "owner": "nix-systems",
-        "repo": "default",
-        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-systems",
-        "repo": "default",
         "type": "github"
       }
     }

--- a/flake.lock
+++ b/flake.lock
@@ -8,11 +8,11 @@
         "rust-analyzer-src": "rust-analyzer-src"
       },
       "locked": {
-        "lastModified": 1758609765,
-        "narHash": "sha256-VIYu7R9Yc/CItjmzLSm21Lr9DgpEsKL5H+JUu8KDTn4=",
+        "lastModified": 1758868653,
+        "narHash": "sha256-5DRLF0k8lZFltFhyO2O7x6z1+H1Z/T3da32TUuXvmtw=",
         "owner": "nix-community",
         "repo": "fenix",
-        "rev": "05545a7f3cd5cd5628b195520758e56e6734b90a",
+        "rev": "09971ed7bf438328a01e1499f9ee4003128f4c40",
         "type": "github"
       },
       "original": {
@@ -39,11 +39,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1758446476,
-        "narHash": "sha256-5rdAi7CTvM/kSs6fHe1bREIva5W3TbImsto+dxG4mBo=",
+        "lastModified": 1758763312,
+        "narHash": "sha256-puBMviZhYlqOdUUgEmMVJpXqC/ToEqSvkyZ30qQ09xM=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "a1f79a1770d05af18111fbbe2a3ab2c42c0f6cd0",
+        "rev": "e57b3b16ad8758fd681511a078f35c416a8cc939",
         "type": "github"
       },
       "original": {
@@ -63,11 +63,11 @@
     "rust-analyzer-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1758556272,
-        "narHash": "sha256-9amq6LAd0CFF3dLrJUItPiG64MQOG4QPrvjbjpa6NFc=",
+        "lastModified": 1758796254,
+        "narHash": "sha256-1Xf7UyqWsmmScXVfmIK4bLeVmI2Ujj7DgmSbjiVkgkY=",
         "owner": "rust-lang",
         "repo": "rust-analyzer",
-        "rev": "d05355db16dc526bb16bd84769ea840668d7015e",
+        "rev": "84e87d5bbaec992e7ded5e79988db2da6c129f6b",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -1,7 +1,6 @@
 {
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
-    flake-utils.url = "github:numtide/flake-utils";
     flake-compat = {
       url = "github:edolstra/flake-compat";
       flake = false;
@@ -15,33 +14,38 @@
     {
       self,
       nixpkgs,
-      flake-utils,
       fenix,
       ...
     }:
-    flake-utils.lib.eachDefaultSystem (
-      system:
-      let
-        pkgs = nixpkgs.outputs.legacyPackages.${system};
-      in
-      {
-        packages.atuin = pkgs.callPackage ./atuin.nix {
+    let
+      inherit (nixpkgs) lib;
+      systems = [
+        "x86_64-linux"
+        "aarch64-linux"
+        "x86_64-darwin"
+        "aarch64-darwin"
+      ];
+      eachSystem = lib.genAttrs systems;
+      pkgsFor = eachSystem (
+        system:
+        import nixpkgs {
+          localSystem.system = system;
+          overlays = [ self.overlays.atuin ];
+        }
+      );
+    in
+    {
 
-          rustPlatform =
-            let
-              toolchain = fenix.packages.${system}.fromToolchainFile {
-                file = ./rust-toolchain.toml;
-                sha256 = "sha256-SJwZ8g0zF2WrKDVmHrVG3pD2RGoQeo24MEXnNx5FyuI=";
-              };
-            in
-            pkgs.makeRustPlatform {
-              cargo = toolchain;
-              rustc = toolchain;
-            };
-        };
-        packages.default = self.outputs.packages.${system}.atuin;
+      
+        packages = eachSystem (system: {
+        inherit (pkgsFor.${system}) atuin;
 
-        devShells.default = self.packages.${system}.default.overrideAttrs (super: {
+        default = self.packages.${system}.atuin;
+      });
+
+      devShells = lib.mapAttrs (system: pkgs: {
+
+        default = self.packages.${system}.default.overrideAttrs (super: {
           nativeBuildInputs =
             with pkgs;
             super.nativeBuildInputs
@@ -66,11 +70,30 @@
             fi
           '';
         });
-      }
-    )
-    // {
-      overlays.default = final: prev: {
-        inherit (self.packages.${final.system}) atuin;
+      }) pkgsFor;
+
+      overlays = {
+
+        atuin =
+          final: _:
+          let
+            toolchain = fenix.packages.${final.system}.fromToolchainFile {
+              file = ./rust-toolchain.toml;
+              sha256 = "sha256-SJwZ8g0zF2WrKDVmHrVG3pD2RGoQeo24MEXnNx5FyuI=";
+            };
+            rustPlatform = final.makeRustPlatform {
+              cargo = toolchain;
+              rustc = toolchain;
+            };
+          in
+          {
+            atuin = final.callPackage ./atuin.nix {
+              inherit rustPlatform;
+              inherit (final.darwin.apple_sdk.frameworks) Security SystemConfiguration AppKit;
+            };
+
+            default = self.overlays.atuin;
+          };
       };
     };
 }

--- a/flake.nix
+++ b/flake.nix
@@ -12,27 +12,27 @@
     };
   };
   outputs =
-    { self
-    , nixpkgs
-    , flake-utils
-    , fenix
-    , ...
+    {
+      self,
+      nixpkgs,
+      flake-utils,
+      fenix,
+      ...
     }:
-    flake-utils.lib.eachDefaultSystem
-      (system:
+    flake-utils.lib.eachDefaultSystem (
+      system:
       let
         pkgs = nixpkgs.outputs.legacyPackages.${system};
       in
       {
         packages.atuin = pkgs.callPackage ./atuin.nix {
+
           rustPlatform =
             let
-              toolchain =
-                fenix.packages.${system}.fromToolchainFile
-                  {
-                    file = ./rust-toolchain.toml;
-                    sha256 = "sha256-SJwZ8g0zF2WrKDVmHrVG3pD2RGoQeo24MEXnNx5FyuI=";
-                  };
+              toolchain = fenix.packages.${system}.fromToolchainFile {
+                file = ./rust-toolchain.toml;
+                sha256 = "sha256-SJwZ8g0zF2WrKDVmHrVG3pD2RGoQeo24MEXnNx5FyuI=";
+              };
             in
             pkgs.makeRustPlatform {
               cargo = toolchain;
@@ -42,7 +42,8 @@
         packages.default = self.outputs.packages.${system}.atuin;
 
         devShells.default = self.packages.${system}.default.overrideAttrs (super: {
-          nativeBuildInputs = with pkgs;
+          nativeBuildInputs =
+            with pkgs;
             super.nativeBuildInputs
             ++ [
               cargo-edit
@@ -65,7 +66,8 @@
             fi
           '';
         });
-      })
+      }
+    )
     // {
       overlays.default = final: prev: {
         inherit (self.packages.${final.system}) atuin;

--- a/flake.nix
+++ b/flake.nix
@@ -91,8 +91,7 @@
           {
             atuin = final.callPackage ./atuin.nix {
               inherit rustPlatform;
-              gitRev = self.shortRev;
-              inherit (final.darwin.apple_sdk.frameworks) Security SystemConfiguration AppKit;
+              gitRev = self.shortRev or "dirty";
             };
 
             default = self.overlays.atuin;

--- a/flake.nix
+++ b/flake.nix
@@ -72,6 +72,8 @@
         });
       }) pkgsFor;
 
+      formatter = lib.mapAttrs (_: pkgs: pkgs.nixfmt) pkgsFor;
+
       overlays = {
 
         atuin =

--- a/flake.nix
+++ b/flake.nix
@@ -33,6 +33,7 @@
           overlays = [ self.overlays.atuin ];
         }
       );
+
     in
     {
 
@@ -75,7 +76,6 @@
       formatter = lib.mapAttrs (_: pkgs: pkgs.nixfmt) pkgsFor;
 
       overlays = {
-
         atuin =
           final: _:
           let
@@ -91,6 +91,7 @@
           {
             atuin = final.callPackage ./atuin.nix {
               inherit rustPlatform;
+              gitRev = self.shortRev;
               inherit (final.darwin.apple_sdk.frameworks) Security SystemConfiguration AppKit;
             };
 


### PR DESCRIPTION
<!-- Thank you for making a PR! Bug fixes are always welcome, but if you're adding a new feature or changing an existing one, we'd really appreciate if you open an issue, post on the forum, or drop in on Discord -->

Cleans up the nix code in various ways, the most important ones being:
- Dropping flake-utils, thus reducing abstraction.
- Decreasing the amount of files in the `src` fileset in `atuin.nix` which prevents changes to files like README.md from changing the derivation's output, thus saving rebuils. 
- Adding a sane default formatter.

## Checks
- [X] I am happy for maintainers to push small adjustments to this PR, to speed up the review cycle
- [X] I have checked that there are no existing pull requests for the same thing
