### PR TITLE
fix(scripts): handle command errors when EDITOR does not exist

### DIFF
--- a/crates/atuin/src/command/client/scripts.rs
+++ b/crates/atuin/src/command/client/scripts.rs
@@ -133,7 +133,7 @@ impl Cmd {
         // Open the file in the user's preferred editor
         let editor = std::env::var("EDITOR").unwrap_or_else(|_| "vi".to_string());
         if let Err(_e) = std::process::Command::new(editor).arg(&path).status() {
-            bail!("failed to open editor");
+            bail!("failed to open editor. Ensure EDITOR is set");
         }
 
         // Read back the edited content

--- a/crates/atuin/src/command/client/scripts.rs
+++ b/crates/atuin/src/command/client/scripts.rs
@@ -132,8 +132,7 @@ impl Cmd {
 
         // Open the file in the user's preferred editor
         let editor = std::env::var("EDITOR").unwrap_or_else(|_| "vi".to_string());
-        let status = std::process::Command::new(editor).arg(&path).status()?;
-        if !status.success() {
+        if let Err(e) = std::process::Command::new(editor).arg(&path).status() {
             bail!("failed to open editor");
         }
 

--- a/crates/atuin/src/command/client/scripts.rs
+++ b/crates/atuin/src/command/client/scripts.rs
@@ -132,7 +132,7 @@ impl Cmd {
 
         // Open the file in the user's preferred editor
         let editor = std::env::var("EDITOR").unwrap_or_else(|_| "vi".to_string());
-        if let Err(e) = std::process::Command::new(editor).arg(&path).status() {
+        if let Err(_e) = std::process::Command::new(editor).arg(&path).status() {
             bail!("failed to open editor");
         }
 


### PR DESCRIPTION
<!-- Thank you for making a PR! Bug fixes are always welcome, but if you're adding a new feature or changing an existing one, we'd really appreciate if you open an issue, post on the forum, or drop in on Discord -->
Closes https://github.com/atuinsh/atuin/issues/2798

Implements a small change to handle errors if the editor does not exist.

Before:
```shell
$ EDITOR=fsdfdgrg atuin scripts new test
Error: No such file or directory (os error 2)

Location:
    crates/atuin/src/command/client/scripts.rs:135:22
```


After:
```shell
$  EDITOR="Fdgdfgd" cargo run -- script new test
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.60s
     Running `target/debug/atuin script new test`
Error: failed to open editor

Location:
    crates/atuin/src/command/client/scripts.rs:136:13
```


## Checks
- [x] I am happy for maintainers to push small adjustments to this PR, to speed up the review cycle
- [x] I have checked that there are no existing pull requests for the same thing
