### PR TITLE
feat: add colors to --help/-h

### DIFF
--- a/crates/atuin/src/main.rs
+++ b/crates/atuin/src/main.rs
@@ -2,6 +2,8 @@
 #![allow(clippy::use_self, clippy::missing_const_for_fn)] // not 100% reliable
 
 use clap::Parser;
+use clap::builder::Styles;
+use clap::builder::styling::{AnsiColor, Effects};
 use eyre::Result;
 
 use command::AtuinCmd;
@@ -26,6 +28,12 @@ static HELP_TEMPLATE: &str = "\
 
 {all-args}{after-help}";
 
+const STYLES: Styles = Styles::styled()
+    .header(AnsiColor::Yellow.on_default().effects(Effects::BOLD))
+    .usage(AnsiColor::Green.on_default().effects(Effects::BOLD))
+    .literal(AnsiColor::Green.on_default().effects(Effects::BOLD))
+    .placeholder(AnsiColor::Green.on_default());
+
 /// Magical shell history
 #[derive(Parser)]
 #[command(
@@ -33,6 +41,7 @@ static HELP_TEMPLATE: &str = "\
     version = VERSION,
     long_version = LONG_VERSION,
     help_template(HELP_TEMPLATE),
+    styles = STYLES,
 )]
 struct Atuin {
     #[command(subcommand)]


### PR DESCRIPTION
<!-- Thank you for making a PR! Bug fixes are always welcome, but if you're adding a new feature or changing an existing one, we'd really appreciate if you open an issue, post on the forum, or drop in on Discord -->

## Checks
- [x] I am happy for maintainers to push small adjustments to this PR, to speed up the review cycle
- [x] I have checked that there are no existing pull requests for the same thing

User can disable colors via `NO_COLOR=1` environment variable if needed

Output of `atuin -h`:
| before | after | `NO_COLOR=1` |
| - | - | - |
| <img width="741" height="768" alt="atuin-before" src="https://github.com/user-attachments/assets/01921ba0-e94d-4f0a-ac85-b170516e41bc" /> | <img width="741" height="768" alt="atuin-colors" src="https://github.com/user-attachments/assets/59d507e1-9a33-4091-bed7-44eef889a72d" /> | <img width="741" height="768" alt="atuin-no-color" src="https://github.com/user-attachments/assets/e6b067c6-cf17-4909-bdbf-cc2bca830244" /> |


