### PR TITLE
feat: add session and uuid column support to history list

### DIFF
--- a/crates/atuin/src/command/client/history.rs
+++ b/crates/atuin/src/command/client/history.rs
@@ -85,7 +85,7 @@ pub enum Cmd {
         #[arg(long, visible_alias = "tz")]
         timezone: Option<Timezone>,
 
-        /// Available variables: {command}, {directory}, {duration}, {user}, {host}, {exit} and {time}.
+        /// Available variables: {command}, {directory}, {duration}, {user}, {host}, {exit}, {time}, {session}, and {uuid}
         /// Example: --format "{time} - [{duration}] - {directory}$\t{command}"
         #[arg(long, short)]
         format: Option<String>,
@@ -108,7 +108,7 @@ pub enum Cmd {
         #[arg(long, visible_alias = "tz")]
         timezone: Option<Timezone>,
 
-        /// Available variables: {command}, {directory}, {duration}, {user}, {host} and {time}.
+        /// Available variables: {command}, {directory}, {duration}, {user}, {host}, {time}, {session}, {uuid} and {relativetime}.
         /// Example: --format "{time} - [{duration}] - {directory}$\t{command}"
         #[arg(long, short)]
         format: Option<String>,
@@ -320,6 +320,8 @@ impl FormatKey for FmtHistory<'_> {
                     .split_once(':')
                     .map_or("", |(_, user)| user),
             )?,
+            "session" => f.write_str(&self.history.session)?,
+            "uuid" => f.write_str(&self.history.id.0)?,
             _ => return Err(FormatKeyError::UnknownKey),
         }
         Ok(())


### PR DESCRIPTION
<!-- Thank you for making a PR! Bug fixes are always welcome, but if you're adding a new feature or changing an existing one, we'd really appreciate if you open an issue, post on the forum, or drop in on Discord -->
Hello. Small PR to add two new columns to the command history, the `session` and the `uuid` for the history. Having these identifiers available can help people do more advanced scripting & comprehension of their history.

## Checks
- [x] I am happy for maintainers to push small adjustments to this PR, to speed up the review cycle
- [x] I have checked that there are no existing pull requests for the same thing
