### PR TITLE
Fix import zsh multiline issue

### DIFF
--- a/crates/atuin-client/src/import/zsh.rs
+++ b/crates/atuin-client/src/import/zsh.rs
@@ -70,7 +70,7 @@ impl Importer for Zsh {
 
             if let Some(s) = s.strip_suffix('\\') {
                 line.push_str(s);
-                line.push_str("\\\n");
+                line.push_str("\n");
             } else {
                 line.push_str(&s);
                 let command = std::mem::take(&mut line);


### PR DESCRIPTION
Here is my case:
```sh
curl -X POST https://example.com/api \
  -H "Content-Type: application/json" \
  -d '{
    "username": "name",
    "password": "pass",
    "details": {
      "age": 30,
      "location": "Earth"
    }
  }'
```

Using current release version i got:
```sh
curl -X POST https://example.com/api \\
  -H "Content-Type: application/json" \\
  -d '{\
    "username": "yourname",\
    "password": "yourpass",\
    "details": {\
      "age": 30,\
      "location": "Earth"\
    }\
  }'
```

and i test with `echo \\` (https://github.com/atuinsh/atuin/pull/100#issuecomment-836477081) it also works;

there is similar PR https://github.com/atuinsh/atuin/pull/2390, it only works on multiline with `\` suffix, in my case i got:
```sh
curl -X POST https://example.com/api \
  -H "Content-Type: application/json" \
  -d '{\
```

## Checks
- [x] I am happy for maintainers to push small adjustments to this PR, to speed up the review cycle
- [ ] I have checked that there are no existing pull requests for the same thing
