### PR TITLE
nushell: fix `get -i` deprecation

### DIFF
--- a/crates/atuin/src/shell/atuin.nu
+++ b/crates/atuin/src/shell/atuin.nu
@@ -15,7 +15,7 @@ hide-env -i ATUIN_HISTORY_ID
 let ATUIN_KEYBINDING_TOKEN = $"# (random uuid)"
 
 let _atuin_pre_execution = {||
-    if ($nu | get -i history-enabled) == false {
+    if ($nu | get history-enabled?) == false {
         return
     }
     let cmd = (commandline)
@@ -65,9 +65,9 @@ $env.config = (
     $env.config | upsert hooks (
         $env.config.hooks
         | upsert pre_execution (
-            $env.config.hooks | get -i pre_execution | default [] | append $_atuin_pre_execution)
+            $env.config.hooks | get pre_execution? | default [] | append $_atuin_pre_execution)
         | upsert pre_prompt (
-            $env.config.hooks | get -i pre_prompt | default [] | append $_atuin_pre_prompt)
+            $env.config.hooks | get pre_prompt? | default [] | append $_atuin_pre_prompt)
     )
 )
 


### PR DESCRIPTION
Since https://github.com/nushell/nushell/pull/16007, the recommended flag to avoid erroring on missing fields is `--optional`. To avoid compatibility issues, the builtin optional access syntax is used instead, which is backwards-compatible.

More specifically, this PR fixes `nushell` showing a warning on every launch due to the syntax being deprecated. This deprecation isn't released (yet), but changing this ahead of time in a backward-compatible way should prevent some future headaches from users :)

## Checks
- [x] I am happy for maintainers to push small adjustments to this PR, to speed up the review cycle
- [x] I have checked that there are no existing pull requests for the same thing
