### PR TITLE
Document `search.filters`

### DIFF
--- a/docs/docs/configuration/config.md
+++ b/docs/docs/configuration/config.md
@@ -198,19 +198,6 @@ within a git repository tree.
 
 Filter modes can still be toggled via ctrl-r.
 
-## search
-
-### `filters`
-
-The list of filter modes available in interactive search, in the order they cycle through when you press ctrl-r. By default, all modes are enabled. Removing a mode from this list disables it entirely. The `workspace` mode is skipped when not in a git repository or when `workspaces = false`. See [`filter_mode`](#filter_mode) for a description of each mode.
-
-The `filter_mode` setting selects the initial mode from this list. If `filter_mode` is set to a mode not in the list, the first available mode is used instead.
-
-```toml
-[search]
-filters = ["global", "host", "session", "directory"]
-```
-
 ### `style`
 
 Default: `compact`
@@ -496,6 +483,21 @@ Enable this, and Atuin will reduce motion in the TUI as much as possible. Users
 with motion sensitivity can find the live-updating timestamps distracting.
 
 Alternatively, set env var NO_MOTION
+
+## search
+
+### `filters`
+
+Atuin version: >= 18.4
+
+The list of filter modes available in interactive search, in the order they cycle through when you press ctrl-r. By default, all modes are enabled. Removing a mode from this list disables it entirely. The `workspace` mode is skipped when not in a git repository or when `workspaces = false`. See [`filter_mode`](#filter_mode) for a description of each mode.
+
+The `filter_mode` setting selects the initial mode from this list. If `filter_mode` is set to a mode not in the list, the first available mode is used instead.
+
+```toml
+[search]
+filters = ["global", "host", "session", "directory"]
+```
 
 ## Stats
 


### PR DESCRIPTION
Noticed this is not in the docs, and I've looked before! Luckily Claude knew about it anyway. @BinaryMuse [said](https://bsky.app/profile/binarymuse.net/post/3mf5obykhfs25) on bsky she'd be happy to get a PR. I kept the description simple and decided against listing the default values because it's affected by `workspaces` and `filter_mode` anyway. Happy to change that, or for you all to change it to whatever you prefer.

I had Claude put together source code citations for the claims in the text:

- **Modes cycle in list order on ctrl-r** — [`rotate_filter_mode`](https://github.com/atuinsh/atuin/blob/61864792fff07e9dcefc09f47829cf74845ad944/crates/atuin/src/command/client/search/engines.rs#L29-L43) iterates through `settings.search.filters` by index.
- **Removing a mode disables it** — same function only considers modes present in the list.
- **Workspace is skipped when not in a git repo or `workspaces = false`** — [`filter_mode_available`](https://github.com/atuinsh/atuin/blob/61864792fff07e9dcefc09f47829cf74845ad944/crates/atuin/src/command/client/search/engines.rs#L46-L52) and [`default_filter_mode`](https://github.com/atuinsh/atuin/blob/61864792fff07e9dcefc09f47829cf74845ad944/crates/atuin-client/src/settings.rs#L993-L995).
- **`filter_mode` selects initial mode; falls back to first available if not in list** — [`default_filter_mode`](https://github.com/atuinsh/atuin/blob/61864792fff07e9dcefc09f47829cf74845ad944/crates/atuin-client/src/settings.rs#L986-L1001) filters through `.contains()` and falls back via `.find()`.


## Checks
- [x] I am happy for maintainers to push small adjustments to this PR, to speed up the review cycle
- [x] I have checked that there are no existing pull requests for the same thing
