### PR TITLE
filter by session with `zsh-autosuggestions` and `nosharehistory`

### DIFF
--- a/crates/atuin/src/shell/atuin.zsh
+++ b/crates/atuin/src/shell/atuin.zsh
@@ -16,11 +16,11 @@ zmodload zsh/datetime 2>/dev/null
 # in your .zshrc
 _zsh_autosuggest_strategy_atuin() {
     if [[ -o nosharehistory ]]; then
-        filter_mode='--filter-mode session'
+        # silence errors, since we don't want to spam the terminal prompt while typing.
+        suggestion=$(ATUIN_QUERY="$1" atuin search --cmd-only --limit 1 --search-mode prefix --filter-mode session 2>/dev/null)
+    else
+        suggestion=$(ATUIN_QUERY="$1" atuin search --cmd-only --limit 1 --search-mode prefix 2>/dev/null)
     fi
-    
-    # silence errors, since we don't want to spam the terminal prompt while typing.
-    suggestion=$(ATUIN_QUERY="$1" atuin search --cmd-only --limit 1 --search-mode prefix "$filter_mode" 2>/dev/null)
 }
 
 if [ -n "${ZSH_AUTOSUGGEST_STRATEGY:-}" ]; then


### PR DESCRIPTION
<!-- Thank you for making a PR! Bug fixes are always welcome, but if you're adding a new feature or changing an existing one, we'd really appreciate if you open an issue, post on the forum, or drop in on Discord -->

## Checks
- [x] I am happy for maintainers to push small adjustments to this PR, to speed up the review cycle
- [x] I have checked that there are no existing pull requests for the same thing

When `sharehistory` setopt is not enabled for zsh with plugin `zsh-autosuggestions` whose `ZSH_AUTOSUGGEST_STRATEGY` array contains `atuin` due to https://github.com/zsh-users/zsh-autosuggestions/issues/797, the suggested text will show the result of `atuin search` with default option `--filter-mode global`, but the prompted text after press <kbd>Up</kbd> will comes from `$(history | tail -n1)`.