### PR TITLE
fix: support Nushell 0.111

### DIFF
--- a/crates/atuin/src/shell/atuin.nu
+++ b/crates/atuin/src/shell/atuin.nu
@@ -36,8 +36,12 @@ let _atuin_pre_prompt = {||
         return
     }
     with-env { ATUIN_LOG: error } {
-        if (version).minor >= 104 or (version).major > 0 {
-            job spawn -t atuin {
+        if (version).minor >= 111 or (version).major > 0 {
+            job spawn -d atuin {
+                ^atuin history end $'--exit=($env.LAST_EXIT_CODE)' -- $env.ATUIN_HISTORY_ID | complete
+            } | ignore
+        } else if (version).minor >= 104 or (version).major > 0 {
+            job spawn {
                 ^atuin history end $'--exit=($env.LAST_EXIT_CODE)' -- $env.ATUIN_HISTORY_ID | complete
             } | ignore
         } else {


### PR DESCRIPTION
The flag for `job spawn` changed, which prevents the script from compiling on Nushell 0.111+. 

## Checks
- [x] I am happy for maintainers to push small adjustments to this PR, to speed up the review cycle
- [x] I have checked that there are no existing pull requests for the same thing
