### PR TITLE
fix: prevent interactive search crash when update check fails

### DIFF
--- a/crates/atuin/src/command/client/search/interactive.rs
+++ b/crates/atuin/src/command/client/search/interactive.rs
@@ -1355,7 +1355,9 @@ pub async fn history(
                 }
             }
             update_needed = &mut update_needed => {
-                app.update_needed = update_needed?;
+                // Don't fail interactive search if update check fails
+                // The update check is a nice-to-have feature, not critical
+                app.update_needed = update_needed.ok().flatten();
             }
         }
 


### PR DESCRIPTION
Relates to #2520 - Gracefully handle update check failures instead of crashing the entire interactive search UI.

## Checks
- [x] I am happy for maintainers to push small adjustments to this PR, to speed up the review cycle
- [x] I have checked that there are no existing pull requests for the same thing
