### PR TITLE
fix(bash/blesh): suppress error message for auto-complete source

### DIFF
--- a/crates/atuin/src/shell/atuin.bash
+++ b/crates/atuin/src/shell/atuin.bash
@@ -312,7 +312,7 @@ __atuin_initialize_blesh() {
     #
     function ble/complete/auto-complete/source:atuin-history {
         local suggestion
-        suggestion=$(ATUIN_QUERY="$_ble_edit_str" atuin search --cmd-only --limit 1 --search-mode prefix)
+        suggestion=$(ATUIN_QUERY="$_ble_edit_str" atuin search --cmd-only --limit 1 --search-mode prefix 2>/dev/null)
         [[ $suggestion == "$_ble_edit_str"?* ]] || return 1
         ble/complete/auto-complete/enter h 0 "${suggestion:${#_ble_edit_str}}" '' "$suggestion"
     }


### PR DESCRIPTION
This patch tries to port a change for zsh-autosuggestion in #2780 to suppress the error messages in typing the command.  The same issue happens with ble.sh, so we want to suppress the error message in the same way as with zsh-autosuggestion.

## Checks
- [x] I am happy for maintainers to push small adjustments to this PR, to speed up the review cycle
- [x] I have checked that there are no existing pull requests for the same thing
