### PR TITLE
fix(tui): space and F1-F24 keys not handled properly by new keybind system

### DIFF
--- a/crates/atuin/src/command/client/search/interactive.rs
+++ b/crates/atuin/src/command/client/search/interactive.rs
@@ -369,12 +369,16 @@ impl State {
             self.execute_action(&action, settings)
         } else {
             // No action matched. In insert-capable modes, insert the character.
-            if self.is_insert_mode()
-                && let KeyCodeValue::Char(c) = single.code
-                && !single.ctrl
-                && !single.alt
-            {
-                self.search.input.insert(c);
+            if self.is_insert_mode() && !single.ctrl && !single.alt {
+                match single.code {
+                    KeyCodeValue::Char(c) => {
+                        self.search.input.insert(c);
+                    }
+                    KeyCodeValue::Space => {
+                        self.search.input.insert(' ');
+                    }
+                    _ => {}
+                }
             }
             InputAction::Continue
         }

--- a/docs/docs/configuration/advanced-key-binding.md
+++ b/docs/docs/configuration/advanced-key-binding.md
@@ -5,7 +5,7 @@ Atuin includes a powerful keybinding system that can be used to fully customize 
 The `[keymap]` section in your config replaces the older `[keys]` section. If any `[keymap]` settings are present, the `[keys]` section is ignored entirely.
 
 !!! warning
-    Modifier keys and some special characters work best with a terminal that implements the kitty keyboard protocol. Notably, the default macOS Terminal app does _not_ include this feature. For more information and a list of terminals that are known to support this protocol, see https://sw.kovidgoyal.net/kitty/keyboard-protocol/
+    Modifier keys, F1-F24 keys, and some special characters work best - or _only_ work - with a terminal that implements the kitty keyboard protocol. Notably, the default macOS Terminal app does _not_ include this feature. For more information and a list of terminals that are known to support this protocol, see [https://sw.kovidgoyal.net/kitty/keyboard-protocol/](https://sw.kovidgoyal.net/kitty/keyboard-protocol/).
 
 ## Keymaps
 
@@ -39,6 +39,7 @@ Lowercase letters, digits, and named keys:
 "enter", "esc", "tab", "space", "backspace", "delete"
 "up", "down", "left", "right"
 "home", "end", "pageup", "pagedown"
+"f1", "f2", ... "f12", ... "f24"
 ```
 
 `return` is an alias for `enter`. `escape` is an alias for `esc`. `del` is an alias for `delete`.


### PR DESCRIPTION
Fixes two keymap issues introduced in #3127:

1. Space key does nothing - Pressing space in the search input didn't insert a space character
2. F12 not recognized - Function keys (F1-F24) couldn't be used in `[keymap]` config

Changes

- Fix space key insertion in emacs/vim-insert modes by handling `KeyCodeValue::Space` in the fallback character insertion logic
- Add `F(u8)` variant to `KeyCodeValue` enum for function key support
- Add parsing for function keys (f1, F12, ctrl-f5, etc.) in key config strings
- Add comprehensive tests for function key parsing and round-tripping
- Update documentation to list function keys in the "Basic keys" section

Resolves #3137 