### PR TITLE
chore: adjust update wording

### DIFF
--- a/crates/atuin/src/command/client/search/interactive.rs
+++ b/crates/atuin/src/command/client/search/interactive.rs
@@ -920,7 +920,7 @@ impl State {
         let title = if self.update_needed.is_some() {
             let error_style: Style = theme.get_error().into();
             Paragraph::new(Text::from(Span::styled(
-                format!("Atuin v{VERSION} - UPGRADE"),
+                format!("Atuin v{VERSION} - UPDATE"),
                 error_style.add_modifier(Modifier::BOLD),
             )))
         } else {


### PR DESCRIPTION
A user mentioned seeing the "UPGRADE" wording, and then expecting `atuin upgrade` to work, when in fact the correct command is `atuin update`

Easy fix, wording adjusted

<!-- Thank you for making a PR! Bug fixes are always welcome, but if you're adding a new feature or changing an existing one, we'd really appreciate if you open an issue, post on the forum, or drop in on Discord -->

## Checks
- [ ] I am happy for maintainers to push small adjustments to this PR, to speed up the review cycle
- [ ] I have checked that there are no existing pull requests for the same thing
