### PR TITLE
feat(stats): add dotnet to default common subcommands

### DIFF
--- a/crates/atuin-client/config.toml
+++ b/crates/atuin-client/config.toml
@@ -192,6 +192,7 @@ enter_accept = true
 #   "composer",
 #   "dnf",
 #   "docker",
+#   "dotnet",
 #   "git",
 #   "go",
 #   "ip",

--- a/crates/atuin-client/src/settings.rs
+++ b/crates/atuin-client/src/settings.rs
@@ -295,6 +295,7 @@ impl Stats {
             "composer",
             "dnf",
             "docker",
+            "dotnet",
             "git",
             "go",
             "ip",


### PR DESCRIPTION
`dotnet` is basically the equivalent of `cargo`.

## Checks
- [x] I am happy for maintainers to push small adjustments to this PR, to speed up the review cycle
- [x] I have checked that there are no existing pull requests for the same thing
