### PR TITLE
fix: improve non-interactive TTY detection in install.sh

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -11,7 +11,13 @@ for arg in "$@"; do
 done
 
 if [ "$ATUIN_NON_INTERACTIVE" != "yes" ]; then
-  if [ -t 0 ] || { true </dev/tty; } 2>/dev/null; then
+  # Check if we have a usable interactive terminal.
+  # Using `true </dev/tty` is not sufficient: /dev/tty may exist as a device
+  # node that can be opened, but not actually be backed by a real terminal
+  # (e.g. in containers, CI, or headless environments). This causes the later
+  # `read </dev/tty` calls to fail or hang.
+  # Instead, open /dev/tty and verify it is a terminal with `test -t`.
+  if [ -t 0 ] || ( exec </dev/tty && [ -t 0 ] ) 2>/dev/null; then
     ATUIN_NON_INTERACTIVE="no"
   else
     ATUIN_NON_INTERACTIVE="yes"
@@ -95,7 +101,7 @@ echo ""
 if [ "$ATUIN_NON_INTERACTIVE" != "yes" ]; then
 
   printf "Would you like to import your existing shell history into Atuin? [Y/n] "
-  read -r import_answer </dev/tty || import_answer="n"
+  read -r import_answer </dev/tty 2>/dev/null || import_answer="n"
   import_answer="${import_answer:-y}"
 
   case "$import_answer" in
@@ -123,7 +129,7 @@ Sync your history across all your machines with Atuin Cloud:
 EOF
 
   printf "Sign up for a sync account? [Y/n] "
-  read -r sync_answer </dev/tty || sync_answer="n"
+  read -r sync_answer </dev/tty 2>/dev/null || sync_answer="n"
   sync_answer="${sync_answer:-y}"
 
   case "$sync_answer" in

--- a/install.sh
+++ b/install.sh
@@ -101,7 +101,7 @@ echo ""
 if [ "$ATUIN_NON_INTERACTIVE" != "yes" ]; then
 
   printf "Would you like to import your existing shell history into Atuin? [Y/n] "
-  read -r import_answer </dev/tty 2>/dev/null || import_answer="n"
+  read -r import_answer </dev/tty || import_answer="n"
   import_answer="${import_answer:-y}"
 
   case "$import_answer" in
@@ -129,7 +129,7 @@ Sync your history across all your machines with Atuin Cloud:
 EOF
 
   printf "Sign up for a sync account? [Y/n] "
-  read -r sync_answer </dev/tty 2>/dev/null || sync_answer="n"
+  read -r sync_answer </dev/tty || sync_answer="n"
   sync_answer="${sync_answer:-y}"
 
   case "$sync_answer" in


### PR DESCRIPTION
Fixes #3294

## Checks
- [x] I am happy for maintainers to push small adjustments to this PR, to speed up the review cycle
- [x] I have checked that there are no existing pull requests for the same thing

## Problem

The install script's non-interactive detection uses `{ true </dev/tty; }` to check if a terminal is available. This only tests whether `/dev/tty` can be *opened*, not whether it is actually a functional terminal. In containers, CI, and headless environments (like the Ona setup described in #3294), `/dev/tty` may exist as a device node that the shell can open, but isn't backed by a real terminal. This causes:

1. The detection to incorrectly conclude the session is interactive
2. The subsequent `read </dev/tty` calls to fail with `cannot open /dev/tty: No such device or address`
3. The final `atuin setup </dev/tty` call to hang indefinitely

## Fix

Two changes, both in `install.sh`:

**1. Stronger TTY detection** — Replace `{ true </dev/tty; }` with `( exec </dev/tty && [ -t 0 ] )`. This opens `/dev/tty` as stdin inside a subshell, then checks it's actually a terminal with `test -t`. The subshell ensures the redirect doesn't affect the parent process.

**2. Suppress stderr on `read` fallbacks** — Add `2>/dev/null` to the two `read </dev/tty` calls. They already have `|| var="n"` fallbacks, but without stderr suppression, failed redirects produce noisy error messages on shells like `dash`.