### PR TITLE
fix: correct grammar in 'history last' help text

### DIFF
--- a/crates/atuin/src/command/client/history.rs
+++ b/crates/atuin/src/command/client/history.rs
@@ -104,7 +104,7 @@ pub enum Cmd {
         format: Option<String>,
     },
 
-    /// Get the last command ran
+    /// Get the last command you ran
     Last {
         #[arg(long)]
         human: bool,


### PR DESCRIPTION
## Summary

- Fixes grammatically incorrect help text in `atuin history last` command
- Changes "Get the last command ran" to "Get the last command you ran"

Fixes #3324

## Test plan

- [x] Built the project successfully (`cargo build`)
- [x] All 259 library unit tests pass (`cargo test --lib`)
- [x] Verified the corrected help text appears in `atuin history last --help`

Bahtya