### PR TITLE
fix: use printf to append fish shell init block

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -46,9 +46,6 @@ __atuin_install_binary(){
 if ! command -v curl > /dev/null; then
     echo "curl not installed. Please install curl."
     exit
-elif ! command -v sed > /dev/null; then
-    echo "sed not installed. Please install sed."
-    exit
 fi
 
 
@@ -71,19 +68,9 @@ if ! grep -q "atuin init bash" ~/.bashrc; then
 fi
 
 if [ -f "$HOME/.config/fish/config.fish" ]; then
-  # Check if the line already exists to prevent duplicates
   if ! grep -q "atuin init fish" "$HOME/.config/fish/config.fish"; then
-        # Detect BSD or GNU sed
-        if sed --version >/dev/null 2>&1; then
-          # GNU
-          sed -i '/if status is-interactive/,/end/ s/end$/    atuin init fish | source\
-end/' "$HOME/.config/fish/config.fish"
-        else
-          # BSD (macOS)
-          sed -i '' '/if status is-interactive/,/end/ s/end$/    atuin init fish | source\
-end/' "$HOME/.config/fish/config.fish"
-        fi
-    fi
+    printf '\nif status is-interactive\n    atuin init fish | source\nend\n' >> "$HOME/.config/fish/config.fish"
+  fi
 fi
 
 ATUIN_BIN="$HOME/.atuin/bin/atuin"


### PR DESCRIPTION
## Summary

- The existing sed-based fish config injection produced malformed output on some systems, concatenating 'atuin init fish | source' and 'end' onto the same line (issue #3192)
- Replace the GNU/BSD sed detection block with a single printf append that writes a self-contained 'if status is-interactive' block
- Remove the now-unnecessary sed dependency check from the installer

## Root cause

sed backslash-newline replacement behaves inconsistently across GNU and BSD (macOS) implementations, causing the newline to be dropped on some systems.

## Fix

Use printf to append a new 'if status is-interactive' block, consistent with how bash/zsh init lines are already added.

## Test plan

- shellcheck -e SC2148 install.sh passes with no warnings
- Idempotency preserved via existing grep -q duplicate guard

Fixes #3192