### PR TITLE
bug: Abort install.sh on cURL fails

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -42,14 +42,14 @@ Please file an issue or reach out on the forum if you encounter any problems!
 EOF
 
 __atuin_install_binary(){
-  curl --proto '=https' --tlsv1.2 -LsSf https://github.com/atuinsh/atuin/releases/latest/download/atuin-installer.sh | sh
+  install_script=$(curl --proto '=https' --tlsv1.2 -LsSf https://github.com/atuinsh/atuin/releases/latest/download/atuin-installer.sh)
+  echo "$install_script" | sh
 }
 
 if ! command -v curl > /dev/null; then
     echo "curl not installed. Please install curl."
     exit
 fi
-
 
 __atuin_install_binary
 


### PR DESCRIPTION
This PR is an attempt to fix the case, in which the script continues it's execution after the `curl` command for getting the installer script fails. I have opted for removing the `__atuin_install_binary` function in order to simplify the flow of the script. Otherwise, an additional conditional statement would have to be added to check whether the function executed correctly.

## Checks
- [x] I am happy for maintainers to push small adjustments to this PR, to speed up the review cycle
- [x] I have checked that there are no existing pull requests for the same thing
