### PR TITLE
ci: add riscv64 to release targets

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -54,7 +54,7 @@ jobs:
         # There was an attempt to make cross-compiles also work on FreeBSD, but that failed with:
         #
         # warning: libelf.so.2, needed by <...>/libkvm.so, not found (try using -rpath or -rpath-link)
-        target: [x86_64-unknown-illumos]
+        target: [x86_64-unknown-illumos, riscv64gc-unknown-linux-gnu]
     runs-on: depot-ubuntu-24.04
     steps:
       - uses: actions/checkout@v7

--- a/dist-workspace.toml
+++ b/dist-workspace.toml
@@ -12,7 +12,7 @@ ci = "github"
 # The installers to generate for each app
 installers = ["shell", "powershell"]
 # Target platforms to build apps for (Rust target-triple syntax)
-targets = ["aarch64-apple-darwin", "aarch64-unknown-linux-gnu", "aarch64-unknown-linux-musl", "x86_64-unknown-linux-gnu", "x86_64-unknown-linux-musl", "x86_64-pc-windows-msvc"]
+targets = ["aarch64-apple-darwin", "aarch64-unknown-linux-gnu", "aarch64-unknown-linux-musl", "riscv64gc-unknown-linux-gnu", "x86_64-unknown-linux-gnu", "x86_64-unknown-linux-musl", "x86_64-pc-windows-msvc"]
 # Which actions to run on pull requests
 pr-run-mode = "plan"
 # Whether to install an updater program
@@ -25,6 +25,7 @@ github-attestations = true
 [dist.github-custom-runners]
 aarch64-unknown-linux-gnu = "depot-ubuntu-24.04-arm-8"
 aarch64-unknown-linux-musl = "depot-ubuntu-24.04-arm-8"
+riscv64gc-unknown-linux-gnu = "ubuntu-24.04-riscv"
 x86_64-unknown-linux-gnu = "depot-ubuntu-24.04-8"
 x86_64-unknown-linux-musl = "depot-ubuntu-24.04-8"
 

--- a/docs/docs/support.md
+++ b/docs/docs/support.md
@@ -71,7 +71,11 @@ and how far continuous integration (CI) exercises it.
     </tr>
     <tr><td><code>WSL-2</code></td><td><code>x86_64</code></td><td class="support-yes">✓</td><td>tested</td><td></td></tr>
     <tr>
-      <td rowspan="2" class="tier"><strong>2</strong></td>
+      <td rowspan="3" class="tier"><strong>2</strong></td>
+      <td><code>Linux</code></td><td><code>riscv64</code></td><td class="support-yes">✓</td><td>build-only</td>
+      <td>Built on <a href="https://riseproject.dev/">RISE Project</a> runners.</td>
+    </tr>
+    <tr>
       <td><code>Illumos</code></td><td><code>x86_64</code></td><td class="support-no">✗</td><td>build-only</td>
       <td></td>
     </tr>


### PR DESCRIPTION
Adds riscv64gc-unknown-linux-gnu to the cargo-dist targets in dist-workspace.toml, with ubuntu-24.04-riscv as the custom runner.

The release workflow reads targets dynamically via `dist plan`, so no workflow changes needed.

RISE runners are provided by the RISE Project (https://riseproject.dev/), free for open source. To enable: install https://github.com/apps/rise-risc-v-runners on this repository. Without it, the riscv64 job stays queued with no runner.

Build validated on native riscv64: https://github.com/gounthar/atuin/actions/runs/23430141128

Closes #3046