### PR TITLE
Theming: explain how to set ANSI codes directly

### DIFF
--- a/docs/docs/guide/theming.md
+++ b/docs/docs/guide/theming.md
@@ -83,6 +83,17 @@ the following are valid color names:
 * `teal`
 * `powderblue`
 
+You can also express colors through Crossterm-supported strings, prefixed by `@`.
+For example,
+
+* `@ansi_(123)`
+* `@dark_yellow`
+
+While there is not currently an official reference, you can see examples in the
+[crossterm tests](https://docs.rs/crossterm/latest/src/crossterm/style/types/color.rs.html#376).
+As this is passed straight to Crossterm, using [ANSI codes](https://www.ditig.com/256-colors-cheat-sheet)
+can be helpful for ensuring your theme is compatible with 256-color terminals.
+
 A theme file, say `my-theme.toml` can then be built up, such as:
 
 ```toml


### PR DESCRIPTION
**Migrated from atuinsh/docs PR:** https://github.com/atuinsh/docs/pull/109
**Original author:** @philtweir

---

### What is the purpose of this pull request?

Short change to note that there is a supported way of directly setting ANSI codes, and other Crossterm colours, directly using the `@` symbol.

### Why is this relevant?

This could provide a workaround for issues such as https://github.com/atuinsh/atuin/issues/2827, where a 256 colour terminal shows all themes as grey.