### PR TITLE
feat: support additional history filenames in replxx importer

### DIFF
--- a/crates/atuin-client/src/import/replxx.rs
+++ b/crates/atuin-client/src/import/replxx.rs
@@ -19,8 +19,23 @@ fn default_histpath() -> Result<PathBuf> {
     let home_dir = user_dirs.home_dir();
 
     // There is no default histfile for replxx.
-    // For simplicity let's use the most common one.
-    Ok(home_dir.join(".histfile"))
+    // Here we try a couple of common names.
+    let mut candidates = ["replxx_history.txt", ".histfile"].iter();
+    loop {
+        match candidates.next() {
+            Some(candidate) => {
+                let histpath = home_dir.join(candidate);
+                if histpath.exists() {
+                    break Ok(histpath);
+                }
+            }
+            None => {
+                break Err(eyre!(
+                    "Could not find history file. Try setting and exporting $HISTFILE"
+                ));
+            }
+        }
+    }
 }
 
 #[async_trait]


### PR DESCRIPTION
<!-- Thank you for making a PR! Bug fixes are always welcome, but if you're adding a new feature or changing an existing one, we'd really appreciate if you open an issue, post on the forum, or drop in on Discord -->

The original implementation of the `replxx` importer, from PR #2024, only supported `.histfile` as a filename for the history file, since there is no default filename. However, the replxx codebase does use `replxx_history.txt` as an example history filename (see [here](https://github.com/AmokHuginnsson/replxx/blob/release-0.0.4/examples/c-api.c#L183) and [here](https://github.com/AmokHuginnsson/replxx/blob/release-0.0.4/examples/cxx-api.cxx#L383)), so this patch adds support for that as an alternative filename.

The implementation was modeled after [the one](https://github.com/atuinsh/atuin/blob/v18.10.0/crates/atuin-client/src/import/zsh.rs#L29-L44) currently used for the `zsh` history file importer, which also means the `replxx` importer now produces a human-friendly error if no history file is found in the expected path(s).

## Checks
- [x] I am happy for maintainers to push small adjustments to this PR, to speed up the review cycle
- [x] I have checked that there are no existing pull requests for the same thing

/cc @amosbird who introduced this importer in #2024.
