### PR TITLE
feat: add inline_height_shell_up_key_binding option

### DIFF
--- a/crates/atuin-client/config.toml
+++ b/crates/atuin-client/config.toml
@@ -71,6 +71,11 @@
 ## set it to 0 to always go full screen
 # inline_height = 0
 
+## the maximum number of lines the interface should take up
+## when atuin is invoked from a shell up-key binding
+## the accepted values are identical to those of "inline_height"
+# inline_height_shell_up_key_binding = 0
+
 ## Invert the UI - put the search bar at the top , Default to `false`
 # invert = false
 

--- a/crates/atuin-client/src/settings.rs
+++ b/crates/atuin-client/src/settings.rs
@@ -462,6 +462,7 @@ pub struct Settings {
     pub search_mode_shell_up_key_binding: Option<SearchMode>,
     pub shell_up_key_binding: bool,
     pub inline_height: u16,
+    pub inline_height_shell_up_key_binding: Option<u16>,
     pub invert: bool,
     pub show_preview: bool,
     pub max_preview_height: u16,

--- a/crates/atuin/src/command/client/search/interactive.rs
+++ b/crates/atuin/src/command/client/search/interactive.rs
@@ -1053,13 +1053,21 @@ pub async fn history(
     history_store: &HistoryStore,
     theme: &Theme,
 ) -> Result<String> {
-    let stdout = Stdout::new(settings.inline_height > 0)?;
+    let inline_height = if settings.shell_up_key_binding {
+        settings
+            .inline_height_shell_up_key_binding
+            .unwrap_or(settings.inline_height)
+    } else {
+        settings.inline_height
+    };
+
+    let stdout = Stdout::new(inline_height > 0)?;
     let backend = CrosstermBackend::new(stdout);
     let mut terminal = Terminal::with_options(
         backend,
         TerminalOptions {
-            viewport: if settings.inline_height > 0 {
-                Viewport::Inline(settings.inline_height)
+            viewport: if inline_height > 0 {
+                Viewport::Inline(inline_height)
             } else {
                 Viewport::Fullscreen
             },
@@ -1122,7 +1130,7 @@ pub async fn history(
 
     let mut results = app.query_results(&mut db, settings.smart_sort).await?;
 
-    if settings.inline_height > 0 {
+    if inline_height > 0 {
         terminal.clear()?;
     }
 
@@ -1203,7 +1211,7 @@ pub async fn history(
 
     app.finalize_keymap_cursor(settings);
 
-    if settings.inline_height > 0 {
+    if inline_height > 0 {
         terminal.clear()?;
     }
 


### PR DESCRIPTION
<!-- Thank you for making a PR! Bug fixes are always welcome, but if you're adding a new feature or changing an existing one, we'd really appreciate if you open an issue, post on the forum, or drop in on Discord -->

I was looking for option to have a small inline height for the up arrow and full screen for ctrl-r.
This PR adds a separate option to configure the inline height of the up arrow: `inline_height_shell_up_key_binding`.

I followed the same structure as the `search_mode_shell_up_key_binding` option.
Resolves #2612.

## Checks
- [ X] I am happy for maintainers to push small adjustments to this PR, to speed up the review cycle
- [ X] I have checked that there are no existing pull requests for the same thing
