### PR TITLE
refactor: shell environment variables

### DIFF
--- a/crates/atuin-common/src/shell.rs
+++ b/crates/atuin-common/src/shell.rs
@@ -62,6 +62,12 @@ impl Shell {
         Shell::from_string(shell.to_string())
     }
 
+    pub fn from_env() -> Shell {
+        std::env::var("ATUIN_SHELL").map_or(Shell::Unknown, |shell| {
+            Shell::from_string(shell.trim().to_lowercase())
+        })
+    }
+
     pub fn config_file(&self) -> Option<std::path::PathBuf> {
         let mut path = if let Some(base) = directories::BaseDirs::new() {
             base.home_dir().to_owned()

--- a/crates/atuin-common/src/utils.rs
+++ b/crates/atuin-common/src/utils.rs
@@ -118,26 +118,6 @@ pub fn broken_symlink<P: Into<PathBuf>>(path: P) -> bool {
     path.is_symlink() && !path.exists()
 }
 
-pub fn is_zsh() -> bool {
-    // only set on zsh
-    env::var("ATUIN_SHELL_ZSH").is_ok()
-}
-
-pub fn is_fish() -> bool {
-    // only set on fish
-    env::var("ATUIN_SHELL_FISH").is_ok()
-}
-
-pub fn is_bash() -> bool {
-    // only set on bash
-    env::var("ATUIN_SHELL_BASH").is_ok()
-}
-
-pub fn is_xonsh() -> bool {
-    // only set on xonsh
-    env::var("ATUIN_SHELL_XONSH").is_ok()
-}
-
 /// Extension trait for anything that can behave like a string to make it easy to escape control
 /// characters.
 ///

--- a/crates/atuin/src/command/client/search/interactive.rs
+++ b/crates/atuin/src/command/client/search/interactive.rs
@@ -3,7 +3,7 @@ use std::{
     time::Duration,
 };
 
-use atuin_common::utils::{self, Escapable as _};
+use atuin_common::{shell::Shell, utils::Escapable as _};
 use eyre::Result;
 use futures_util::FutureExt;
 use semver::Version;
@@ -1273,7 +1273,10 @@ pub async fn history(
             if is_command_chaining {
                 command = format!("{} {}", original_query.trim_end(), command);
             } else if accept
-                && (utils::is_zsh() || utils::is_fish() || utils::is_bash() || utils::is_xonsh())
+                && matches!(
+                    Shell::from_env(),
+                    Shell::Zsh | Shell::Fish | Shell::Bash | Shell::Xonsh
+                )
             {
                 command = String::from("__atuin_accept__:") + &command;
             }

--- a/crates/atuin/src/shell/atuin.bash
+++ b/crates/atuin/src/shell/atuin.bash
@@ -254,7 +254,7 @@ __atuin_history() {
         local READLINE_LINE="" READLINE_POINT=0
 
     local __atuin_output
-    __atuin_output=$(ATUIN_SHELL_BASH=t ATUIN_LOG=error ATUIN_QUERY="$READLINE_LINE" atuin search "$@" -i 3>&1 1>&2 2>&3)
+    __atuin_output=$(ATUIN_SHELL=bash ATUIN_LOG=error ATUIN_QUERY="$READLINE_LINE" atuin search "$@" -i 3>&1 1>&2 2>&3)
 
     # We do nothing when the search is canceled.
     [[ $__atuin_output ]] || return 0

--- a/crates/atuin/src/shell/atuin.fish
+++ b/crates/atuin/src/shell/atuin.fish
@@ -35,7 +35,7 @@ function _atuin_search
     # In fish 3.4 and above we can use `"$(some command)"` to keep multiple lines separate;
     # but to support fish 3.3 we need to use `(some command | string collect)`.
     # https://fishshell.com/docs/current/relnotes.html#id24 (fish 3.4 "Notable improvements and fixes")
-    set -l ATUIN_H (ATUIN_SHELL_FISH=t ATUIN_LOG=error ATUIN_QUERY=(commandline -b) atuin search --keymap-mode=$keymap_mode $argv -i 3>&1 1>&2 2>&3 | string collect)
+    set -l ATUIN_H (ATUIN_SHELL=fish ATUIN_LOG=error ATUIN_QUERY=(commandline -b) atuin search --keymap-mode=$keymap_mode $argv -i 3>&1 1>&2 2>&3 | string collect)
 
     if test -n "$ATUIN_H"
         if string match --quiet '__atuin_accept__:*' "$ATUIN_H"

--- a/crates/atuin/src/shell/atuin.xsh
+++ b/crates/atuin/src/shell/atuin.xsh
@@ -35,7 +35,7 @@ def _search(event, extra_args: list[str]):
     cmd = ["atuin", "search", "--interactive", *extra_args]
     # We need to explicitly pass in xonsh env, in case user has set XDG_HOME or something else that matters
     env = ${...}.detype()
-    env["ATUIN_SHELL_XONSH"] = "t"
+    env["ATUIN_SHELL"] = "xonsh"
     env["ATUIN_QUERY"] = buffer.text
 
     p = subprocess.run(cmd, stderr=subprocess.PIPE, encoding="utf-8", env=env)

--- a/crates/atuin/src/shell/atuin.zsh
+++ b/crates/atuin/src/shell/atuin.zsh
@@ -57,7 +57,7 @@ _atuin_search() {
     # TODO: not this
     local output
     # shellcheck disable=SC2048
-    output=$(ATUIN_SHELL_ZSH=t ATUIN_LOG=error ATUIN_QUERY=$BUFFER atuin search $* -i 3>&1 1>&2 2>&3)
+    output=$(ATUIN_SHELL=zsh ATUIN_LOG=error ATUIN_QUERY=$BUFFER atuin search $* -i 3>&1 1>&2 2>&3)
 
     zle reset-prompt
     # re-enable bracketed paste


### PR DESCRIPTION
I had this waiting around since #2861, but needed to know what you'd chose to do with `__atuin_chain_command__`, so I didn't include it. It's just a cleanup anyway.

I initially figured maintaining several lists such as `utils::is_zsh() || utils::is_fish() || utils::is_bash()` wasn't pretty, so I refactored it (there's now a single list, but I still think it's better than before).

The scripts now use a single environment variable (`ATUIN_SHELL`), I didn't think it should be a problem but maybe there's something I missed. In any case, running one shell from another should be more reliable.

## Checks
- [x] I am happy for maintainers to push small adjustments to this PR, to speed up the review cycle
- [x] I have checked that there are no existing pull requests for the same thing
