### PR TITLE
feat: nu ≥ 0.106.0 support commandline accept

### DIFF
--- a/crates/atuin/src/command/client/search/interactive.rs
+++ b/crates/atuin/src/command/client/search/interactive.rs
@@ -1418,7 +1418,7 @@ pub async fn history(
                     if accept
                         && matches!(
                             Shell::from_env(),
-                            Shell::Zsh | Shell::Fish | Shell::Bash | Shell::Xonsh
+                            Shell::Zsh | Shell::Fish | Shell::Bash | Shell::Xonsh | Shell::Nu
                         )
                     {
                         command = String::from("__atuin_accept__:") + &command;
@@ -1438,7 +1438,7 @@ pub async fn history(
             } else if accept
                 && matches!(
                     Shell::from_env(),
-                    Shell::Zsh | Shell::Fish | Shell::Bash | Shell::Xonsh
+                    Shell::Zsh | Shell::Fish | Shell::Bash | Shell::Xonsh | Shell::Nu
                 )
             {
                 command = String::from("__atuin_accept__:") + &command;


### PR DESCRIPTION
# Summary

Adjust the Nushell script to check the version and enable accept support when Nushell 0.106.0 or greater is found.

See: https://github.com/nushell/nushell/pull/16193

<!-- Thank you for making a PR! Bug fixes are always welcome, but if you're adding a new feature or changing an existing one, we'd really appreciate if you open an issue, post on the forum, or drop in on Discord -->

## Checks
- [x] I am happy for maintainers to push small adjustments to this PR, to speed up the review cycle
- [x] I have checked that there are no existing pull requests for the same thing
