### PR TITLE
chore(deps): update whoami dependency to v2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -311,7 +311,7 @@ dependencies = [
  "typed-builder",
  "urlencoding",
  "uuid",
- "whoami",
+ "whoami 2.1.0",
 ]
 
 [[package]]
@@ -1725,7 +1725,7 @@ checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
 dependencies = [
  "cfg-if",
  "libc",
- "wasi",
+ "wasi 0.11.1+wasi-snapshot-preview1",
 ]
 
 [[package]]
@@ -2611,7 +2611,7 @@ checksum = "a69bcab0ad47271a0234d9422b131806bf3968021e5dc9328caf2d4cd58557fc"
 dependencies = [
  "libc",
  "log",
- "wasi",
+ "wasi 0.11.1+wasi-snapshot-preview1",
  "windows-sys 0.61.2",
 ]
 
@@ -3347,7 +3347,7 @@ dependencies = [
  "libc",
  "once_cell",
  "raw-cpuid",
- "wasi",
+ "wasi 0.11.1+wasi-snapshot-preview1",
  "web-sys",
  "winapi",
 ]
@@ -4428,7 +4428,7 @@ dependencies = [
  "time",
  "tracing",
  "uuid",
- "whoami",
+ "whoami 1.6.1",
 ]
 
 [[package]]
@@ -4467,7 +4467,7 @@ dependencies = [
  "time",
  "tracing",
  "uuid",
- "whoami",
+ "whoami 1.6.1",
 ]
 
 [[package]]
@@ -5357,6 +5357,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
+name = "wasi"
+version = "0.14.7+wasi-0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "883478de20367e224c0090af9cf5f9fa85bed63a95c1abf3afc5c083ebc06e8c"
+dependencies = [
+ "wasip2",
+]
+
+[[package]]
 name = "wasip2"
 version = "1.0.2+wasi-0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5370,6 +5379,15 @@ name = "wasite"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8dad83b4f25e74f184f64c43b150b91efe7647395b42289f38e50566d82855b"
+
+[[package]]
+name = "wasite"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66fe902b4a6b8028a753d5424909b764ccf79b7a209eac9bf97e59cda9f71a42"
+dependencies = [
+ "wasi 0.14.7+wasi-0.2.4",
+]
 
 [[package]]
 name = "wasm-bindgen"
@@ -5632,7 +5650,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d4a4db5077702ca3015d3d02d74974948aba2ad9e12ab7df718ee64ccd7e97d"
 dependencies = [
  "libredox",
- "wasite",
+ "wasite 0.1.0",
+]
+
+[[package]]
+name = "whoami"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fae98cf96deed1b7572272dfc777713c249ae40aa1cf8862e091e8b745f5361"
+dependencies = [
+ "libredox",
+ "wasite 1.0.2",
  "web-sys",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ serde = { version = "1.0.202", features = ["derive"] }
 serde_json = "1.0.119"
 tokio = { version = "1", features = ["full"] }
 uuid = { version = "1.9", features = ["v4", "v7", "serde"] }
-whoami = "1.5.1"
+whoami = "2.1.0"
 typed-builder = "0.18.2"
 pretty_assertions = "1.3.0"
 thiserror = "1.0"

--- a/crates/atuin-client/src/utils.rs
+++ b/crates/atuin-client/src/utils.rs
@@ -1,11 +1,11 @@
 pub(crate) fn get_hostname() -> String {
-    std::env::var("ATUIN_HOST_NAME").unwrap_or_else(|_| {
-        whoami::fallible::hostname().unwrap_or_else(|_| "unknown-host".to_string())
-    })
+    std::env::var("ATUIN_HOST_NAME")
+        .unwrap_or_else(|_| whoami::hostname().unwrap_or_else(|_| "unknown-host".to_string()))
 }
 
 pub(crate) fn get_username() -> String {
-    std::env::var("ATUIN_HOST_USER").unwrap_or_else(|_| whoami::username())
+    std::env::var("ATUIN_HOST_USER")
+        .unwrap_or_else(|_| whoami::username().unwrap_or_else(|_| "unknown-user".to_string()))
 }
 
 /// Returns a pair of the hostname and username, separated by a colon.


### PR DESCRIPTION
<!-- Thank you for making a PR! Bug fixes are always welcome, but if you're adding a new feature or changing an existing one, we'd really appreciate if you open an issue, post on the forum, or drop in on Discord -->
In the [2.0.0](https://github.com/ardaku/whoami/releases/tag/v2.0.0) series, `whoami` removed all infallible function variants, and removed the `fallible` module, moving those functions to the root module.

Therefore, I replaced `whoami::fallible::hostname` with `whoami::hostname` (the same function with the same signature, just moved to the root module).

For `whoami::username`, the infallible function that `atuin` was using before is gone, and we must add error handling. I chose to fall back to the string `"unknown-user"` if getting the username fails, just as `"unknown-host"` is already the fallback when getting the hostname fails. This seemed reasonable to me, but it’s worth double-checking if there could be any unintended consequences, especially if `unknown-user` happens to be a real, valid username on the system. The alternatives I can see would be to panic on failure or to amend the signature of `get_username()` and all of its call sites with some kind of more graceful error handling (what?).

## Checks
- [x] I am happy for maintainers to push small adjustments to this PR, to speed up the review cycle
- [x] I have checked that there are no existing pull requests for the same thing
