### PR TITLE
feat: add various acceptance keys

### DIFF
--- a/crates/atuin-client/config.toml
+++ b/crates/atuin-client/config.toml
@@ -227,6 +227,10 @@ enter_accept = true
 # exit_past_line_start = true
 # Defaults to true. The right arrow key performs the same functionality as Tab and copies the selected line to the command line to be modified.
 # accept_past_line_end = true
+# Defaults to false. The left arrow key performs the same functionality as Tab and copies the selected line to the command line to be modified.
+# accept_past_line_start = false
+# Defaults to false. The backspace key performs the same functionality as Tab and copies the selected line to the command line to be modified when at the start of the line.
+# accept_with_backspace = false
 
 [sync]
 # Enable sync v2 by default

--- a/crates/atuin-client/src/settings.rs
+++ b/crates/atuin-client/src/settings.rs
@@ -342,6 +342,8 @@ pub struct Keys {
     pub scroll_exits: bool,
     pub exit_past_line_start: bool,
     pub accept_past_line_end: bool,
+    pub accept_past_line_start: bool,
+    pub accept_with_backspace: bool,
     pub prefix: String,
 }
 
@@ -804,6 +806,8 @@ impl Settings {
             .set_default("keys.scroll_exits", true)?
             .set_default("keys.accept_past_line_end", true)?
             .set_default("keys.exit_past_line_start", true)?
+            .set_default("keys.accept_past_line_start", false)?
+            .set_default("keys.accept_with_backspace", false)?
             .set_default("keys.prefix", "a")?
             .set_default("keymap_mode", "emacs")?
             .set_default("keymap_mode_shell", "auto")?


### PR DESCRIPTION
This change introduces (optional) acceptance keys of Backspace and Left Arrow, when at the start of a line. These two are common muscle memory actions for users.

The configuration defaults to false so as not to disrupt existing user patterns.

This also adds a test that exercises the various acceptance modes, which as it turns out was quite easy to do.

I discussed this on discord where [Ellie suggested I raised an issue](https://discord.com/channels/954121165239115808/1421180955657244703/1422642337481228400), but I felt like a PR would be more tangiable. I've tested this locally and I'm very happy with how these keys work, it fits my needs well.

`exit_past_line_start` and `accept_past_line_start` can technically co-exist. When this happens `accept_past_line_start` takes precedence. Is this okay, or should we reconsider the config? Perhaps `acceptance_keys = []` would be better here? I'm very open to changes here.

<!-- Thank you for making a PR! Bug fixes are always welcome, but if you're adding a new feature or changing an existing one, we'd really appreciate if you open an issue, post on the forum, or drop in on Discord -->

## Checks
- [x] I am happy for maintainers to push small adjustments to this PR, to speed up the review cycle
- [x] I have checked that there are no existing pull requests for the same thing
