### PR TITLE
fix(powershell): run `atuin history end` in the background

### DIFF
--- a/crates/atuin/src/shell/atuin.ps1
+++ b/crates/atuin/src/shell/atuin.ps1
@@ -59,9 +59,11 @@ New-Module -Name Atuin -ScriptBlock {
             $process.StartInfo.CreateNoWindow = $true
             $process.StartInfo.RedirectStandardInput = $true
             $process.StartInfo.RedirectStandardOutput = $true
+            $process.StartInfo.RedirectStandardError = $true
             $process.Start() | Out-Null
             $process.StandardInput.Close()
             $process.BeginOutputReadLine()
+            $process.BeginErrorReadLine()
 
             $script:atuinHistoryId = $null
         }


### PR DESCRIPTION
This runs `atuin history end` in the background, since it could delay the next prompt when syncing.

Sorry I didn't realize this command could be slow (I currently don't use sync).

I went for the .NET [`Process` class](https://learn.microsoft.com/en-us/dotnet/api/system.diagnostics.process), which is not pretty, but the other solutions I thought about all had their own issues (`Start-Process` needs a file to redirect the output so you can't just ignore it, `Start-Job` creates job objects that will linger, `&` does the same but doesn't work on PS 5.1, ...). I'm surprised I couldn't find a nice way to do the equivalent of `command & >/dev/null` in PowerShell. 😕 

This replaces #3033

## Checks
- [x] I am happy for maintainers to push small adjustments to this PR, to speed up the review cycle
- [x] I have checked that there are no existing pull requests for the same thing
