### PR TITLE
docs: add PowerShell and Windows install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ I wanted to. And I **really** don't want to.
 - fish
 - nushell
 - xonsh
+- powershell (tier 2 support)
 
 ## Community
 

--- a/docs/docs/guide/dotfiles.md
+++ b/docs/docs/guide/dotfiles.md
@@ -13,6 +13,7 @@ The following shells are supported:
 - bash
 - fish
 - xonsh
+- powershell
 
 Note: Atuin handles your configuration internally, so once it is installed you
 no longer need to edit your config files manually.

--- a/docs/docs/guide/getting-started.md
+++ b/docs/docs/guide/getting-started.md
@@ -20,6 +20,7 @@ If you have any problems, please open an [issue](https://github.com/ellie/atuin/
 - fish
 - nushell
 - xonsh
+- powershell (tier 2 support)
 
 ## Quickstart
 

--- a/docs/docs/guide/installation.md
+++ b/docs/docs/guide/installation.md
@@ -2,6 +2,8 @@
 
 ## Recommended installation approach
 
+### On Unix
+
 Let's get started! First up, you will want to install Atuin. The recommended
 approach is to use the installation script, which automatically handles the
 installation of Atuin including the requirements for your environment.
@@ -15,6 +17,21 @@ curl --proto '=https' --tlsv1.2 -LsSf https://setup.atuin.sh | sh
 ```
 
 [**Set up sync** - Move on to the next step, or read on to manually install Atuin instead.](sync.md)
+
+### On Windows
+
+The recommended approach on Windows is to use WinGet to install Atuin. Then, if you use PowerShell,
+add the initialization command to your PowerShell profile, and restart your shell.
+
+```shell
+winget install -e Atuinsh.Atuin
+if (-not (Test-Path -Path $PROFILE)) { New-Item -ItemType File -Path $PROFILE -Force | Out-Null }
+Write-Output 'atuin init powershell | Out-String | Invoke-Expression' >> $PROFILE
+```
+
+Note that the `$PROFILE` path may depend on your PowerShell version.
+
+[**Set up sync** - Move on to the next step.](sync.md)
 
 ## Manual installation
 
@@ -103,6 +120,14 @@ If you don't wish to use the installer, the manual installation steps are as fol
         atclone"./atuin init zsh > init.zsh; ./atuin gen-completions --shell zsh > _atuin" \
         atpull"%atclone" src"init.zsh"
     zinit light atuinsh/atuin
+    ```
+
+=== "WinGet"
+
+    Atuin is available on WinGet:
+
+    ```shell
+    winget install -e Atuinsh.Atuin
     ```
 
 === "Source"
@@ -231,6 +256,14 @@ After installing, remember to restart your shell.
     execx($(atuin init xonsh))
     ```
     to the end of your `~/.xonshrc`
+
+=== "PowerShell"
+
+    Add the following to the end of your `$PROFILE` file:
+
+    ```shell
+    atuin init powershell | Out-String | Invoke-Expression
+    ```
 
 ## Upgrade
 

--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -22,6 +22,7 @@ Alternatively, get in touch on our [Discord](https://discord.gg/Fq8bJSKPHh) or o
 - fish
 - nushell
 - xonsh
+- powershell (tier 2 support)
 
 ## Quickstart
 


### PR DESCRIPTION
This adds instructions for:

- Installing Atuin on Windows using [WinGet](https://github.com/microsoft/winget-cli), which is the official Windows package manager shipped with Windows 11,
- Initializing Atuin in PowerShell by editing its profile file.

It also adds mentions of PowerShell support at the tier 2 level. I hope this is ok, as we now have a Windows build in the releases and an easy way to distribute it using a package manager.

Many thanks to @mloskot for [submitting the manifest](https://github.com/microsoft/winget-pkgs/pull/331328) to the WinGet community repository. 🚀 

Closes #2386

## Checks
- [x] I am happy for maintainers to push small adjustments to this PR, to speed up the review cycle
- [x] I have checked that there are no existing pull requests for the same thing
