### PR TITLE
docs: fix typo in alternative projects FAQ

### DIFF
--- a/docs/docs/faq.md
+++ b/docs/docs/faq.md
@@ -80,7 +80,7 @@ If you have a backup of `~/.local/share/atuin`, you can import it by:
 
 ## Alternative projects
 
-If you dont like atuin, perhaps one of these works better for you:
+If you don't like atuin, perhaps one of these works better for you:
 
 - https://github.com/ddworken/hishtory
   - written in go


### PR DESCRIPTION
## Checks
- [x] I am happy for maintainers to push small adjustments to this PR, to speed up the review cycle
- [x] I have checked that there are no existing pull requests for the same thing

## Summary
- fix a typo in the alternative-projects section of the FAQ
- keep the change limited to one docs file with no behavior impact

## Related issue
- N/A

## Guideline alignment
- Minimal docs-only change following the repo contribution guidance: https://github.com/atuinsh/atuin/blob/main/CONTRIBUTING.md

## Validation/testing
- Not run; docs-only change
