### PR TITLE
fix: Make status exit 1 if not logged in

### DIFF
--- a/crates/atuin/src/command/client/sync/status.rs
+++ b/crates/atuin/src/command/client/sync/status.rs
@@ -3,15 +3,13 @@ use std::path::PathBuf;
 use crate::{SHA, VERSION};
 use atuin_client::{api_client, database::Database, settings::Settings};
 use colored::Colorize;
-use eyre::Result;
+use eyre::{Result, bail};
 
 pub async fn run(settings: &Settings, db: &impl Database) -> Result<()> {
     let session_path = settings.session_path.as_str();
 
     if !PathBuf::from(session_path).exists() {
-        println!("You are not logged in to a sync server - cannot show sync status");
-
-        return Ok(());
+        bail!("You are not logged in to a sync server - cannot show sync status");
     }
 
     let client = api_client::Client::new(


### PR DESCRIPTION
Another small one that makes `atuin status` also exit 1 when not logged in.

## Checks
- [x] I am happy for maintainers to push small adjustments to this PR, to speed up the review cycle
- [x] I have checked that there are no existing pull requests for the same thing
