### PR TITLE
feat: add info for 'official' plugins

### DIFF
--- a/crates/atuin-client/src/lib.rs
+++ b/crates/atuin-client/src/lib.rs
@@ -15,6 +15,7 @@ pub mod import;
 pub mod login;
 pub mod logout;
 pub mod ordering;
+pub mod plugin;
 pub mod record;
 pub mod register;
 pub mod secrets;

--- a/crates/atuin-client/src/plugin.rs
+++ b/crates/atuin-client/src/plugin.rs
@@ -1,0 +1,97 @@
+use std::collections::HashMap;
+
+#[derive(Debug, Clone)]
+pub struct OfficialPlugin {
+    pub name: String,
+    pub description: String,
+    pub install_message: String,
+}
+
+impl OfficialPlugin {
+    pub fn new(name: &str, description: &str, install_message: &str) -> Self {
+        Self {
+            name: name.to_string(),
+            description: description.to_string(),
+            install_message: install_message.to_string(),
+        }
+    }
+}
+
+pub struct OfficialPluginRegistry {
+    plugins: HashMap<String, OfficialPlugin>,
+}
+
+impl OfficialPluginRegistry {
+    pub fn new() -> Self {
+        let mut registry = Self {
+            plugins: HashMap::new(),
+        };
+
+        // Register official plugins
+        registry.register_official_plugins();
+
+        registry
+    }
+
+    fn register_official_plugins(&mut self) {
+        // atuin-update plugin
+        self.plugins.insert(
+            "update".to_string(),
+            OfficialPlugin::new(
+                "update",
+                "Update atuin to the latest version",
+                "The 'atuin update' command is provided by the atuin-update plugin.\n\
+                 It is only installed if you used the install script\n  \
+                 If you used a package manager (brew, apt, etc), please continue to use it for updates"
+            ),
+        );
+    }
+
+    pub fn get_plugin(&self, name: &str) -> Option<&OfficialPlugin> {
+        self.plugins.get(name)
+    }
+
+    pub fn is_official_plugin(&self, name: &str) -> bool {
+        self.plugins.contains_key(name)
+    }
+
+    pub fn get_install_message(&self, name: &str) -> Option<&str> {
+        self.plugins
+            .get(name)
+            .map(|plugin| plugin.install_message.as_str())
+    }
+}
+
+impl Default for OfficialPluginRegistry {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_registry_creation() {
+        let registry = OfficialPluginRegistry::new();
+        assert!(registry.is_official_plugin("update"));
+        assert!(!registry.is_official_plugin("nonexistent"));
+    }
+
+    #[test]
+    fn test_get_plugin() {
+        let registry = OfficialPluginRegistry::new();
+        let plugin = registry.get_plugin("update");
+        assert!(plugin.is_some());
+        assert_eq!(plugin.unwrap().name, "update");
+    }
+
+    #[test]
+    fn test_get_install_message() {
+        let registry = OfficialPluginRegistry::new();
+        let message = registry.get_install_message("update");
+        assert!(message.is_some());
+        assert!(message.unwrap().contains("atuin-update"));
+    }
+}

--- a/crates/atuin/src/command/external.rs
+++ b/crates/atuin/src/command/external.rs
@@ -2,6 +2,7 @@ use std::fmt::Write as _;
 use std::process::Command;
 use std::{io, process};
 
+use atuin_client::plugin::OfficialPluginRegistry;
 use clap::CommandFactory;
 use clap::builder::{StyledStr, Styles};
 use eyre::Result;
@@ -44,29 +45,42 @@ pub fn run(args: &[String]) -> Result<()> {
 fn render_not_found(subcommand: &str, bin: &str) -> StyledStr {
     let mut output = StyledStr::new();
     let styles = Styles::styled();
-    let mut atuin_cmd = Atuin::command();
-    let usage = atuin_cmd.render_usage();
+    let registry = OfficialPluginRegistry::new();
 
     let error = styles.get_error();
     let invalid = styles.get_invalid();
     let literal = styles.get_literal();
 
-    let _ = write!(output, "{error}error:{error:#} ");
-    let _ = write!(
-        output,
-        "unrecognized subcommand '{invalid}{subcommand}{invalid:#}' "
-    );
-    let _ = write!(
-        output,
-        "and no executable named '{invalid}{bin}{invalid:#}' found in your PATH"
-    );
-    let _ = write!(output, "\n\n");
-    let _ = write!(output, "{usage}");
-    let _ = write!(output, "\n\n");
-    let _ = write!(
-        output,
-        "For more information, try '{literal}--help{literal:#}'."
-    );
+    // Check if this is an official plugin
+    if let Some(install_message) = registry.get_install_message(subcommand) {
+        let _ = write!(output, "{error}error:{error:#} ");
+        let _ = write!(
+            output,
+            "'{invalid}{subcommand}{invalid:#}' is an official atuin plugin, but it's not installed"
+        );
+        let _ = write!(output, "\n\n");
+        let _ = write!(output, "{install_message}");
+    } else {
+        let mut atuin_cmd = Atuin::command();
+        let usage = atuin_cmd.render_usage();
+
+        let _ = write!(output, "{error}error:{error:#} ");
+        let _ = write!(
+            output,
+            "unrecognized subcommand '{invalid}{subcommand}{invalid:#}' "
+        );
+        let _ = write!(
+            output,
+            "and no executable named '{invalid}{bin}{invalid:#}' found in your PATH"
+        );
+        let _ = write!(output, "\n\n");
+        let _ = write!(output, "{usage}");
+        let _ = write!(output, "\n\n");
+        let _ = write!(
+            output,
+            "For more information, try '{literal}--help{literal:#}'."
+        );
+    }
 
     output
 }

--- a/crates/atuin/src/command/external.rs
+++ b/crates/atuin/src/command/external.rs
@@ -2,6 +2,7 @@ use std::fmt::Write as _;
 use std::process::Command;
 use std::{io, process};
 
+#[cfg(feature = "client")]
 use atuin_client::plugin::OfficialPluginRegistry;
 use clap::CommandFactory;
 use clap::builder::{StyledStr, Styles};
@@ -45,42 +46,47 @@ pub fn run(args: &[String]) -> Result<()> {
 fn render_not_found(subcommand: &str, bin: &str) -> StyledStr {
     let mut output = StyledStr::new();
     let styles = Styles::styled();
-    let registry = OfficialPluginRegistry::new();
 
     let error = styles.get_error();
     let invalid = styles.get_invalid();
     let literal = styles.get_literal();
 
-    // Check if this is an official plugin
-    if let Some(install_message) = registry.get_install_message(subcommand) {
-        let _ = write!(output, "{error}error:{error:#} ");
-        let _ = write!(
-            output,
-            "'{invalid}{subcommand}{invalid:#}' is an official atuin plugin, but it's not installed"
-        );
-        let _ = write!(output, "\n\n");
-        let _ = write!(output, "{install_message}");
-    } else {
-        let mut atuin_cmd = Atuin::command();
-        let usage = atuin_cmd.render_usage();
+    #[cfg(feature = "client")]
+    {
+        let registry = OfficialPluginRegistry::new();
 
-        let _ = write!(output, "{error}error:{error:#} ");
-        let _ = write!(
-            output,
-            "unrecognized subcommand '{invalid}{subcommand}{invalid:#}' "
-        );
-        let _ = write!(
-            output,
-            "and no executable named '{invalid}{bin}{invalid:#}' found in your PATH"
-        );
-        let _ = write!(output, "\n\n");
-        let _ = write!(output, "{usage}");
-        let _ = write!(output, "\n\n");
-        let _ = write!(
-            output,
-            "For more information, try '{literal}--help{literal:#}'."
-        );
+        // Check if this is an official plugin
+        if let Some(install_message) = registry.get_install_message(subcommand) {
+            let _ = write!(output, "{error}error:{error:#} ");
+            let _ = write!(
+                output,
+                "'{invalid}{subcommand}{invalid:#}' is an official atuin plugin, but it's not installed"
+            );
+            let _ = write!(output, "\n\n");
+            let _ = write!(output, "{install_message}");
+            return output;
+        }
     }
+
+    let mut atuin_cmd = Atuin::command();
+    let usage = atuin_cmd.render_usage();
+
+    let _ = write!(output, "{error}error:{error:#} ");
+    let _ = write!(
+        output,
+        "unrecognized subcommand '{invalid}{subcommand}{invalid:#}' "
+    );
+    let _ = write!(
+        output,
+        "and no executable named '{invalid}{bin}{invalid:#}' found in your PATH"
+    );
+    let _ = write!(output, "\n\n");
+    let _ = write!(output, "{usage}");
+    let _ = write!(output, "\n\n");
+    let _ = write!(
+        output,
+        "For more information, try '{literal}--help{literal:#}'."
+    );
 
     output
 }


### PR DESCRIPTION
Cover the case where users try to `atuin update` but they did not use the install scripts. Also covers other plugins (I have a few in mind)

Longer term things like `kv` should be a plugin

<!-- Thank you for making a PR! Bug fixes are always welcome, but if you're adding a new feature or changing an existing one, we'd really appreciate if you open an issue, post on the forum, or drop in on Discord -->

## Checks
- [ ] I am happy for maintainers to push small adjustments to this PR, to speed up the review cycle
- [ ] I have checked that there are no existing pull requests for the same thing
