### PR TITLE
Add FAQ entry on how to import unsynced atuin history

### DIFF
--- a/docs/docs/faq.md
+++ b/docs/docs/faq.md
@@ -37,3 +37,11 @@ may change soon, but in the meantime so long as you're still logged in on at
 least one account, it's safe to delete and re-create the account.
 
 We're aware this isn't optimal.
+
+## I did not set up sync, and now I have to reinstall my system!
+
+If you have a backup of `~/.local/share/atuin`, you can import it by:
+1. disabling atuin by commenting out the shell integration, e.g. for bash it's `eval "$(atuin init bash)"`
+2. copying the backup to `~/.local/share/atuin`
+3. reenabling atuin
+4. setting up sync!


### PR DESCRIPTION
**Migrated from atuinsh/docs PR:** https://github.com/atuinsh/docs/pull/78
**Original author:** @kzdnk

---

I found myself stuck in this situation, and thought it might be useful to someone else.
Please let me now if this should rather be on the on the discourse forum and I will post it there.

If atuin is not disabled, `~/.local/share/atuin` will be emptied after the copying is finished.