### PR TITLE
feat: add session-preload filter mode to include global history from before session start

### DIFF
--- a/crates/atuin-client/config.toml
+++ b/crates/atuin-client/config.toml
@@ -41,7 +41,7 @@
 # search_mode = "fuzzy"
 
 ## which filter mode to use by default
-## possible values: "global", "host", "session", "directory", "workspace"
+## possible values: "global", "host", "session", "session-preload", "directory", "workspace"
 ## consider using search.filters to customize the enablement and order of filter modes
 # filter_mode = "global"
 
@@ -281,4 +281,4 @@ records = true
 ## The list of enabled filter modes, in order of priority.
 ## The "workspace" mode is skipped when not in a workspace or workspaces = false.
 ## Default filter mode can be overridden with the filter_mode setting.
-# filters = [ "global", "host", "session", "workspace", "directory" ]
+# filters = [ "global", "host", "session", "session-preload", "workspace", "directory" ]

--- a/crates/atuin-client/src/settings.rs
+++ b/crates/atuin-client/src/settings.rs
@@ -86,6 +86,9 @@ pub enum FilterMode {
 
     #[serde(rename = "workspace")]
     Workspace = 4,
+
+    #[serde(rename = "session-preload")]
+    SessionPreload = 5,
 }
 
 impl FilterMode {
@@ -96,6 +99,7 @@ impl FilterMode {
             FilterMode::Session => "SESSION",
             FilterMode::Directory => "DIRECTORY",
             FilterMode::Workspace => "WORKSPACE",
+            FilterMode::SessionPreload => "SESSION+",
         }
     }
 }
@@ -420,6 +424,7 @@ impl Default for Search {
                 FilterMode::Global,
                 FilterMode::Host,
                 FilterMode::Session,
+                FilterMode::SessionPreload,
                 FilterMode::Workspace,
                 FilterMode::Directory,
             ],
@@ -814,7 +819,14 @@ impl Settings {
             .set_default("scripts.db_path", scripts_path.to_str())?
             .set_default(
                 "search.filters",
-                vec!["global", "host", "session", "workspace", "directory"],
+                vec![
+                    "global",
+                    "host",
+                    "session",
+                    "workspace",
+                    "directory",
+                    "session-preload",
+                ],
             )?
             .set_default("theme.name", "default")?
             .set_default("theme.debug", None::<bool>)?


### PR DESCRIPTION
This mode mimics the default behavior for many shells.

<!-- Thank you for making a PR! Bug fixes are always welcome, but if you're adding a new feature or changing an existing one, we'd really appreciate if you open an issue, post on the forum, or drop in on Discord -->

## Checks
- [x] I am happy for maintainers to push small adjustments to this PR, to speed up the review cycle
- [x] I have checked that there are no existing pull requests for the same thing
