### PR TITLE
Fix Bash prompt comment wording

### DIFF
--- a/crates/atuin/src/shell/atuin.bash
+++ b/crates/atuin/src/shell/atuin.bash
@@ -132,7 +132,7 @@ if ((BASH_VERSINFO[0] >= 5 || BASH_VERSINFO[0] == 4 && BASH_VERSINFO[1] >= 4)); 
         # Note: Strip the control characters ^A (\001) and ^B (\002), which
         # Bash internally uses to enclose the escape sequences.  They are
         # produced by '\[' and '\]', respectively, in $PS1 and used to tell
-        # Bash that the strings inbetween do not contribute to the prompt
+        # Bash that the strings in between do not contribute to the prompt
         # width.  After the prompt width calculation, Bash strips those control
         # characters before outputting it to the terminal.  We here strip these
         # characters following Bash's behavior.


### PR DESCRIPTION
## Checks
- [x] I am happy for maintainers to push small adjustments to this PR, to speed up the review cycle
- [x] I have checked that there are no existing pull requests for the same thing

## Summary

Fix a typo in a Bash shell integration comment by changing "inbetween" to "in between".

## Related issue

N/A

## Guideline alignment

Single-file comment-only change from main, aligned with CONTRIBUTING.md.

## Validation/testing

Not run; comment-only change.