### PR TITLE
chore: clarify docstring of the enter_accept config key

### DIFF
--- a/crates/atuin-client/config.toml
+++ b/crates/atuin-client/config.toml
@@ -155,7 +155,7 @@
 # secrets_filter = true
 
 ## Defaults to true. If enabled, upon hitting enter Atuin will immediately execute the command,
-## whereas tab will put the command in the promt for editing.
+## whereas tab will put the command in the prompt for editing.
 ## If set to false, both enter and tab will place the command in the prompt for editing.
 ## This applies for new installs. Old installs will keep the old behaviour unless configured otherwise.
 enter_accept = true


### PR DESCRIPTION
While the [docs for this option](https://docs.atuin.sh/configuration/config/#enter_accept) are pretty clear, the explanation in the comment in the config file was slightly ambiguous. I have rephrased it to hopefully be clearer and more explicit.

I've also fixed the comment prefix in a line that should have used `##` instead of a single `#`, which is otherwise only used in lines that can be toggled on and off, i.e. actual configuration values.

<!-- Thank you for making a PR! Bug fixes are always welcome, but if you're adding a new feature or changing an existing one, we'd really appreciate if you open an issue, post on the forum, or drop in on Discord -->

## Checks
- [x] I am happy for maintainers to push small adjustments to this PR, to speed up the review cycle
- [x] I have checked that there are no existing pull requests for the same thing
