### PR TITLE
docs: fix duplicate word in nucleo comment

### DIFF
--- a/crates/atuin-nucleo/src/lib.rs
+++ b/crates/atuin-nucleo/src/lib.rs
@@ -375,7 +375,7 @@ impl<T: Sync + Send + 'static> Nucleo<T> {
         }
     }
 
-    /// Restart the the item stream. Removes all items and disconnects all
+    /// Restart the item stream. Removes all items and disconnects all
     /// previously created injectors from this instance. If `clear_snapshot`
     /// is `true` then all items and matched are removed from the [`Snapshot`]
     /// immediately. Otherwise the snapshot will keep the current matches until


### PR DESCRIPTION
## Checks
- [x] I am happy for maintainers to push small adjustments to this PR, to speed up the review cycle
- [x] I have checked that there are no existing pull requests for the same thing

## Summary
- Fix the duplicated `the` in a comment in `crates/atuin-nucleo/src/lib.rs`.

## Related issue
- N/A (trivial comment fix)

## Guideline alignment
- Reviewed `CONTRIBUTING.md` and the PR template before editing.
- Kept the diff to one file with no behavior changes.

## Validation
- Not run (comment-only change).