### PR TITLE
feat(tui): add show_numeric_shortcuts to hide 1-9 shortcuts (#2766)

### DIFF
--- a/crates/atuin-client/config.toml
+++ b/crates/atuin-client/config.toml
@@ -100,6 +100,10 @@
 ## alt-0 .. alt-9
 # ctrl_n_shortcuts = false
 
+## Show numeric shortcuts (1..9) beside list items in the TUI
+## set to false to hide the moving numbers if you find them distracting
+# show_numeric_shortcuts = true
+
 ## default history list format - can also be specified with the --format arg
 # history_format = "{time}\t{command}\t{duration}"
 

--- a/crates/atuin-client/src/settings.rs
+++ b/crates/atuin-client/src/settings.rs
@@ -468,6 +468,7 @@ pub struct Settings {
     pub max_preview_height: u16,
     pub show_help: bool,
     pub show_tabs: bool,
+    pub show_numeric_shortcuts: bool,
     pub auto_hide_height: u16,
     pub exit_mode: ExitMode,
     pub keymap_mode: KeymapMode,
@@ -770,6 +771,7 @@ impl Settings {
             .set_default("max_preview_height", 4)?
             .set_default("show_help", true)?
             .set_default("show_tabs", true)?
+            .set_default("show_numeric_shortcuts", true)?
             .set_default("auto_hide_height", 8)?
             .set_default("invert", false)?
             .set_default("exit_mode", "return-original")?

--- a/crates/atuin/src/command/client/search/interactive.rs
+++ b/crates/atuin/src/command/client/search/interactive.rs
@@ -744,6 +744,7 @@ impl State {
                     indicator.as_str(),
                     theme,
                     history_highlighter,
+                    settings.show_numeric_shortcuts,
                 );
                 f.render_stateful_widget(results_list, results_list_chunk, &mut self.results_state);
             }
@@ -880,6 +881,7 @@ impl State {
         .alignment(Alignment::Right)
     }
 
+    #[allow(clippy::too_many_arguments)]
     fn build_results_list<'a>(
         style: StyleState,
         results: &'a [History],
@@ -888,6 +890,7 @@ impl State {
         indicator: &'a str,
         theme: &'a Theme,
         history_highlighter: HistoryHighlighter<'a>,
+        show_numeric_shortcuts: bool,
     ) -> HistoryList<'a> {
         let results_list = HistoryList::new(
             results,
@@ -897,6 +900,7 @@ impl State {
             indicator,
             theme,
             history_highlighter,
+            show_numeric_shortcuts,
         );
 
         if style.compact {


### PR DESCRIPTION
Adds config show_numeric_shortcuts (default: true). When false, hides numeric badges 1–9 in the interactive search; indicator remains for selection. Adds example key to config.toml. Closes #2766.