### PR TITLE
docs: fix duplicated word in Kubernetes guide

### DIFF
--- a/docs/docs/self-hosting/kubernetes.md
+++ b/docs/docs/self-hosting/kubernetes.md
@@ -228,7 +228,7 @@ Note that this configuration will store the database folder _outside_ the kubern
 
 You should also change the password string in `ATUIN_DB_PASSWORD` and `ATUIN_DB_URI` in the`secrets.yaml` file to a more secure one.
 
-The atuin service on the port `30530` of the host system. That is configured by the `nodePort` property. Kubernetes has a strict rule that you are not allowed to expose a port numbered lower than 30000. To make the clients work, you can simply set the port in in your `config.toml` file, e.g. `sync_address = "http://192.168.1.10:30530"`.
+The atuin service on the port `30530` of the host system. That is configured by the `nodePort` property. Kubernetes has a strict rule that you are not allowed to expose a port numbered lower than 30000. To make the clients work, you can simply set the port in your `config.toml` file, e.g. `sync_address = "http://192.168.1.10:30530"`.
 
 Deploy the Atuin server using `kubectl`:
 


### PR DESCRIPTION
## Checks
- [x] I am happy for maintainers to push small adjustments to this PR, to speed up the review cycle
- [x] I have checked that there are no existing pull requests for the same thing

## Summary
- fix a duplicated `in` in the Kubernetes self-hosting guide

## Related issue
- N/A (trivial documentation typo fix)

## Guideline alignment
- Read https://github.com/atuinsh/atuin/blob/main/CONTRIBUTING.md
- one-file docs-only change
- no behavior change

## Validation
- Not run (docs-only change)
