### PR TITLE
Tag docker images with semantic versions on tag creation

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -3,6 +3,8 @@ name: build-docker
 on:
   push:
     branches: [main]
+    tags:
+      - 'v*'
 
 jobs:
   publish:
@@ -31,9 +33,18 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
           registry: ghcr.io
 
-      - name: Get short sha
-        id: shortsha
-        run: echo "short_sha=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/${{ env.REPO_OWNER }}/atuin
+          flavor: |
+            latest=false
+          tags: |
+            type=ref,event=branch
+            type=sha,prefix=
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
 
       - name: Build and push
         uses: depot/build-push-action@v1
@@ -44,7 +55,7 @@ jobs:
           context: .
           provenance: false
           build-args: |
-            Version=dev
-            GitCommit=${{ steps.shortsha.outputs.short_sha }}
-          tags: |
-            ghcr.io/${{ env.REPO_OWNER }}/atuin:${{ steps.shortsha.outputs.short_sha }}
+            Version=${{ fromJSON(steps.meta.outputs.json).labels['org.opencontainers.image.version'] || 'dev' }}
+            GitCommit=${{ github.sha }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
- use the docker metadata action to add tags based on metadata
- do not add the `latest` tag; it's discouraged for self-hosting safety
- continue to include the SHA based tags for granularity

Fixes https://github.com/atuinsh/atuin/issues/3202

<!-- Thank you for making a PR! Bug fixes are always welcome, but if you're adding a new feature or changing an existing one, we'd really appreciate if you open an issue, post on the forum, or drop in on Discord -->

## Checks
- [x] I am happy for maintainers to push small adjustments to this PR, to speed up the review cycle
- [x] I have checked that there are no existing pull requests for the same thing
