### PR TITLE
Feat: Add Portuguese (Brazil) documentation

### DIFF
--- a/docs/pt-BR/README.md
+++ b/docs/pt-BR/README.md
@@ -1,0 +1,234 @@
+<p align="center">
+ <picture>
+  <source media="(prefers-color-scheme: dark)" srcset="https://github.com/atuinsh/atuin/assets/53315310/13216a1d-1ac0-4c99-b0eb-d88290fe0efd">
+  <img alt="Texto mudando dependendo do modo. Claro: 'Tão claro!' Escuro: 'Tão escuro!'" src="https://github.com/atuinsh/atuin/assets/53315310/08bc86d4-a781-4aaa-8d7e-478ae6bcd129">
+</picture>
+</p>
+
+<p align="center">
+<em>Histórico de shell mágico</em>
+</p>
+
+<hr/>
+
+<p align="center">
+  <a href="https://github.com/atuinsh/atuin/actions?query=workflow%3ARust"><img src="https://img.shields.io/github/actions/workflow/status/atuinsh/atuin/rust.yml?style=flat-square" /></a>
+  <a href="https://crates.io/crates/atuin"><img src="https://img.shields.io/crates/v/atuin.svg?style=flat-square" /></a>
+  <a href="https://crates.io/crates/atuin"><img src="https://img.shields.io/crates/d/atuin.svg?style=flat-square" /></a>
+  <a href="https://github.com/atuinsh/atuin/blob/main/LICENSE"><img src="https://img.shields.io/crates/l/atuin.svg?style=flat-square" /></a>
+  <a href="https://discord.gg/Fq8bJSKPHh"><img src="https://img.shields.io/discord/954121165239115808" /></a>
+  <a rel="me" href="https://hachyderm.io/@atuin"><img src="https://img.io/mastodon/follow/109944632283122560?domain=https%3A%2F%2Fhachyderm.io&style=social"/></a>
+  <a href="https://twitter.com/atuinsh"><img src="https://img.shields.io/twitter/follow/atuinsh?style=social" /></a>
+</p>
+
+
+[English] | [Português (Brasil)]
+
+Atuin substitui seu histórico de shell existente por um banco de dados SQLite e registra conteúdo adicional para seus comandos. Além disso, ele fornece sincronização de histórico opcional e totalmente criptografada entre máquinas via servidor Atuin.
+
+<p align="center">
+  <img src="../../demo.gif" alt="animado" width="80%" />
+</p>
+
+<p align="center">
+<em>Mostra o código de saída, duração do comando, última execução e o comando executado</em>
+</p>
+
+Além da interface de pesquisa, ele também pode fazer o seguinte:
+
+```
+# Pesquisar todos os comandos `make` bem-sucedidos registrados após as 15h de ontem
+atuin search --exit 0 --after "yesterday 3pm" make
+```
+
+Você pode usar o servidor que eu (ellie) hospedo, ou você pode hospedar o seu próprio! Ou simplesmente não usar o recurso de sincronização. Toda a sincronização do histórico é criptografada, então mesmo que eu quisesse, não conseguiria acessar seus dados. E eu **realmente** não quero.
+
+## Recursos
+
+- Interface de pesquisa de histórico de tela cheia que rebinda `up` e `ctrl-r`
+- Armazena o histórico do shell usando um banco de dados sqlite
+- Backup e sincronização do histórico de shell criptografado
+- Tenha o mesmo histórico em diferentes terminais, diferentes sessões e diferentes máquinas
+- Registra o código de saída, cwd, nome do host, sessão, duração do comando, etc.
+- Calcula estatísticas, como "comandos mais usados"
+- Não substitui arquivos de histórico antigos
+- Salto rápido para registros anteriores via atalho <kbd>Alt-\<num\></kbd>
+- Alternar modos de filtro via ctrl-r; pode pesquisar o histórico apenas da sessão atual, diretório ou globalmente
+
+## Documentação
+
+- [Início Rápido](#início-rápido)
+- [Instalação](#instalação)
+- [Importar](./import.md)
+- [Configuração](./config.md)
+- [Pesquisa de Histórico](./search.md)
+- [Sincronização de Histórico na Nuvem](./sync.md)
+- [Estatísticas de Histórico](./stats.md)
+- [Executando seu próprio servidor](./server.md)
+- [Vinculação de Teclas](./key-binding.md)
+- [Conclusões de Shell](./shell-completions.md)
+
+## Shells Suportados
+
+- zsh
+- bash
+- fish
+
+## Comunidade
+
+Atuin tem uma comunidade Discord, disponível [aqui](https://discord.gg/Fq8bJSKPHh).
+
+# Início Rápido
+
+## Usando o servidor de sincronização padrão
+
+Isso irá registrá-lo no servidor de sincronização padrão que eu hospedo. Tudo é criptografado de ponta a ponta, então seus segredos estão seguros!
+
+Leia mais abaixo para uso apenas offline ou para hospedar seu próprio servidor.
+
+```
+bash <(curl https://raw.githubusercontent.com/ellie/atuin/main/install.sh)
+
+atuin register -u <USERNAME> -e <EMAIL> -p <PASSWORD>
+atuin import auto
+atuin sync
+```
+
+### Usando o gráfico de atividade
+
+Além de hospedar o servidor Atuin, há também um serviço que pode ser usado para gerar seu gráfico de atividade de uso do histórico do shell! Este recurso é inspirado no gráfico de atividade do GitHub.
+
+Por exemplo, este é o meu:
+
+![](https://api.atuin.sh/img/ellie.png?token=0722830c382b42777bdb652da5b71efb61d8d387)
+
+Se você também quiser, depois de fazer login no seu servidor de sincronização, execute:
+
+```
+curl https://api.atuin.sh/enable -d $(cat ~/.local/share/atuin/session)
+```
+
+O resultado será o URL do seu gráfico de atividade. Este URL pode ser compartilhado ou incorporado, o token *não* é criptografado, apenas para evitar ataques de enumeração.
+
+## Apenas Offline (sem sincronização)
+
+```
+bash <(curl https://raw.githubusercontent.com/ellie/atuin/main/install.sh)
+
+atuin import auto
+```
+
+## Instalação
+
+### Script (recomendado)
+
+O script de instalação irá ajudá-lo a configurar, garantindo que seu shell esteja configurado corretamente. Ele também usará um dos seguintes métodos, preferindo o gerenciador de pacotes do sistema (pacman, homebrew, etc.) sempre que possível.
+
+```
+# Não execute como root, ele pedirá root se necessário.
+bash <(curl https://raw.githubusercontent.com/ellie/atuin/main/install.sh)
+```
+
+Então, você pode ir diretamente para [Plugin de Shell](#shell-plugin).
+
+### Via cargo
+
+É melhor usar [rustup](https://rustup.rs/) para configurar a toolchain do Rust, então você pode executar o seguinte comando:
+
+```
+cargo install atuin
+```
+
+Então, você pode ir diretamente para [Plugin de Shell](#shell-plugin).
+
+### Homebrew
+
+```
+brew install atuin
+```
+
+Então, você pode ir diretamente para [Plugin de Shell](#shell-plugin).
+
+### MacPorts
+
+Atuin também está disponível no [MacPorts](https://ports.macports.org/port/atuin/).
+
+```
+sudo port install atuin
+```
+
+Então, você pode ir diretamente para [Plugin de Shell](#shell-plugin).
+
+### Pacman
+
+Atuin está disponível no [repositório da comunidade](https://archlinux.org/packages/community/x86_64/atuin/) do Arch Linux.
+
+```
+pacman -S atuin
+```
+
+Então, você pode ir diretamente para [Plugin de Shell](#shell-plugin).
+
+### Compilar e instalar a partir do código-fonte
+
+```
+git clone https://github.com/ellie/atuin.git
+cd atuin/crates/atuin
+cargo install --path .
+```
+
+Então, você pode ir diretamente para [Plugin de Shell](#shell-plugin).
+
+## <a id="shell-plugin">Plugin de Shell</a>
+
+Depois de instalar o binário, você precisará instalar o plugin do shell. Se você usou o script de instalação, tudo isso deve ser feito para você!
+
+### zsh
+
+```
+echo 'eval "$(atuin init zsh)"' >> ~/.zshrc
+```
+
+Ou use um gerenciador de plugins:
+
+```
+zinit load ellie/atuin
+```
+
+### bash
+
+Precisamos configurar alguns hooks, então primeiro você precisa instalar o bash-preexec:
+
+```
+curl https://raw.githubusercontent.com/rcaloras/bash-preexec/master/bash-preexec.sh -o ~/.bash-preexec.sh
+echo '[[ -f ~/.bash-preexec.sh ]] && source ~/.bash-preexec.sh' >> ~/.bashrc
+```
+
+Então configure o Atuin:
+
+```
+echo 'eval "$(atuin init bash)"' >> ~/.bashrc
+```
+
+### fish
+
+Adicione:
+
+```
+atuin init fish | source
+```
+
+no bloco `is-interactive` em `~/.config/fish/config.fish`.
+
+### Fig
+
+Através do [Fig](https://fig.io), você pode instalar o plugin de script `atuin` para zsh, bash ou fish com um clique.
+
+<a href="https://fig.io/plugins/other/atuin" target="_blank"><img src="https://fig.io/badges/install-with-fig.svg" /></a>
+
+## ...O que significa esse nome?
+
+Atuin é nomeado em homenagem a "The Great A'Tuin", uma tartaruga gigante da série de livros Discworld de Terry Pratchett.
+
+[English]: ../../README.md
+[Português (Brasil)]: ./README.md

--- a/docs/pt-BR/config.md
+++ b/docs/pt-BR/config.md
@@ -1,0 +1,132 @@
+# Configuração
+
+O Atuin mantém dois arquivos de configuração, armazenados em `~/.config/atuin/`. Armazenamos os dados em `~/.local/share/atuin` (a menos que substituído por XDG_*).
+
+Você pode alterar o caminho do diretório de configuração definindo `ATUIN_CONFIG_DIR`. Por exemplo:
+
+```
+export ATUIN_CONFIG_DIR = /home/ellie/.atuin
+```
+
+## Configuração do Cliente
+
+```
+~/.config/atuin/config.toml
+```
+
+O cliente é executado na máquina do usuário, e é isso que você deve se preocupar, a menos que esteja executando o servidor.
+
+Veja o exemplo em [config.toml](../../atuin-client/config.toml)
+
+### `dialect`
+
+Isso configura a forma como o comando [stats](stats.md) analisa as datas. Ele tem dois valores possíveis:
+
+```
+dialect = "uk"
+```
+
+ou
+
+```
+dialect = "us"
+```
+
+O padrão é "us".
+
+### `auto_sync`
+
+Configura se a sincronização automática deve ocorrer ao fazer login. O padrão é `true`.
+
+```
+auto_sync = true/false
+```
+
+### `sync_address`
+
+O endereço do servidor de sincronização! O padrão é `https://api.atuin.sh`.
+
+```
+sync_address = "https://api.atuin.sh"
+```
+
+### `sync_frequency`
+
+Com que frequência sincronizar automaticamente com o servidor. Isso pode ser dado em um formato "legível por humanos". Por exemplo, `10s`, `20m`, `1h`, etc. O padrão é `1h`.
+
+Se definido como `0`, o Atuin sincronizará após cada comando. Alguns servidores podem ter limites de taxa em potencial, o que não causará problemas.
+
+```
+sync_frequency = "1h"
+```
+
+### `db_path`
+
+O caminho para o banco de dados SQLite do Atuin. O padrão é `~/.local/share/atuin/history.db`.
+
+```
+db_path = "~/.history.db"
+```
+
+### `key_path`
+
+O caminho para a chave de criptografia do Atuin. O padrão é `~/.local/share/atuin/key`.
+
+```
+key = "~/.atuin-key"
+```
+
+### `session_path`
+
+O caminho para o arquivo de sessão do servidor Atuin. O padrão é `~/.local/share/atuin/session`. Isso é essencialmente apenas um token de API.
+
+```
+key = "~/.atuin-session"
+```
+
+### `search_mode`
+
+Qual modo de pesquisa usar. O Atuin suporta os modos de pesquisa "prefix" (prefixo), "fulltext" (texto completo) e "fuzzy" (difuso). A sintaxe de pesquisa de prefixo é "query*", a sintaxe de pesquisa de texto completo é "*query*", e a sintaxe de pesquisa difusa é [descrita abaixo](#sintaxe-de-pesquisa-difusa).
+
+A configuração padrão é "fuzzy".
+
+### `filter_mode`
+
+O filtro padrão a ser usado ao pesquisar.
+
+| Modo | Descrição |
+|---|---|
+| global (padrão) | Pesquisa o histórico de todos os hosts, todas as sessões, todos os diretórios |
+| host | Pesquisa o histórico apenas deste host |
+| session | Pesquisa o histórico apenas da sessão atual |
+| directory | Pesquisa o histórico apenas do diretório atual |
+
+O modo de filtro ainda pode ser alternado via `ctrl-r`.
+
+```
+search_mode = "fulltext"
+```
+
+#### Sintaxe de Pesquisa Difusa
+
+A sintaxe de pesquisa `fuzzy` é baseada na [sintaxe de pesquisa do fzf](https://github.com/junegunn/fzf#search-syntax).
+
+| Conteúdo | Tipo de Correspondência | Descrição |
+|---|---|---|
+| `sbtrkt` | fuzzy-match | Itens que correspondem a `sbtrkt` |
+| `'wild` | exact-match (entre aspas) | Itens que contêm `wild` |
+| `^music` | prefix-exact-match | Itens que começam com `music` |
+| `.mp3$` | suffix-exact-match | Itens que terminam com `.mp3` |
+| `!fire` | inverse-exact-match | Itens que não incluem `fire` |
+| `!^music` | inverse-prefix-exact-match | Itens que não começam com `music` |
+| `!.mp3$` | inverse-suffix-exact-match | Itens que não terminam com `.mp3` |
+
+Termos de barra única atuam como um operador OR. Por exemplo, a seguinte consulta corresponde a entradas que começam com `core` e terminam com `go`, `rb` ou `py`.
+
+```
+^core go$ | rb$ | py$
+```
+
+## Configuração do Servidor
+
+`// TODO`

--- a/docs/pt-BR/docker.md
+++ b/docs/pt-BR/docker.md
@@ -1,0 +1,90 @@
+# Docker
+
+O Atuin fornece uma imagem Docker que facilita a implantação do servidor como um contêiner.
+
+```sh
+docker run -d -v "$USER/.config/atuin:/config" ghcr.io/ellie/atuin:latest server start
+```
+
+# Docker Compose
+
+Para hospedar seu próprio Atuin usando imagens Docker existentes, você pode usar o arquivo `docker-compose` fornecido.
+
+Crie um arquivo `.env` no mesmo diretório do `docker-compose.yml` com o seguinte conteúdo:
+
+```
+ATUIN_DB_USERNAME=atuin
+# Preencha sua senha
+ATUIN_DB_PASSWORD=really-insecure
+```
+
+Crie o arquivo `docker-compose.yml`:
+
+```yaml
+version: '3.5'
+services:
+  atuin:
+    restart: always
+    image: ghcr.io/ellie/atuin:main
+    command: server start
+    volumes:
+      - "./config:/config"
+    links:
+      - postgresql:db
+    ports:
+      - 8888:8888
+    environment:
+      ATUIN_HOST: "0.0.0.0"
+      ATUIN_OPEN_REGISTRATION: "true"
+      ATUIN_DB_URI: postgres://$ATUIN_DB_USERNAME:$ATUIN_DB_PASSWORD@db/atuin
+  postgresql:
+    image: postgres:14
+    restart: unless-stopped
+    volumes: # Não exclua o armazenamento persistente do arquivo de banco de dados de índice!
+      - "./database:/var/lib/postgresql/data/"
+    environment:
+      POSTGRES_USER: $ATUIN_DB_USERNAME
+      POSTGRES_PASSWORD: $ATUIN_DB_PASSWORD
+      POSTGRES_DB: atuin
+```
+
+Use `docker-compose` para iniciar o serviço:
+
+```sh
+docker-compose up -d
+```
+
+## Gerenciando seu servidor Atuin com systemd
+
+O seguinte arquivo de configuração do `systemd` é usado para gerenciar seu serviço hospedado pelo `docker-compose`:
+
+```
+[Unit]
+Description=Docker Compose Atuin Service
+Requires=docker.service
+After=docker.service
+
+[Service]
+# Onde o arquivo docker-compose está localizado
+WorkingDirectory=/srv/atuin-server
+ExecStart=/usr/bin/docker-compose up
+ExecStop=/usr/bin/docker-compose down
+TimeoutStartSec=0
+Restart=on-failure
+StartLimitBurst=3
+
+[Install]
+WantedBy=multi-user.target
+```
+
+Habilite o serviço:
+
+```sh
+systemctl enable --now atuin
+```
+
+Verifique se o serviço está funcionando corretamente:
+
+```sh
+systemctl status atuin
+```

--- a/docs/pt-BR/import.md
+++ b/docs/pt-BR/import.md
@@ -1,0 +1,25 @@
+# `atuin import`
+
+O Atuin pode importar seu histórico de comandos de seus arquivos de histórico "antigos".
+
+`atuin import auto` tentará descobrir seu shell (via $SHELL) e executar o importador correto.
+
+Infelizmente, esses arquivos antigos não armazenam tantas informações quanto o Atuin, então nem todos os recursos estarão disponíveis para os dados importados.
+
+# zsh
+
+```
+atuin import zsh
+```
+
+Se você definiu HISTFILE, isso deve ser selecionado! Caso contrário, você pode tentar o seguinte:
+
+```
+HISTFILE=/path/to/history/file atuin import zsh
+```
+
+Isso suporta formas simples e estendidas.
+
+# bash
+
+TODO

--- a/docs/pt-BR/k8s.md
+++ b/docs/pt-BR/k8s.md
@@ -1,0 +1,194 @@
+# Kubernetes
+
+Você pode usar o Kubernetes para hospedar seu servidor Atuin.
+
+Crie o arquivo `secrets.yaml` para as credenciais do banco de dados:
+
+```yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: atuin-secrets
+type: Opaque
+stringData:
+  ATUIN_DB_USERNAME: atuin
+  ATUIN_DB_PASSWORD: seriously-insecure
+  ATUIN_HOST: "127.0.0.1"
+  ATUIN_PORT: "8888"
+  ATUIN_OPEN_REGISTRATION: "true"
+  ATUIN_DB_URI: "postgres://atuin:seriously-insecure@localhost/atuin"
+immutable: true
+```
+
+Crie o arquivo `atuin.yaml` para o servidor Atuin:
+
+```yaml
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: atuin
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      io.kompose.service: atuin
+  template:
+    metadata:
+      labels:
+        io.kompose.service: atuin
+    spec:
+      containers:
+        - args:
+            - server
+            - start
+          env:
+            - name: ATUIN_DB_URI
+              valueFrom:
+                secretKeyRef:
+                  name: atuin-secrets
+                  key: ATUIN_DB_URI
+                  optional: false
+            - name: ATUIN_HOST
+              value: 0.0.0.0
+            - name: ATUIN_PORT
+              value: "8888"
+            - name: ATUIN_OPEN_REGISTRATION
+              value: "true"
+          image: ghcr.io/atuinsh/atuin:latest
+          name: atuin
+          ports:
+            - containerPort: 8888
+          resources:
+            limits:
+              cpu: 250m
+              memory: 1Gi
+            requests:
+              cpu: 250m
+              memory: 1Gi
+          volumeMounts:
+            - mountPath: /config
+              name: atuin-claim0
+        - name: postgresql
+          image: postgres:14
+          ports:
+            - containerPort: 5432
+          env:
+            - name: POSTGRES_DB
+              value: atuin
+            - name: POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: atuin-secrets
+                  key: ATUIN_DB_PASSWORD
+                  optional: false
+            - name: POSTGRES_USER
+              valueFrom:
+                secretKeyRef:
+                  name: atuin-secrets
+                  key: ATUIN_DB_USERNAME
+                  optional: false
+          resources:
+            limits:
+              cpu: 250m
+              memory: 1Gi
+            requests:
+              cpu: 250m
+              memory: 1Gi
+          volumeMounts:
+            - mountPath: /var/lib/postgresql/data/
+              name: database
+      volumes:
+        - name: database
+          persistentVolumeClaim:
+            claimName: database
+        - name: atuin-claim0
+          persistentVolumeClaim:
+            claimName: atuin-claim0
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    io.kompose.service: atuin
+  name: atuin
+spec:
+  type: NodePort
+  ports:
+    - name: "8888"
+      port: 8888
+      nodePort: 30530
+  selector:
+    io.kompose.service: atuin
+---
+kind: PersistentVolume
+apiVersion: v1
+metadata:
+  name: database-pv
+  labels:
+    app: database
+    type: local
+spec:
+  storageClassName: manual
+  capacity:
+    storage: 300Mi
+  accessModes:
+    - ReadWriteOnce
+  hostPath:
+    path: "/Users/firstname.lastname/.kube/database"
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  labels:
+    io.kompose.service: database
+  name: database
+spec:
+  storageClassName: manual
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 300Mi
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  labels:
+    io.kompose.service: atuin-claim0
+  name: atuin-claim0
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 10Mi
+```
+
+Finalmente, você pode querer que o Atuin use um namespace separado, crie o arquivo `namespace.yaml`:
+
+```yaml
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: atuin-namespace
+  labels:
+    name: atuin
+```
+
+Ao implantar em um ambiente de produção, você provavelmente desejará que o conteúdo do banco de dados seja armazenado persistentemente no cluster, em vez de no sistema host. Na configuração acima, `storageClassName` está definido como `manual` e o diretório de montagem do sistema host está definido como `/Users/firstname.lastname/.kube/database`. Observe que essas configurações farão com que o conteúdo do banco de dados seja armazenado *fora* do cluster Kubernetes.
+
+Você também deve alterar `ATUIN_DB_PASSWORD` e `ATUIN_DB_URI` no arquivo `secrets.yaml` para strings criptografadas mais seguras.
+
+O Atuin é executado na porta `30530` do sistema host. Isso é configurado através da propriedade `nodePort`. O Kubernetes tem uma regra estrita que não permite expor números de porta menores que 30000. Para que o cliente funcione corretamente, você precisará definir o número da porta no seu arquivo `config.toml`, por exemplo, `sync_address = "http://192.168.1.10:30530"`.
+
+Use `kubectl` para implantar o servidor Atuin:
+
+```shell
+  kubectl apply -f ./namespaces.yaml
+  kubectl apply -n atuin-namespace \
+                -f ./secrets.yaml \
+                -f ./atuin.yaml
+```
+
+O exemplo acima também está localizado no diretório [k8s](../../k8s) do repositório do Atuin.

--- a/docs/pt-BR/key-binding.md
+++ b/docs/pt-BR/key-binding.md
@@ -1,0 +1,48 @@
+# Vinculação de Teclas
+
+Por padrão, o Atuin irá rebindar `Ctrl-r` e a tecla `up`. Se você não quiser usar as vinculações padrão, defina `ATUIN_NOBIND` antes de chamar `atuin init`.
+
+Por exemplo:
+
+```
+export ATUIN_NOBIND="true"
+eval "$(atuin init zsh)"
+```
+
+Você pode rebindar o Atuin após chamar `atuin init`, se necessário.
+
+# zsh
+
+O Atuin define o widget ZLE "atuin-search".
+
+```
+export ATUIN_NOBIND="true"
+eval "$(atuin init zsh)"
+
+bindkey '^r' atuin-search
+
+# Dependendo do modo do terminal
+bindkey '^[[A' atuin-search
+bindkey '^[OA' atuin-search
+```
+
+# bash
+
+```
+export ATUIN_NOBIND="true"
+eval "$(atuin init bash)"
+
+# Vincula a ctrl-r, você também pode adicionar quaisquer outras vinculações que desejar aqui
+bind -x '"\C-r": __atuin_history'
+```
+
+# fish
+
+```
+set -gx ATUIN_NOBIND "true"
+atuin init fish | source
+
+# Vincula a ctrl-r nos modos normal e de inserção, você também pode adicionar outras vinculações de teclas aqui
+bind \cr _atuin_search
+bind -M insert \cr _atuin_search
+```

--- a/docs/pt-BR/list.md
+++ b/docs/pt-BR/list.md
@@ -1,0 +1,11 @@
+# Lista de Histórico
+
+```
+atuin history list
+```
+
+| Parâmetro | Descrição |
+|---|---|
+| `--cwd/-c` | Diretório para listar o histórico (padrão: todos os diretórios) |
+| `--session/-s` | Habilita a listagem do histórico apenas para a sessão atual (padrão: false) |
+| `--human` | Usa formato legível para humanos para carimbos de data/hora e durações (padrão: false) |

--- a/docs/pt-BR/search.md
+++ b/docs/pt-BR/search.md
@@ -1,0 +1,37 @@
+# `atuin search`
+
+```
+atuin search <query>
+```
+
+A pesquisa do Atuin também suporta curingas com os caracteres `*` ou `%`. Por padrão, uma pesquisa de prefixo é executada (ou seja, todos os termos de pesquisa são automaticamente anexados com um curinga).
+
+| Parâmetro | Descrição |
+|---|---|
+| `--cwd/-c` | Diretório para listar o histórico (padrão: todos os diretórios) |
+| `--exclude-cwd` | Exclui comandos executados neste diretório (padrão: nenhum) |
+| `--exit/-e` | Filtra por código de saída (padrão: nenhum) |
+| `--exclude-exit` | Exclui comandos com este código de saída (padrão: nenhum) |
+| `--before` | Inclui apenas comandos executados antes desta data (padrão: nenhum) |
+| `--after` | Inclui apenas comandos executados depois desta data (padrão: nenhum) |
+| `--interactive/-i` | Abre a interface de usuário de pesquisa interativa (padrão: false) |
+| `--human` | Usa formato legível para humanos para carimbos de data/hora e durações (padrão: false) |
+
+## Exemplos
+
+```
+# Abrir a TUI de pesquisa interativa
+atuin search -i
+
+# Abrir a TUI de pesquisa interativa pré-preenchida com uma consulta
+atuin search -i atuin
+
+# Pesquisar todos os comandos que começam com cargo e saíram com sucesso.
+atuin search --exit 0 cargo
+
+# Pesquisar todos os comandos que falharam, foram executados antes de 1º de abril de 2021 e no diretório atual.
+atuin search --exclude-exit 0 --before 01/04/2021 --cwd .
+
+# Pesquisar todos os comandos que começam com cargo, saíram com sucesso e foram executados após as 15h de ontem.
+atuin search --exit 0 --after "yesterday 3pm" cargo
+```

--- a/docs/pt-BR/server.md
+++ b/docs/pt-BR/server.md
@@ -1,0 +1,75 @@
+# `atuin server`
+
+O Atuin permite que você execute seu próprio servidor de sincronização, caso não queira usar o servidor que eu (ellie) hospedo :)
+
+Atualmente, há apenas um subcomando, `atuin server start`, que iniciará o servidor de sincronização HTTP do Atuin.
+
+```
+USO:
+    atuin server start [OPÇÕES]
+
+FLAGS:
+        --help       Imprime informações de ajuda
+    -V, --version    Imprime informações da versão
+
+OPÇÕES:
+    -h, --host <host>
+    -p, --port <port>
+```
+
+## Configuração
+
+A configuração do servidor é separada da configuração do cliente, mesmo que sejam o mesmo binário. A configuração do servidor pode ser encontrada em `~/.config/atuin/server.toml`.
+
+Ela se parece com isto:
+
+```toml
+host = "0.0.0.0"
+port = 8888
+open_registration = true
+db_uri="postgres://user:password@hostname/database"
+```
+
+Alternativamente, a configuração também pode ser fornecida por variáveis de ambiente.
+
+```sh
+ATUIN_HOST="0.0.0.0"
+ATUIN_PORT=8888
+ATUIN_OPEN_REGISTRATION=true
+ATUIN_DB_URI="postgres://user:password@hostname/database"
+```
+
+### host
+
+O endereço no qual o servidor Atuin deve escutar.
+
+O padrão é `127.0.0.1`.
+
+### port
+
+A porta na qual o servidor Atuin deve escutar.
+
+O padrão é `8888`.
+
+### open_registration
+
+Se `true`, o Atuin aceitará novos registros de usuários. Se você não quiser que outras pessoas possam usar seu servidor, defina isso como `false` depois de criar sua própria conta.
+
+O padrão é `false`.
+
+### db_uri
+
+Um URI postgres válido, onde os dados do usuário e do histórico serão salvos.
+
+### path
+
+`path` refere-se ao prefixo de rota adicionado ao servidor. Um valor de string vazia não adicionará um prefixo de rota.
+
+O padrão é `""`.
+
+## Notas de Implantação em Contêiner
+
+Você pode implantar seu próprio servidor Atuin em um contêiner:
+
+* Para um exemplo de configuração Docker, consulte [docker](docker.md).
+* Para um exemplo de configuração Kubernetes, consulte [k8s](k8s.md).

--- a/docs/pt-BR/shell-completions.md
+++ b/docs/pt-BR/shell-completions.md
@@ -1,0 +1,19 @@
+# `atuin gen-completions`
+
+As [conclusões de shell](https://en.wikipedia.org/wiki/Command-line_completion) do Atuin podem ser geradas usando o subcomando `gen-completions`, especificando o diretório de saída e o shell desejado.
+
+```
+$ atuin gen-completions --shell bash --out-dir $HOME
+
+Conclusão de shell para BASH é gerada em "/home/user"
+```
+
+Os valores possíveis para o parâmetro `--shell` são:
+
+- `bash`
+- `fish`
+- `zsh`
+- `powershell`
+- `elvish`
+
+Além disso, consulte [Shells Suportados](./README.md#shells-suportados).

--- a/docs/pt-BR/stats.md
+++ b/docs/pt-BR/stats.md
@@ -1,0 +1,35 @@
+# `atuin stats`
+
+O Atuin também pode calcular estatísticas com base no seu histórico - atualmente é apenas um recurso básico, mas mais estão por vir.
+
+```
+$ atuin stats day last friday
+
++---------------------+------------+
+| Estatística         | Valor      |
++---------------------+------------+
+| Comando mais usado  | git status |
++---------------------+------------+
+| Comandos executados |        450 |
++---------------------+------------+
+| Comandos únicos     |        213 |
++---------------------+------------+
+
+$ atuin stats day 01/01/21 # Também aceita datas absolutas
+```
+
+Ele também pode calcular estatísticas para todo o histórico conhecido.
+
+```
+$ atuin stats all
+
++---------------------+-------+
+| Estatística         | Valor |
++---------------------+-------+
+| Comando mais usado  |    ls |
++---------------------+-------+
+| Comandos executados |  8190 |
++---------------------+-------+
+| Comandos únicos     |  2996 |
++---------------------+-------+
+```

--- a/docs/pt-BR/sync.md
+++ b/docs/pt-BR/sync.md
@@ -1,0 +1,51 @@
+# `atuin sync`
+
+O Atuin pode fazer backup do seu histórico para um servidor e usá-lo para garantir que várias máquinas tenham o mesmo histórico de shell. Tudo é criptografado de ponta a ponta, então o operador do servidor *nunca* pode ver seus dados!
+
+Qualquer um pode hospedar um servidor (tente `atuin server start`, mais documentação virá depois), mas eu (ellie) hospedo um em https://api.atuin.sh. Este é o endereço do servidor padrão e pode ser alterado na [configuração](config.md). Novamente, eu *não* posso ver seus dados, nem quero.
+
+## Frequência de Sincronização
+
+A sincronização ocorrerá automaticamente, a menos que configurado de outra forma. A frequência da sincronização pode ser configurada na [configuração](config.md).
+
+## Sincronizar
+
+Você pode acionar uma sincronização manualmente com `atuin sync`.
+
+## Registrar
+
+Registre uma conta de sincronização.
+
+```
+atuin register -u <USERNAME> -e <EMAIL> -p <PASSWORD>
+```
+
+O NOME DE USUÁRIO deve ser único, e o EMAIL é usado apenas para notificações importantes (vulnerabilidades de segurança, alterações de serviço, etc.).
+
+Uma vez registrado, você também estará logado :) A sincronização deve ocorrer automaticamente a partir daqui!
+
+## Chave
+
+Como seus dados são criptografados, o Atuin gerará uma chave para você. Ela é armazenada no diretório de dados do Atuin (em Linux, `~/.local/share/atuin`).
+
+Você também pode obtê-la com:
+
+```
+atuin key
+```
+
+Nunca compartilhe isso com ninguém!
+
+## Login
+
+Se você quiser fazer login em uma nova máquina, precisará de sua chave de criptografia (`atuin key`).
+
+```
+atuin login -u <USERNAME> -p <PASSWORD> -k <KEY>
+```
+
+## Logout
+
+```
+atuin logout
+```


### PR DESCRIPTION
This PR introduces the complete Atuin documentation in Brazilian Portuguese, located in the `docs/pt-BR` directory.
    
The goal is to make Atuin more accessible to the Portuguese-speaking user and contributor community, facilitating the understanding and use of the tool.

The following files have been translated/added:
- `docs/pt-BR/config.md`
- `docs/pt-BR/docker.md`
- `docs/pt-BR/import.md`
- `docs/pt-BR/k8s.md`
- `docs/pt-BR/key-binding.md`
- `docs/pt-BR/list.md`
- `docs/pt-BR/README.md`
- `docs/pt-BR/search.md`
- `docs/pt-BR/server.md`
- `docs/pt-BR/shell-completions.md`
- `docs/pt-BR/stats.md`
- `docs/pt-BR/sync.md`


## Checks
- [x] I am happy for maintainers to push small adjustments to this PR, to speed up the review cycle
- [x] I have checked that there are no existing pull requests for the same thing
