### PR TITLE
feat: 'atuin script list' add tag filtering

### DIFF
--- a/crates/atuin/src/command/client/scripts.rs
+++ b/crates/atuin/src/command/client/scripts.rs
@@ -54,7 +54,10 @@ pub struct Run {
 }
 
 #[derive(Parser, Debug)]
-pub struct List {}
+pub struct List {
+    #[arg(short, long)]
+    pub tag: Option<String>,
+}
 
 #[derive(Parser, Debug)]
 pub struct Get {
@@ -356,10 +359,14 @@ impl Cmd {
 
     async fn handle_list(
         _settings: &Settings,
-        _list: List,
+        list: List,
         script_db: atuin_scripts::database::Database,
     ) -> Result<()> {
-        let scripts = script_db.list().await?;
+        let scripts = if let Some(tag) = list.tag {
+            script_db.get_by_tag(&tag).await?
+        } else {
+            script_db.list().await?
+        };
 
         if scripts.is_empty() {
             println!("No scripts found");


### PR DESCRIPTION
We have tag in db schema, add script list with tag support, let user maintain scripts easier.

- atuin script list -t <tag>
- refactor database queries

```
$ atuin scripts list - t testing
Available scripts:
- hello [tags: abc, kkk, testing]
  Description: dasdas
```

```
$ atuin scripts list
Available scripts:
- hello [tags: abc, kkk, testing]
  Description: dasdas
- termux-init
```

## Checks
- [x] I am happy for maintainers to push small adjustments to this PR, to speed up the review cycle
- [x] I have checked that there are no existing pull requests for the same thing

-----

Related: https://github.com/atuinsh/atuin/issues/2785