### PR TITLE
chore(release): prepare for release 18.13.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -217,7 +217,7 @@ checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "atuin"
-version = "18.13.0"
+version = "18.13.1"
 dependencies = [
  "arboard",
  "async-trait",
@@ -276,7 +276,7 @@ dependencies = [
 
 [[package]]
 name = "atuin-ai"
-version = "18.13.0"
+version = "18.13.1"
 dependencies = [
  "async-stream",
  "atuin-client",
@@ -304,7 +304,7 @@ dependencies = [
 
 [[package]]
 name = "atuin-client"
-version = "18.13.0"
+version = "18.13.1"
 dependencies = [
  "async-trait",
  "atuin-common",
@@ -359,7 +359,7 @@ dependencies = [
 
 [[package]]
 name = "atuin-common"
-version = "18.13.0"
+version = "18.13.1"
 dependencies = [
  "base64",
  "directories",
@@ -379,7 +379,7 @@ dependencies = [
 
 [[package]]
 name = "atuin-daemon"
-version = "18.13.0"
+version = "18.13.1"
 dependencies = [
  "atuin-client",
  "atuin-common",
@@ -412,7 +412,7 @@ dependencies = [
 
 [[package]]
 name = "atuin-dotfiles"
-version = "18.13.0"
+version = "18.13.1"
 dependencies = [
  "atuin-client",
  "atuin-common",
@@ -426,7 +426,7 @@ dependencies = [
 
 [[package]]
 name = "atuin-hex"
-version = "18.13.0"
+version = "18.13.1"
 dependencies = [
  "clap",
  "crossterm",
@@ -438,7 +438,7 @@ dependencies = [
 
 [[package]]
 name = "atuin-history"
-version = "18.13.0"
+version = "18.13.1"
 dependencies = [
  "atuin-client",
  "crossterm",
@@ -451,7 +451,7 @@ dependencies = [
 
 [[package]]
 name = "atuin-kv"
-version = "18.13.0"
+version = "18.13.1"
 dependencies = [
  "atuin-client",
  "atuin-common",
@@ -467,7 +467,7 @@ dependencies = [
 
 [[package]]
 name = "atuin-scripts"
-version = "18.13.0"
+version = "18.13.1"
 dependencies = [
  "atuin-client",
  "atuin-common",
@@ -489,7 +489,7 @@ dependencies = [
 
 [[package]]
 name = "atuin-server"
-version = "18.13.0"
+version = "18.13.1"
 dependencies = [
  "argon2",
  "atuin-common",
@@ -518,7 +518,7 @@ dependencies = [
 
 [[package]]
 name = "atuin-server-database"
-version = "18.13.0"
+version = "18.13.1"
 dependencies = [
  "async-trait",
  "atuin-common",
@@ -531,7 +531,7 @@ dependencies = [
 
 [[package]]
 name = "atuin-server-postgres"
-version = "18.13.0"
+version = "18.13.1"
 dependencies = [
  "async-trait",
  "atuin-common",
@@ -549,7 +549,7 @@ dependencies = [
 
 [[package]]
 name = "atuin-server-sqlite"
-version = "18.13.0"
+version = "18.13.1"
 dependencies = [
  "async-trait",
  "atuin-common",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ resolver = "2"
 exclude = ["ui/backend"]
 
 [workspace.package]
-version = "18.13.0"
+version = "18.13.1"
 authors = ["Ellie Huxtable <ellie@atuin.sh>"]
 rust-version = "1.94.0"
 license = "MIT"
@@ -15,17 +15,17 @@ readme = "README.md"
 
 [workspace.dependencies]
 async-trait = "0.1.58"
-atuin-client = { path = "crates/atuin-client", version = "18.13.0" }
-atuin-common = { path = "crates/atuin-common", version = "18.13.0" }
-atuin-daemon = { path = "crates/atuin-daemon", version = "18.13.0" }
-atuin-dotfiles = { path = "crates/atuin-dotfiles", version = "18.13.0" }
-atuin-history = { path = "crates/atuin-history", version = "18.13.0" }
-atuin-kv = { path = "crates/atuin-kv", version = "18.13.0" }
-atuin-scripts = { path = "crates/atuin-scripts", version = "18.13.0" }
-atuin-server = { path = "crates/atuin-server", version = "18.13.0" }
-atuin-server-database = { path = "crates/atuin-server-database", version = "18.13.0" }
-atuin-server-postgres = { path = "crates/atuin-server-postgres", version = "18.13.0" }
-atuin-server-sqlite = { path = "crates/atuin-server-sqlite", version = "18.13.0" }
+atuin-client = { path = "crates/atuin-client", version = "18.13.1" }
+atuin-common = { path = "crates/atuin-common", version = "18.13.1" }
+atuin-daemon = { path = "crates/atuin-daemon", version = "18.13.1" }
+atuin-dotfiles = { path = "crates/atuin-dotfiles", version = "18.13.1" }
+atuin-history = { path = "crates/atuin-history", version = "18.13.1" }
+atuin-kv = { path = "crates/atuin-kv", version = "18.13.1" }
+atuin-scripts = { path = "crates/atuin-scripts", version = "18.13.1" }
+atuin-server = { path = "crates/atuin-server", version = "18.13.1" }
+atuin-server-database = { path = "crates/atuin-server-database", version = "18.13.1" }
+atuin-server-postgres = { path = "crates/atuin-server-postgres", version = "18.13.1" }
+atuin-server-sqlite = { path = "crates/atuin-server-sqlite", version = "18.13.1" }
 base64 = "0.22"
 crossterm = "0.29.0"
 log = "0.4"

--- a/crates/atuin-client/Cargo.toml
+++ b/crates/atuin-client/Cargo.toml
@@ -20,7 +20,7 @@ daemon = []
 check-update = []
 
 [dependencies]
-atuin-common = { path = "../atuin-common", version = "18.13.0" }
+atuin-common = { path = "../atuin-common", version = "18.13.1" }
 
 log = { workspace = true }
 base64 = { workspace = true }

--- a/crates/atuin-daemon/Cargo.toml
+++ b/crates/atuin-daemon/Cargo.toml
@@ -46,7 +46,7 @@ listenfd = "1.0.1"
 
 [dev-dependencies]
 tempfile = { workspace = true }
-atuin-common = { path = "../atuin-common", version = "18.13.0" }
+atuin-common = { path = "../atuin-common", version = "18.13.1" }
 
 [build-dependencies]
 protox = "0.9"

--- a/crates/atuin-dotfiles/Cargo.toml
+++ b/crates/atuin-dotfiles/Cargo.toml
@@ -14,8 +14,8 @@ readme.workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-atuin-common = { path = "../atuin-common", version = "18.13.0" }
-atuin-client = { path = "../atuin-client", version = "18.13.0" }
+atuin-common = { path = "../atuin-common", version = "18.13.1" }
+atuin-client = { path = "../atuin-client", version = "18.13.1" }
 
 eyre = { workspace = true }
 tokio = { workspace = true }

--- a/crates/atuin-history/Cargo.toml
+++ b/crates/atuin-history/Cargo.toml
@@ -14,7 +14,7 @@ readme.workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-atuin-client = { path = "../atuin-client", version = "18.13.0" }
+atuin-client = { path = "../atuin-client", version = "18.13.1" }
 
 time = { workspace = true }
 serde = { workspace = true }

--- a/crates/atuin-kv/Cargo.toml
+++ b/crates/atuin-kv/Cargo.toml
@@ -14,8 +14,8 @@ readme.workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-atuin-client = { path = "../atuin-client", version = "18.13.0" }
-atuin-common = { path = "../atuin-common", version = "18.13.0" }
+atuin-client = { path = "../atuin-client", version = "18.13.1" }
+atuin-common = { path = "../atuin-common", version = "18.13.1" }
 
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }

--- a/crates/atuin-scripts/Cargo.toml
+++ b/crates/atuin-scripts/Cargo.toml
@@ -14,8 +14,8 @@ readme.workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-atuin-client = { path = "../atuin-client", version = "18.13.0" }
-atuin-common = { path = "../atuin-common", version = "18.13.0" }
+atuin-client = { path = "../atuin-client", version = "18.13.1" }
+atuin-common = { path = "../atuin-common", version = "18.13.1" }
 
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }

--- a/crates/atuin-server-database/Cargo.toml
+++ b/crates/atuin-server-database/Cargo.toml
@@ -10,7 +10,7 @@ homepage = { workspace = true }
 repository = { workspace = true }
 
 [dependencies]
-atuin-common = { path = "../atuin-common", version = "18.13.0" }
+atuin-common = { path = "../atuin-common", version = "18.13.1" }
 
 tracing = { workspace = true }
 time = { workspace = true }

--- a/crates/atuin-server-postgres/Cargo.toml
+++ b/crates/atuin-server-postgres/Cargo.toml
@@ -10,8 +10,8 @@ homepage = { workspace = true }
 repository = { workspace = true }
 
 [dependencies]
-atuin-common = { path = "../atuin-common", version = "18.13.0" }
-atuin-server-database = { path = "../atuin-server-database", version = "18.13.0" }
+atuin-common = { path = "../atuin-common", version = "18.13.1" }
+atuin-server-database = { path = "../atuin-server-database", version = "18.13.1" }
 
 eyre = { workspace = true }
 tracing = { workspace = true }

--- a/crates/atuin-server-sqlite/Cargo.toml
+++ b/crates/atuin-server-sqlite/Cargo.toml
@@ -10,8 +10,8 @@ homepage = { workspace = true }
 repository = { workspace = true }
 
 [dependencies]
-atuin-common = { path = "../atuin-common", version = "18.13.0" }
-atuin-server-database = { path = "../atuin-server-database", version = "18.13.0" }
+atuin-common = { path = "../atuin-common", version = "18.13.1" }
+atuin-server-database = { path = "../atuin-server-database", version = "18.13.1" }
 
 eyre = { workspace = true }
 tracing = { workspace = true }

--- a/crates/atuin/Cargo.toml
+++ b/crates/atuin/Cargo.toml
@@ -43,13 +43,13 @@ clipboard = ["arboard"]
 check-update = ["atuin-client/check-update"]
 
 [dependencies]
-atuin-ai = { path = "../atuin-ai", version = "18.13.0", optional = true, default-features = false }
-atuin-client = { path = "../atuin-client", version = "18.13.0", optional = true, default-features = false }
+atuin-ai = { path = "../atuin-ai", version = "18.13.1", optional = true, default-features = false }
+atuin-client = { path = "../atuin-client", version = "18.13.1", optional = true, default-features = false }
 atuin-common = { workspace = true }
 atuin-dotfiles = { workspace = true }
 atuin-history = { workspace = true }
-atuin-daemon = { path = "../atuin-daemon", version = "18.13.0", optional = true, default-features = false }
-atuin-hex = { path = "../atuin-hex", version = "18.13.0", optional = true, default-features = false }
+atuin-daemon = { path = "../atuin-daemon", version = "18.13.1", optional = true, default-features = false }
+atuin-hex = { path = "../atuin-hex", version = "18.13.1", optional = true, default-features = false }
 atuin-scripts = { workspace = true }
 atuin-kv = { workspace = true }
 


### PR DESCRIPTION
We were using buildjet as our runners previously, but it looks like they have gone under. Luckily, GitHub now provides the arm runners we need

## Checks
- [ ] I am happy for maintainers to push small adjustments to this PR, to speed up the review cycle
- [ ] I have checked that there are no existing pull requests for the same thing
