### PR TITLE
fix(bash): fix issues with intermediate key sequences in the vi editing mode

### DIFF
--- a/crates/atuin/src/shell/atuin.bash
+++ b/crates/atuin/src/shell/atuin.bash
@@ -497,14 +497,26 @@ else
         for __atuin_keymap in emacs vi-insert vi-command; do
             bind -m "$__atuin_keymap" '"\C-x\C-_A1\a": beginning-of-line'
             bind -m "$__atuin_keymap" '"\C-x\C-_A2\a": kill-line'
-            bind -m "$__atuin_keymap" '"\C-x\C-_A3\a": shell-expand-line'
-            bind -m "$__atuin_keymap" '"\C-x\C-_A4\a": accept-line'
+            # shellcheck disable=SC2016
+            bind -m "$__atuin_keymap" '"\C-x\C-_A3\a": "$READLINE_LINE"'
+            bind -m "$__atuin_keymap" '"\C-x\C-_A4\a": shell-expand-line'
+            bind -m "$__atuin_keymap" '"\C-x\C-_A5\a": accept-line'
+            bind -m "$__atuin_keymap" '"\C-x\C-_A6\a": end-of-line'
         done
         unset -v __atuin_keymap
-        # shellcheck disable=SC2016
-        __atuin_macro_accept_line='"\C-x\C-_A1\a\C-x\C-_A2\a$READLINE_LINE\C-x\C-_A3\a\C-x\C-_A4\a"'
-        # shellcheck disable=SC2016
-        __atuin_macro_insert_line='"\C-x\C-_A1\a\C-x\C-_A2\a$READLINE_LINE\C-x\C-_A3\a"'
+
+        bind -m vi-command '"\C-x\C-_A7\a": vi-insertion-mode'
+        bind -m vi-insert  '"\C-x\C-_A7\a": vi-movement-mode'
+
+        # "\C-x\C-_A10\a": Replace the command line with READLINE_LINE.  When we are
+        #   in the vi-command keymap, we go to vi-insert, input
+        #   "$READLINE_LINE", and come back to vi-command.
+        bind -m emacs      '"\C-x\C-_A10\a": "\C-x\C-_A1\a\C-x\C-_A2\a\C-x\C-_A3\a\C-x\C-_A4\a"'
+        bind -m vi-insert  '"\C-x\C-_A10\a": "\C-x\C-_A1\a\C-x\C-_A2\a\C-x\C-_A3\a\C-x\C-_A4\a"'
+        bind -m vi-command '"\C-x\C-_A10\a": "\C-x\C-_A1\a\C-x\C-_A2\a\C-x\C-_A7\a\C-x\C-_A3\a\C-x\C-_A7\a\C-x\C-_A4\a"'
+
+        __atuin_macro_accept_line='"\C-x\C-_A10\a\C-x\C-_A5\a"'
+        __atuin_macro_insert_line='"\C-x\C-_A10\a\C-x\C-_A6\a"'
     fi
 
     __atuin_bash42_dispatch_selector=


### PR DESCRIPTION
In #2953, I chose `\e[0;<n>A`  as special key sequences for `enter_accept` in Bash, but I realized that the sequence `\e[0;<n>A` doesn't actually work in the `vi-insert` keymap. I instead suggest using the key sequences of the form `\C-x\C-_A0\a` (99ddcbf7), which is unlikely to conflict with the users' keybindings. In addition, for Bash <= 3.2, I also noticed that we cannot insert `$READLINE_LINE` in the command line when we are in the `vi-command` keymap. I suggest switching from `vi-command` to `vi-insert` temporarily (e6c4e9fd).

## Checks
- [x] I am happy for maintainers to push small adjustments to this PR, to speed up the review cycle
- [x] I have checked that there are no existing pull requests for the same thing
