### PR TITLE
feat: autoinstall ai shell history hooks

### DIFF
--- a/docs/docs/guide/agent-hooks.md
+++ b/docs/docs/guide/agent-hooks.md
@@ -38,15 +38,11 @@ Only `Bash` tool invocations are captured. Other tool types (file writes, web fe
 
 By default, Atuin's interactive search shows only your own commands. Agent-run commands are hidden so they don't clutter your history.
 
-This is controlled by the `search.authors` setting in `~/.config/atuin/config.toml`:
+Today this default is built into the search UI rather than configurable via `config.toml`. Interactive search uses the equivalent of:
 
-```toml
-[search]
-# Default: only show commands from human users
-authors = ["$all-user"]
-```
+- `$all-user` — any author that is **not** a known AI agent
 
-### Special filter values
+For explicit author filtering, use the CLI `atuin search --author ...` flag. Special values:
 
 | Value | Meaning |
 |-------|---------|
@@ -55,22 +51,19 @@ authors = ["$all-user"]
 
 You can also use literal author names:
 
-```toml
-[search]
+```shell
 # Show only your own commands and Claude Code commands
-authors = ["$all-user", "claude-code"]
+atuin search --author '$all-user' --author 'claude-code' -- ''
 ```
 
-```toml
-[search]
+```shell
 # Show everything (no filtering)
-authors = []
+atuin search -- ''
 ```
 
-```toml
-[search]
+```shell
 # Show only agent commands
-authors = ["$all-agent"]
+atuin search --author '$all-agent' -- ''
 ```
 
 Currently recognized agent names are: `claude-code`, `codex`, and `copilot`.

--- a/install.sh
+++ b/install.sh
@@ -75,6 +75,39 @@ fi
 
 ATUIN_BIN="$HOME/.atuin/bin/atuin"
 
+__atuin_install_agent_hook(){
+  agent="$1"
+  agent_name="$2"
+  agent_config_dir="$3"
+  shift 3
+
+  detected="no"
+
+  if [ -d "$agent_config_dir" ]; then
+    detected="yes"
+  else
+    for agent_command in "$@"; do
+      if command -v "$agent_command" > /dev/null 2>&1; then
+        detected="yes"
+        break
+      fi
+    done
+  fi
+
+  if [ "$detected" = "yes" ]; then
+    echo "Detected $agent_name — installing Atuin hooks..."
+    if ! "$ATUIN_BIN" hook install "$agent"; then
+      echo "Failed to install Atuin hooks for $agent_name (this version of Atuin may not support it yet)."
+    fi
+    echo ""
+  fi
+}
+
+__atuin_install_agent_hook "claude-code" "Claude Code" "$HOME/.claude" claude
+__atuin_install_agent_hook "codex" "Codex" "$HOME/.codex" codex
+__atuin_install_agent_hook "pi" "pi" "$HOME/.config/pi" pi
+__atuin_install_agent_hook "opencode" "OpenCode" "$HOME/.config/opencode" opencode
+
 echo ""
 echo "Atuin installed successfully!"
 echo ""


### PR DESCRIPTION
Follows our existing behaviour of automatically installing shell hooks, extend this for ai agents too

## Checks
- [ ] I am happy for maintainers to push small adjustments to this PR, to speed up the review cycle
- [ ] I have checked that there are no existing pull requests for the same thing
