### PR TITLE
Update config.md to remove NuShell support note

### DIFF
--- a/docs/docs/configuration/config.md
+++ b/docs/docs/configuration/config.md
@@ -423,8 +423,6 @@ Atuin version: >= 17.0
 
 Default: `false`
 
-Not supported by NuShell presently
-
 When set to true, Atuin will default to immediately executing a command rather
 than the user having to press enter twice. Pressing tab will return to the
 shell and give the user a chance to edit.


### PR DESCRIPTION
Removed unsupported note about NuShell from configuration documentation.

Possibly better alternative would be to say from which version of nushell and atuin support started. Didn't want to spend the time researching that in case it wasn't of value.

<!-- Thank you for making a PR! Bug fixes are always welcome, but if you're adding a new feature or changing an existing one, we'd really appreciate if you open an issue, post on the forum, or drop in on Discord -->

## Checks
- [x] I am happy for maintainers to push small adjustments to this PR, to speed up the review cycle
- [x] I have checked that there are no existing pull requests for the same thing
