### PR TITLE
fix: replace `e>|` with `|` in nushell integration to restore history recording

### DIFF
--- a/crates/atuin/src/shell/atuin.nu
+++ b/crates/atuin/src/shell/atuin.nu
@@ -26,7 +26,7 @@ let _atuin_pre_execution = {||
         return
     }
     if not ($cmd | str starts-with $ATUIN_KEYBINDING_TOKEN) {
-        $env.ATUIN_HISTORY_ID = (atuin history start -- $cmd e>| complete | get stdout | str trim)
+        $env.ATUIN_HISTORY_ID = (atuin history start -- $cmd | complete | get stdout | str trim)
     }
 }
 


### PR DESCRIPTION
<!-- Thank you for making a PR! Bug fixes are always welcome, but if you're adding a new feature or changing an existing one, we'd really appreciate if you open an issue, post on the forum, or drop in on Discord -->

## Summary

Fix nushell history recording completely broken since v18.13.0. No commands are recorded because `ATUIN_HISTORY_ID` is always set to an empty string.

Closes #3308

## Root Cause

PR #3183 (first included in v18.13.0) changed the `_atuin_pre_execution` hook:

```diff
- $env.ATUIN_HISTORY_ID = (atuin history start -- $cmd)
+ $env.ATUIN_HISTORY_ID = (atuin history start -- $cmd e>| complete | get stdout | str trim)
```

The intent was to silence DB errors (e.g. when disk is full) by using `complete` to swallow failures. However, `e>|` redirects exclusively stderr into the pipe, dropping stdout. `complete` then sees atuin's stdout in the `stderr` field and the `stdout` field is empty. The result is that `ATUIN_HISTORY_ID` is always empty, and no commands are ever recorded.

All nushell versions are affected. Not only 0.111.0, as I incorrectly wrote in [the issue](https://github.com/atuinsh/atuin/issues/3308#issuecomment-4113840110).

## Fix

Replace `e>|` with `|`. The `| complete | get stdout` pattern still silences errors: `complete` captures stdout, stderr, and exit code into a record, and `get stdout` discards the rest, preserving the error suppression from #3183 without breaking stdout capture.

## Testing

Tested with nix shells across three nushell versions (0.98, 0.103, 0.111):

**History recording:**

| Version | `e>\| complete \| get stdout` | `\| complete \| get stdout` |
|---------|-------------------------------|------------------------------|
| 0.98    | empty (broken)                | valid history ID             |
| 0.103   | empty (broken)                | valid history ID             |
| 0.111   | empty (broken)                | valid history ID             |

**Error silencing** (verified `| complete | get stdout` on a failing command):

| Version | Error shown to user? | stdout field |
|---------|---------------------|--------------|
| 0.98    | No                  | empty        |
| 0.103   | No                  | empty        |
| 0.111   | No                  | empty        |



## Checks
- [x] I am happy for maintainers to push small adjustments to this PR, to speed up the review cycle
- [x] I have checked that there are no existing pull requests for the same thing
