### PR TITLE
fix: build warnings and Clippy issues on Windows

### DIFF
--- a/crates/atuin-client/src/database.rs
+++ b/crates/atuin-client/src/database.rs
@@ -839,7 +839,7 @@ mod test {
     use super::*;
     use std::time::{Duration, Instant};
 
-    async fn assert_search_eq<'a>(
+    async fn assert_search_eq(
         db: &impl Database,
         mode: SearchMode,
         filter_mode: FilterMode,

--- a/crates/atuin-common/src/utils.rs
+++ b/crates/atuin-common/src/utils.rs
@@ -200,7 +200,6 @@ mod tests {
     use pretty_assertions::assert_ne;
 
     use super::*;
-    use std::env;
 
     use std::collections::HashSet;
 
@@ -214,6 +213,7 @@ mod tests {
         test_data_dir();
     }
 
+    #[cfg(not(windows))]
     fn test_config_dir_xdg() {
         // TODO: Audit that the environment access only happens in single-threaded code.
         unsafe { env::remove_var("HOME") };
@@ -227,6 +227,7 @@ mod tests {
         unsafe { env::remove_var("XDG_CONFIG_HOME") };
     }
 
+    #[cfg(not(windows))]
     fn test_config_dir() {
         // TODO: Audit that the environment access only happens in single-threaded code.
         unsafe { env::set_var("HOME", "/home/user") };
@@ -239,6 +240,7 @@ mod tests {
         unsafe { env::remove_var("HOME") };
     }
 
+    #[cfg(not(windows))]
     fn test_data_dir_xdg() {
         // TODO: Audit that the environment access only happens in single-threaded code.
         unsafe { env::remove_var("HOME") };
@@ -249,6 +251,7 @@ mod tests {
         unsafe { env::remove_var("XDG_DATA_HOME") };
     }
 
+    #[cfg(not(windows))]
     fn test_data_dir() {
         // TODO: Audit that the environment access only happens in single-threaded code.
         unsafe { env::set_var("HOME", "/home/user") };

--- a/crates/atuin-daemon/src/client.rs
+++ b/crates/atuin-daemon/src/client.rs
@@ -49,7 +49,7 @@ impl HistoryClient {
     pub async fn new(port: u64) -> Result<Self> {
         let channel = Endpoint::try_from("http://atuin_local_daemon:0")?
             .connect_with_connector(service_fn(move |_: Uri| {
-                let url = format!("127.0.0.1:{}", port);
+                let url = format!("127.0.0.1:{port}");
 
                 async move {
                     Ok::<_, std::io::Error>(TokioIo::new(TcpStream::connect(url.clone()).await?))
@@ -58,8 +58,7 @@ impl HistoryClient {
             .await
             .wrap_err_with(|| {
                 format!(
-                    "failed to connect to local atuin daemon at 127.0.0.1:{}. Is it running?",
-                    port
+                    "failed to connect to local atuin daemon at 127.0.0.1:{port}. Is it running?"
                 )
             })?;
 

--- a/crates/atuin-daemon/src/server.rs
+++ b/crates/atuin-daemon/src/server.rs
@@ -4,6 +4,7 @@ use atuin_client::encryption;
 use atuin_client::history::store::HistoryStore;
 use atuin_client::record::sqlite_store::SqliteStore;
 use atuin_client::settings::Settings;
+#[cfg(unix)]
 use std::path::PathBuf;
 use std::sync::Arc;
 use time::OffsetDateTime;
@@ -227,7 +228,7 @@ async fn start_server(settings: Settings, history: HistoryService) -> Result<()>
     use tokio_stream::wrappers::TcpListenerStream;
 
     let port = settings.daemon.tcp_port;
-    let url = format!("127.0.0.1:{}", port);
+    let url = format!("127.0.0.1:{port}");
     let tcp = TcpListener::bind(url).await?;
     let tcp_stream = TcpListenerStream::new(tcp);
 

--- a/crates/atuin-scripts/src/execution.rs
+++ b/crates/atuin-scripts/src/execution.rs
@@ -1,7 +1,6 @@
 use crate::store::script::Script;
 use eyre::Result;
 use std::collections::{HashMap, HashSet};
-use std::fs;
 use std::process::Stdio;
 use tempfile::NamedTempFile;
 use tokio::io::{AsyncReadExt, AsyncWriteExt, BufReader};
@@ -98,9 +97,9 @@ pub async fn execute_script_interactive(
     {
         debug!("making script executable");
         use std::os::unix::fs::PermissionsExt;
-        let mut perms = fs::metadata(&temp_path)?.permissions();
+        let mut perms = std::fs::metadata(&temp_path)?.permissions();
         perms.set_mode(0o755);
-        fs::set_permissions(&temp_path, perms)?;
+        std::fs::set_permissions(&temp_path, perms)?;
     }
 
     // Store the temp_file to prevent it from being dropped

--- a/crates/atuin/src/command/client/search/interactive.rs
+++ b/crates/atuin/src/command/client/search/interactive.rs
@@ -34,8 +34,7 @@ use ratatui::{
         cursor::SetCursorStyle,
         event::{
             self, DisableMouseCapture, EnableMouseCapture, Event, KeyCode, KeyEvent, KeyModifiers,
-            KeyboardEnhancementFlags, MouseEvent, PopKeyboardEnhancementFlags,
-            PushKeyboardEnhancementFlags,
+            MouseEvent,
         },
         execute, terminal,
     },
@@ -44,6 +43,11 @@ use ratatui::{
     style::{Modifier, Style},
     text::{Line, Span, Text},
     widgets::{Block, BorderType, Borders, Padding, Paragraph, Tabs, block::Title},
+};
+
+#[cfg(not(target_os = "windows"))]
+use ratatui::crossterm::event::{
+    KeyboardEnhancementFlags, PopKeyboardEnhancementFlags, PushKeyboardEnhancementFlags,
 };
 
 const TAB_TITLES: [&str; 2] = ["Search", "Inspect"];
@@ -1303,6 +1307,7 @@ mod tests {
     use super::State;
 
     #[test]
+    #[allow(clippy::too_many_lines)]
     fn calc_preview_height_test() {
         let settings_preview_auto = Settings {
             preview: Preview {


### PR DESCRIPTION
This fixes a few build warnings and issues reported by Clippy on Windows.

This is essentially the second commit of #2714, updated with a few new lints.

## Checks
- [x] I am happy for maintainers to push small adjustments to this PR, to speed up the review cycle
- [x] I have checked that there are no existing pull requests for the same thing
