### PR TITLE
build(nix): update rust toolchain hash

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -31,7 +31,7 @@
                 fenix.packages.${system}.fromToolchainFile
                   {
                     file = ./rust-toolchain.toml;
-                    sha256 = "sha256-2eWc3xVTKqg5wKSHGwt1XoM/kUBC6y3MWfKg74Zn+fY=";
+                    sha256 = "sha256-SDu4snEWjuZU475PERvu+iO50Mi39KVjqCeJeNvpguU=";
                   };
             in
             pkgs.makeRustPlatform {


### PR DESCRIPTION
Fixes #2989.

The nix build fails, because the sha256 in the toolchain fetcher doesn't match.

## Checks

- [x] I am happy for maintainers to push small adjustments to this PR, to speed up the review cycle
- [x] I have checked that there are no existing pull requests for the same thing

> [!IMPORTANT]
>
> Before merging this, we should probably investigate why the hash has changed. It could be a sign of a supply chain attack.