### PR TITLE
feat: Support multi part commands (Fixes #2836)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -257,6 +257,7 @@ dependencies = [
  "semver",
  "serde",
  "serde_json",
+ "shlex",
  "sysinfo",
  "tempfile",
  "time",

--- a/crates/atuin/Cargo.toml
+++ b/crates/atuin/Cargo.toml
@@ -90,6 +90,7 @@ uuid = { workspace = true }
 sysinfo = "0.30.7"
 regex = "1.10.5"
 tempfile = { workspace = true }
+shlex = "1.3.0"
 
 [target.'cfg(any(target_os = "windows", target_os = "macos"))'.dependencies]
 arboard = { version = "3.4", optional = true }

--- a/crates/atuin/src/command/client/scripts.rs
+++ b/crates/atuin/src/command/client/scripts.rs
@@ -138,7 +138,7 @@ impl Cmd {
         let parts = shlex::split(&editor_str).ok_or_eyre("Failed to parse editor command")?;
         let (command, args) = parts.split_first().ok_or_eyre("No editor command found")?;
 
-        let status = std::process::Command::new(&command)
+        let status = std::process::Command::new(command)
             .args(args)
             .arg(&path)
             .status()?;

--- a/crates/atuin/src/command/client/scripts.rs
+++ b/crates/atuin/src/command/client/scripts.rs
@@ -10,6 +10,7 @@ use atuin_scripts::{
     store::{ScriptStore, script::Script},
 };
 use clap::{Parser, Subcommand};
+use eyre::OptionExt;
 use eyre::{Result, bail};
 use tempfile::NamedTempFile;
 
@@ -131,8 +132,16 @@ impl Cmd {
         }
 
         // Open the file in the user's preferred editor
-        let editor = std::env::var("EDITOR").unwrap_or_else(|_| "vi".to_string());
-        let status = std::process::Command::new(editor).arg(&path).status()?;
+        let editor_str = std::env::var("EDITOR").unwrap_or_else(|_| "vi".to_string());
+
+        // Use shlex to safely split the string into shell-like parts.
+        let parts = shlex::split(&editor_str).ok_or_eyre("Failed to parse editor command")?;
+        let (command, args) = parts.split_first().ok_or_eyre("No editor command found")?;
+
+        let status = std::process::Command::new(&command)
+            .args(args)
+            .arg(&path)
+            .status()?;
         if !status.success() {
             bail!("failed to open editor");
         }


### PR DESCRIPTION
Support `$EDITOR` with args

## Example

```sh
export EDITOR="code --wait"
atuin scripts new test
```


## Checks
- [x] I am happy for maintainers to push small adjustments to this PR, to speed up the review cycle
- [x] I have checked that there are no existing pull requests for the same thing
