### PR TITLE
fix: dissociate `command_chaining` from `enter_accept`

### DIFF
--- a/crates/atuin/src/command/client/search/interactive.rs
+++ b/crates/atuin/src/command/client/search/interactive.rs
@@ -1251,8 +1251,8 @@ pub async fn history(
         InputAction::Accept(index) if index < results.len() => {
             let mut command = results.swap_remove(index).command;
 
-            if is_command_chaining && (utils::is_zsh() || utils::is_fish() || utils::is_bash()) {
-                command = String::from("__atuin_chain_command__:") + &command;
+            if is_command_chaining {
+                command = format!("{} {}", original_query.trim_end(), command);
             } else if accept
                 && (utils::is_zsh() || utils::is_fish() || utils::is_bash() || utils::is_xonsh())
             {

--- a/crates/atuin/src/command/client/search/interactive.rs
+++ b/crates/atuin/src/command/client/search/interactive.rs
@@ -1250,14 +1250,13 @@ pub async fn history(
     match result {
         InputAction::Accept(index) if index < results.len() => {
             let mut command = results.swap_remove(index).command;
-            if accept
+
+            if is_command_chaining && (utils::is_zsh() || utils::is_fish() || utils::is_bash()) {
+                command = String::from("__atuin_chain_command__:") + &command;
+            } else if accept
                 && (utils::is_zsh() || utils::is_fish() || utils::is_bash() || utils::is_xonsh())
             {
-                if is_command_chaining {
-                    command = String::from("__atuin_chain_command__:") + &command;
-                } else {
-                    command = String::from("__atuin_accept__:") + &command;
-                }
+                command = String::from("__atuin_accept__:") + &command;
             }
 
             // index is in bounds so we return that entry

--- a/crates/atuin/src/shell/atuin.bash
+++ b/crates/atuin/src/shell/atuin.bash
@@ -271,10 +271,6 @@ __atuin_history() {
 
         READLINE_LINE=""
         READLINE_POINT=${#READLINE_LINE}
-    elif [[ $__atuin_output == __atuin_chain_command__:* ]]; then
-        local new_command=${__atuin_output#__atuin_chain_command__:}
-        READLINE_LINE="$READLINE_LINE $new_command"
-        READLINE_POINT=${#READLINE_LINE}
     else
         READLINE_LINE=$__atuin_output
         READLINE_POINT=${#READLINE_LINE}

--- a/crates/atuin/src/shell/atuin.fish
+++ b/crates/atuin/src/shell/atuin.fish
@@ -44,10 +44,6 @@ function _atuin_search
           commandline -f repaint
           commandline -f execute
           return
-        else if string match --quiet '__atuin_chain_command__:*' "$ATUIN_H"
-          set -l new_command (string replace "__atuin_chain_command__:" "" -- "$ATUIN_H" | string collect)
-          set -l current_command (commandline -b)
-          commandline -r "$current_command $new_command"
         else
           commandline -r "$ATUIN_H"
         end

--- a/crates/atuin/src/shell/atuin.zsh
+++ b/crates/atuin/src/shell/atuin.zsh
@@ -65,7 +65,6 @@ _atuin_search() {
     echo -n ${zle_bracketed_paste[1]} >/dev/tty
 
     if [[ -n $output ]]; then
-        local original_buffer=$BUFFER
         RBUFFER=""
         LBUFFER=$output
 
@@ -73,10 +72,6 @@ _atuin_search() {
         then
             LBUFFER=${LBUFFER#__atuin_accept__:}
             zle accept-line
-        elif [[ $LBUFFER == __atuin_chain_command__:* ]]
-        then
-            local new_command=${LBUFFER#__atuin_chain_command__:}
-            LBUFFER="$original_buffer $new_command"
         fi
     fi
 }


### PR DESCRIPTION
I noticed that `command_chaining` requires `enter_accept` to be enabled in order to work. I suppose this wasn't intentional, so this PR dissociates these two features.

Also, xonsh doesn't handle `__atuin_chain_command__:`, so I separated the shell lists for these features.

One question though: is `__atuin_chain_command__:` necessary? Atuin could return the input query with the selected command appended, and that would be compatible with all shells. I suppose `query.join(" ")` could change the whitespace in some cases, but is there another reason?


## Checks
- [x] I am happy for maintainers to push small adjustments to this PR, to speed up the review cycle
- [x] I have checked that there are no existing pull requests for the same thing
