### PR TITLE
docs: update the `[keys]` docs

### DIFF
--- a/crates/atuin-client/config.toml
+++ b/crates/atuin-client/config.toml
@@ -231,12 +231,16 @@ enter_accept = true
 [keys]
 # Defaults to true. If disabled, using the up/down key won't exit the TUI when scrolled past the first/last entry.
 # scroll_exits = true
+
 # Defaults to true. The left arrow key will exit the TUI when scrolling before the first character
 # exit_past_line_start = true
+
 # Defaults to true. The right arrow key performs the same functionality as Tab and copies the selected line to the command line to be modified.
 # accept_past_line_end = true
+
 # Defaults to false. The left arrow key performs the same functionality as Tab and copies the selected line to the command line to be modified.
 # accept_past_line_start = false
+
 # Defaults to false. The backspace key performs the same functionality as Tab and copies the selected line to the command line to be modified when at the start of the line.
 # accept_with_backspace = false
 

--- a/docs/docs/configuration/config.md
+++ b/docs/docs/configuration/config.md
@@ -619,13 +619,32 @@ Default: `true`
 
 Exits the TUI when scrolling left while the cursor is at the start of the line.
 
-### `exit_past_line_end`
+### `accept_past_line_end`
 
 Atuin version: >= 18.5
 
 Default: `true`
 
-Exits the TUI when scrolling right while the cursor is at the end of the line.
+The right arrow key performs the same functionality as Tab and copies the selected line to the command line to be
+modified.
+
+### `accept_past_line_start`
+
+Atuin version: >= 18.9
+
+Default: `false`
+
+The left arrow key performs the same functionality as Tab and copies the selected line to the command line to be
+modified.
+
+### `accept_with_backspace`
+
+Atuin version: >= 18.9
+
+Default: `false`
+
+The backspace key performs the same functionality as Tab and copies the selected line to the command line to be
+modified.
 
 ## preview
 


### PR DESCRIPTION
This is related to:
- #3090
- #1906

---

## No longer relevant:

~I often just hold the backspace key to clear the query line in Atuin, and the change in #3090 makes it no longer possible: it accepts the current history entry instead.~ 🤯

~It may be a muscle memory thing, but it also feels wrong to me for the left key to accept the current entry. I'd prefer for it to do nothing when the cursor is at the start of the line (I've set `exit_past_line_start = false` in my config).~

~This PR makes the new behavior configurable: it adds an `accept_past_empty_line` setting (naming is *hard*, feel free to find a better name) which lets you disable it. It also updates the `[keys]` docs.~

BTW wouldn't setting the `accept_past_line_start` and `accept_with_backspace` settings to `true` (maybe by default) have the same effect as what #3090 introduced?

## Checks
- [x] I am happy for maintainers to push small adjustments to this PR, to speed up the review cycle
- [x] I have checked that there are no existing pull requests for the same thing
