### PR TITLE
feat(search): Bind `Shift` + `Delete` to directly delete selected entry

### DIFF
--- a/crates/atuin/src/command/client/search/interactive.rs
+++ b/crates/atuin/src/command/client/search/interactive.rs
@@ -368,6 +368,7 @@ impl State {
     fn handle_search_input(&mut self, settings: &Settings, input: &KeyEvent) -> InputAction {
         let ctrl = input.modifiers.contains(KeyModifiers::CONTROL);
         let alt = input.modifiers.contains(KeyModifiers::ALT);
+        let shift = input.modifiers.contains(KeyModifiers::SHIFT);
 
         // Use Ctrl-n instead of Alt-n?
         let modfr = if settings.ctrl_n_shortcuts { ctrl } else { alt };
@@ -525,6 +526,9 @@ impl State {
                 .search
                 .input
                 .remove_next_word(&settings.word_chars, settings.word_jump_mode),
+            KeyCode::Delete if shift => {
+                return InputAction::Delete(self.results_state.selected());
+            }
             KeyCode::Delete => {
                 self.search.input.remove();
             }


### PR DESCRIPTION
Adds `SHIFT` modifier & binds `Shift` + `Delete` to directly delete a selected entry without modifying existing assignments

## Checks
- [x] I am happy for maintainers to push small adjustments to this PR, to speed up the review cycle
- [x] I have checked that there are no existing pull requests for the same thing
