### PR TITLE
feat(tui): add clear-to-start/end actions

### DIFF
--- a/crates/atuin/src/command/client/search/cursor.rs
+++ b/crates/atuin/src/command/client/search/cursor.rs
@@ -192,6 +192,16 @@ impl Cursor {
         self.index = 0;
     }
 
+    pub fn clear_to_start(&mut self) {
+        self.source.replace_range(..self.index, "");
+        self.index = 0;
+    }
+
+    pub fn clear_to_end(&mut self) {
+        self.source.replace_range(self.index.., "");
+        self.index = self.source.len();
+    }
+
     pub fn end(&mut self) {
         self.index = self.source.len();
     }

--- a/crates/atuin/src/command/client/search/interactive.rs
+++ b/crates/atuin/src/command/client/search/interactive.rs
@@ -482,6 +482,14 @@ impl State {
                 self.search.input.clear();
                 InputAction::Continue
             }
+            Action::ClearToStart => {
+                self.search.input.clear_to_start();
+                InputAction::Continue
+            }
+            Action::ClearToEnd => {
+                self.search.input.clear_to_end();
+                InputAction::Continue
+            }
 
             // -- List navigation (invert-aware) --
             Action::SelectNext => {

--- a/crates/atuin/src/command/client/search/keybindings/actions.rs
+++ b/crates/atuin/src/command/client/search/keybindings/actions.rs
@@ -20,6 +20,8 @@ pub enum Action {
     DeleteWordAfter,
     DeleteToWordBoundary,
     ClearLine,
+    ClearToStart,
+    ClearToEnd,
 
     // List navigation
     SelectNext,
@@ -99,6 +101,8 @@ impl Action {
             "delete-word-after" => Ok(Action::DeleteWordAfter),
             "delete-to-word-boundary" => Ok(Action::DeleteToWordBoundary),
             "clear-line" => Ok(Action::ClearLine),
+            "clear-to-start" => Ok(Action::ClearToStart),
+            "clear-to-end" => Ok(Action::ClearToEnd),
 
             "select-next" => Ok(Action::SelectNext),
             "select-previous" => Ok(Action::SelectPrevious),
@@ -157,6 +161,8 @@ impl Action {
             Action::DeleteWordAfter => "delete-word-after".to_string(),
             Action::DeleteToWordBoundary => "delete-to-word-boundary".to_string(),
             Action::ClearLine => "clear-line".to_string(),
+            Action::ClearToStart => "clear-to-start".to_string(),
+            Action::ClearToEnd => "clear-to-end".to_string(),
 
             Action::SelectNext => "select-next".to_string(),
             Action::SelectPrevious => "select-previous".to_string(),

--- a/docs/docs/configuration/advanced-key-binding.md
+++ b/docs/docs/configuration/advanced-key-binding.md
@@ -140,6 +140,8 @@ Actions are specified as kebab-case strings.
 | `delete-word-after` | Delete the word after the cursor |
 | `delete-to-word-boundary` | Delete to the next word boundary (like `ctrl-w`) |
 | `clear-line` | Clear the entire input line |
+| `clear-to-start` | Clear the start of input line |
+| `clear-to-end` | Clear the end of input line |
 
 ### List navigation
 


### PR DESCRIPTION
e.g. bash has these mapped to Ctrl-u/k.

<!-- Thank you for making a PR! Bug fixes are always welcome, but if you're adding a new feature or changing an existing one, we'd really appreciate if you open an issue, post on the forum, or drop in on Discord -->

## Checks
- [x] I am happy for maintainers to push small adjustments to this PR, to speed up the review cycle
- [x] I have checked that there are no existing pull requests for the same thing
