### PR TITLE
fix: Server start commands for Docker.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ services:
   atuin:
     restart: always
     image: ghcr.io/atuinsh/atuin:<LATEST TAGGED RELEASE>
-    command: server start
+    command: start
     volumes:
       - "./config:/config"
     ports:

--- a/k8s/atuin.yaml
+++ b/k8s/atuin.yaml
@@ -15,7 +15,6 @@ spec:
     spec:
       containers:
         - args:
-            - server
             - start
           env:
             - name: ATUIN_DB_URI


### PR DESCRIPTION
With the new atuin-server binary the startup command for the server is
now just start rather than server start. This needs reflected in the
docker compose and k8s configs.

Closes #3159

## Checks
- [x] I am happy for maintainers to push small adjustments to this PR, to speed up the review cycle
- [x] I have checked that there are no existing pull requests for the same thing
