### PR TITLE
feat: allow disabling sync v1

### DIFF
--- a/crates/atuin-server/server.toml
+++ b/crates/atuin-server/server.toml
@@ -37,3 +37,7 @@
 # enable = false
 # cert_path = ""
 # pkey_path = ""
+
+## Enable legacy sync v1 routes (history-based sync)
+## Set to false to disable and use only the newer record-based sync
+# sync_v1_enabled = true

--- a/crates/atuin-server/src/router.rs
+++ b/crates/atuin-server/src/router.rs
@@ -109,15 +109,22 @@ pub struct AppState<DB: Database> {
 }
 
 pub fn router<DB: Database>(database: DB, settings: Settings) -> Router {
-    let routes = Router::new()
+    let mut routes = Router::new()
         .route("/", get(handlers::index))
-        .route("/healthz", get(handlers::health::health_check))
-        .route("/sync/count", get(handlers::history::count))
-        .route("/sync/history", get(handlers::history::list))
-        .route("/sync/calendar/:focus", get(handlers::history::calendar))
-        .route("/sync/status", get(handlers::status::status))
-        .route("/history", post(handlers::history::add))
-        .route("/history", delete(handlers::history::delete))
+        .route("/healthz", get(handlers::health::health_check));
+
+    // Sync v1 routes - can be disabled in favor of record-based sync
+    if settings.sync_v1_enabled {
+        routes = routes
+            .route("/sync/count", get(handlers::history::count))
+            .route("/sync/history", get(handlers::history::list))
+            .route("/sync/calendar/:focus", get(handlers::history::calendar))
+            .route("/sync/status", get(handlers::status::status))
+            .route("/history", post(handlers::history::add))
+            .route("/history", delete(handlers::history::delete));
+    }
+
+    let routes = routes
         .route("/user/:username", get(handlers::user::get))
         .route("/account", delete(handlers::user::delete))
         .route("/account/password", patch(handlers::user::change_password))

--- a/crates/atuin-server/src/settings.rs
+++ b/crates/atuin-server/src/settings.rs
@@ -68,6 +68,10 @@ pub struct Settings {
     pub tls: Tls,
     pub mail: Mail,
 
+    /// Enable legacy sync v1 routes (history-based sync)
+    /// Set to false to use only the newer record-based sync
+    pub sync_v1_enabled: bool,
+
     /// Advertise a version that is not what we are _actually_ running
     /// Many clients compare their version with api.atuin.sh, and if they differ, notify the user
     /// that an update is available.
@@ -109,6 +113,7 @@ impl Settings {
             .set_default("tls.enable", false)?
             .set_default("tls.cert_path", "")?
             .set_default("tls.pkey_path", "")?
+            .set_default("sync_v1_enabled", true)?
             .add_source(
                 Environment::with_prefix("atuin")
                     .prefix_separator("_")

--- a/crates/atuin/tests/common/mod.rs
+++ b/crates/atuin/tests/common/mod.rs
@@ -30,6 +30,7 @@ pub async fn start_server(path: &str) -> (String, oneshot::Sender<()>, JoinHandl
         host: "127.0.0.1".to_owned(),
         port: 0,
         path: path.to_owned(),
+        sync_v1_enabled: true,
         open_registration: true,
         max_history_length: 8192,
         max_record_size: 1024 * 1024 * 1024,


### PR DESCRIPTION
It takes up a very large amount of our query time, despite having been replaced for >1yr now. We will be dropping support for it on atuin hub