### PR TITLE
chore: Add Timezone and restart policy for postgres backup docker

### DIFF
--- a/docs/docs/self-hosting/docker.md
+++ b/docs/docs/self-hosting/docker.md
@@ -54,6 +54,8 @@ services:
       POSTGRES_USER: ${ATUIN_DB_USERNAME}
       POSTGRES_PASSWORD: ${ATUIN_DB_PASSWORD}
       POSTGRES_DB: ${ATUIN_DB_NAME}
+      TZ: Europe/London
+      PGTZ: Europe/London
 ```
 
 Start the services using `docker compose`:
@@ -103,6 +105,7 @@ You can add another service to your `docker-compose.yml` file to have it run dai
 
 ```yaml
   backup:
+    restart: unless-stopped
     container_name: atuin_db_dumper
     image: prodrigestivill/postgres-backup-local
     env_file:
@@ -114,6 +117,8 @@ You can add another service to your `docker-compose.yml` file to have it run dai
       POSTGRES_PASSWORD: ${ATUIN_DB_PASSWORD}
       SCHEDULE: "@daily"
       BACKUP_DIR: /db_dumps
+      TZ: Europe/London
+      HEALTHCHECK_PORT: 5432
     volumes:
       - ./db_dumps:/db_dumps
     depends_on:

--- a/docs/docs/self-hosting/docker.md
+++ b/docs/docs/self-hosting/docker.md
@@ -111,18 +111,17 @@ You can add another service to your `docker-compose.yml` file to have it run dai
     env_file:
       - .env
     environment:
-      POSTGRES_HOST: postgresql
+      POSTGRES_HOST: db
       POSTGRES_DB: ${ATUIN_DB_NAME}
       POSTGRES_USER: ${ATUIN_DB_USERNAME}
       POSTGRES_PASSWORD: ${ATUIN_DB_PASSWORD}
       SCHEDULE: "@daily"
       BACKUP_DIR: /db_dumps
       TZ: Europe/London
-      HEALTHCHECK_PORT: 5432
     volumes:
       - ./db_dumps:/db_dumps
     depends_on:
-      - postgresql
+      - db
 ```
 
 This will create daily backups of your database for that additional layer of comfort.


### PR DESCRIPTION
Add TZ/PGTZ environment variables and restart policy for better reliability of the docker backup setup.

---

Migrated from https://github.com/atuinsh/docs/pull/62
Original author: @mateuscomh