### PR TITLE
feat: add shell pipelines to command chaining

### DIFF
--- a/crates/atuin-client/config.toml
+++ b/crates/atuin-client/config.toml
@@ -158,7 +158,7 @@
 # This applies for new installs. Old installs will keep the old behaviour unless configured otherwise.
 enter_accept = true
 
-## Defaults to false. If enabled, when triggered after && or ||, Atuin will complete commands to chain rather than replace the current line.
+## Defaults to false. If enabled, when triggered after &&, || or |, Atuin will complete commands to chain rather than replace the current line.
 # command_chaining = false
 
 ## Defaults to "emacs".  This specifies the keymap on the startup of `atuin

--- a/crates/atuin/src/command/client/search/interactive.rs
+++ b/crates/atuin/src/command/client/search/interactive.rs
@@ -1121,7 +1121,7 @@ pub async fn history(
     // Check if this is a command chaining scenario
     let is_command_chaining = if settings.command_chaining {
         let trimmed = original_query.trim_end();
-        trimmed.ends_with("&&") || trimmed.ends_with("||")
+        trimmed.ends_with("&&") || trimmed.ends_with('|')
     } else {
         false
     };


### PR DESCRIPTION
I wanted to use `command_chaining` to write a pipeline (`cmdA | cmdB`) and was genuinely surprised it didn't work.

## Checks
- [x] I am happy for maintainers to push small adjustments to this PR, to speed up the review cycle
- [x] I have checked that there are no existing pull requests for the same thing
