### PR TITLE
chore(ci): switch most workflows to depot ci

### DIFF
--- a/.depot/workflows/codespell.yml
+++ b/.depot/workflows/codespell.yml
@@ -1,0 +1,28 @@
+# Depot CI Migration
+# Source: .github/workflows/codespell.yml
+#
+# No changes were necessary.
+
+# Codespell configuration is within .codespellrc
+name: Codespell
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+permissions:
+  contents: read
+jobs:
+  codespell:
+    name: Check for spelling errors
+    runs-on: depot-ubuntu-24.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+      - name: Codespell
+        uses: codespell-project/actions-codespell@v2
+        with:
+          # This is regenerated from commit history
+          # we cannot rewrite commit history, and I'd rather not correct it
+          # every time
+          exclude_file: CHANGELOG.md

--- a/.depot/workflows/installer.yml
+++ b/.depot/workflows/installer.yml
@@ -1,0 +1,36 @@
+# Depot CI Migration
+# Source: .github/workflows/installer.yml
+#
+# No changes were necessary.
+
+name: Install
+on:
+  push:
+    branches: [main]
+  pull_request:
+    paths: .github/workflows/installer.yml
+env:
+  CARGO_TERM_COLOR: always
+jobs:
+  install:
+    strategy:
+      matrix:
+        os: [depot-ubuntu-24.04, macos-14]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v6
+      - name: Install zsh for ubuntu
+        if: matrix.os == 'depot-ubuntu-24.04'
+        run: |
+          sudo apt install zsh
+      - name: Test install script on bash
+        run: |
+          /bin/bash -c "$(curl --proto '=https' --tlsv1.2 -sSf https://setup.atuin.sh)"
+          [ -d "$HOME/.atuin" ] && source $HOME/.atuin/bin/env
+          atuin --help
+      - name: Test install script on zsh
+        shell: zsh {0}
+        run: |
+          /bin/bash -c "$(curl --proto '=https' --tlsv1.2 -sSf https://setup.atuin.sh)"
+          [ -d "$HOME/.atuin" ] && source $HOME/.atuin/bin/env
+          atuin --help

--- a/.depot/workflows/nix.yml
+++ b/.depot/workflows/nix.yml
@@ -1,0 +1,33 @@
+# Depot CI Migration
+# Source: .github/workflows/nix.yml
+#
+# No changes were necessary.
+
+# Verify the Nix build is working
+# Failures will usually occur due to an out of date Rust version
+# That can be updated to the latest version in nixpkgs-unstable with `nix flake update`
+name: Nix
+on:
+  push:
+    branches: [main]
+    paths-ignore:
+      - 'ui/**'
+  pull_request:
+    branches: [main]
+    paths-ignore:
+      - 'ui/**'
+jobs:
+  check:
+    runs-on: depot-ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v6
+      - uses: cachix/install-nix-action@v31
+      - name: Run nix flake check
+        run: nix flake check --print-build-logs
+  build-test:
+    runs-on: depot-ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v6
+      - uses: cachix/install-nix-action@v31
+      - name: Run nix build
+        run: nix build --print-build-logs

--- a/.depot/workflows/rust.yml
+++ b/.depot/workflows/rust.yml
@@ -1,0 +1,187 @@
+# Depot CI Migration
+# Source: .github/workflows/rust.yml
+#
+# No changes were necessary.
+
+name: Rust
+on:
+  push:
+    branches: [main]
+    paths-ignore:
+      - "ui/**"
+  pull_request:
+    branches: [main]
+    paths-ignore:
+      - "ui/**"
+env:
+  CARGO_TERM_COLOR: always
+jobs:
+  build:
+    strategy:
+      matrix:
+        os: [depot-ubuntu-24.04, macos-14, windows-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v6
+      - name: Install rust
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: 1.94.0
+      - uses: actions/cache@v5
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-release-${{ hashFiles('**/Cargo.lock') }}
+      - name: Run cargo build common
+        run: cargo build -p atuin-common --locked --release
+      - name: Run cargo build client
+        run: cargo build -p atuin-client --locked --release
+      - name: Run cargo build server
+        run: cargo build -p atuin-server --locked --release
+      - name: Run cargo build main
+        run: cargo build --all --locked --release
+  cross-compile:
+    strategy:
+      matrix:
+        # There was an attempt to make cross-compiles also work on FreeBSD, but that failed with:
+        #
+        # warning: libelf.so.2, needed by <...>/libkvm.so, not found (try using -rpath or -rpath-link)
+        target: [x86_64-unknown-illumos]
+    runs-on: depot-ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v6
+      - name: Install cross
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cross
+      - uses: actions/cache@v5
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ matrix.target }}-cross-compile-${{ hashFiles('**/Cargo.lock') }}
+      - name: Run cross build common
+        run: cross build -p atuin-common --locked --target ${{ matrix.target }}
+      - name: Run cross build client
+        run: cross build -p atuin-client --locked --target ${{ matrix.target }}
+      - name: Run cross build server
+        run: cross build -p atuin-server --locked --target ${{ matrix.target }}
+      - name: Run cross build main
+        run: |
+          cross build --all --locked --target ${{ matrix.target }}
+  unit-test:
+    strategy:
+      matrix:
+        os: [depot-ubuntu-24.04, macos-14, windows-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v6
+      - name: Install rust
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: 1.94.0
+      - uses: taiki-e/install-action@v2
+        name: Install nextest
+        with:
+          tool: cargo-nextest
+      - uses: actions/cache@v5
+        with:
+          path: |
+            ~/.cargo/registry
+             ~/.cargo/git
+             target
+          key: ${{ runner.os }}-cargo-debug-${{ hashFiles('**/Cargo.lock') }}
+      - name: Run cargo test
+        run: cargo nextest run --lib --bins
+  check:
+    strategy:
+      matrix:
+        os: [depot-ubuntu-24.04, macos-14, windows-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v6
+      - name: Install rust
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: 1.94.0
+      - uses: actions/cache@v5
+        with:
+          path: |
+            ~/.cargo/registry
+             ~/.cargo/git
+             target
+          key: ${{ runner.os }}-cargo-debug-${{ hashFiles('**/Cargo.lock') }}
+      - name: Run cargo check (all features)
+        run: cargo check --all-features --workspace
+      - name: Run cargo check (no features)
+        run: cargo check --no-default-features --workspace
+      - name: Run cargo check (sync)
+        run: cargo check --no-default-features --features sync --workspace
+      - name: Run cargo check (server)
+        run: cargo check -p atuin-server
+      - name: Run cargo check (client only)
+        run: cargo check --no-default-features --features client --workspace
+  integration-test:
+    runs-on: depot-ubuntu-24.04
+    services:
+      postgres:
+        image: postgres
+        env:
+          POSTGRES_USER: atuin
+          POSTGRES_PASSWORD: pass
+          POSTGRES_DB: atuin
+        ports:
+          - 5432:5432
+    steps:
+      - uses: actions/checkout@v6
+      - name: Install rust
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: 1.94.0
+      - uses: taiki-e/install-action@v2
+        name: Install nextest
+        with:
+          tool: cargo-nextest
+      - uses: actions/cache@v5
+        with:
+          path: |
+            ~/.cargo/registry
+             ~/.cargo/git
+             target
+          key: ${{ runner.os }}-cargo-debug-${{ hashFiles('**/Cargo.lock') }}
+      - name: Run cargo test
+        run: cargo nextest run --test '*'
+        env:
+          ATUIN_DB_URI: postgres://atuin:pass@localhost:5432/atuin
+  clippy:
+    runs-on: depot-ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v6
+      - name: Install latest rust
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: 1.94.0
+          components: clippy
+      - uses: actions/cache@v5
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-debug-${{ hashFiles('**/Cargo.lock') }}
+      - name: Run clippy
+        run: cargo clippy -- -D warnings -D clippy::redundant_clone
+  format:
+    runs-on: depot-ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v6
+      - name: Install latest rust
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: 1.94.0
+          components: rustfmt
+      - name: Format
+        run: cargo fmt -- --check

--- a/.depot/workflows/shellcheck.yml
+++ b/.depot/workflows/shellcheck.yml
@@ -1,0 +1,20 @@
+# Depot CI Migration
+# Source: .github/workflows/shellcheck.yml
+#
+# No changes were necessary.
+
+name: Shellcheck
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+jobs:
+  shellcheck:
+    runs-on: depot-ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v6
+      - name: Run shellcheck
+        uses: ludeeus/action-shellcheck@master
+        env:
+          SHELLCHECK_OPTS: "-e SC2148"

--- a/.depot/workflows/update-nix-deps.yml
+++ b/.depot/workflows/update-nix-deps.yml
@@ -1,0 +1,25 @@
+# Depot CI Migration
+# Source: .github/workflows/update-nix-deps.yml
+#
+# No changes were necessary.
+
+name: Update Nix Deps
+on:
+  workflow_dispatch: # allows manual triggering
+  schedule:
+    - cron: '0 0 1 * *' # runs monthly on the first day of the month at 00:00
+jobs:
+  lockfile:
+    runs-on: depot-ubuntu-24.04
+    if: github.repository == 'atuinsh/atuin'
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+      - name: Install Nix
+        uses: DeterminateSystems/nix-installer-action@main
+      - name: Update flake.lock
+        uses: DeterminateSystems/update-flake-lock@main
+        with:
+          pr-title: "chore(deps): update flake.lock"
+          pr-labels: |
+            dependencies


### PR DESCRIPTION
Continuing the trend of shifting away from GitHub services. Depot is faster, and more reliable.

Avoiding docker + release workflows for now, as those have been a pain in the ass to get correct.

Will check and see if we can ensure the logs/etc can be public.

I'm going to merge this, see how well it works, and if we're good delete the matching github workflows

<!-- Thank you for making a PR! Bug fixes are always welcome, but if you're adding a new feature or changing an existing one, we'd really appreciate if you open an issue, post on the forum, or drop in on Discord -->

## Checks
- [ ] I am happy for maintainers to push small adjustments to this PR, to speed up the review cycle
- [ ] I have checked that there are no existing pull requests for the same thing
