### PR TITLE
fix(powershell): handle non-FileSystem drives

### DIFF
--- a/crates/atuin/src/shell/atuin.ps1
+++ b/crates/atuin/src/shell/atuin.ps1
@@ -144,7 +144,7 @@ New-Module -Name Atuin -ScriptBlock {
             # Start-Process does some crazy stuff, just use the Process class directly to have more control.
             $process = New-Object System.Diagnostics.Process
             $process.StartInfo.FileName = "atuin"
-            $process.StartInfo.Arguments = "search -i --result-file ""$resultFile"" $ExtraArgs"
+            $process.StartInfo.Arguments = "search -i --result-file ""$($resultFile.FullName)"" $ExtraArgs"
             $process.StartInfo.UseShellExecute = $false
             $process.StartInfo.RedirectStandardError = $true
             $process.StartInfo.StandardErrorEncoding = [System.Text.Encoding]::UTF8
@@ -159,7 +159,7 @@ New-Module -Name Atuin -ScriptBlock {
                 $errorOutput = $process.StandardError.ReadToEnd().Trim()
                 $process.WaitForExit()
 
-                $suggestion = (Get-Content -Raw $resultFile -Encoding UTF8 | Out-String).Trim()
+                $suggestion = (Get-Content -LiteralPath $resultFile.FullName -Raw -Encoding UTF8 | Out-String).Trim()
             }
             catch {
                 $errorOutput = $_
@@ -203,7 +203,7 @@ New-Module -Name Atuin -ScriptBlock {
         }
         finally {
             [System.Console]::OutputEncoding = $previousOutputEncoding
-            Remove-Item $resultFile
+            $resultFile.Delete()
         }
     }
 


### PR DESCRIPTION
The current version generates the following error when PowerShell's current directory is on a [non-FileSystem drive](https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_providers):

> A parameter cannot be found that matches parameter name 'Raw'.

Repro:

<img width="475" height="166" alt="image" src="https://github.com/user-attachments/assets/72af2dd1-ff80-46e1-936d-808d0563796a" />


<!-- Thank you for making a PR! Bug fixes are always welcome, but if you're adding a new feature or changing an existing one, we'd really appreciate if you open an issue, post on the forum, or drop in on Discord -->

## Checks
- [x] I am happy for maintainers to push small adjustments to this PR, to speed up the review cycle
- [x] I have checked that there are no existing pull requests for the same thing
