### PR TITLE
fix(client): use localtime for day of week in inspector stats

### DIFF
--- a/crates/atuin-client/src/database.rs
+++ b/crates/atuin-client/src/database.rs
@@ -718,7 +718,7 @@ impl Database for Sqlite {
         let mut day_of_week = SqlBuilder::select_from("history");
         day_of_week
             .fields(&[
-                "strftime('%w', ROUND(timestamp / 1000000000), 'unixepoch') AS day_of_week",
+                "strftime('%w', ROUND(timestamp / 1000000000), 'unixepoch', 'localtime') AS day_of_week",
                 "count(1) as count",
             ])
             .and_where("command = ?1")
@@ -731,7 +731,7 @@ impl Database for Sqlite {
         let mut duration_over_time = SqlBuilder::select_from("history");
         duration_over_time
             .fields(&[
-                "strftime('01-%m-%Y', ROUND(timestamp / 1000000000), 'unixepoch') AS month_year",
+                "strftime('01-%m-%Y', ROUND(timestamp / 1000000000), 'unixepoch', 'localtime') AS month_year",
                 "avg(duration) as duration",
             ])
             .and_where("command = ?1")


### PR DESCRIPTION
The 'Runs per day' graph in the inspector was showing incorrect days for users in non-UTC timezones. SQLite's strftime with 'unixepoch' interprets timestamps as UTC, causing the day of week calculation to be wrong when the local day differs from UTC day.

Add 'localtime' modifier to convert UTC timestamps to local time before extracting the day of week and month/year.

Fixes #3251

---

## Checks
- [x] I am happy for maintainers to push small adjustments to this PR, to speed up the review cycle
- [x] I have checked that there are no existing pull requests for the same thing