### PR TITLE
build: remove legacy Apple SDK frameworks

### DIFF
--- a/atuin.nix
+++ b/atuin.nix
@@ -10,9 +10,6 @@
   installShellFiles,
   rustPlatform,
   libiconv,
-  Security,
-  SystemConfiguration,
-  AppKit,
 }:
 rustPlatform.buildRustPackage {
   name = "atuin";
@@ -27,7 +24,7 @@ rustPlatform.buildRustPackage {
 
   nativeBuildInputs = [installShellFiles];
 
-  buildInputs = lib.optionals stdenv.isDarwin [libiconv Security SystemConfiguration AppKit];
+  buildInputs = lib.optionals stdenv.isDarwin [libiconv];
 
   postInstall = ''
     installShellCompletion --cmd atuin \

--- a/flake.nix
+++ b/flake.nix
@@ -25,7 +25,6 @@
       in
       {
         packages.atuin = pkgs.callPackage ./atuin.nix {
-          inherit (pkgs.darwin.apple_sdk.frameworks) Security SystemConfiguration AppKit;
           rustPlatform =
             let
               toolchain =


### PR DESCRIPTION
Thanks for your work on atuin! I've loved using it over the past year.

According to nixos.org[^1], the `darwin.apple_sdk` frameworks have been stubs for some time, and are now removed. Evaluating `atuin` on darwin on `nixpkgs-unstable` results in the following evaluation error:

```
error: darwin.apple_sdk_11_0 has been
  removed as it was a legacy compatibility stub; see
  <https://nixos.org/manual/nixpkgs/stable/#sec-darwin-legacy-frameworks>
  for migration instructions
```

According to those linked docs, the fix is to remove references to these SDKs, which will not have any other effect since they were stubs anyway.

[^1]: https://nixos.org/manual/nixpkgs/stable/#sec-darwin-legacy-frameworks

<!-- Thank you for making a PR! Bug fixes are always welcome, but if you're adding a new feature or changing an existing one, we'd really appreciate if you open an issue, post on the forum, or drop in on Discord -->

## Checks
- [x] I am happy for maintainers to push small adjustments to this PR, to speed up the review cycle
- [x] I have checked that there are no existing pull requests for the same thing
