### PR TITLE
fix(docs): Update Postgres volume path in Docker as required by pg18

### DIFF
--- a/docs/docs/self-hosting/docker.md
+++ b/docs/docs/self-hosting/docker.md
@@ -52,7 +52,7 @@ services:
     image: postgres:18
     restart: unless-stopped
     volumes: # Don't remove permanent storage for index database files!
-      - "./database:/var/lib/postgresql/data/"
+      - "./database:/var/lib/postgresql/"
     environment:
       POSTGRES_USER: ${ATUIN_DB_USERNAME}
       POSTGRES_PASSWORD: ${ATUIN_DB_PASSWORD}


### PR DESCRIPTION
Postgresql requires a different volume path for docker since version 18, see https://hub.docker.com/_/postgres#pgdata

<!-- Thank you for making a PR! Bug fixes are always welcome, but if you're adding a new feature or changing an existing one, we'd really appreciate if you open an issue, post on the forum, or drop in on Discord -->

## Checks
- [x] I am happy for maintainers to push small adjustments to this PR, to speed up the review cycle
- [x] I have checked that there are no existing pull requests for the same thing
