### PR TITLE
fix: fish up binding

### DIFF
--- a/crates/atuin/src/command/client/init/fish.rs
+++ b/crates/atuin/src/command/client/init/fish.rs
@@ -10,30 +10,27 @@ pub fn init_static(disable_up_arrow: bool, disable_ctrl_r: bool) {
     // We keep it for compatibility with fish 3.x
     if std::env::var("ATUIN_NOBIND").is_err() {
         const BIND_CTRL_R: &str = r"bind \cr _atuin_search";
+        const BIND_UP_ARROW: &str = r"if string match -q '4.*' $version
+    bind up _atuin_bind_up
+else
+    bind -k up _atuin_bind_up
+end
+bind \eOA _atuin_bind_up
+bind \e\[A _atuin_bind_up";
         const BIND_CTRL_R_INS: &str = r"bind -M insert \cr _atuin_search";
-        const BIND_UP_ARROW_INS: &str = r"bind -M insert -k up _atuin_bind_up
+        const BIND_UP_ARROW_INS: &str = r"if string match -q '4.*' $version
+    bind -M insert up _atuin_bind_up
+else
+    bind -M insert -k up _atuin_bind_up
+end
 bind -M insert \eOA _atuin_bind_up
 bind -M insert \e\[A _atuin_bind_up";
-
-        let bind_up_arrow = match std::env::var("FISH_VERSION") {
-            Ok(ref version) if version.starts_with("4.") => r"bind up _atuin_bind_up",
-            Ok(_) => r"bind -k up _atuin_bind_up",
-
-            // do nothing - we can't panic or error as this could be in use in
-            // non-fish pipelines
-            _ => "",
-        }
-        .to_string();
 
         if !disable_ctrl_r {
             println!("{BIND_CTRL_R}");
         }
         if !disable_up_arrow {
-            println!(
-                r"{bind_up_arrow}
-bind \eOA _atuin_bind_up
-bind \e\[A _atuin_bind_up"
-            );
+            println!("{BIND_UP_ARROW}");
         }
 
         println!("if bind -M insert > /dev/null 2>&1");

--- a/crates/atuin/src/command/client/init/fish.rs
+++ b/crates/atuin/src/command/client/init/fish.rs
@@ -1,45 +1,77 @@
 use atuin_dotfiles::store::{AliasStore, var::VarStore};
 use eyre::Result;
 
+fn print_bindings(
+    indent: &str,
+    disable_up_arrow: bool,
+    disable_ctrl_r: bool,
+    bind_ctrl_r: &str,
+    bind_up_arrow: &str,
+    bind_ctrl_r_ins: &str,
+    bind_up_arrow_ins: &str,
+) {
+    if !disable_ctrl_r {
+        println!("{indent}{bind_ctrl_r}");
+    }
+    if !disable_up_arrow {
+        println!("{indent}{bind_up_arrow}");
+    }
+
+    println!("{indent}if bind -M insert >/dev/null 2>&1");
+    if !disable_ctrl_r {
+        println!("{indent}{indent}{bind_ctrl_r_ins}");
+    }
+    if !disable_up_arrow {
+        println!("{indent}{indent}{bind_up_arrow_ins}");
+    }
+    println!("{indent}end");
+}
+
 pub fn init_static(disable_up_arrow: bool, disable_ctrl_r: bool) {
+    let indent = " ".repeat(4);
+
     let base = include_str!("../../../shell/atuin.fish");
 
     println!("{base}");
 
-    // In fish 4.0 and above the option bind -k doesn't exist anymore.
-    // We keep it for compatibility with fish 3.x
     if std::env::var("ATUIN_NOBIND").is_err() {
-        const BIND_CTRL_R: &str = r"bind \cr _atuin_search";
-        const BIND_UP_ARROW: &str = r"if string match -q '4.*' $version
-    bind up _atuin_bind_up
-else
-    bind -k up _atuin_bind_up
-end
-bind \eOA _atuin_bind_up
-bind \e\[A _atuin_bind_up";
-        const BIND_CTRL_R_INS: &str = r"bind -M insert \cr _atuin_search";
-        const BIND_UP_ARROW_INS: &str = r"if string match -q '4.*' $version
-    bind -M insert up _atuin_bind_up
-else
-    bind -M insert -k up _atuin_bind_up
-end
-bind -M insert \eOA _atuin_bind_up
-bind -M insert \e\[A _atuin_bind_up";
+        println!("if string match -q '4.*' $version");
 
-        if !disable_ctrl_r {
-            println!("{BIND_CTRL_R}");
-        }
-        if !disable_up_arrow {
-            println!("{BIND_UP_ARROW}");
-        }
+        // In fish 4.0 and above the option bind -k doesn't exist anymore,
+        // instead we can use key names and modifiers directly.
+        print_bindings(
+            &indent,
+            disable_up_arrow,
+            disable_ctrl_r,
+            "bind ctrl-r _atuin_search",
+            "bind up _atuin_bind_up",
+            "bind -M insert ctrl-r _atuin_search",
+            "bind -M insert up _atuin_bind_up",
+        );
 
-        println!("if bind -M insert > /dev/null 2>&1");
-        if !disable_ctrl_r {
-            println!("{BIND_CTRL_R_INS}");
-        }
-        if !disable_up_arrow {
-            println!("{BIND_UP_ARROW_INS}");
-        }
+        println!("else");
+
+        // We keep these for compatibility with fish 3.x
+        print_bindings(
+            &indent,
+            disable_up_arrow,
+            disable_ctrl_r,
+            r"bind \cr _atuin_search",
+            &[
+                r"bind -k up _atuin_bind_up",
+                r"bind \eOA _atuin_bind_up",
+                r"bind \e\[A _atuin_bind_up",
+            ]
+            .join("; "),
+            r"bind -M insert \cr _atuin_search",
+            &[
+                r"bind -M insert -k up _atuin_bind_up",
+                r"bind -M insert \eOA _atuin_bind_up",
+                r"bind -M insert \e\[A _atuin_bind_up",
+            ]
+            .join("; "),
+        );
+
         println!("end");
     }
 }


### PR DESCRIPTION
https://github.com/atuinsh/atuin/pull/2677 introduced logic based on `$FISH_VERSION` to determine how to bind keys in fish.
However, this env var is not exported to child processes, as you can see by running `sh -c 'echo $FISH_VERSION'` from fish.

Instead, we can simply push the if statement into the actual fish code that we generate, since fish is aware of its own version, and then we can decide which binding syntax to use.

<!-- Thank you for making a PR! Bug fixes are always welcome, but if you're adding a new feature or changing an existing one, we'd really appreciate if you open an issue, post on the forum, or drop in on Discord -->

## Checks
- [x] I am happy for maintainers to push small adjustments to this PR, to speed up the review cycle
- [x] I have checked that there are no existing pull requests for the same thing
