### PR TITLE
Draft:  Themes v2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -467,6 +467,7 @@ dependencies = [
  "crossterm 0.29.0",
  "divan",
  "rand 0.8.5",
+ "ratatui-crossterm",
  "serde",
  "time",
  "unicode-segmentation",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -235,7 +235,7 @@ dependencies = [
  "clap_complete",
  "clap_complete_nushell",
  "colored",
- "crossterm",
+ "crossterm 0.29.0",
  "daemonize",
  "eyre",
  "fs-err",
@@ -252,7 +252,7 @@ dependencies = [
  "regex",
  "rpassword",
  "runtime-format",
- "rustix",
+ "rustix 1.1.4",
  "semver",
  "serde",
  "serde_json",
@@ -283,7 +283,7 @@ dependencies = [
  "chrono",
  "chrono-humanize",
  "clap",
- "crossterm",
+ "crossterm 0.29.0",
  "directories",
  "eventsource-stream",
  "eye_declare",
@@ -333,7 +333,7 @@ dependencies = [
  "base64",
  "clap",
  "config",
- "crossterm",
+ "crossterm 0.29.0",
  "crypto_secretbox",
  "directories",
  "eyre",
@@ -352,6 +352,7 @@ dependencies = [
  "palette",
  "pretty_assertions",
  "rand 0.8.5",
+ "ratatui",
  "regex",
  "reqwest",
  "rmp",
@@ -451,7 +452,7 @@ name = "atuin-hex"
 version = "18.16.0-beta.1"
 dependencies = [
  "clap",
- "crossterm",
+ "crossterm 0.29.0",
  "eyre",
  "portable-pty",
  "signal-hook",
@@ -463,7 +464,7 @@ name = "atuin-history"
 version = "18.16.0-beta.1"
 dependencies = [
  "atuin-client",
- "crossterm",
+ "crossterm 0.29.0",
  "divan",
  "rand 0.8.5",
  "serde",
@@ -971,6 +972,7 @@ dependencies = [
  "itoa",
  "rustversion",
  "ryu",
+ "serde",
  "static_assertions",
 ]
 
@@ -1113,6 +1115,23 @@ checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
 name = "crossterm"
+version = "0.28.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "829d955a0bb380ef178a640b91779e3987da38c9aea133b20614cfed8cdea9c6"
+dependencies = [
+ "bitflags 2.11.0",
+ "crossterm_winapi",
+ "mio",
+ "parking_lot",
+ "rustix 0.38.44",
+ "serde",
+ "signal-hook",
+ "signal-hook-mio",
+ "winapi",
+]
+
+[[package]]
+name = "crossterm"
 version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8b9f2e4c67f833b660cdb0a3523065869fb35570177239812ed4c905aeff87b"
@@ -1125,7 +1144,7 @@ dependencies = [
  "futures-core",
  "mio",
  "parking_lot",
- "rustix",
+ "rustix 1.1.4",
  "serde",
  "signal-hook",
  "signal-hook-mio",
@@ -1555,7 +1574,7 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e4caff9f5574315258489ecb2d27aad2cc057521f4b0bc6819a1cd82a648f40"
 dependencies = [
- "crossterm",
+ "crossterm 0.29.0",
  "eye_declare_macros",
  "futures",
  "ratatui-core",
@@ -1713,7 +1732,7 @@ version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8640e34b88f7652208ce9e88b1a37a2ae95227d84abec377ccd3c5cfeb141ed4"
 dependencies = [
- "rustix",
+ "rustix 1.1.4",
  "windows-sys 0.59.0",
 ]
 
@@ -1852,7 +1871,7 @@ version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1bd49230192a3797a9a4d6abe9b3eed6f7fa4c8a8a4947977c6f80025f92cbd8"
 dependencies = [
- "rustix",
+ "rustix 1.1.4",
  "windows-link",
 ]
 
@@ -2612,6 +2631,12 @@ dependencies = [
 
 [[package]]
 name = "linux-raw-sys"
+version = "0.4.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
+
+[[package]]
+name = "linux-raw-sys"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
@@ -3037,6 +3062,12 @@ checksum = "5c7398b9c8b70908f6371f47ed36737907c87c52af34c268fed0bf0ceb92ead9"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "numtoa"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6aa2c4e539b869820a2b82e1aef6ff40aa85e65decdd5185e83fb4b1249cd00f"
 
 [[package]]
 name = "objc2"
@@ -3781,8 +3812,10 @@ dependencies = [
  "ratatui-core",
  "ratatui-crossterm",
  "ratatui-macros",
+ "ratatui-termion",
  "ratatui-termwiz",
  "ratatui-widgets",
+ "serde",
 ]
 
 [[package]]
@@ -3798,6 +3831,7 @@ dependencies = [
  "itertools",
  "kasuari",
  "lru",
+ "serde",
  "strum",
  "thiserror 2.0.18",
  "unicode-segmentation",
@@ -3812,7 +3846,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "577c9b9f652b4c121fb25c6a391dd06406d3b092ba68827e6d2f09550edc54b3"
 dependencies = [
  "cfg-if",
- "crossterm",
+ "crossterm 0.28.1",
+ "crossterm 0.29.0",
  "instability",
  "ratatui-core",
 ]
@@ -3825,6 +3860,17 @@ checksum = "a7f1342a13e83e4bb9d0b793d0ea762be633f9582048c892ae9041ef39c936f4"
 dependencies = [
  "ratatui-core",
  "ratatui-widgets",
+]
+
+[[package]]
+name = "ratatui-termion"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cade85a8591fbc911e147951422f0d6fd40f4948b271b6216c7dc01838996f8"
+dependencies = [
+ "instability",
+ "ratatui-core",
+ "termion",
 ]
 
 [[package]]
@@ -3850,6 +3896,7 @@ dependencies = [
  "itertools",
  "line-clipping",
  "ratatui-core",
+ "serde",
  "strum",
  "time",
  "unicode-segmentation",
@@ -4098,6 +4145,19 @@ dependencies = [
 
 [[package]]
 name = "rustix"
+version = "0.38.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
+dependencies = [
+ "bitflags 2.11.0",
+ "errno",
+ "libc",
+ "linux-raw-sys 0.4.15",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rustix"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
@@ -4105,7 +4165,7 @@ dependencies = [
  "bitflags 2.11.0",
  "errno",
  "libc",
- "linux-raw-sys",
+ "linux-raw-sys 0.12.1",
  "windows-sys 0.61.2",
 ]
 
@@ -4948,7 +5008,7 @@ dependencies = [
  "fastrand",
  "getrandom 0.4.2",
  "once_cell",
- "rustix",
+ "rustix 1.1.4",
  "windows-sys 0.61.2",
 ]
 
@@ -4958,7 +5018,7 @@ version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "60b8cb979cb11c32ce1603f8137b22262a9d131aaa5c37b5678025f22b8becd0"
 dependencies = [
- "rustix",
+ "rustix 1.1.4",
  "windows-sys 0.60.2",
 ]
 
@@ -4972,6 +5032,17 @@ dependencies = [
  "nom 7.1.3",
  "phf",
  "phf_codegen",
+]
+
+[[package]]
+name = "termion"
+version = "4.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f44138a9ae08f0f502f24104d82517ef4da7330c35acd638f1f29d3cd5475ecb"
+dependencies = [
+ "libc",
+ "numtoa",
+ "serde",
 ]
 
 [[package]]
@@ -5008,6 +5079,7 @@ dependencies = [
  "pest",
  "pest_derive",
  "phf",
+ "serde",
  "sha2",
  "signal-hook",
  "siphasher",
@@ -5563,7 +5635,7 @@ version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74a31ca0965e3ff6a7ac5ecb02b20a88b4f68ebf138d8ae438e8510b27a1f00f"
 dependencies = [
- "crossterm",
+ "crossterm 0.29.0",
  "portable-atomic",
  "ratatui-core",
  "ratatui-widgets",
@@ -5985,7 +6057,7 @@ checksum = "aa75f400b7f719bcd68b3f47cd939ba654cedeef690f486db71331eec4c6a406"
 dependencies = [
  "cc",
  "downcast-rs",
- "rustix",
+ "rustix 1.1.4",
  "smallvec",
  "wayland-sys",
 ]
@@ -5997,7 +6069,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab51d9f7c071abeee76007e2b742499e535148035bb835f97aaed1338cf516c3"
 dependencies = [
  "bitflags 2.11.0",
- "rustix",
+ "rustix 1.1.4",
  "wayland-backend",
  "wayland-scanner",
 ]
@@ -6112,6 +6184,7 @@ checksum = "692daff6d93d94e29e4114544ef6d5c942a7ed998b37abdc19b17136ea428eb7"
 dependencies = [
  "getrandom 0.3.4",
  "mac_address",
+ "serde",
  "sha2",
  "thiserror 1.0.69",
  "uuid",
@@ -6126,6 +6199,7 @@ dependencies = [
  "csscolorparser",
  "deltae",
  "lazy_static",
+ "serde",
  "wezterm-dynamic",
 ]
 
@@ -6716,7 +6790,7 @@ dependencies = [
  "libc",
  "log",
  "os_pipe",
- "rustix",
+ "rustix 1.1.4",
  "thiserror 2.0.18",
  "tree_magic_mini",
  "wayland-backend",
@@ -6738,7 +6812,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9993aa5be5a26815fe2c3eacfc1fde061fc1a1f094bf1ad2a18bf9c495dd7414"
 dependencies = [
  "gethostname",
- "rustix",
+ "rustix 1.1.4",
  "x11rb-protocol",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,6 +62,7 @@ rustix = { version = "1.1.4", features = ["process", "fs"] }
 tower = "0.5"
 tracing = "0.1"
 ratatui = "0.30.0"
+ratatui-crossterm = "0.1.0"
 sql-builder = "3"
 tempfile = { version = "3.19" }
 minijinja = "2.9.0"

--- a/crates/atuin-client/Cargo.toml
+++ b/crates/atuin-client/Cargo.toml
@@ -73,6 +73,7 @@ indicatif = "0.18.0"
 tiny-bip39 = "2.0.0"
 
 # theme
+ratatui = { workspace = true, features = ["serde"] }
 crossterm = { workspace = true, features = ["serde"] }
 palette = { version = "0.7.5", features = ["serializing"] }
 strum_macros = "0.27"

--- a/crates/atuin-client/src/theme.rs
+++ b/crates/atuin-client/src/theme.rs
@@ -54,10 +54,11 @@ pub enum Meaning {
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct StyleBlock {
-    pub foreground_color: Option<String>,
-    pub background_color: Option<String>,
+    pub fg: Option<String>,
+    pub bg: Option<String>,
     pub underline_color: Option<String>,
-    pub attributes: Option<Vec<String>>,
+    pub add_modifier: Option<Vec<String>>,
+    pub sub_modifier: Option<Vec<String>>,
 }
 
 impl fmt::Display for StyleBlock {
@@ -96,14 +97,21 @@ pub struct ThemeDefinitionConfigBlock {
     pub parent: Option<String>,
 }
 
-use crossterm::style::{Attribute, Attributes, Color, ContentStyle};
+use ratatui::{
+    backend::FromCrossterm,
+    buffer::Buffer,
+    crossterm::style,
+    layout::Rect,
+    style::{Modifier, Style, Color},
+    widgets::{Block, StatefulWidget, Widget},
+};
 
 // For now, a theme is loaded as a mapping of meanings to colors, but it may be desirable to
-// expand that in the future to general styles, so we populate a Meaning->ContentStyle hashmap.
+// expand that in the future to general styles, so we populate a Meaning->Style hashmap.
 pub struct Theme {
     pub name: String,
     pub parent: Option<String>,
-    pub styles: HashMap<Meaning, ContentStyle>,
+    pub styles: HashMap<Meaning, Style>,
 }
 
 // Themes have a number of convenience functions for the most commonly used meanings.
@@ -111,32 +119,32 @@ pub struct Theme {
 // theme-related boilerplate minimal, the convenience functions give a color.
 impl Theme {
     // This is the base "default" color, for general text
-    pub fn get_base(&self) -> ContentStyle {
+    pub fn get_base(&self) -> Style {
         self.styles[&Meaning::Base]
     }
 
-    pub fn get_info(&self) -> ContentStyle {
+    pub fn get_info(&self) -> Style {
         self.get_alert(log::Level::Info)
     }
 
-    pub fn get_warning(&self) -> ContentStyle {
+    pub fn get_warning(&self) -> Style {
         self.get_alert(log::Level::Warn)
     }
 
-    pub fn get_error(&self) -> ContentStyle {
+    pub fn get_error(&self) -> Style {
         self.get_alert(log::Level::Error)
     }
 
     // The alert meanings may be chosen by the Level enum, rather than the methods above
     // or the full Meaning enum, to simplify programmatic selection of a log-level.
-    pub fn get_alert(&self, severity: log::Level) -> ContentStyle {
+    pub fn get_alert(&self, severity: log::Level) -> Style {
         self.styles[ALERT_TYPES.get(&severity).unwrap()]
     }
 
     pub fn new(
         name: String,
         parent: Option<String>,
-        styles: HashMap<Meaning, ContentStyle>,
+        styles: HashMap<Meaning, Style>,
     ) -> Theme {
         let mut theme = Theme {
             name,
@@ -150,7 +158,7 @@ impl Theme {
     fn initialize_styles(&mut self) {
         let mut updates = Vec::new();
         for (key, style) in self.styles.iter() {
-            if style.foreground_color.is_none() {
+            if style.fg.is_none() {
                 // In the event that we have an attribute-only style,
                 // this allows us to fallback to a meaning color that might be
                 // defined in the theme. Note that this is _not_ falling back
@@ -163,10 +171,10 @@ impl Theme {
                 // (and used) Meanings.
                 // TODO: how to properly provide debugging here?
                 if let Some(fallback) = MEANING_FALLBACKS.get(key)
-                    && let Some(color) = self.as_style(*fallback).foreground_color
+                    && let Some(color) = self.as_style(*fallback).fg
                 {
                     let new_style =
-                        StyleFactory::from_fg_color_and_attributes(color, style.attributes);
+                        StyleFactory::from_fg_color_and_modifiers(color, style.add_modifier, style.sub_modifier);
                     updates.push((*key, new_style));
                 }
             }
@@ -187,7 +195,7 @@ impl Theme {
     }
 
     // General access - if you have a meaning, this will give you a (crossterm) style
-    pub fn as_style(&self, meaning: Meaning) -> ContentStyle {
+    pub fn as_style(&self, meaning: Meaning) -> Style {
         self.styles[self.closest_meaning(&meaning)]
     }
 
@@ -199,19 +207,20 @@ impl Theme {
     pub fn from_styles(
         name: String,
         parent: Option<&Theme>,
-        foreground_colors: HashMap<Meaning, StyleExpression>,
+        fgs: HashMap<Meaning, StyleExpression>,
         debug: bool,
     ) -> Theme {
-        let styles: HashMap<Meaning, ContentStyle> = foreground_colors
+        let styles: HashMap<Meaning, Style> = fgs
             .iter()
             .map(|(name, style)| {
                 let style_block = match style {
                     StyleExpression::String(color_name) => {
                         StyleBlock {
-                            foreground_color: Some(color_name.clone()),
-                            background_color: None,
+                            fg: Some(color_name.clone()),
+                            bg: None,
                             underline_color: None,
-                            attributes: None
+                            add_modifier: None,
+                            sub_modifier: None,
                         }
                     },
                     StyleExpression::StyleBlock(block) => block.clone()
@@ -222,7 +231,7 @@ impl Theme {
                         if debug {
                             log::warn!("Tried to load style as a style block unsuccessfully: ({name}={style_block}) {err}");
                         }
-                        ContentStyle::default()
+                        Style::default()
                     }),
                 )
             })
@@ -235,7 +244,7 @@ impl Theme {
     fn from_map(
         name: String,
         parent: Option<&Theme>,
-        overrides: &HashMap<Meaning, ContentStyle>,
+        overrides: &HashMap<Meaning, Style>,
     ) -> Theme {
         let styles = match parent {
             Some(theme) => Box::new(theme.styles.clone()),
@@ -255,13 +264,27 @@ pub struct StyleFactory {}
 
 impl StyleFactory {
 // Use palette to get a color from a string name, if possible
-    fn from_style_block(block: StyleBlock) -> Result<ContentStyle, String> {
-        let content_style = ContentStyle {
-            foreground_color: match block.foreground_color {
+    fn from_style_block(block: StyleBlock) -> Result<Style, String> {
+        let to_modifier = |avec: Vec<String>| -> Result<Modifier, String> {
+            let attrs: Vec<Modifier> = avec
+                .iter()
+                .map(|av| StyleFactory::from_modifier_string(av.as_str()))
+                .collect::<Result<Vec<Modifier>, String>>()?;
+            Ok(
+                attrs.iter().fold(
+                    Modifier::default(),
+                    |acc: Modifier, a: &Modifier| {
+                        acc | *a
+                    },
+                )
+            )
+        };
+        let content_style = Style {
+            fg: match block.fg {
                 Some(fg) => Some(StyleFactory::from_color_string(fg.as_str())?),
                 _ => None,
             },
-            background_color: match block.background_color {
+            bg: match block.bg {
                 Some(bg) => Some(StyleFactory::from_color_string(bg.as_str())?),
                 _ => None,
             },
@@ -269,32 +292,24 @@ impl StyleFactory {
                 Some(ul) => Some(StyleFactory::from_color_string(ul.as_str())?),
                 _ => None,
             },
-            attributes: match block.attributes {
-                Some(avec) => {
-                    let attrs: Vec<Attribute> = avec
-                        .iter()
-                        .map(|av| StyleFactory::from_attribute_string(av.as_str()))
-                        .collect::<Result<Vec<Attribute>, String>>()?;
-                    attrs.iter().fold(
-                        Attributes::default(),
-                        |mut acc: Attributes, a: &Attribute| {
-                            acc.set(*a);
-                            acc
-                        },
-                    )
-                }
-                _ => Attributes::default(),
+            add_modifier: match block.add_modifier {
+                Some(avec) => to_modifier(avec)?,
+                _ => Modifier::default(),
+            },
+            sub_modifier: match block.sub_modifier {
+                Some(avec) => to_modifier(avec)?,
+                _ => Modifier::default(),
             },
         };
         Ok(content_style)
     }
 
-    fn from_attribute_string(name: &str) -> Result<Attribute, String> {
+    fn from_modifier_string(name: &str) -> Result<Modifier, String> {
         if name.is_empty() {
             return Err("Empty string".into());
         }
-        serde_json::from_str::<Attribute>(format!("\"{}\"", name).as_str())
-            .map_err(|_| format!("Could not convert attribute name {name} to Crossterm attribute (use SGR names, not numbers)"))
+        Modifier::from_name(name)
+            .ok_or_else(|| format!("Could not convert attribute name {name} to Ratatui attribute (use SGR names, not numbers)"))
     }
 
     fn from_color_string(name: &str) -> Result<Color, String> {
@@ -315,55 +330,48 @@ impl StyleFactory {
             if vec.len() != 3 {
                 return Err("Could not parse 3 hex values from string".into());
             }
-            Ok(Color::Rgb {
-                r: vec[0],
-                g: vec[1],
-                b: vec[2],
-            })
+            Ok(Color::Rgb(vec[0], vec[1], vec[2]))
         }
         '@' => {
-            // For full flexibility, we need to use serde_json, given
-            // crossterm's approach.
-            serde_json::from_str::<Color>(format!("\"{}\"", &name[1..]).as_str())
-                .map_err(|_| format!("Could not convert color name {name} to Crossterm color"))
+            // For full flexibility, we need to use serde_json
+            serde_json::from_str(&name[1..])
+                .map_err(|_| format!("Could not convert color name {name} to Ratatui color"))
         }
         _ => {
             let srgb = named::from_str(name).ok_or("No such color in palette")?;
-            Ok(Color::Rgb {
-                r: srgb.red,
-                g: srgb.green,
-                b: srgb.blue,
-            })
+            Ok(Color::Rgb(srgb.red, srgb.green, srgb.blue))
         }
     }
 }
 
     // For succinctness, if we are confident that the name will be known,
     // this routine is available to keep the code readable
-    fn known_fg_string(name: &str) -> ContentStyle {
+    fn known_fg_string(name: &str) -> Style {
         StyleFactory::from_fg_color(StyleFactory::from_color_string(name).unwrap())
     }
 
-    fn from_fg_color(color: Color) -> ContentStyle {
-        ContentStyle {
-            foreground_color: Some(color),
-            ..ContentStyle::default()
+    fn from_fg_color(color: Color) -> Style {
+        Style {
+            fg: Some(color),
+            ..Style::default()
         }
     }
 
-    fn from_fg_color_and_attributes(color: Color, attributes: Attributes) -> ContentStyle {
-        ContentStyle {
-            foreground_color: Some(color),
-            attributes,
-            ..ContentStyle::default()
+    fn from_fg_color_and_modifiers(color: Color, add_modifier: Modifier, sub_modifier: Modifier) -> Style {
+        Style {
+            fg: Some(color),
+            add_modifier,
+            sub_modifier,
+            ..Style::default()
         }
     }
 
-    fn from_attributes_only(attributes: Attributes) -> ContentStyle {
-        ContentStyle {
-            foreground_color: None,
-            attributes,
-            ..ContentStyle::default()
+    fn from_modifiers_only(add_modifier: Modifier, sub_modifier: Modifier) -> Style {
+        Style {
+            fg: None,
+            add_modifier,
+            sub_modifier,
+            ..Style::default()
         }
     }
 }
@@ -384,12 +392,12 @@ static MEANING_FALLBACKS: LazyLock<HashMap<Meaning, Meaning>> = LazyLock::new(||
         (Meaning::Guidance, Meaning::AlertInfo),
         (Meaning::Annotation, Meaning::AlertInfo),
         (Meaning::Title, Meaning::Important),
-            (Meaning::Selection, Meaning::AlertError),
-            (Meaning::Match, Meaning::Base),
-            (Meaning::Footnote, Meaning::Base),
-            (Meaning::Highlight, Meaning::AlertWarn),
-            (Meaning::Failure, Meaning::AlertError),
-            (Meaning::Success, Meaning::AlertInfo),
+        (Meaning::Selection, Meaning::AlertError),
+        (Meaning::Match, Meaning::Base),
+        (Meaning::Footnote, Meaning::Base),
+        (Meaning::Highlight, Meaning::AlertWarn),
+        (Meaning::Failure, Meaning::AlertError),
+        (Meaning::Success, Meaning::AlertInfo),
     ])
 });
 
@@ -400,41 +408,42 @@ static DEFAULT_THEME: LazyLock<Theme> = LazyLock::new(|| {
         HashMap::from([
             (
                 Meaning::AlertError,
-                StyleFactory::from_fg_color(Color::DarkRed),
+                StyleFactory::from_fg_color(Color::Red),
             ),
             (
                 Meaning::AlertWarn,
-                StyleFactory::from_fg_color(Color::DarkYellow),
+                StyleFactory::from_fg_color(Color::Yellow),
             ),
             (
                 Meaning::AlertInfo,
-                StyleFactory::from_fg_color(Color::DarkGreen),
+                StyleFactory::from_fg_color(Color::Green),
             ),
             (
                 Meaning::Annotation,
-                StyleFactory::from_fg_color(Color::DarkGrey),
+                StyleFactory::from_fg_color(Color::DarkGray),
             ),
             (
                 Meaning::Guidance,
-                StyleFactory::from_fg_color(Color::DarkBlue),
+                StyleFactory::from_fg_color(Color::Blue),
             ),
             (
                 Meaning::Important,
-                StyleFactory::from_fg_color_and_attributes(
+                StyleFactory::from_fg_color_and_modifiers(
                     Color::White,
-                    Attributes::from(Attribute::Bold),
+                    Modifier::BOLD,
+                    Modifier::empty()
                 ),
             ),
-                (
-                    Meaning::Highlight,
-                    StyleFactory::from_attributes_only(Attributes::from(Attribute::Bold)),
-                ),
-                (
-                    Meaning::Match,
-                    StyleFactory::from_attributes_only(Attributes::from(Attribute::Bold)),
-                ),
-            (Meaning::Muted, StyleFactory::from_fg_color(Color::Grey)),
-            (Meaning::Base, ContentStyle::default()),
+            (
+                Meaning::Highlight,
+                StyleFactory::from_modifiers_only(Modifier::BOLD, Modifier::empty()),
+            ),
+            (
+                Meaning::Match,
+                StyleFactory::from_modifiers_only(Modifier::BOLD, Modifier::empty()),
+            ),
+            (Meaning::Muted, StyleFactory::from_fg_color(Color::Gray)),
+            (Meaning::Base, Style::default()),
         ]),
     )
 });
@@ -445,14 +454,14 @@ static BUILTIN_THEMES: LazyLock<HashMap<&'static str, Theme>> = LazyLock::new(||
         (
             "(none)",
             HashMap::from([
-                (Meaning::AlertError, ContentStyle::default()),
-                (Meaning::AlertWarn, ContentStyle::default()),
-                (Meaning::AlertInfo, ContentStyle::default()),
-                (Meaning::Annotation, ContentStyle::default()),
-                (Meaning::Guidance, ContentStyle::default()),
-                (Meaning::Important, ContentStyle::default()),
-                (Meaning::Muted, ContentStyle::default()),
-                (Meaning::Base, ContentStyle::default()),
+                (Meaning::AlertError, Style::default()),
+                (Meaning::AlertWarn, Style::default()),
+                (Meaning::AlertInfo, Style::default()),
+                (Meaning::Annotation, Style::default()),
+                (Meaning::Guidance, Style::default()),
+                (Meaning::Important, Style::default()),
+                (Meaning::Muted, Style::default()),
+                (Meaning::Base, Style::default()),
             ]),
         ),
         (
@@ -469,7 +478,7 @@ static BUILTIN_THEMES: LazyLock<HashMap<&'static str, Theme>> = LazyLock::new(||
                 (Meaning::AlertInfo, StyleFactory::known_fg_string("gold")),
                 (
                     Meaning::Annotation,
-                    StyleFactory::from_fg_color(Color::DarkGrey),
+                    StyleFactory::from_fg_color(Color::DarkGray),
                 ),
                 (Meaning::Guidance, StyleFactory::known_fg_string("brown")),
             ]),
@@ -630,10 +639,10 @@ impl ThemeManager {
 
         if let Some(styles) = styles {
             let theme = Theme::from_styles(theme_config.theme.name, parent, styles, debug);
-        let name = name.to_string();
-        self.loaded_themes.insert(name.clone(), theme);
-        let theme = self.loaded_themes.get(&name).unwrap();
-        Ok(theme)
+            let name = name.to_string();
+            self.loaded_themes.insert(name.clone(), theme);
+            let theme = self.loaded_themes.get(&name).unwrap();
+            Ok(theme)
         } else {
             Err(Box::new(Error::new(
                 ErrorKind::InvalidInput,
@@ -671,7 +680,7 @@ mod theme_tests {
         let mut manager = ThemeManager::new(Some(false), Some("".to_string()));
         let theme = manager.load_theme("autumn", None);
         assert_eq!(
-            theme.as_style(Meaning::Guidance).foreground_color,
+            theme.as_style(Meaning::Guidance).fg,
             StyleFactory::from_color_string("brown").ok()
         );
     }
@@ -690,7 +699,7 @@ mod theme_tests {
         manager.loaded_themes.insert("mytheme".to_string(), mytheme);
         let theme = manager.load_theme("mytheme", None);
         assert_eq!(
-            theme.as_style(Meaning::AlertError).foreground_color,
+            theme.as_style(Meaning::AlertError).fg,
             StyleFactory::from_color_string("yellowgreen").ok()
         );
     }
@@ -723,26 +732,26 @@ mod theme_tests {
 
         // Correctly picks overridden color.
         assert_eq!(
-            theme.as_style(Meaning::Guidance).foreground_color,
+            theme.as_style(Meaning::Guidance).fg,
             StyleFactory::from_color_string("white").ok()
         );
 
         // Does not fall back to any color.
-        assert_eq!(theme.as_style(Meaning::AlertInfo).foreground_color, None);
+        assert_eq!(theme.as_style(Meaning::AlertInfo).fg, None);
 
         // Even for the base.
-        assert_eq!(theme.as_style(Meaning::Base).foreground_color, None);
+        assert_eq!(theme.as_style(Meaning::Base).fg, None);
 
         // Falls back to red as meaning missing from theme, so picks base default.
         assert_eq!(
-            theme.as_style(Meaning::AlertError).foreground_color,
-            Some(Color::DarkRed)
+            theme.as_style(Meaning::AlertError).fg,
+            Some(Color::Red)
         );
 
         // Falls back to Important as Title not available.
         assert_eq!(
-            theme.as_style(Meaning::Title).foreground_color,
-            theme.as_style(Meaning::Important).foreground_color,
+            theme.as_style(Meaning::Title).fg,
+            theme.as_style(Meaning::Important).fg,
         );
 
         let title_config = Config::builder()
@@ -764,7 +773,7 @@ mod theme_tests {
             .unwrap();
 
         assert_eq!(
-            title_theme.as_style(Meaning::Title).foreground_color,
+            title_theme.as_style(Meaning::Title).fg,
             Some(Color::White)
         );
     }
@@ -781,16 +790,16 @@ mod theme_tests {
     fn test_can_get_colors_via_convenience_functions() {
         let mut manager = ThemeManager::new(Some(true), Some("".to_string()));
         let theme = manager.load_theme("default", None);
-        assert_eq!(theme.get_error().foreground_color.unwrap(), Color::DarkRed);
+        assert_eq!(theme.get_error().fg.unwrap(), Color::Red);
         assert_eq!(
-            theme.get_warning().foreground_color.unwrap(),
-            Color::DarkYellow
+            theme.get_warning().fg.unwrap(),
+            Color::Yellow
         );
-        assert_eq!(theme.get_info().foreground_color.unwrap(), Color::DarkGreen);
-        assert_eq!(theme.get_base().foreground_color, None);
+        assert_eq!(theme.get_info().fg.unwrap(), Color::Green);
+        assert_eq!(theme.get_base().fg, None);
         assert_eq!(
-            theme.get_alert(log::Level::Error).foreground_color.unwrap(),
-            Color::DarkRed
+            theme.get_alert(log::Level::Error).fg.unwrap(),
+            Color::Red
         )
     }
 
@@ -822,7 +831,7 @@ mod theme_tests {
         assert_eq!(
             solarized_theme
                 .as_style(Meaning::AlertInfo)
-                .foreground_color,
+                .fg,
             StyleFactory::from_color_string("pink").ok()
         );
 
@@ -849,7 +858,7 @@ mod theme_tests {
         assert_eq!(
             unsolarized_theme
                 .as_style(Meaning::AlertInfo)
-                .foreground_color,
+                .fg,
             StyleFactory::from_color_string("red").ok()
         );
 
@@ -857,7 +866,7 @@ mod theme_tests {
         assert_eq!(
             unsolarized_theme
                 .as_style(Meaning::Guidance)
-                .foreground_color,
+                .fg,
             StyleFactory::from_color_string("white").ok()
         );
 
@@ -886,8 +895,8 @@ mod theme_tests {
         assert_eq!(
             nunsolarized_theme
                 .as_style(Meaning::Guidance)
-                .foreground_color,
-            Some(Color::Rgb { r: 255, g: 0, b: 0 }) // The base AlertInfo color.
+                .fg,
+            Some(Color::Rgb(255, 0, 0)) // The base AlertInfo color.
         );
 
         testing_logger::validate(|captured_logs| {
@@ -937,7 +946,7 @@ mod theme_tests {
                     assert_eq!(captured_logs[1].level, log::Level::Warn);
                     assert_eq!(
                         captured_logs[2].body,
-                        "Tried to load style as a style block unsuccessfully: (AlertInfo={\"foreground_color\":\"xinetic\",\"background_color\":null,\"underline_color\":null,\"attributes\":null}) No such color in palette"
+                        "Tried to load style as a style block unsuccessfully: (AlertInfo={\"fg\":\"xinetic\",\"bg\":null,\"underline_color\":null,\"add_modifier\":null,\"sub_modifier\":null}) No such color in palette"
                     );
                     assert_eq!(captured_logs[2].level, log::Level::Warn)
                 } else {
@@ -951,11 +960,7 @@ mod theme_tests {
     fn test_can_parse_color_strings_correctly() {
         assert_eq!(
             StyleFactory::from_color_string("brown").unwrap(),
-            Color::Rgb {
-                r: 165,
-                g: 42,
-                b: 42
-            }
+            Color::Rgb(165, 42, 42)
         );
 
         assert_eq!(
@@ -974,11 +979,7 @@ mod theme_tests {
 
         assert_eq!(
             StyleFactory::from_color_string("#ff1122").unwrap(),
-            Color::Rgb {
-                r: 255,
-                g: 17,
-                b: 34
-            }
+            Color::Rgb(255, 17, 34)
         );
         ["#1122", "#ffaa112", "#brown"].iter().for_each(|inp| {
             assert_eq!(
@@ -988,20 +989,16 @@ mod theme_tests {
         });
 
         assert_eq!(
-            StyleFactory::from_color_string("@dark_grey").unwrap(),
-            Color::DarkGrey
+            StyleFactory::from_color_string("@\"dark-gray\"").unwrap(),
+            Color::DarkGray
         );
         assert_eq!(
-            StyleFactory::from_color_string("@rgb_(255,255,255)").unwrap(),
-            Color::Rgb {
-                r: 255,
-                g: 255,
-                b: 255
-            }
+            StyleFactory::from_color_string("@{\"Rgb\":[255,255,255]}").unwrap(),
+            Color::Rgb(255, 255, 255)
         );
         assert_eq!(
-            StyleFactory::from_color_string("@ansi_(255)").unwrap(),
-            Color::AnsiValue(255)
+            StyleFactory::from_color_string("@{\"Indexed\":255}").unwrap(),
+            Color::Indexed(255)
         );
         ["@", "@DarkGray", "@Dark 4ay", "@ansi(256)"]
             .iter()
@@ -1009,7 +1006,7 @@ mod theme_tests {
                 assert_eq!(
                     StyleFactory::from_color_string(inp),
                     Err(format!(
-                        "Could not convert color name {inp} to Crossterm color"
+                        "Could not convert color name {inp} to Ratatui color"
                     ))
                 );
             });
@@ -1025,7 +1022,7 @@ mod theme_tests {
         name = \"mytheme\"
 
         [styles]
-        Guidance = { foreground_color = \"white\", attributes = [\"RapidBlink\", \"Bold\"] }
+        Guidance = { fg = \"white\", add_modifier = [\"RAPID_BLINK\", \"BOLD\"], sub_modifier = [] }
         ",
                 FileFormat::Toml,
             ))
@@ -1039,20 +1036,16 @@ mod theme_tests {
         let style = mytheme.as_style(Meaning::Guidance);
 
         assert_eq!(
-            style.foreground_color,
-            Some(Color::Rgb {
-                r: 255,
-                g: 255,
-                b: 255
-            })
+            style.fg,
+            Some(Color::Rgb(255, 255, 255))
         );
 
-        assert_eq!(style.background_color, None);
+        assert_eq!(style.bg, None);
         assert_eq!(style.underline_color, None);
 
         assert_eq!(
-            style.attributes,
-            Attributes::from([Attribute::Bold, Attribute::RapidBlink].as_ref())
+            style.add_modifier,
+            Modifier::BOLD | Modifier::RAPID_BLINK
         );
     }
 
@@ -1068,7 +1061,7 @@ mod theme_tests {
             name = \"mytheme\"
 
             [styles]
-            Guidance = { foreground_color = \"white\", attributes = [\"RapidBlink\", \"VeryBold\"] }
+            Guidance = { fg = \"white\", add_modifier = [\"RAPID_BLINK\", \"VERY_BOLD\"], sub_modifier = [] }
             ",
                     FileFormat::Toml,
                 ))
@@ -1082,19 +1075,20 @@ mod theme_tests {
             let style = mytheme.as_style(Meaning::Guidance);
 
             // This is dark green because the failing attribute fails the whole block.
-            assert_eq!(style.foreground_color, Some(Color::DarkGreen));
+            assert_eq!(style.fg, Some(Color::Green));
 
-            assert_eq!(style.background_color, None);
+            assert_eq!(style.bg, None);
             assert_eq!(style.underline_color, None);
 
-            assert_eq!(style.attributes, Attributes::none());
+            assert_eq!(style.add_modifier, Modifier::empty());
+            assert_eq!(style.sub_modifier, Modifier::empty());
 
             testing_logger::validate(|captured_logs| {
                 if *debug {
                     assert_eq!(captured_logs.len(), 1);
                     assert_eq!(
                         captured_logs[0].body,
-                        "Tried to load style as a style block unsuccessfully: (Guidance={\"foreground_color\":\"white\",\"background_color\":null,\"underline_color\":null,\"attributes\":[\"RapidBlink\",\"VeryBold\"]}) Could not convert attribute name VeryBold to Crossterm attribute (use SGR names, not numbers)"
+                        "Tried to load style as a style block unsuccessfully: (Guidance={\"fg\":\"white\",\"bg\":null,\"underline_color\":null,\"add_modifier\":[\"RAPID_BLINK\",\"VERY_BOLD\"],\"sub_modifier\":[]}) Could not convert attribute name VERY_BOLD to Ratatui attribute (use SGR names, not numbers)"
 
                     );
                     assert_eq!(captured_logs[0].level, log::Level::Warn);

--- a/crates/atuin-client/src/theme.rs
+++ b/crates/atuin-client/src/theme.rs
@@ -97,9 +97,7 @@ pub struct ThemeDefinitionConfigBlock {
     pub parent: Option<String>,
 }
 
-use ratatui::{
-    style::{Modifier, Style, Color}
-};
+use ratatui::style::{Color, Modifier, Style};
 
 // For now, a theme is loaded as a mapping of meanings to colors, but it may be desirable to
 // expand that in the future to general styles, so we populate a Meaning->Style hashmap.
@@ -136,11 +134,7 @@ impl Theme {
         self.styles[ALERT_TYPES.get(&severity).unwrap()]
     }
 
-    pub fn new(
-        name: String,
-        parent: Option<String>,
-        styles: HashMap<Meaning, Style>,
-    ) -> Theme {
+    pub fn new(name: String, parent: Option<String>, styles: HashMap<Meaning, Style>) -> Theme {
         let mut theme = Theme {
             name,
             parent,
@@ -168,8 +162,11 @@ impl Theme {
                 if let Some(fallback) = MEANING_FALLBACKS.get(key)
                     && let Some(color) = self.as_style(*fallback).fg
                 {
-                    let new_style =
-                        StyleFactory::from_fg_color_and_modifiers(color, style.add_modifier, style.sub_modifier);
+                    let new_style = StyleFactory::from_fg_color_and_modifiers(
+                        color,
+                        style.add_modifier,
+                        style.sub_modifier,
+                    );
                     updates.push((*key, new_style));
                 }
             }
@@ -258,21 +255,16 @@ impl Theme {
 pub struct StyleFactory {}
 
 impl StyleFactory {
-// Use palette to get a color from a string name, if possible
+    // Use palette to get a color from a string name, if possible
     fn from_style_block(block: StyleBlock) -> Result<Style, String> {
         let to_modifier = |avec: Vec<String>| -> Result<Modifier, String> {
             let attrs: Vec<Modifier> = avec
                 .iter()
                 .map(|av| StyleFactory::from_modifier_string(av.as_str()))
                 .collect::<Result<Vec<Modifier>, String>>()?;
-            Ok(
-                attrs.iter().fold(
-                    Modifier::default(),
-                    |acc: Modifier, a: &Modifier| {
-                        acc | *a
-                    },
-                )
-            )
+            Ok(attrs
+                .iter()
+                .fold(Modifier::default(), |acc: Modifier, a: &Modifier| acc | *a))
         };
         let content_style = Style {
             fg: match block.fg {
@@ -308,36 +300,36 @@ impl StyleFactory {
     }
 
     fn from_color_string(name: &str) -> Result<Color, String> {
-    if name.is_empty() {
-        return Err("Empty string".into());
-    }
-    let first_char = name.chars().next().unwrap();
-    match first_char {
-        '#' => {
-            let hexcode = &name[1..];
-            let vec: Vec<u8> = hexcode
-                .chars()
-                .collect::<Vec<char>>()
-                .chunks(2)
-                .map(|pair| u8::from_str_radix(pair.iter().collect::<String>().as_str(), 16))
-                .filter_map(|n| n.ok())
-                .collect();
-            if vec.len() != 3 {
-                return Err("Could not parse 3 hex values from string".into());
+        if name.is_empty() {
+            return Err("Empty string".into());
+        }
+        let first_char = name.chars().next().unwrap();
+        match first_char {
+            '#' => {
+                let hexcode = &name[1..];
+                let vec: Vec<u8> = hexcode
+                    .chars()
+                    .collect::<Vec<char>>()
+                    .chunks(2)
+                    .map(|pair| u8::from_str_radix(pair.iter().collect::<String>().as_str(), 16))
+                    .filter_map(|n| n.ok())
+                    .collect();
+                if vec.len() != 3 {
+                    return Err("Could not parse 3 hex values from string".into());
+                }
+                Ok(Color::Rgb(vec[0], vec[1], vec[2]))
             }
-            Ok(Color::Rgb(vec[0], vec[1], vec[2]))
-        }
-        '@' => {
-            // For full flexibility, we need to use serde_json
-            serde_json::from_str(&name[1..])
-                .map_err(|_| format!("Could not convert color name {name} to Ratatui color"))
-        }
-        _ => {
-            let srgb = named::from_str(name).ok_or("No such color in palette")?;
-            Ok(Color::Rgb(srgb.red, srgb.green, srgb.blue))
+            '@' => {
+                // For full flexibility, we need to use serde_json
+                serde_json::from_str(&name[1..])
+                    .map_err(|_| format!("Could not convert color name {name} to Ratatui color"))
+            }
+            _ => {
+                let srgb = named::from_str(name).ok_or("No such color in palette")?;
+                Ok(Color::Rgb(srgb.red, srgb.green, srgb.blue))
+            }
         }
     }
-}
 
     // For succinctness, if we are confident that the name will be known,
     // this routine is available to keep the code readable
@@ -352,7 +344,11 @@ impl StyleFactory {
         }
     }
 
-    fn from_fg_color_and_modifiers(color: Color, add_modifier: Modifier, sub_modifier: Modifier) -> Style {
+    fn from_fg_color_and_modifiers(
+        color: Color,
+        add_modifier: Modifier,
+        sub_modifier: Modifier,
+    ) -> Style {
         Style {
             fg: Some(color),
             add_modifier,
@@ -401,10 +397,7 @@ static DEFAULT_THEME: LazyLock<Theme> = LazyLock::new(|| {
         "default".to_string(),
         None,
         HashMap::from([
-            (
-                Meaning::AlertError,
-                StyleFactory::from_fg_color(Color::Red),
-            ),
+            (Meaning::AlertError, StyleFactory::from_fg_color(Color::Red)),
             (
                 Meaning::AlertWarn,
                 StyleFactory::from_fg_color(Color::Yellow),
@@ -417,16 +410,13 @@ static DEFAULT_THEME: LazyLock<Theme> = LazyLock::new(|| {
                 Meaning::Annotation,
                 StyleFactory::from_fg_color(Color::DarkGray),
             ),
-            (
-                Meaning::Guidance,
-                StyleFactory::from_fg_color(Color::Blue),
-            ),
+            (Meaning::Guidance, StyleFactory::from_fg_color(Color::Blue)),
             (
                 Meaning::Important,
                 StyleFactory::from_fg_color_and_modifiers(
                     Color::White,
                     Modifier::BOLD,
-                    Modifier::empty()
+                    Modifier::empty(),
                 ),
             ),
             (
@@ -738,10 +728,7 @@ mod theme_tests {
         assert_eq!(theme.as_style(Meaning::Base).fg, None);
 
         // Falls back to red as meaning missing from theme, so picks base default.
-        assert_eq!(
-            theme.as_style(Meaning::AlertError).fg,
-            Some(Color::Red)
-        );
+        assert_eq!(theme.as_style(Meaning::AlertError).fg, Some(Color::Red));
 
         // Falls back to Important as Title not available.
         assert_eq!(
@@ -767,10 +754,7 @@ mod theme_tests {
             .load_theme_from_config("title_theme", title_config, 1)
             .unwrap();
 
-        assert_eq!(
-            title_theme.as_style(Meaning::Title).fg,
-            Some(Color::White)
-        );
+        assert_eq!(title_theme.as_style(Meaning::Title).fg, Some(Color::White));
     }
 
     #[test]
@@ -786,16 +770,10 @@ mod theme_tests {
         let mut manager = ThemeManager::new(Some(true), Some("".to_string()));
         let theme = manager.load_theme("default", None);
         assert_eq!(theme.get_error().fg.unwrap(), Color::Red);
-        assert_eq!(
-            theme.get_warning().fg.unwrap(),
-            Color::Yellow
-        );
+        assert_eq!(theme.get_warning().fg.unwrap(), Color::Yellow);
         assert_eq!(theme.get_info().fg.unwrap(), Color::Green);
         assert_eq!(theme.get_base().fg, None);
-        assert_eq!(
-            theme.get_alert(log::Level::Error).fg.unwrap(),
-            Color::Red
-        )
+        assert_eq!(theme.get_alert(log::Level::Error).fg.unwrap(), Color::Red)
     }
 
     #[test]
@@ -824,9 +802,7 @@ mod theme_tests {
             .unwrap();
 
         assert_eq!(
-            solarized_theme
-                .as_style(Meaning::AlertInfo)
-                .fg,
+            solarized_theme.as_style(Meaning::AlertInfo).fg,
             StyleFactory::from_color_string("pink").ok()
         );
 
@@ -851,17 +827,13 @@ mod theme_tests {
 
         // It will take its own values
         assert_eq!(
-            unsolarized_theme
-                .as_style(Meaning::AlertInfo)
-                .fg,
+            unsolarized_theme.as_style(Meaning::AlertInfo).fg,
             StyleFactory::from_color_string("red").ok()
         );
 
         // ...or fall back to the parent
         assert_eq!(
-            unsolarized_theme
-                .as_style(Meaning::Guidance)
-                .fg,
+            unsolarized_theme.as_style(Meaning::Guidance).fg,
             StyleFactory::from_color_string("white").ok()
         );
 
@@ -888,9 +860,7 @@ mod theme_tests {
             .unwrap();
 
         assert_eq!(
-            nunsolarized_theme
-                .as_style(Meaning::Guidance)
-                .fg,
+            nunsolarized_theme.as_style(Meaning::Guidance).fg,
             Some(Color::Rgb(255, 0, 0)) // The base AlertInfo color.
         );
 
@@ -1030,18 +1000,12 @@ mod theme_tests {
 
         let style = mytheme.as_style(Meaning::Guidance);
 
-        assert_eq!(
-            style.fg,
-            Some(Color::Rgb(255, 255, 255))
-        );
+        assert_eq!(style.fg, Some(Color::Rgb(255, 255, 255)));
 
         assert_eq!(style.bg, None);
         assert_eq!(style.underline_color, None);
 
-        assert_eq!(
-            style.add_modifier,
-            Modifier::BOLD | Modifier::RAPID_BLINK
-        );
+        assert_eq!(style.add_modifier, Modifier::BOLD | Modifier::RAPID_BLINK);
     }
 
     #[test]

--- a/crates/atuin-client/src/theme.rs
+++ b/crates/atuin-client/src/theme.rs
@@ -5,6 +5,7 @@ use serde::{Deserialize, Serialize};
 use serde_json;
 use std::collections::HashMap;
 use std::error;
+use std::fmt;
 use std::io::{Error, ErrorKind};
 use std::path::PathBuf;
 use std::sync::LazyLock;
@@ -22,15 +23,58 @@ static DEFAULT_MAX_DEPTH: u8 = 10;
 )]
 #[strum(serialize_all = "camel_case")]
 pub enum Meaning {
+    /**
+     * Log-level style fallbacks. These should underlie most
+     * meanings, if not Base.
+     */
+    /* - General info, equivalent to an INFO log-level */
     AlertInfo,
+    /* - General warning, equivalent to a WARN log-level */
     AlertWarn,
+    /* - General error, equivalent to an ERROR log-level */
     AlertError,
+
+    /**
+     * Behavioural meanings. These should be used in preference
+     * to non-semantic names.
+     */
     Annotation,
     Base,
     Guidance,
     Important,
     Title,
     Muted,
+    Match,
+    Highlight,
+    Selection,
+    Failure,
+    Success,
+    Footnote,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct StyleBlock {
+    pub foreground_color: Option<String>,
+    pub background_color: Option<String>,
+    pub underline_color: Option<String>,
+    pub attributes: Option<Vec<String>>,
+}
+
+impl fmt::Display for StyleBlock {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "{}",
+            serde_json::to_string(&self).map_err(|_| std::fmt::Error)?
+        )
+    }
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged)]
+pub enum StyleExpression {
+    String(String),
+    StyleBlock(StyleBlock),
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -38,8 +82,9 @@ pub struct ThemeConfig {
     // Definition of the theme
     pub theme: ThemeDefinitionConfigBlock,
 
-    // Colors
-    pub colors: HashMap<Meaning, String>,
+    // DEPRECATED: Colors
+    pub colors: Option<HashMap<Meaning, StyleExpression>>,
+    pub styles: Option<HashMap<Meaning, StyleExpression>>,
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -93,10 +138,41 @@ impl Theme {
         parent: Option<String>,
         styles: HashMap<Meaning, ContentStyle>,
     ) -> Theme {
-        Theme {
+        let mut theme = Theme {
             name,
             parent,
             styles,
+        };
+        theme.initialize_styles();
+        theme
+    }
+
+    fn initialize_styles(&mut self) {
+        let mut updates = Vec::new();
+        for (key, style) in self.styles.iter() {
+            if style.foreground_color.is_none() {
+                // In the event that we have an attribute-only style,
+                // this allows us to fallback to a meaning color that might be
+                // defined in the theme. Note that this is _not_ falling back
+                // to a parent, but to a different meaning.
+                // It might seem desirable to allow falling back to a parent
+                // theme - e.g. the child has the parent's AlertInfo, but bold
+                // but in reality, the theme writer can handle this (they know
+                // the parent theme), but falling back to another meaning, lets
+                // us derive new Meanings as bold/italic variations on well-known
+                // (and used) Meanings.
+                // TODO: how to properly provide debugging here?
+                if let Some(fallback) = MEANING_FALLBACKS.get(key)
+                    && let Some(color) = self.as_style(*fallback).foreground_color
+                {
+                    let new_style =
+                        StyleFactory::from_fg_color_and_attributes(color, style.attributes);
+                    updates.push((*key, new_style));
+                }
+            }
+        }
+        for (key, style) in updates.into_iter() {
+            self.styles.insert(key, style);
         }
     }
 
@@ -120,20 +196,31 @@ impl Theme {
     // but we do not have this on in general, as it could print unfiltered text to the terminal
     // from a theme TOML file. However, it will always return a theme, falling back to
     // defaults on error, so that a TOML file does not break loading
-    pub fn from_foreground_colors(
+    pub fn from_styles(
         name: String,
         parent: Option<&Theme>,
-        foreground_colors: HashMap<Meaning, String>,
+        foreground_colors: HashMap<Meaning, StyleExpression>,
         debug: bool,
     ) -> Theme {
         let styles: HashMap<Meaning, ContentStyle> = foreground_colors
             .iter()
-            .map(|(name, color)| {
+            .map(|(name, style)| {
+                let style_block = match style {
+                    StyleExpression::String(color_name) => {
+                        StyleBlock {
+                            foreground_color: Some(color_name.clone()),
+                            background_color: None,
+                            underline_color: None,
+                            attributes: None
+                        }
+                    },
+                    StyleExpression::StyleBlock(block) => block.clone()
+                };
                 (
                     *name,
-                    StyleFactory::from_fg_string(color).unwrap_or_else(|err| {
+                    StyleFactory::from_style_block(style_block.clone()).unwrap_or_else(|err| {
                         if debug {
-                            log::warn!("Tried to load string as a color unsuccessfully: ({name}={color}) {err}");
+                            log::warn!("Tried to load style as a style block unsuccessfully: ({name}={style_block}) {err}");
                         }
                         ContentStyle::default()
                     }),
@@ -164,8 +251,53 @@ impl Theme {
     }
 }
 
+pub struct StyleFactory {}
+
+impl StyleFactory {
 // Use palette to get a color from a string name, if possible
-fn from_string(name: &str) -> Result<Color, String> {
+    fn from_style_block(block: StyleBlock) -> Result<ContentStyle, String> {
+        let content_style = ContentStyle {
+            foreground_color: match block.foreground_color {
+                Some(fg) => Some(StyleFactory::from_color_string(fg.as_str())?),
+                _ => None,
+            },
+            background_color: match block.background_color {
+                Some(bg) => Some(StyleFactory::from_color_string(bg.as_str())?),
+                _ => None,
+            },
+            underline_color: match block.underline_color {
+                Some(ul) => Some(StyleFactory::from_color_string(ul.as_str())?),
+                _ => None,
+            },
+            attributes: match block.attributes {
+                Some(avec) => {
+                    let attrs: Vec<Attribute> = avec
+                        .iter()
+                        .map(|av| StyleFactory::from_attribute_string(av.as_str()))
+                        .collect::<Result<Vec<Attribute>, String>>()?;
+                    attrs.iter().fold(
+                        Attributes::default(),
+                        |mut acc: Attributes, a: &Attribute| {
+                            acc.set(*a);
+                            acc
+                        },
+                    )
+                }
+                _ => Attributes::default(),
+            },
+        };
+        Ok(content_style)
+    }
+
+    fn from_attribute_string(name: &str) -> Result<Attribute, String> {
+        if name.is_empty() {
+            return Err("Empty string".into());
+        }
+        serde_json::from_str::<Attribute>(format!("\"{}\"", name).as_str())
+            .map_err(|_| format!("Could not convert attribute name {name} to Crossterm attribute (use SGR names, not numbers)"))
+    }
+
+    fn from_color_string(name: &str) -> Result<Color, String> {
     if name.is_empty() {
         return Err("Empty string".into());
     }
@@ -206,20 +338,10 @@ fn from_string(name: &str) -> Result<Color, String> {
     }
 }
 
-pub struct StyleFactory {}
-
-impl StyleFactory {
-    fn from_fg_string(name: &str) -> Result<ContentStyle, String> {
-        match from_string(name) {
-            Ok(color) => Ok(Self::from_fg_color(color)),
-            Err(err) => Err(err),
-        }
-    }
-
     // For succinctness, if we are confident that the name will be known,
     // this routine is available to keep the code readable
     fn known_fg_string(name: &str) -> ContentStyle {
-        Self::from_fg_string(name).unwrap()
+        StyleFactory::from_fg_color(StyleFactory::from_color_string(name).unwrap())
     }
 
     fn from_fg_color(color: Color) -> ContentStyle {
@@ -232,6 +354,14 @@ impl StyleFactory {
     fn from_fg_color_and_attributes(color: Color, attributes: Attributes) -> ContentStyle {
         ContentStyle {
             foreground_color: Some(color),
+            attributes,
+            ..ContentStyle::default()
+        }
+    }
+
+    fn from_attributes_only(attributes: Attributes) -> ContentStyle {
+        ContentStyle {
+            foreground_color: None,
             attributes,
             ..ContentStyle::default()
         }
@@ -254,6 +384,12 @@ static MEANING_FALLBACKS: LazyLock<HashMap<Meaning, Meaning>> = LazyLock::new(||
         (Meaning::Guidance, Meaning::AlertInfo),
         (Meaning::Annotation, Meaning::AlertInfo),
         (Meaning::Title, Meaning::Important),
+            (Meaning::Selection, Meaning::AlertError),
+            (Meaning::Match, Meaning::Base),
+            (Meaning::Footnote, Meaning::Base),
+            (Meaning::Highlight, Meaning::AlertWarn),
+            (Meaning::Failure, Meaning::AlertError),
+            (Meaning::Success, Meaning::AlertInfo),
     ])
 });
 
@@ -289,6 +425,14 @@ static DEFAULT_THEME: LazyLock<Theme> = LazyLock::new(|| {
                     Attributes::from(Attribute::Bold),
                 ),
             ),
+                (
+                    Meaning::Highlight,
+                    StyleFactory::from_attributes_only(Attributes::from(Attribute::Bold)),
+                ),
+                (
+                    Meaning::Match,
+                    StyleFactory::from_attributes_only(Attributes::from(Attribute::Bold)),
+                ),
             (Meaning::Muted, StyleFactory::from_fg_color(Color::Grey)),
             (Meaning::Base, ContentStyle::default()),
         ]),
@@ -444,7 +588,25 @@ impl ThemeManager {
                 )));
             }
         };
-        let colors: HashMap<Meaning, String> = theme_config.colors;
+        let mut styles: Option<HashMap<Meaning, StyleExpression>> = None;
+        if let Some(colors) = theme_config.colors {
+            if debug {
+                log::warn!(
+                    "Your theme {} has the deprecated `colors` key, you should change this to `styles`.",
+                    theme_config.theme.name
+                );
+            }
+            styles = Some(colors);
+        }
+        if let Some(sty) = theme_config.styles {
+            if styles.is_some() {
+                return Err(Box::new(Error::new(
+                    ErrorKind::InvalidInput,
+                    "Only specify the `styles` block, not also `colors`.",
+                )));
+            }
+            styles = Some(sty);
+        }
         let parent: Option<&Theme> = match theme_config.theme.parent {
             Some(parent_name) => {
                 if max_depth == 0 {
@@ -466,11 +628,18 @@ impl ThemeManager {
             );
         }
 
-        let theme = Theme::from_foreground_colors(theme_config.theme.name, parent, colors, debug);
+        if let Some(styles) = styles {
+            let theme = Theme::from_styles(theme_config.theme.name, parent, styles, debug);
         let name = name.to_string();
         self.loaded_themes.insert(name.clone(), theme);
         let theme = self.loaded_themes.get(&name).unwrap();
         Ok(theme)
+        } else {
+            Err(Box::new(Error::new(
+                ErrorKind::InvalidInput,
+                "You forgot to supply a `styles` block for your theme.",
+            )))
+        }
     }
 
     // Check if the requested theme is loaded and, if not, then attempt to get it
@@ -503,7 +672,7 @@ mod theme_tests {
         let theme = manager.load_theme("autumn", None);
         assert_eq!(
             theme.as_style(Meaning::Guidance).foreground_color,
-            from_string("brown").ok()
+            StyleFactory::from_color_string("brown").ok()
         );
     }
 
@@ -522,7 +691,7 @@ mod theme_tests {
         let theme = manager.load_theme("mytheme", None);
         assert_eq!(
             theme.as_style(Meaning::AlertError).foreground_color,
-            from_string("yellowgreen").ok()
+            StyleFactory::from_color_string("yellowgreen").ok()
         );
     }
 
@@ -555,7 +724,7 @@ mod theme_tests {
         // Correctly picks overridden color.
         assert_eq!(
             theme.as_style(Meaning::Guidance).foreground_color,
-            from_string("white").ok()
+            StyleFactory::from_color_string("white").ok()
         );
 
         // Does not fall back to any color.
@@ -654,7 +823,7 @@ mod theme_tests {
             solarized_theme
                 .as_style(Meaning::AlertInfo)
                 .foreground_color,
-            from_string("pink").ok()
+            StyleFactory::from_color_string("pink").ok()
         );
 
         // Then we introduce a derived theme
@@ -681,7 +850,7 @@ mod theme_tests {
             unsolarized_theme
                 .as_style(Meaning::AlertInfo)
                 .foreground_color,
-            from_string("red").ok()
+            StyleFactory::from_color_string("red").ok()
         );
 
         // ...or fall back to the parent
@@ -689,7 +858,7 @@ mod theme_tests {
             unsolarized_theme
                 .as_style(Meaning::Guidance)
                 .foreground_color,
-            from_string("white").ok()
+            StyleFactory::from_color_string("white").ok()
         );
 
         testing_logger::validate(|captured_logs| assert_eq!(captured_logs.len(), 0));
@@ -718,7 +887,7 @@ mod theme_tests {
             nunsolarized_theme
                 .as_style(Meaning::Guidance)
                 .foreground_color,
-            None
+            Some(Color::Rgb { r: 255, g: 0, b: 0 }) // The base AlertInfo color.
         );
 
         testing_logger::validate(|captured_logs| {
@@ -755,17 +924,22 @@ mod theme_tests {
                 .unwrap();
             testing_logger::validate(|captured_logs| {
                 if *debug {
-                    assert_eq!(captured_logs.len(), 2);
+                    assert_eq!(captured_logs.len(), 3);
                     assert_eq!(
                         captured_logs[0].body,
-                        "Your theme config name is not the name of your loaded theme config_theme != mytheme"
+                        "Your theme mytheme has the deprecated `colors` key, you should change this to `styles`."
                     );
                     assert_eq!(captured_logs[0].level, log::Level::Warn);
                     assert_eq!(
                         captured_logs[1].body,
-                        "Tried to load string as a color unsuccessfully: (AlertInfo=xinetic) No such color in palette"
+                        "Your theme config name is not the name of your loaded theme config_theme != mytheme"
                     );
-                    assert_eq!(captured_logs[1].level, log::Level::Warn)
+                    assert_eq!(captured_logs[1].level, log::Level::Warn);
+                    assert_eq!(
+                        captured_logs[2].body,
+                        "Tried to load style as a style block unsuccessfully: (AlertInfo={\"foreground_color\":\"xinetic\",\"background_color\":null,\"underline_color\":null,\"attributes\":null}) No such color in palette"
+                    );
+                    assert_eq!(captured_logs[2].level, log::Level::Warn)
                 } else {
                     assert_eq!(captured_logs.len(), 0)
                 }
@@ -776,7 +950,7 @@ mod theme_tests {
     #[test]
     fn test_can_parse_color_strings_correctly() {
         assert_eq!(
-            from_string("brown").unwrap(),
+            StyleFactory::from_color_string("brown").unwrap(),
             Color::Rgb {
                 r: 165,
                 g: 42,
@@ -784,16 +958,22 @@ mod theme_tests {
             }
         );
 
-        assert_eq!(from_string(""), Err("Empty string".into()));
+        assert_eq!(
+            StyleFactory::from_color_string(""),
+            Err("Empty string".into())
+        );
 
         ["manatee", "caput mortuum", "123456"]
             .iter()
             .for_each(|inp| {
-                assert_eq!(from_string(inp), Err("No such color in palette".into()));
+                assert_eq!(
+                    StyleFactory::from_color_string(inp),
+                    Err("No such color in palette".into())
+                );
             });
 
         assert_eq!(
-            from_string("#ff1122").unwrap(),
+            StyleFactory::from_color_string("#ff1122").unwrap(),
             Color::Rgb {
                 r: 255,
                 g: 17,
@@ -802,30 +982,126 @@ mod theme_tests {
         );
         ["#1122", "#ffaa112", "#brown"].iter().for_each(|inp| {
             assert_eq!(
-                from_string(inp),
+                StyleFactory::from_color_string(inp),
                 Err("Could not parse 3 hex values from string".into())
             );
         });
 
-        assert_eq!(from_string("@dark_grey").unwrap(), Color::DarkGrey);
         assert_eq!(
-            from_string("@rgb_(255,255,255)").unwrap(),
+            StyleFactory::from_color_string("@dark_grey").unwrap(),
+            Color::DarkGrey
+        );
+        assert_eq!(
+            StyleFactory::from_color_string("@rgb_(255,255,255)").unwrap(),
             Color::Rgb {
                 r: 255,
                 g: 255,
                 b: 255
             }
         );
-        assert_eq!(from_string("@ansi_(255)").unwrap(), Color::AnsiValue(255));
+        assert_eq!(
+            StyleFactory::from_color_string("@ansi_(255)").unwrap(),
+            Color::AnsiValue(255)
+        );
         ["@", "@DarkGray", "@Dark 4ay", "@ansi(256)"]
             .iter()
             .for_each(|inp| {
                 assert_eq!(
-                    from_string(inp),
+                    StyleFactory::from_color_string(inp),
                     Err(format!(
                         "Could not convert color name {inp} to Crossterm color"
                     ))
                 );
             });
+    }
+
+    #[test]
+    fn test_can_parse_style_blocks_correctly() {
+        let mut manager = ThemeManager::new(Some(true), Some("".to_string()));
+        let config = Config::builder()
+            .add_source(ConfigFile::from_str(
+                "
+        [theme]
+        name = \"mytheme\"
+
+        [styles]
+        Guidance = { foreground_color = \"white\", attributes = [\"RapidBlink\", \"Bold\"] }
+        ",
+                FileFormat::Toml,
+            ))
+            .build()
+            .unwrap();
+
+        let mytheme = manager
+            .load_theme_from_config("mytheme", config, 1)
+            .unwrap();
+
+        let style = mytheme.as_style(Meaning::Guidance);
+
+        assert_eq!(
+            style.foreground_color,
+            Some(Color::Rgb {
+                r: 255,
+                g: 255,
+                b: 255
+            })
+        );
+
+        assert_eq!(style.background_color, None);
+        assert_eq!(style.underline_color, None);
+
+        assert_eq!(
+            style.attributes,
+            Attributes::from([Attribute::Bold, Attribute::RapidBlink].as_ref())
+        );
+    }
+
+    #[test]
+    fn test_can_fail_gracefully_if_style_blocks_incorrect() {
+        testing_logger::setup();
+        [true, false].iter().for_each(|debug| {
+            let mut manager = ThemeManager::new(Some(*debug), Some("".to_string()));
+            let config = Config::builder()
+                .add_source(ConfigFile::from_str(
+                    "
+            [theme]
+            name = \"mytheme\"
+
+            [styles]
+            Guidance = { foreground_color = \"white\", attributes = [\"RapidBlink\", \"VeryBold\"] }
+            ",
+                    FileFormat::Toml,
+                ))
+                .build()
+                .unwrap();
+
+            let mytheme = manager
+                .load_theme_from_config("mytheme", config, 1)
+                .unwrap();
+
+            let style = mytheme.as_style(Meaning::Guidance);
+
+            // This is dark green because the failing attribute fails the whole block.
+            assert_eq!(style.foreground_color, Some(Color::DarkGreen));
+
+            assert_eq!(style.background_color, None);
+            assert_eq!(style.underline_color, None);
+
+            assert_eq!(style.attributes, Attributes::none());
+
+            testing_logger::validate(|captured_logs| {
+                if *debug {
+                    assert_eq!(captured_logs.len(), 1);
+                    assert_eq!(
+                        captured_logs[0].body,
+                        "Tried to load style as a style block unsuccessfully: (Guidance={\"foreground_color\":\"white\",\"background_color\":null,\"underline_color\":null,\"attributes\":[\"RapidBlink\",\"VeryBold\"]}) Could not convert attribute name VeryBold to Crossterm attribute (use SGR names, not numbers)"
+
+                    );
+                    assert_eq!(captured_logs[0].level, log::Level::Warn);
+                } else {
+                    assert_eq!(captured_logs.len(), 0)
+                }
+            })
+        })
     }
 }

--- a/crates/atuin-client/src/theme.rs
+++ b/crates/atuin-client/src/theme.rs
@@ -98,12 +98,7 @@ pub struct ThemeDefinitionConfigBlock {
 }
 
 use ratatui::{
-    backend::FromCrossterm,
-    buffer::Buffer,
-    crossterm::style,
-    layout::Rect,
-    style::{Modifier, Style, Color},
-    widgets::{Block, StatefulWidget, Widget},
+    style::{Modifier, Style, Color}
 };
 
 // For now, a theme is loaded as a mapping of meanings to colors, but it may be desirable to

--- a/crates/atuin-history/Cargo.toml
+++ b/crates/atuin-history/Cargo.toml
@@ -18,6 +18,7 @@ atuin-client = { path = "../atuin-client", version = "18.16.0-beta.1" }
 
 time = { workspace = true }
 serde = { workspace = true }
+ratatui-crossterm = { workspace = true }
 crossterm = { workspace = true, features = ["use-dev-tty"] }
 unicode-segmentation = "1.11.0"
 

--- a/crates/atuin-history/src/stats.rs
+++ b/crates/atuin-history/src/stats.rs
@@ -179,7 +179,7 @@ pub fn pretty_print(stats: Stats, ngram_size: usize, theme: &Theme) {
         });
 
     for (command, count) in stats.top {
-        let gray = SetForegroundColor(match theme.as_style(Meaning::Muted).foreground_color {
+        let gray = SetForegroundColor(match theme.as_style(Meaning::Muted).fg {
             Some(color) => color,
             None => Color::Grey,
         });
@@ -190,7 +190,7 @@ pub fn pretty_print(stats: Stats, ngram_size: usize, theme: &Theme) {
         print!("[");
         print!(
             "{}",
-            SetForegroundColor(match theme.get_error().foreground_color {
+            SetForegroundColor(match theme.get_error().fg {
                 Some(color) => color,
                 None => Color::Red,
             })
@@ -200,7 +200,7 @@ pub fn pretty_print(stats: Stats, ngram_size: usize, theme: &Theme) {
             if i == 2 {
                 print!(
                     "{}",
-                    SetForegroundColor(match theme.get_warning().foreground_color {
+                    SetForegroundColor(match theme.get_warning().fg {
                         Some(color) => color,
                         None => Color::Yellow,
                     })
@@ -210,7 +210,7 @@ pub fn pretty_print(stats: Stats, ngram_size: usize, theme: &Theme) {
             if i == 5 {
                 print!(
                     "{}",
-                    SetForegroundColor(match theme.get_info().foreground_color {
+                    SetForegroundColor(match theme.get_info().fg {
                         Some(color) => color,
                         None => Color::Green,
                     })

--- a/crates/atuin-history/src/stats.rs
+++ b/crates/atuin-history/src/stats.rs
@@ -1,6 +1,8 @@
 use std::collections::{HashMap, HashSet};
 
 use crossterm::style::{Color, ResetColor, SetAttribute, SetForegroundColor};
+use ratatui_crossterm::IntoCrossterm;
+
 use serde::{Deserialize, Serialize};
 use unicode_segmentation::UnicodeSegmentation;
 
@@ -180,7 +182,7 @@ pub fn pretty_print(stats: Stats, ngram_size: usize, theme: &Theme) {
 
     for (command, count) in stats.top {
         let gray = SetForegroundColor(match theme.as_style(Meaning::Muted).fg {
-            Some(color) => color,
+            Some(color) => color.into_crossterm(),
             None => Color::Grey,
         });
         let bold = SetAttribute(crossterm::style::Attribute::Bold);
@@ -191,7 +193,7 @@ pub fn pretty_print(stats: Stats, ngram_size: usize, theme: &Theme) {
         print!(
             "{}",
             SetForegroundColor(match theme.get_error().fg {
-                Some(color) => color,
+                Some(color) => color.into_crossterm(),
                 None => Color::Red,
             })
         );
@@ -201,7 +203,7 @@ pub fn pretty_print(stats: Stats, ngram_size: usize, theme: &Theme) {
                 print!(
                     "{}",
                     SetForegroundColor(match theme.get_warning().fg {
-                        Some(color) => color,
+                        Some(color) => color.into_crossterm(),
                         None => Color::Yellow,
                     })
                 );
@@ -211,7 +213,7 @@ pub fn pretty_print(stats: Stats, ngram_size: usize, theme: &Theme) {
                 print!(
                     "{}",
                     SetForegroundColor(match theme.get_info().fg {
-                        Some(color) => color,
+                        Some(color) => color.into_crossterm(),
                         None => Color::Green,
                     })
                 );

--- a/crates/atuin/src/command/client/search/history_list.rs
+++ b/crates/atuin/src/command/client/search/history_list.rs
@@ -12,7 +12,6 @@ use itertools::Itertools;
 use ratatui::{
     backend::FromCrossterm,
     buffer::Buffer,
-    crossterm::style,
     layout::Rect,
     style::{Modifier, Style},
     widgets::{Block, StatefulWidget, Widget},
@@ -232,7 +231,7 @@ impl DrawState<'_> {
             let i = self.y as usize + self.state.offset;
             let is_selected = i == self.state.selected();
             let prompt: &str = if is_selected { self.indicator } else { "   " };
-            self.draw(prompt, Style::default());
+            self.draw(prompt, self.theme.as_style(Meaning::Base).into());
             return;
         }
 
@@ -247,14 +246,14 @@ impl DrawState<'_> {
         } else {
             &SLICES[i..i + 3]
         };
-        self.draw(prompt, Style::default());
+        self.draw(prompt, self.theme.as_style(Meaning::Base).into());
     }
 
     fn duration(&mut self, h: &History, width: u16) {
-        let style = self.theme.as_style(if h.success() {
-            Meaning::AlertInfo
+        let status = self.theme.as_style(if h.success() {
+            Meaning::Success
         } else {
-            Meaning::AlertError
+            Meaning::Failure
         });
         let duration = Duration::from_nanos(u64::try_from(h.duration).unwrap_or(0));
         let formatted = format_duration(duration);
@@ -290,8 +289,7 @@ impl DrawState<'_> {
         {
             row_highlighted = true;
             // if not applying alternative highlighting to the whole row, color the command
-            style = self.theme.as_style(Meaning::AlertError);
-            style.attributes.set(style::Attribute::Bold);
+            style = self.theme.as_style(Meaning::Selection);
         }
 
         let highlight_indices = self.history_highlighter.get_highlight_indices(
@@ -318,9 +316,10 @@ impl DrawState<'_> {
                     if row_highlighted {
                         // if the row is highlighted bold is not enough as the whole row is bold
                         // change the color too
-                        style = self.theme.as_style(Meaning::AlertWarn);
+                        style = self.theme.as_style(Meaning::Highlight);
+                    } else {
+                        style = self.theme.as_style(Meaning::Match);
                     }
-                    style.attributes.set(style::Attribute::Bold);
                 }
                 let s = ch.to_string();
                 self.draw(&s, Style::from_crossterm(style));

--- a/crates/atuin/src/command/client/search/history_list.rs
+++ b/crates/atuin/src/command/client/search/history_list.rs
@@ -250,7 +250,7 @@ impl DrawState<'_> {
     }
 
     fn duration(&mut self, h: &History, width: u16) {
-        let status = self.theme.as_style(if h.success() {
+        let style = self.theme.as_style(if h.success() {
             Meaning::Success
         } else {
             Meaning::Failure

--- a/crates/atuin/src/command/client/search/history_list.rs
+++ b/crates/atuin/src/command/client/search/history_list.rs
@@ -10,7 +10,6 @@ use atuin_client::{
 use atuin_common::utils::Escapable as _;
 use itertools::Itertools;
 use ratatui::{
-    backend::FromCrossterm,
     buffer::Buffer,
     layout::Rect,
     style::{Modifier, Style},
@@ -206,7 +205,7 @@ impl DrawState<'_> {
         // Render each configured column
         for (idx, column) in self.columns.iter().enumerate() {
             if idx != 0 {
-                self.draw(" ", Style::from_crossterm(style));
+                self.draw(" ", style);
             }
             let width = if column.expand {
                 expand_width
@@ -231,7 +230,7 @@ impl DrawState<'_> {
             let i = self.y as usize + self.state.offset;
             let is_selected = i == self.state.selected();
             let prompt: &str = if is_selected { self.indicator } else { "   " };
-            self.draw(prompt, self.theme.as_style(Meaning::Base).into());
+            self.draw(prompt, self.theme.as_style(Meaning::Base));
             return;
         }
 
@@ -246,7 +245,7 @@ impl DrawState<'_> {
         } else {
             &SLICES[i..i + 3]
         };
-        self.draw(prompt, self.theme.as_style(Meaning::Base).into());
+        self.draw(prompt, self.theme.as_style(Meaning::Base));
     }
 
     fn duration(&mut self, h: &History, width: u16) {
@@ -260,7 +259,7 @@ impl DrawState<'_> {
         let w = width as usize;
         // Right-align duration within its column width, plus trailing space
         let display = format!("{formatted:>w$}");
-        self.draw(&display, Style::from_crossterm(style));
+        self.draw(&display, style);
     }
 
     fn time(&mut self, h: &History, width: u16) {
@@ -279,7 +278,7 @@ impl DrawState<'_> {
         let time_str = format!("{time} ago");
 
         let display = format!("{time_str:>w$}");
-        self.draw(&display, Style::from_crossterm(style));
+        self.draw(&display, style);
     }
 
     fn command(&mut self, h: &History) {
@@ -303,7 +302,7 @@ impl DrawState<'_> {
         let mut pos = 0;
         for section in h.command.escape_control().split_ascii_whitespace() {
             if pos != 0 {
-                self.draw(" ", Style::from_crossterm(style));
+                self.draw(" ", style);
             }
             for ch in section.chars() {
                 if self.x > self.list_area.width {
@@ -322,7 +321,7 @@ impl DrawState<'_> {
                     }
                 }
                 let s = ch.to_string();
-                self.draw(&s, Style::from_crossterm(style));
+                self.draw(&s, style);
                 pos += s.len();
             }
             pos += 1;
@@ -342,7 +341,7 @@ impl DrawState<'_> {
             .unwrap_or_else(|_| "????-??-?? ??:??".to_string());
         let w = width as usize;
         let display = format!("{formatted:w$}");
-        self.draw(&display, Style::from_crossterm(style));
+        self.draw(&display, style);
     }
 
     /// Render the directory column (working directory, truncated)
@@ -359,7 +358,7 @@ impl DrawState<'_> {
         } else {
             format!("{cwd:w$}")
         };
-        self.draw(&display, Style::from_crossterm(style));
+        self.draw(&display, style);
     }
 
     /// Render the host column (just the hostname)
@@ -376,7 +375,7 @@ impl DrawState<'_> {
         } else {
             format!("{host:w$}")
         };
-        self.draw(&display, Style::from_crossterm(style));
+        self.draw(&display, style);
     }
 
     /// Render the user column
@@ -393,7 +392,7 @@ impl DrawState<'_> {
         } else {
             format!("{user:w$}")
         };
-        self.draw(&display, Style::from_crossterm(style));
+        self.draw(&display, style);
     }
 
     /// Render the exit code column
@@ -405,7 +404,7 @@ impl DrawState<'_> {
         };
         let w = width as usize;
         let display = format!("{:>w$}", h.exit);
-        self.draw(&display, Style::from_crossterm(style));
+        self.draw(&display, style);
     }
 
     fn draw(&mut self, s: &str, mut style: Style) {

--- a/crates/atuin/src/command/client/search/inspector.rs
+++ b/crates/atuin/src/command/client/search/inspector.rs
@@ -7,7 +7,6 @@ use atuin_client::{
 };
 use ratatui::{
     Frame,
-    backend::FromCrossterm,
     layout::Rect,
     prelude::{Constraint, Direction, Layout},
     style::Style,
@@ -56,16 +55,16 @@ pub fn draw_commands(
 
     let command = Paragraph::new(Text::from(Span::styled(
         history.command.clone(),
-        Style::from_crossterm(theme.as_style(Meaning::Important)),
+        theme.as_style(Meaning::Important),
     )))
     .block(if compact {
         Block::new()
             .borders(Borders::NONE)
-            .style(Style::from_crossterm(theme.as_style(Meaning::Base)))
+            .style(theme.as_style(Meaning::Base))
     } else {
         Block::new()
             .borders(Borders::ALL)
-            .style(Style::from_crossterm(theme.as_style(Meaning::Base)))
+            .style(theme.as_style(Meaning::Base))
             .title("Command")
             .padding(Padding::horizontal(1))
     });
@@ -79,11 +78,11 @@ pub fn draw_commands(
     .block(if compact {
         Block::new()
             .borders(Borders::NONE)
-            .style(Style::from_crossterm(theme.as_style(Meaning::Annotation)))
+            .style(theme.as_style(Meaning::Annotation))
     } else {
         Block::new()
             .borders(Borders::ALL)
-            .style(Style::from_crossterm(theme.as_style(Meaning::Annotation)))
+            .style(theme.as_style(Meaning::Annotation))
             .title("Previous command")
             .padding(Padding::horizontal(1))
     });
@@ -99,13 +98,13 @@ pub fn draw_commands(
     .block(if compact {
         Block::new()
             .borders(Borders::NONE)
-            .style(Style::from_crossterm(theme.as_style(Meaning::Annotation)))
+            .style(theme.as_style(Meaning::Annotation))
     } else {
         Block::new()
             .borders(Borders::ALL)
             .title("Next command")
             .padding(Padding::horizontal(1))
-            .style(Style::from_crossterm(theme.as_style(Meaning::Annotation)))
+            .style(theme.as_style(Meaning::Annotation))
     });
 
     f.render_widget(previous, commands[0]);
@@ -149,7 +148,7 @@ pub fn draw_stats_table(
         Block::default()
             .title("Command stats")
             .borders(Borders::ALL)
-            .style(Style::from_crossterm(theme.as_style(Meaning::Base)))
+            .style(theme.as_style(Meaning::Base))
             .padding(Padding::vertical(1)),
     );
 
@@ -211,7 +210,7 @@ fn draw_stats_charts(f: &mut Frame<'_>, parent: Rect, stats: &HistoryStats, them
         .block(
             Block::default()
                 .title("Exit code distribution")
-                .style(Style::from_crossterm(theme.as_style(Meaning::Base)))
+                .style(theme.as_style(Meaning::Base))
                 .borders(Borders::ALL),
         )
         .bar_width(3)
@@ -235,7 +234,7 @@ fn draw_stats_charts(f: &mut Frame<'_>, parent: Rect, stats: &HistoryStats, them
         .block(
             Block::default()
                 .title("Runs per day")
-                .style(Style::from_crossterm(theme.as_style(Meaning::Base)))
+                .style(theme.as_style(Meaning::Base))
                 .borders(Borders::ALL),
         )
         .bar_width(3)
@@ -261,7 +260,7 @@ fn draw_stats_charts(f: &mut Frame<'_>, parent: Rect, stats: &HistoryStats, them
         .block(
             Block::default()
                 .title("Duration over time")
-                .style(Style::from_crossterm(theme.as_style(Meaning::Base)))
+                .style(theme.as_style(Meaning::Base))
                 .borders(Borders::ALL),
         )
         .bar_width(5)

--- a/crates/atuin/src/command/client/search/interactive.rs
+++ b/crates/atuin/src/command/client/search/interactive.rs
@@ -1285,8 +1285,7 @@ impl State {
                     .border_type(BorderType::Rounded)
                     .title(format!("{:─>width$}", "", width = chunk_width - 2)),
             ),
-            _ => Paragraph::new(command)
-                .style(theme.as_style(Meaning::Annotation)),
+            _ => Paragraph::new(command).style(theme.as_style(Meaning::Annotation)),
         }
     }
 }

--- a/crates/atuin/src/command/client/search/interactive.rs
+++ b/crates/atuin/src/command/client/search/interactive.rs
@@ -905,9 +905,13 @@ impl State {
 
         if show_tabs {
             let tabs = Tabs::new(titles)
-                .block(Block::default().borders(Borders::NONE))
+                .block(
+                    Block::default()
+                        .borders(Borders::NONE)
+                        .style(theme.as_style(Meaning::Base)),
+                )
                 .select(self.tab_index)
-                .style(Style::default())
+                .style(theme.as_style(Meaning::Base))
                 .highlight_style(Style::from_crossterm(theme.as_style(Meaning::Important)));
 
             f.render_widget(tabs, tabs_chunk);
@@ -987,6 +991,7 @@ impl State {
                                 .title(Line::from(" Info ".to_string()))
                                 .title_alignment(Alignment::Center)
                                 .borders(Borders::ALL)
+                                .style(theme.as_style(Meaning::Base))
                                 .padding(Padding::vertical(2)),
                         )
                         .alignment(Alignment::Center);
@@ -1011,7 +1016,7 @@ impl State {
                 // sub-widget for search + for inspector
                 let feedback = Paragraph::new(
                     "The inspector is new - please give feedback (good, or bad) at https://forum.atuin.sh",
-                );
+                ).style(theme.as_style(Meaning::Footnote));
                 f.render_widget(feedback, input_chunk);
 
                 return;
@@ -1061,16 +1066,14 @@ impl State {
     fn draw_preview(
         &self,
         f: &mut Frame,
-        style: StyleState,
+        input: Paragraph,
         input_chunk: Rect,
-        compactness: Compactness,
-        preview_chunk: Rect,
         preview: Paragraph,
-        prefix_width: u16,
+        prefix_width: u16, // TODO: remove this or below
+        preview_chunk: Rect,
+        compactness: Compactness,
     ) {
-        let input = self.build_input(style, prefix_width);
         f.render_widget(input, input_chunk);
-
         f.render_widget(preview, preview_chunk);
 
         let extra_width = UnicodeWidthStr::width(self.search.input.substring());
@@ -1181,6 +1184,7 @@ impl State {
                     results_list.block(
                         Block::default()
                             .borders(Borders::LEFT | Borders::RIGHT)
+                            .style(theme.as_style(Meaning::Base))
                             .border_type(BorderType::Rounded)
                             .title(format!("{:─>width$}", "", width = style.inner_width - 2)),
                     )
@@ -1188,6 +1192,7 @@ impl State {
                     results_list.block(
                         Block::default()
                             .borders(Borders::TOP | Borders::LEFT | Borders::RIGHT)
+                            .style(theme.as_style(Meaning::Base))
                             .border_type(BorderType::Rounded),
                     )
                 }
@@ -1196,7 +1201,7 @@ impl State {
         }
     }
 
-    fn build_input(&self, style: StyleState, prefix_width: u16) -> Paragraph<'_> {
+    fn build_input(&self, style: StyleState, prefix_width: u16, theme: &Theme) -> Paragraph<'_> {
         let (pref, mode) = if self.switched_search_mode {
             (" SRCH:", self.search_mode.as_str())
         } else if self.search.custom_context.is_some() {
@@ -1209,19 +1214,21 @@ impl State {
         // sanity check to ensure we don't exceed the layout limits
         debug_assert!(mode_width >= mode.len(), "mode name '{mode}' is too long!");
         let input = format!("[{pref}{mode:^mode_width$}] {}", self.search.input.as_str());
-        let input = Paragraph::new(input);
+        let input = Paragraph::new(input).style(theme.as_style(Meaning::Base));
         match style.compactness {
             Compactness::Full => {
                 if style.invert {
                     input.block(
                         Block::default()
                             .borders(Borders::LEFT | Borders::RIGHT | Borders::TOP)
+                            .style(theme.as_style(Meaning::Base))
                             .border_type(BorderType::Rounded),
                     )
                 } else {
                     input.block(
                         Block::default()
                             .borders(Borders::LEFT | Borders::RIGHT)
+                            .style(theme.as_style(Meaning::Base))
                             .border_type(BorderType::Rounded)
                             .title(format!("{:─>width$}", "", width = style.inner_width - 2)),
                     )
@@ -1270,6 +1277,7 @@ impl State {
             Compactness::Full => Paragraph::new(command).block(
                 Block::default()
                     .borders(Borders::BOTTOM | Borders::LEFT | Borders::RIGHT)
+                    .style(theme.as_style(Meaning::Base))
                     .border_type(BorderType::Rounded)
                     .title(format!("{:─>width$}", "", width = chunk_width - 2)),
             ),

--- a/crates/atuin/src/command/client/search/interactive.rs
+++ b/crates/atuin/src/command/client/search/interactive.rs
@@ -34,7 +34,7 @@ use crate::{VERSION, command::client::search::engines};
 
 use ratatui::{
     Frame, Terminal, TerminalOptions, Viewport,
-    backend::{CrosstermBackend, FromCrossterm},
+    backend::CrosstermBackend,
     crossterm::{
         cursor::SetCursorStyle,
         event::{self, Event, KeyEvent, MouseEvent},
@@ -912,7 +912,7 @@ impl State {
                 )
                 .select(self.tab_index)
                 .style(theme.as_style(Meaning::Base))
-                .highlight_style(Style::from_crossterm(theme.as_style(Meaning::Important)));
+                .highlight_style(theme.as_style(Meaning::Important));
 
             f.render_widget(tabs, tabs_chunk);
         }
@@ -1058,6 +1058,7 @@ impl State {
                 preview_chunk,
                 preview,
                 std::cmp::max(prefix_width, min_prefix_width),
+                theme,
             );
         }
     }
@@ -1066,14 +1067,17 @@ impl State {
     fn draw_preview(
         &self,
         f: &mut Frame,
-        input: Paragraph,
+        style: StyleState,
         input_chunk: Rect,
-        preview: Paragraph,
-        prefix_width: u16, // TODO: remove this or below
-        preview_chunk: Rect,
         compactness: Compactness,
+        preview_chunk: Rect,
+        preview: Paragraph,
+        prefix_width: u16,
+        theme: &Theme,
     ) {
+        let input = self.build_input(style, prefix_width, theme);
         f.render_widget(input, input_chunk);
+
         f.render_widget(preview, preview_chunk);
 
         let extra_width = UnicodeWidthStr::width(self.search.input.substring());
@@ -1091,13 +1095,13 @@ impl State {
 
     fn build_title(&self, theme: &Theme) -> Paragraph<'_> {
         let title = if self.update_needed.is_some() {
-            let error_style: Style = Style::from_crossterm(theme.get_error());
+            let error_style: Style = theme.get_error();
             Paragraph::new(Text::from(Span::styled(
                 format!("Atuin v{VERSION} - UPDATE"),
                 error_style.add_modifier(Modifier::BOLD),
             )))
         } else {
-            let style: Style = Style::from_crossterm(theme.as_style(Meaning::Base));
+            let style: Style = theme.as_style(Meaning::Base);
             Paragraph::new(Text::from(Span::styled(
                 format!("Atuin v{VERSION}"),
                 style.add_modifier(Modifier::BOLD),
@@ -1141,7 +1145,7 @@ impl State {
 
             _ => unreachable!("invalid tab index"),
         }
-        .style(Style::from_crossterm(theme.as_style(Meaning::Annotation)))
+        .style(theme.as_style(Meaning::Annotation))
         .alignment(Alignment::Center)
     }
 
@@ -1150,7 +1154,7 @@ impl State {
             "history count: {}",
             self.history_count,
         ))))
-        .style(Style::from_crossterm(theme.as_style(Meaning::Annotation)))
+        .style(theme.as_style(Meaning::Annotation))
         .alignment(Alignment::Right)
     }
 
@@ -1282,7 +1286,7 @@ impl State {
                     .title(format!("{:─>width$}", "", width = chunk_width - 2)),
             ),
             _ => Paragraph::new(command)
-                .style(Style::from_crossterm(theme.as_style(Meaning::Annotation))),
+                .style(theme.as_style(Meaning::Annotation)),
         }
     }
 }


### PR DESCRIPTION
Introduces a range of enhancement for themes:

 - new meanings: Match, Highlight, Selection, Failure, Success, Footnote
 - greater styling coverage
 - ability to express attributes, not just colours (also therefore underline and background colours)
 - _partial, restricted_ support for attribute-only fallback definitions (e.g. Highlight=AlertWarn+Bold by default)
 - deprecates `[colors]` in favour of `[styles]` in theme config

Attributes can be expressed as described [in Crossterm's documentation](https://docs.rs/crossterm/latest/crossterm/style/enum.Attribute.html). Bear in mind that, right now, general fallbacks/overrides are whole-style, i.e. if you subtheme you must override everything for that meaning or nothing, so you can say you want to inherit Selection from the parent theme (by omitting it in your theme file), or you want Selection to be blue and bold (by being explicit), but you can't say you want Selection to be bolded with its default colour.

https://github.com/user-attachments/assets/2c3a8bf0-6579-4c17-b52f-dc5590277091

Showing this to demonstrate the [SGR](https://en.wikipedia.org/wiki/ANSI_escape_code#Select_Graphic_Rendition_parameters) parameters work, but for everyone's sake, please don't use blinking text. Also, not all of these work on every terminal, and there is no fallback mechanism (other than decided by the terminal).

I am thinking of including the debug logging fixes that are not yet integrated into this PR, if @ellie reckons that is a good plan? (they are fairly small and I have used the old debug approach for a couple new lines here).

## Checks
- [x] I am happy for maintainers to push small adjustments to this PR, to speed up the review cycle
- [x] I have checked that there are no existing pull requests for the same thing
