### PR TITLE
fix(nushell): reposition cursor back to original prompt after atuin invoked

### DIFF
--- a/crates/atuin/src/shell/atuin.nu
+++ b/crates/atuin/src/shell/atuin.nu
@@ -73,10 +73,14 @@ def _atuin_search_cmd [...flags: string] {
             $ATUIN_KEYBINDING_TOKEN,
             ([
                 `with-env { ATUIN_LOG: error, ATUIN_QUERY: (commandline) } {`,
+                    # Add a newline so that the atuin TUI initializes on the line below the prompt
+                    'print "";',
                     'commandline edit',
                     '(run-external atuin search',
                         ($flags | append [--interactive] | each {|e| $'"($e)"'}),
-                    ' e>| str trim)',
+                    ' e>| str trim);',
+                    # Move the cursor back up two lines to put it on the original prompt after the tui has closed
+                    '$"(ansi --escape "2A")"',
                 `}`,
             ] | flatten | str join ' '),
         ]


### PR DESCRIPTION
The nushell integration script has a weird quirk where when keybinding ran `atuin search --interactive` and invoked the tui, the tui would initialize on the same line and replace the prompt text. 

Gif of the prompt being replaced: 
![demo](https://github.com/user-attachments/assets/477b6cc3-9b5d-41ea-af4f-af7f41557706)

The fix: 
![demo](https://github.com/user-attachments/assets/32d37bed-d9da-4a13-b1ed-85e00074098b)

I'm not entirely sure WHY this behavior only seemingly exists in nushell but this does fix it. There is perhaps a better or different way im not aware of. 

## Checks
- [x] I am happy for maintainers to push small adjustments to this PR, to speed up the review cycle
- [ ] I have checked that there are no existing pull requests for the same thing
