### PR TITLE
fix(nushell): remove invalid -d flag from job spawn command

### DIFF
--- a/crates/atuin/src/shell/atuin.nu
+++ b/crates/atuin/src/shell/atuin.nu
@@ -37,7 +37,7 @@ let _atuin_pre_prompt = {||
     }
     with-env { ATUIN_LOG: error } {
         if (version).minor >= 111 or (version).major > 0 {
-            job spawn -d atuin {
+            job spawn {
                 ^atuin history end $'--exit=($env.LAST_EXIT_CODE)' -- $env.ATUIN_HISTORY_ID | complete
             } | ignore
         } else if (version).minor >= 104 or (version).major > 0 {


### PR DESCRIPTION
## Description

Fixes #3268

The `-d` flag is not a valid option for the `job spawn` command in Nushell. This was causing an error when using Atuin with Nushell 0.111+:

```
× The job spawn command doesn't have flag -d.
╭─[.../.local/share/atuin/init.nu:40:24]
40 │ job spawn -d atuin {
   │           ┬
   │           ╰── unknown flag
```

## Changes

- Removed the invalid `-d atuin` arguments from the `job spawn` command
- The job now spawns correctly without the unknown flag error

## Testing

The fix aligns with the existing pattern used for Nushell 0.104+ (line 43), which uses `job spawn` without the `-d` flag.