### PR TITLE
feat: add IDX_CACHE_ROLLOUT

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -489,6 +489,7 @@ dependencies = [
  "eyre",
  "futures-util",
  "metrics",
+ "rand 0.8.5",
  "serde",
  "sqlx",
  "time",

--- a/crates/atuin-server-postgres/Cargo.toml
+++ b/crates/atuin-server-postgres/Cargo.toml
@@ -22,3 +22,4 @@ async-trait = { workspace = true }
 uuid = { workspace = true }
 metrics = "0.21.1"
 futures-util = "0.3"
+rand.workspace = true


### PR DESCRIPTION
Only really useful for Atuin cloud

Given a % chance, either use the idx cache or use the old aggregation query

This is to enable us to test rollout the idx cache, without breaking all queries in weird ways. Can monitor for a change in http codes/etc, and easily roll back.

This is intentionally NOT a setting, as it will be removed very soon.

<!-- Thank you for making a PR! Bug fixes are always welcome, but if you're adding a new feature or changing an existing one, we'd really appreciate if you open an issue, post on the forum, or drop in on Discord -->

## Checks
- [ ] I am happy for maintainers to push small adjustments to this PR, to speed up the review cycle
- [ ] I have checked that there are no existing pull requests for the same thing
