### PR TITLE
fix: highlight the correct place when multibyte characters are involved

### DIFF
--- a/crates/atuin/src/command/client/search/history_list.rs
+++ b/crates/atuin/src/command/client/search/history_list.rs
@@ -273,8 +273,9 @@ impl DrawState<'_> {
                     }
                     style.attributes.set(style::Attribute::Bold);
                 }
-                self.draw(&ch.to_string(), style.into());
-                pos += 1;
+                let s = ch.to_string();
+                self.draw(&s, style.into());
+                pos += s.len();
             }
             pos += 1;
         }


### PR DESCRIPTION
<!-- Thank you for making a PR! Bug fixes are always welcome, but if you're adding a new feature or changing an existing one, we'd really appreciate if you open an issue, post on the forum, or drop in on Discord -->

## Checks
- [x] I am happy for maintainers to push small adjustments to this PR, to speed up the review cycle
- [x] I have checked that there are no existing pull requests for the same thing
