### PR TITLE
fix: silent DB failures e.g. when disk is full

### DIFF
--- a/crates/atuin/src/shell/atuin.bash
+++ b/crates/atuin/src/shell/atuin.bash
@@ -57,7 +57,7 @@ __atuin_preexec() {
     __atuin_update_preexec_backend
 
     local id
-    id=$(atuin history start -- "$1")
+    id=$(atuin history start -- "$1" 2>/dev/null)
     export ATUIN_HISTORY_ID=$id
     __atuin_preexec_time=${EPOCHREALTIME-}
 }

--- a/crates/atuin/src/shell/atuin.fish
+++ b/crates/atuin/src/shell/atuin.fish
@@ -6,7 +6,7 @@ set --erase ATUIN_HISTORY_ID
 
 function _atuin_preexec --on-event fish_preexec
     if not test -n "$fish_private_mode"
-        set -g ATUIN_HISTORY_ID (atuin history start -- "$argv[1]")
+        set -g ATUIN_HISTORY_ID (atuin history start -- "$argv[1]" 2>/dev/null)
     end
 end
 
@@ -28,7 +28,7 @@ function _atuin_tmux_popup_check
         return
     end
 
-    if test "$ATUIN_TMUX_POPUP" = "false"
+    if test "$ATUIN_TMUX_POPUP" = false
         echo 0
         return
     end
@@ -55,7 +55,9 @@ function _atuin_tmux_popup_check
         set m2 0
     end
 
-    if test "$m1" -gt 3 2>/dev/null; or begin; test "$m1" -eq 3 2>/dev/null; and test "$m2" -ge 2 2>/dev/null; end
+    if test "$m1" -gt 3 2>/dev/null; or begin
+            test "$m1" -eq 3 2>/dev/null; and test "$m2" -ge 2 2>/dev/null
+        end
         echo 1
     else
         echo 0
@@ -118,13 +120,13 @@ function _atuin_search
 
     if test -n "$ATUIN_H"
         if string match --quiet '__atuin_accept__:*' "$ATUIN_H"
-          set -l ATUIN_HIST (string replace "__atuin_accept__:" "" -- "$ATUIN_H" | string collect)
-          commandline -r "$ATUIN_HIST"
-          commandline -f repaint
-          commandline -f execute
-          return
+            set -l ATUIN_HIST (string replace "__atuin_accept__:" "" -- "$ATUIN_H" | string collect)
+            commandline -r "$ATUIN_HIST"
+            commandline -f repaint
+            commandline -f execute
+            return
         else
-          commandline -r "$ATUIN_H"
+            commandline -r "$ATUIN_H"
         end
     end
 

--- a/crates/atuin/src/shell/atuin.nu
+++ b/crates/atuin/src/shell/atuin.nu
@@ -26,7 +26,7 @@ let _atuin_pre_execution = {||
         return
     }
     if not ($cmd | str starts-with $ATUIN_KEYBINDING_TOKEN) {
-        $env.ATUIN_HISTORY_ID = (atuin history start -- $cmd)
+        $env.ATUIN_HISTORY_ID = (atuin history start -- $cmd e>| complete | get stdout | str trim)
     }
 }
 

--- a/crates/atuin/src/shell/atuin.xsh
+++ b/crates/atuin/src/shell/atuin.xsh
@@ -12,7 +12,10 @@ if "ATUIN_SESSION" not in ${...} or ${...}.get("ATUIN_SHLVL", "") != ${...}.get(
 @events.on_precommand
 def _atuin_precommand(cmd: str):
     cmd = cmd.rstrip("\n")
-    $ATUIN_HISTORY_ID = $(atuin history start -- @(cmd)).rstrip("\n")
+    try:
+        $ATUIN_HISTORY_ID = $(atuin history start -- @(cmd) 2>/dev/null).rstrip("\n")
+    except:
+        $ATUIN_HISTORY_ID = ""
 
 
 @events.on_postcommand

--- a/crates/atuin/src/shell/atuin.zsh
+++ b/crates/atuin/src/shell/atuin.zsh
@@ -33,7 +33,7 @@ ATUIN_HISTORY_ID=""
 
 _atuin_preexec() {
     local id
-    id=$(atuin history start -- "$1")
+    id=$(atuin history start -- "$1" 2>/dev/null)
     export ATUIN_HISTORY_ID="$id"
     __atuin_preexec_time=${EPOCHREALTIME-}
 }


### PR DESCRIPTION
<!-- Thank you for making a PR! Bug fixes are always welcome, but if you're adding a new feature or changing an existing one, we'd really appreciate if you open an issue, post on the forum, or drop in on Discord -->

## Checks
- [x] I am happy for maintainers to push small adjustments to this PR, to speed up the review cycle
- [x] I have checked that there are no existing pull requests for the same thing

Silent DB failures breaking shell when disk is full

When storage runs out (i.e. disk full), atuin breaks the shell by continuously printing database errors for every character typed. This is a fix to silence the DB errors