### PR TITLE
Support passing `--limit` to `atuin search --delete`

### DIFF
--- a/crates/atuin/src/command/client/search.rs
+++ b/crates/atuin/src/command/client/search.rs
@@ -193,19 +193,7 @@ impl Cmd {
             self.query
         };
 
-        if (self.delete_it_all || self.delete) && self.limit.is_some() {
-            // Because of how deletion is implemented, it will always delete all matches
-            // and disregard the limit option. It is also not clear what deletion with a
-            // limit would even mean. Deleting the LIMIT most recent entries that match
-            // the search query would make sense, but that wouldn't match what's displayed
-            // when running the equivalent search, but deleting those entries that are
-            // displayed with the search would leave any duplicates of those lines which may
-            // or may not have been intended to be deleted.
-            eprintln!("\"--limit\" is not compatible with deletion.");
-            return Ok(());
-        }
-
-        if self.delete && query.is_empty() {
+        if self.delete && query.is_empty() && self.limit.is_none() {
             eprintln!(
                 "Please specify a query to match the items you wish to delete. If you wish to delete all history, pass --delete-it-all"
             );
@@ -265,7 +253,7 @@ impl Cmd {
             let authors = OrFilter::from_list(self.author).unwrap_or_default();
             let shells = OrFilter::from_list(self.shell).unwrap_or_default();
 
-            let opt_filter = OptFilters {
+            let mut opt_filter = OptFilters {
                 exit: self.exit,
                 exclude_exit: self.exclude_exit,
                 only_failed: false,
@@ -289,19 +277,21 @@ impl Cmd {
 
             // if we aren't deleting, print it all
             if self.delete || self.delete_it_all {
-                // delete it
-                // it only took me _years_ to add this
-                // sorry
-                while !entries.is_empty() {
-                    for entry in &entries {
-                        eprintln!("deleting {}", entry.id);
-                    }
-
-                    let ids = history_store.delete_entries(entries).await?;
-                    history_store.build_all(&db, &ids).await?;
-
-                    entries = run_non_interactive(settings, opt_filter, &query, &db).await?;
+                // To preserve existing behaviour (deleting a command deletes all instances of that
+                // command), we must include duplicates here. However, if a limit is set, that could
+                // cause a different set of commands to be printed vs deleted: to avoid this, we
+                // explicitly require --include-duplicates if --limit is passed.
+                if self.limit.is_some() && !self.include_duplicates {
+                    eprintln!(
+                        "Using \"--limit\" with \"--delete\" causes individual usages of commands to be deleted, so it requires \"--include-duplicates\"."
+                    );
+                    return Ok(());
                 }
+                opt_filter.include_duplicates = true;
+                entries = run_non_interactive(settings, opt_filter, &query, &db).await?;
+
+                let ids = history_store.delete_entries(entries).await?;
+                history_store.build_all(&db, &ids).await?;
             } else {
                 let format = self
                     .format


### PR DESCRIPTION
Fixes #3177.

As pointed out previously (#1436), there are two plausible ways this could be expected to work:

1. The search is executed across (deduplicated) commands, then every usage of the first N commands in the result is deleted.
2. The search is executed across history entries, then the first N history entries in the result are deleted (and other usages of the same command are left intact).

With option 1, it's nonsensical to pass `--include-duplicates`: if the results for `atuin search --include-duplicates --limit 3` were "foo", "bar", and "foo", then only two commands would actually be deleted. (If the command "baz" was executed before those three, then without `--include-duplicates` it would have been included in the results – so passing that flag would actually have *reduced* the number of commands being deleted!)

With option 2, it's easier to reason about what's happening: every deletion already acts as if `--include-duplicates` was passed, so deletions always operate on individual history entries (not aggregated commands), therefore we don't have to worry about what would happen if `--include-duplicates` was/wasn't passed. To make it obvious that this is how `--limit` works, we require that `--include-duplicates` is *explicitly* passed whenever using `--delete` together with `--limit`.

Therefore this PR implements option 2.

<!-- Thank you for making a PR! Bug fixes are always welcome, but if you're adding a new feature or changing an existing one, we'd really appreciate if you open an issue, post on the forum, or drop in on Discord -->

## Checks
- [x] I am happy for maintainers to push small adjustments to this PR, to speed up the review cycle
- [x] I have checked that there are no existing pull requests for the same thing
