### PR TITLE
fix: remove invalid IF EXISTS from sqlite drop column migration

### DIFF
--- a/crates/atuin-server-sqlite/migrations/20260127000000_remove-email-verification.sql
+++ b/crates/atuin-server-sqlite/migrations/20260127000000_remove-email-verification.sql
@@ -1,2 +1,2 @@
 drop table if exists user_verification_token;
-alter table users drop column if exists verified_at;
+alter table users drop column verified_at;


### PR DESCRIPTION
<!-- Thank you for making a PR! Bug fixes are always welcome, but if you're adding a new feature or changing an existing one, we'd really appreciate if you open an issue, post on the forum, or drop in on Discord -->

## Checks
- [x] I am happy for maintainers to push small adjustments to this PR, to speed up the review cycle
- [x] I have checked that there are no existing pull requests for the same thing

## Summary

SQLite doesn't support an `IF NOT EXISTS` on `ALTER TABLE`

> https://www.sqlite.org/lang_altertable.html

```
atuin  | Caused by:
atuin  |     Other(while executing migration 20260127000000: error returned from database: (code: 1) near "exists": syntax error
atuin  |
atuin  |     Caused by:
atuin  |        0: error returned from database: (code: 1) near "exists": syntax error
atuin  |        1: (code: 1) near "exists": syntax error
```

The fix works on my setup

Ref: https://github.com/atuinsh/atuin/pull/3108#pullrequestreview-3713606584
