### PR TITLE
fix: larger exit column width on Windows

### DIFF
--- a/crates/atuin-client/src/settings.rs
+++ b/crates/atuin-client/src/settings.rs
@@ -509,7 +509,13 @@ impl UiColumnType {
             UiColumnType::Directory => 20,
             UiColumnType::Host => 15,
             UiColumnType::User => 10,
-            UiColumnType::Exit => 3,
+            UiColumnType::Exit => {
+                if cfg!(windows) {
+                    11 // 32-bit integer on Windows: "-1978335212"
+                } else {
+                    3 // Usually a byte on Unix
+                }
+            }
             UiColumnType::Command => 0, // Expands to fill
         }
     }


### PR DESCRIPTION
The default width of the `exit` column is 3, which matches the 0-255 values on Linux. However, on Windows it is a 32-bit integer, and can be anything from -2147483648 to 2147483647. Popular tools such as `winget` apparently make use of that.

Here's an example with `columns = ["exit", "time", "duration", "directory", "command"]`:

<img width="647" height="416" alt="image" src="https://github.com/user-attachments/assets/d73b0487-3c77-4049-8487-01b2aab29a44" />


This PR changes the default column width to 11 on Windows to match these values. The result is:

<img width="601" height="412" alt="image" src="https://github.com/user-attachments/assets/b4b95f40-f223-400d-83c4-74d71e070b3e" />


## Checks
- [x] I am happy for maintainers to push small adjustments to this PR, to speed up the review cycle
- [x] I have checked that there are no existing pull requests for the same thing
