### PR TITLE
docs: fix typo in FAQ alternatives section

### DIFF
--- a/docs/docs/faq.md
+++ b/docs/docs/faq.md
@@ -80,7 +80,7 @@ If you have a backup of `~/.local/share/atuin`, you can import it by:
 
 ## Alternative projects
 
-If you dont like atuin, perhaps one of these works better for you:
+If you don't like atuin, perhaps one of these works better for you:
 
 - https://github.com/ddworken/hishtory
   - written in go


### PR DESCRIPTION
## Checks
- [x] I am happy for maintainers to push small adjustments to this PR, to speed up the review cycle
- [x] I have checked that there are no existing pull requests for the same thing

## Summary
- fix "dont" to "don't" in the FAQ alternatives section

## Related issue
- N/A (trivial docs fix)

## Guideline alignment
- Follows [CONTRIBUTING.md](https://github.com/atuinsh/atuin/blob/main/CONTRIBUTING.md): single-file docs-only change with no behavior impact.

## Validation
- Not run (documentation-only change)
