### PR TITLE
fix: set WorkingDirectory in PowerShell Invoke-AtuinSearch

### DIFF
--- a/crates/atuin/src/shell/atuin.ps1
+++ b/crates/atuin/src/shell/atuin.ps1
@@ -150,6 +150,8 @@ New-Module -Name Atuin -ScriptBlock {
             $process.StartInfo.StandardErrorEncoding = [System.Text.Encoding]::UTF8
             $process.StartInfo.EnvironmentVariables["ATUIN_SHELL"] = "powershell"
             $process.StartInfo.EnvironmentVariables["ATUIN_QUERY"] = Get-CommandLine
+            # PowerShell's Set-Location (cd) doesn't update the process-level working directory, set it explicitly
+            $process.StartInfo.WorkingDirectory = (Get-Location -PSProvider FileSystem).ProviderPath
 
             try {
                 $process.Start() | Out-Null


### PR DESCRIPTION
Fixes #3350

PowerShell's Set-Location (cd) doesn't update the process-level working directory, so the spawned search process sees a stale cwd and directory filter mode matches against the wrong directory. Setting `WorkingDirectory` on the `ProcessStartInfo` ensures the correct cwd is passed through.