### PR TITLE
feat: add commit to displayed version info

### DIFF
--- a/crates/atuin/src/command/client/doctor.rs
+++ b/crates/atuin/src/command/client/doctor.rs
@@ -296,6 +296,7 @@ impl SettingPaths {
 #[derive(Debug, Serialize)]
 struct AtuinInfo {
     pub version: String,
+    pub commit: String,
 
     /// Whether the main Atuin sync server is in use
     /// I'm just calling it Atuin Cloud for lack of a better name atm
@@ -328,6 +329,7 @@ impl AtuinInfo {
 
         Self {
             version: crate::VERSION.to_string(),
+            commit: crate::SHA.to_string(),
             sync,
             sqlite_version,
             setting_paths: SettingPaths::new(settings),

--- a/crates/atuin/src/command/client/info.rs
+++ b/crates/atuin/src/command/client/info.rs
@@ -1,6 +1,6 @@
 use atuin_client::settings::Settings;
 
-use crate::VERSION;
+use crate::{SHA, VERSION};
 
 pub fn run(settings: &Settings) {
     let config = atuin_common::utils::config_dir();
@@ -23,7 +23,7 @@ pub fn run(settings: &Settings) {
         std::env::var("ATUIN_CONFIG_DIR").unwrap_or_else(|_| "None".into())
     );
 
-    let general_info = format!("Version info:\nversion: {VERSION}");
+    let general_info = format!("Version info:\nversion: {VERSION}\ncommit:  {SHA}");
 
     let print_out = format!("{config_paths}\n\n{env_vars}\n\n{general_info}");
 

--- a/crates/atuin/src/main.rs
+++ b/crates/atuin/src/main.rs
@@ -14,6 +14,8 @@ mod sync;
 const VERSION: &str = env!("CARGO_PKG_VERSION");
 const SHA: &str = env!("GIT_HASH");
 
+const LONG_VERSION: &str = concat!(env!("CARGO_PKG_VERSION"), " (", env!("GIT_HASH"), ")");
+
 static HELP_TEMPLATE: &str = "\
 {before-help}{name} {version}
 {author}
@@ -29,6 +31,7 @@ static HELP_TEMPLATE: &str = "\
 #[command(
     author = "Ellie Huxtable <ellie@atuin.sh>",
     version = VERSION,
+    long_version = LONG_VERSION,
     help_template(HELP_TEMPLATE),
 )]
 struct Atuin {


### PR DESCRIPTION
This adds the commit SHA to the following:
- `atuin doctor`
- `atuin info` (which already displays the version)
- `atuin --version` (but not `atuin -V` in order not to affect `atuin --help`)

I'm submitting this because I had issue reports in #2543 which were already resolved, so being able to easily ask for the commit id would have been helpful, as the version number isn't meaningful in a PR.

Also, I suppose the info should have been included in `atuin doctor` in the first place, so that's probably an oversight.

## Checks
- [x] I am happy for maintainers to push small adjustments to this PR, to speed up the review cycle
- [x] I have checked that there are no existing pull requests for the same thing
