### PR TITLE
fix: use fullscreen if `inline_height` is too large

### DIFF
--- a/crates/atuin/src/command/client/search/interactive.rs
+++ b/crates/atuin/src/command/client/search/interactive.rs
@@ -1076,6 +1076,16 @@ pub async fn history(
         settings.inline_height
     };
 
+    // Use fullscreen mode if the inline height doesn't fit in the terminal,
+    // this will preserve the scroll position upon exit
+    let inline_height = if let Ok(size) = terminal::size()
+        && inline_height >= size.1
+    {
+        0
+    } else {
+        inline_height
+    };
+
     let stdout = Stdout::new(inline_height > 0)?;
     let backend = CrosstermBackend::new(stdout);
     let mut terminal = Terminal::with_options(


### PR DESCRIPTION
This uses fullscreen mode if `inline_height` is larger than the terminal height.

Currently, in that situation, the screen is always cleared upon exit from `atuin search -i`. This change will preserve the buffer when Atuin takes the whole screen, which is a much friendlier behavior.

Demo by @LecrisUT: https://github.com/atuinsh/atuin/pull/2600#issuecomment-3228255130
Closes #2207

## Checks
- [x] I am happy for maintainers to push small adjustments to this PR, to speed up the review cycle
- [x] I have checked that there are no existing pull requests for the same thing
