### PR TITLE
feat(ultracompact): Adds setting for ultracompact mode

### DIFF
--- a/docs/docs/configuration/config.md
+++ b/docs/docs/configuration/config.md
@@ -267,6 +267,16 @@ Default: `true`
 
 Configure whether or not to show tabs for search and inspect.
 
+### `auto_hide_height`
+
+Atuin version: >= 18.4
+
+Default: `8`
+
+Set Atuin to hide lines when a minimum number of rows is subceeded. This has no effect except
+when `compact` style is being used (see `style` above), and currently applies to only the
+interactive search and inspector. It can be turned off entirely by setting to `0`.
+
 ### `exit_mode`
 
 Default: `return-original`

--- a/docs/docs/configuration/key-binding.md
+++ b/docs/docs/configuration/key-binding.md
@@ -206,3 +206,6 @@ Open the inspector with ctrl-o
 | Esc      | Close the inspector, returning to the shell   |
 | ctrl+o   | Close the inspector, returning to search view |
 | ctrl+d   | Delete the inspected item from the history    |
+| ↑        | Inspect the previous item in the history      |
+| ↓        | Inspect the next item in the history          |
+| tab      | Select current item and edit                  |

--- a/docs/docs/guide/theming.md
+++ b/docs/docs/guide/theming.md
@@ -20,6 +20,7 @@ Where `THEMENAME` is a known theme. The following themes are available out-of-th
 * default theme (can be explicitly referenced with an empty name `""`)
 * `autumn` theme
 * `marine` theme
+* `(none)` theme (removes all styling)
 
 These are present to ensure users and developers can try out theming, but in general, you
 will need to download themes or make your own.
@@ -99,6 +100,10 @@ Guidance = "#888844"
 where not all of the *Meanings* need to be explicitly defined. If they are absent,
 then the color will be chosen from the parent theme, if one is defined, or if that
 key is missing in the `theme` block, from the default theme.
+
+If the entire named theme is missing, which is inherently an error, then the theme
+will drop to `(none)` and leave Atuin unstyled, rather than trying to fallback to
+the any default, or other, theme.
 
 This theme file should be moved to `~/.config/atuin/themes/my-theme.toml` and the
 following added to `~/.config/atuin/config.toml`:


### PR DESCRIPTION
**Migrated from atuinsh/docs PR:** https://github.com/atuinsh/docs/pull/72
**Original author:** @philtweir

---

### What does this PR do?

Adds the `auto_hide_height` setting to enable/disable/configure ultracompact mode when fewer than a minimum number of lines are available and the `compact` style has been configured. The new keybindings for the inspector are outlined also.

Notes the new `(none)` theme, which will be used for functional code-tests and as a fallback when the requested theme is unloadable.

Corresponds to: https://github.com/atuinsh/atuin/pull/2319