### PR TITLE
fix(powershell): add error safety and cleanup

### DIFF
--- a/crates/atuin/src/shell/atuin.ps1
+++ b/crates/atuin/src/shell/atuin.ps1
@@ -47,16 +47,8 @@ New-Module -Name Atuin -ScriptBlock {
     function Set-CommandLine {
         param([string]$Text)
 
-        try {
-            # This needs to be done using Replace, since the ListView prediction style breaks RevertLine: https://github.com/PowerShell/PSReadLine/issues/5047
-            $commandLine = Get-CommandLine
-            [Microsoft.PowerShell.PSConsoleReadLine]::Replace(0, $commandLine.Length, $Text)
-        }
-        catch {
-            # Fallback, just in case.
-            [Microsoft.PowerShell.PSConsoleReadLine]::RevertLine()
-            [Microsoft.PowerShell.PSConsoleReadLine]::Insert($Text)
-        }
+        $commandLine = Get-CommandLine
+        [Microsoft.PowerShell.PSConsoleReadLine]::Replace(0, $commandLine.Length, $Text)
     }
 
     # This function name is called by PSReadLine to read the next command line to execute.


### PR DESCRIPTION
This PR does a few things:

- Includes a fix by @sususu98 (added as co-author):
  - Fix: #3032
  - Issue: https://github.com/PowerShell/PSReadLine/issues/5047
- Adds a couple `catch` blocks for better error safety in `PSConsoleHostReadLine`.
- Allows reloading the Atuin module on v7+ if it's already loaded, which could be useful when updating Atuin.
- Refactors the code to clean it up.

I'll be AFK next week, so I preferred to submit this sooner than later.

Closes #3032

## Checks
- [x] I am happy for maintainers to push small adjustments to this PR, to speed up the review cycle
- [x] I have checked that there are no existing pull requests for the same thing
