### PR TITLE
fix(powershell): preserve `$LASTEXITCODE`

### DIFF
--- a/crates/atuin/src/shell/atuin.ps1
+++ b/crates/atuin/src/shell/atuin.ps1
@@ -63,7 +63,8 @@ New-Module -Name Atuin -ScriptBlock {
         $lastRunStatus = $?
 
         # Exit statuses are maintained separately for native and PowerShell commands, this needs to be taken into account.
-        $exitCode = if ($lastRunStatus) { 0 } elseif ($global:LASTEXITCODE) { $global:LASTEXITCODE } else { 1 }
+        $lastNativeExitCode = $global:LASTEXITCODE
+        $exitCode = if ($lastRunStatus) { 0 } elseif ($lastNativeExitCode) { $lastNativeExitCode } else { 1 }
 
         ## 2. Report the status of the previous command to Atuin (atuin history end).
 
@@ -125,6 +126,7 @@ New-Module -Name Atuin -ScriptBlock {
             $env:ATUIN_COMMAND_LINE = $null
         }
 
+        $global:LASTEXITCODE = $lastNativeExitCode
         return $line
     }
 


### PR DESCRIPTION
`$LASTEXITCODE` is an [automatic variable](https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_automatic_variables?view=powershell-7.5#lastexitcode) in PowerShell which holds the exit code of the last *native* program which has run. It's a close equivalent to `$?` in bash (PowerShell also has [its own `$?` variable](https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_automatic_variables?view=powershell-7.5#section-1), but it's a boolean).

Atuin is a native program, and the `PSConsoleHostReadLine` function calls `atuin history start`, which resets this variable to 0 (or to something else if it fails).

This PR resets this variable to its previous value, as it is that one which the user will expect.

Before:

<img width="453" height="225" alt="image" src="https://github.com/user-attachments/assets/5fc781d3-dbba-4737-b2ec-7ba73739d006" />

After:

<img width="460" height="212" alt="image" src="https://github.com/user-attachments/assets/a2db9bca-343c-48fc-ab45-167e0dd6f7f9" />

Default behavior (without a profile file or Atuin):

<img width="351" height="147" alt="image" src="https://github.com/user-attachments/assets/47d6aa28-1ea9-4e55-9879-98359ad3fbcf" />


## Checks
- [x] I am happy for maintainers to push small adjustments to this PR, to speed up the review cycle
- [x] I have checked that there are no existing pull requests for the same thing
