### PR TITLE
fix(bash): work around a keybinding bug of Bash 5.1

### DIFF
--- a/crates/atuin/src/shell/atuin.bash
+++ b/crates/atuin/src/shell/atuin.bash
@@ -411,6 +411,17 @@ if ((BASH_VERSINFO[0] >= 5 || BASH_VERSINFO[0] == 4 && BASH_VERSINFO[1] >= 3)); 
         local ikeyseq1='\e[0;'$((1 + widget))'A'
         local ikeyseq2=$__atuin_macro_chain
 
+        if ((BASH_VERSINFO[0] == 5 && BASH_VERSINFO[1] == 1)); then
+            # Workaround for Bash 5.1: Bash 5.1 has a bug that overwriting an
+            # existing "bind -x" keybinding breaks other existing "bind -x"
+            # keybindings [1,2].  To work around the problem, we explicitly
+            # unbind an existing keybinding before overwriting it.
+            #
+            # [1] https://lists.gnu.org/archive/html/bug-bash/2021-04/msg00135.html
+            # [2] https://github.com/atuinsh/atuin/issues/962#issuecomment-3451132291
+            bind -m "$keymap" -r "$keyseq"
+        fi
+
         bind -m "$keymap" "\"$keyseq\": \"$ikeyseq1$ikeyseq2\""
         bind -m "$keymap" -x "\"$ikeyseq1\": __atuin_widget_run $widget"
     }


### PR DESCRIPTION
This adds a workaround for an issue with a Bash-5.1 bug reported by @MaxenceG2M at https://github.com/atuinsh/atuin/issues/962#issuecomment-3451132291. See the added code comments for details.

## Checks
- [x] I am happy for maintainers to push small adjustments to this PR, to speed up the review cycle
- [x] I have checked that there are no existing pull requests for the same thing
