### PR TITLE
build(nix): prevent deprecation warning on evaluation

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -68,7 +68,7 @@
       })
     // {
       overlays.default = final: prev: {
-        inherit (self.packages.${final.system}) atuin;
+        inherit (self.packages.${final.stdenv.hostPlatform.system}) atuin;
       };
     };
 }


### PR DESCRIPTION
Evaluating the overlay produces the following evaluation warning: `'system' has been renamed to/replaced by 'stdenv.hostPlatform.system'`

<!-- Thank you for making a PR! Bug fixes are always welcome, but if you're adding a new feature or changing an existing one, we'd really appreciate if you open an issue, post on the forum, or drop in on Discord -->

## Checks
- [x] I am happy for maintainers to push small adjustments to this PR, to speed up the review cycle
- [x] I have checked that there are no existing pull requests for the same thing
