### PR TITLE
feat: use `ATUIN_COMMAND_LINE` for improved compatibility with Nushell

### DIFF
--- a/crates/atuin/src/shell/atuin.nu
+++ b/crates/atuin/src/shell/atuin.nu
@@ -23,7 +23,9 @@ let _atuin_pre_execution = {||
         return
     }
     if not ($cmd | str starts-with $ATUIN_KEYBINDING_TOKEN) {
-        $env.ATUIN_HISTORY_ID = (atuin history start -- $cmd)
+        $env.ATUIN_COMMAND_LINE = $cmd
+        $env.ATUIN_HISTORY_ID = (atuin history start --command-from-env)
+        hide-env ATUIN_COMMAND_LINE
     }
 }
 


### PR DESCRIPTION
# Summary

Use `ATUIN_COMMAND_LINE` env variable with Nushell

# Background

I found some commands are not added to history, such as

```nu
lsregister -f -R /a/long/apth/Some.app/
```

<!-- Thank you for making a PR! Bug fixes are always welcome, but if you're adding a new feature or changing an existing one, we'd really appreciate if you open an issue, post on the forum, or drop in on Discord -->

## Checks
- [x] I am happy for maintainers to push small adjustments to this PR, to speed up the review cycle
- [x] I have checked that there are no existing pull requests for the same thing
