### PR TITLE
feat(client): add scope_boost config to prioritize results by scope hierarchy

### DIFF
--- a/crates/atuin-client/config.toml
+++ b/crates/atuin-client/config.toml
@@ -163,6 +163,11 @@ enter_accept = true
 ## Defaults to false. If enabled, when triggered after &&, || or |, Atuin will complete commands to chain rather than replace the current line.
 # command_chaining = false
 
+## Defaults to false. If enabled, search results are reordered by scope priority:
+## session (current shell) → directory (current cwd) → host (current machine) → global.
+## This helps when working with multiple terminals by showing the most relevant commands first.
+# scope_boost = false
+
 ## Defaults to "emacs".  This specifies the keymap on the startup of `atuin
 ## search`.  If this is set to "auto", the startup keymap mode in the Atuin
 ## search is automatically selected based on the shell's keymap where the

--- a/crates/atuin-client/src/ordering.rs
+++ b/crates/atuin-client/src/ordering.rs
@@ -1,6 +1,6 @@
 use minspan::minspan;
 
-use super::{history::History, settings::SearchMode};
+use super::{database::Context, history::History, settings::SearchMode};
 
 pub fn reorder_fuzzy(mode: SearchMode, query: &str, res: Vec<History>) -> Vec<History> {
     match mode {
@@ -29,4 +29,144 @@ where
         1 + to - from
     });
     r
+}
+
+/// Scope priority levels from narrowest (most specific) to broadest.
+/// Lower values = higher priority.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+enum ScopePriority {
+    Session = 0,   // Current shell session
+    Directory = 1, // Current working directory
+    Host = 2,      // Current machine
+    Global = 3,    // Everything else
+}
+
+/// Determine the scope priority for a history entry based on current context.
+fn get_scope_priority(history: &History, context: &Context) -> ScopePriority {
+    if history.session == context.session {
+        ScopePriority::Session
+    } else if history.cwd == context.cwd {
+        ScopePriority::Directory
+    } else if history.hostname == context.hostname {
+        ScopePriority::Host
+    } else {
+        ScopePriority::Global
+    }
+}
+
+/// Reorder results by scope priority: session → directory → host → global.
+/// Within each scope tier, the original order (typically by timestamp desc) is preserved.
+pub fn reorder_by_scope_priority(context: &Context, res: Vec<History>) -> Vec<History> {
+    // Group results by scope priority while preserving original order within each tier
+    let mut session: Vec<History> = Vec::new();
+    let mut directory: Vec<History> = Vec::new();
+    let mut host: Vec<History> = Vec::new();
+    let mut global: Vec<History> = Vec::new();
+
+    for h in res {
+        match get_scope_priority(&h, context) {
+            ScopePriority::Session => session.push(h),
+            ScopePriority::Directory => directory.push(h),
+            ScopePriority::Host => host.push(h),
+            ScopePriority::Global => global.push(h),
+        }
+    }
+
+    // Combine in priority order
+    let mut result = session;
+    result.extend(directory);
+    result.extend(host);
+    result.extend(global);
+    result
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use time::OffsetDateTime;
+
+    fn make_history_full(command: &str, session: &str, cwd: &str, hostname: &str) -> History {
+        History::import()
+            .command(command.to_string())
+            .session(session.to_string())
+            .cwd(cwd.to_string())
+            .hostname(hostname.to_string())
+            .timestamp(OffsetDateTime::now_utc())
+            .build()
+            .into()
+    }
+
+    fn make_context() -> Context {
+        Context {
+            session: "current-session".to_string(),
+            cwd: "/home/user/project".to_string(),
+            hostname: "my-host".to_string(),
+            host_id: "host-id-123".to_string(),
+            git_root: None,
+        }
+    }
+
+    #[test]
+    fn test_scope_priority_orders_by_narrowest_first() {
+        let context = make_context();
+        let results = vec![
+            make_history_full("global-cmd", "other-session", "/other/dir", "other-host"),
+            make_history_full("session-cmd", "current-session", "/other/dir", "other-host"),
+            make_history_full("host-cmd", "other-session", "/other/dir", "my-host"),
+            make_history_full(
+                "dir-cmd",
+                "other-session",
+                "/home/user/project",
+                "other-host",
+            ),
+        ];
+
+        let ordered = reorder_by_scope_priority(&context, results);
+
+        // Session first, then directory, then host, then global
+        assert_eq!(ordered[0].command, "session-cmd");
+        assert_eq!(ordered[1].command, "dir-cmd");
+        assert_eq!(ordered[2].command, "host-cmd");
+        assert_eq!(ordered[3].command, "global-cmd");
+    }
+
+    #[test]
+    fn test_scope_priority_preserves_order_within_tier() {
+        let context = make_context();
+        let results = vec![
+            make_history_full("cmd1", "current-session", "/x", "x"),
+            make_history_full("cmd2", "current-session", "/y", "y"),
+            make_history_full("cmd3", "current-session", "/z", "z"),
+        ];
+
+        let ordered = reorder_by_scope_priority(&context, results);
+
+        // All are session scope, so original order preserved
+        assert_eq!(ordered[0].command, "cmd1");
+        assert_eq!(ordered[1].command, "cmd2");
+        assert_eq!(ordered[2].command, "cmd3");
+    }
+
+    #[test]
+    fn test_scope_priority_with_mixed_tiers() {
+        let context = make_context();
+        let results = vec![
+            make_history_full("g1", "x", "/x", "x"), // global
+            make_history_full("s1", "current-session", "/x", "x"), // session
+            make_history_full("h1", "x", "/x", "my-host"), // host
+            make_history_full("d1", "x", "/home/user/project", "x"), // directory
+            make_history_full("g2", "y", "/y", "y"), // global
+            make_history_full("s2", "current-session", "/y", "y"), // session
+        ];
+
+        let ordered = reorder_by_scope_priority(&context, results);
+
+        // Sessions first (in order), then directory, then host, then globals (in order)
+        assert_eq!(ordered[0].command, "s1");
+        assert_eq!(ordered[1].command, "s2");
+        assert_eq!(ordered[2].command, "d1");
+        assert_eq!(ordered[3].command, "h1");
+        assert_eq!(ordered[4].command, "g1");
+        assert_eq!(ordered[5].command, "g2");
+    }
 }

--- a/crates/atuin-client/src/settings.rs
+++ b/crates/atuin-client/src/settings.rs
@@ -504,6 +504,7 @@ pub struct Settings {
     pub local_timeout: f64,
     pub enter_accept: bool,
     pub smart_sort: bool,
+    pub scope_boost: bool,
     pub command_chaining: bool,
 
     #[serde(default)]
@@ -823,6 +824,7 @@ impl Settings {
             .set_default("keymap_mode_shell", "auto")?
             .set_default("keymap_cursor", HashMap::<String, String>::new())?
             .set_default("smart_sort", false)?
+            .set_default("scope_boost", false)?
             .set_default("command_chaining", false)?
             .set_default("store_failed", true)?
             .set_default("daemon.sync_frequency", 300)?


### PR DESCRIPTION
## Summary

This adds a new config option `scope_boost` (default: `false`) that, when enabled, reorders search results by scope priority:

1. **Session** - commands from the current shell session
2. **Directory** - commands run in the current working directory  
3. **Host** - commands run on the current machine
4. **Global** - all other commands

Within each tier, the original timestamp order is preserved.

## Motivation

When working with multiple terminal tabs/windows, pressing up-arrow or searching can show commands from other sessions, directories, or machines that ran more recently, pushing your most contextually relevant commands further down.

With `scope_boost = true`, commands are prioritized by how closely they match your current context, while still showing all global history below.

## Changes

- **[crates/atuin-client/src/ordering.rs](cci:7://file:///Users/julsh/git/atuin/crates/atuin-client/src/ordering.rs:0:0-0:0)**: Added [reorder_by_scope_priority()](cci:1://file:///Users/julsh/git/atuin/crates/atuin-client/src/ordering.rs:56:0-80:1) function with `ScopePriority` enum (Session/Directory/Host/Global)
- **[crates/atuin-client/src/settings.rs](cci:7://file:///Users/julsh/git/atuin/crates/atuin-client/src/settings.rs:0:0-0:0)**: Added `scope_boost: bool` config field with default `false`
- **[crates/atuin/src/command/client/search/interactive.rs](cci:7://file:///Users/julsh/git/atuin/crates/atuin/src/command/client/search/interactive.rs:0:0-0:0)**: Wired up the boost in [query_results()](cci:1://file:///Users/julsh/git/atuin/crates/atuin/src/command/client/search/interactive.rs:142:4-173:5) before smart_sort
- **[crates/atuin-client/config.toml](cci:7://file:///Users/julsh/git/atuin/crates/atuin-client/config.toml:0:0-0:0)**: Added documentation for the new option

## Usage

```toml
# ~/.config/atuin/config.toml
scope_boost = true