### PR TITLE
fix: better tty check

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -11,7 +11,7 @@ for arg in "$@"; do
 done
 
 if [ "$ATUIN_NON_INTERACTIVE" != "yes" ]; then
-  if [ -t 0 ] || [ -c /dev/tty ]; then
+  if [ -t 0 ] || { true </dev/tty; } 2>/dev/null; then
     ATUIN_NON_INTERACTIVE="no"
   else
     ATUIN_NON_INTERACTIVE="yes"


### PR DESCRIPTION
Our previous tty check could return true in environments where the tty device node exists, but cannot actually be opened.

<!-- Thank you for making a PR! Bug fixes are always welcome, but if you're adding a new feature or changing an existing one, we'd really appreciate if you open an issue, post on the forum, or drop in on Discord -->

## Checks
- [ ] I am happy for maintainers to push small adjustments to this PR, to speed up the review cycle
- [ ] I have checked that there are no existing pull requests for the same thing
