### PR TITLE
feat: allow setting kv values via stdin

### DIFF
--- a/crates/atuin/src/command/client/kv.rs
+++ b/crates/atuin/src/command/client/kv.rs
@@ -1,4 +1,4 @@
-use std::io::{self, Read};
+use std::io::{self, IsTerminal, Read};
 
 use clap::Subcommand;
 use eyre::{Context, Result, eyre};
@@ -84,12 +84,16 @@ impl Cmd {
 
                 let value = if let Some(v) = value {
                     v.clone()
-                } else {
+                } else if !io::stdin().is_terminal() {
                     let mut buf = String::new();
                     io::stdin()
                         .read_to_string(&mut buf)
                         .context("failed to read value from stdin")?;
                     buf
+                } else {
+                    return Err(eyre!(
+                        "no value provided. Pass as an argument or pipe via stdin"
+                    ));
                 };
 
                 kv_store.set(namespace, key, &value).await


### PR DESCRIPTION
also ensures we error properly if neither stdin nor an argument are supplied

```bash
echo -n "bar" | atuin kv set -k foo
```

## Checks
- [ ] I am happy for maintainers to push small adjustments to this PR, to speed up the review cycle
- [ ] I have checked that there are no existing pull requests for the same thing
