### PR TITLE
fix: minor issues with fish's vim mode(s)

### DIFF
--- a/crates/atuin-ai/src/commands/init.rs
+++ b/crates/atuin-ai/src/commands/init.rs
@@ -176,7 +176,7 @@ function _atuin_ai_question_mark
         else
             commandline -f repaint
         end
-    else
+    else if test "$fish_key_bindings" = "fish_default_key_bindings"
         # Not at empty prompt, just insert the question mark
         commandline -i "?"
     end

--- a/crates/atuin-ai/src/commands/init.rs
+++ b/crates/atuin-ai/src/commands/init.rs
@@ -176,7 +176,7 @@ function _atuin_ai_question_mark
         else
             commandline -f repaint
         end
-    else if test "$fish_key_bindings" = "fish_default_key_bindings"
+    else if not contains -- "$fish_key_bindings" fish_vi_key_bindings fish_hybrid_key_bindings
         # Not at empty prompt, just insert the question mark
         commandline -i "?"
     end

--- a/crates/atuin/src/shell/atuin.fish
+++ b/crates/atuin/src/shell/atuin.fish
@@ -67,7 +67,7 @@ end
 function _atuin_search
     set -l keymap_mode
     switch $fish_key_bindings
-        case fish_vi_key_bindings
+        case fish_vi_key_bindings fish_hybrid_key_bindings
             switch $fish_bind_mode
                 case default
                     set keymap_mode vim-normal


### PR DESCRIPTION
This PR fixes two minor issues when using Atuin with fish's vim mode(s):
1. Add support for `fish_hybrid_key_bindings`: in addition to `fish_vi_key_bindings`, fish also provides `fish_hybrid_key_bindings`, which is a vi-based mode with some extra keybinds; but the key bind check for `atuin search` only checks for the former.
2. The AI keybind inserts a `?` on the command line in vim mode even though it can only be called from normal mode, when pressing `?` normally does nothing.

Fixes #3446.

## Checks
- [x] I am happy for maintainers to push small adjustments to this PR, to speed up the review cycle
- [x] I have checked that there are no existing pull requests for the same thing
