### PR TITLE
feat: option to disable mouse support

### DIFF
--- a/crates/atuin-client/src/settings.rs
+++ b/crates/atuin-client/src/settings.rs
@@ -1094,6 +1094,7 @@ pub struct Settings {
     pub history_format: String,
     pub prefers_reduced_motion: bool,
     pub store_failed: bool,
+    pub no_mouse: bool,
 
     #[serde(with = "serde_regex", default = "RegexSet::empty", skip_serializing)]
     pub history_filter: RegexSet,
@@ -1563,6 +1564,7 @@ impl Settings {
                     .map(|_| config::Value::new(None, config::ValueKind::Boolean(true)))
                     .unwrap_or_else(|| config::Value::new(None, config::ValueKind::Boolean(false))),
             )?
+            .set_default("no_mouse", false)?
             .add_source(
                 Environment::with_prefix("atuin")
                     .prefix_separator("_")

--- a/crates/atuin/src/command/client/search/interactive.rs
+++ b/crates/atuin/src/command/client/search/interactive.rs
@@ -1488,10 +1488,11 @@ fn restore_popup_area(saved: &SavedScreen, popup_rect: Rect, scroll_offset: u16)
 struct Stdout {
     writer: TerminalWriter,
     inline_mode: bool,
+    no_mouse: bool,
 }
 
 impl Stdout {
-    pub fn new(inline_mode: bool) -> std::io::Result<Self> {
+    pub fn new(inline_mode: bool, no_mouse: bool) -> std::io::Result<Self> {
         terminal::enable_raw_mode()?;
 
         let mut writer = TerminalWriter::new()?;
@@ -1500,11 +1501,11 @@ impl Stdout {
             execute!(writer, terminal::EnterAlternateScreen)?;
         }
 
-        execute!(
-            writer,
-            event::EnableMouseCapture,
-            event::EnableBracketedPaste,
-        )?;
+        if !no_mouse {
+            execute!(writer, event::EnableMouseCapture)?;
+        }
+
+        execute!(writer, event::EnableBracketedPaste)?;
 
         #[cfg(not(target_os = "windows"))]
         execute!(
@@ -1519,6 +1520,7 @@ impl Stdout {
         Ok(Self {
             writer,
             inline_mode,
+            no_mouse,
         })
     }
 }
@@ -1531,12 +1533,10 @@ impl Drop for Stdout {
         if !self.inline_mode {
             execute!(self.writer, terminal::LeaveAlternateScreen).unwrap();
         }
-        execute!(
-            self.writer,
-            event::DisableMouseCapture,
-            event::DisableBracketedPaste,
-        )
-        .unwrap();
+        if !self.no_mouse {
+            execute!(self.writer, event::DisableMouseCapture).unwrap();
+        }
+        execute!(self.writer, event::DisableBracketedPaste).unwrap();
 
         terminal::disable_raw_mode().unwrap();
     }
@@ -1665,7 +1665,7 @@ pub async fn history(
 
     let popup_mode = saved_screen.is_some();
 
-    let stdout = Stdout::new(inline_height > 0)?;
+    let stdout = Stdout::new(inline_height > 0, settings.no_mouse)?;
 
     // In popup mode, clear the popup region on the physical terminal before
     // ratatui takes over. Ratatui's diff-based rendering compares against an


### PR DESCRIPTION
<!-- Thank you for making a PR! Bug fixes are always welcome, but if you're adding a new feature or changing an existing one, we'd really appreciate if you open an issue, post on the forum, or drop in on Discord -->

## Checks
- [x] I am happy for maintainers to push small adjustments to this PR, to speed up the review cycle
- [x] I have checked that there are no existing pull requests for the same thing

This adds an option to disable mouse support, so that the terminal handles mouse events, making it easy to select text. I've found myself needing to copy from history frequently recently and holding Shift is not convenient.

However, this makes mouse scrolling not work as expected, e.g. in my case it scrolls six lines at a time.

Also see #1209.