### PR TITLE
fix: use directories crate for home dir resolution

### DIFF
--- a/crates/atuin-common/src/utils.rs
+++ b/crates/atuin-common/src/utils.rs
@@ -65,16 +65,10 @@ pub fn in_git_repo(path: &str) -> Option<PathBuf> {
 // I don't want to use ProjectDirs, it puts config in awkward places on
 // mac. Data too. Seems to be more intended for GUI apps.
 
-#[cfg(not(target_os = "windows"))]
 pub fn home_dir() -> PathBuf {
-    let home = std::env::var("HOME").expect("$HOME not found");
-    PathBuf::from(home)
-}
-
-#[cfg(target_os = "windows")]
-pub fn home_dir() -> PathBuf {
-    let home = std::env::var("USERPROFILE").expect("%userprofile% not found");
-    PathBuf::from(home)
+    directories::BaseDirs::new()
+        .map(|d| d.home_dir().to_path_buf())
+        .expect("could not determine home directory")
 }
 
 pub fn config_dir() -> PathBuf {


### PR DESCRIPTION
Previously, home_dir() read $HOME directly and panicked if it wasn't set. This could happen in environments like `nix develop -i` which strip the environment.

The directories crate (already a dependency) falls back to getpwuid_r when $HOME is not set, resolving the home directory from /etc/passwd.

Fixes #3123

<!-- Thank you for making a PR! Bug fixes are always welcome, but if you're adding a new feature or changing an existing one, we'd really appreciate if you open an issue, post on the forum, or drop in on Discord -->

## Checks
- [ ] I am happy for maintainers to push small adjustments to this PR, to speed up the review cycle
- [ ] I have checked that there are no existing pull requests for the same thing
