### PR TITLE
docs(config): clarify scope of directory filter_mode

### DIFF
--- a/docs/docs/configuration/config.md
+++ b/docs/docs/configuration/config.md
@@ -144,7 +144,7 @@ The default filter to use when searching
 | global (default) | Search history from all hosts, all sessions, all directories |
 | host             | Search history just from this host                           |
 | session          | Search history just from the current session                 |
-| directory        | Search history just from the current directory               |
+| directory        | Search history just from the current directory (global)      |
 | workspace        | Search history just from the current git repository (>17.0)  |
 
 Filter modes can still be toggled via ctrl-r


### PR DESCRIPTION
Clarify that the directory filter_mode searches across all hosts/sessions, just filtering by directory path.

---

Migrated from https://github.com/atuinsh/docs/pull/67
Original author: @tessarek