### PR TITLE
Add OCI standard labels to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,9 @@ COPY . .
 RUN cargo build --release --bin atuin-server
 
 FROM debian:bookworm-20260202-slim AS runtime
+LABEL org.opencontainers.image.source="https://github.com/atuinsh/atuin" \
+  org.opencontainers.image.url="https://atuin.sh" \
+  org.opencontainers.image.licenses="MIT"
 
 RUN useradd -c 'atuin user' atuin && mkdir /config && chown atuin:atuin /config
 # Install ca-certificates for webhooks to work


### PR DESCRIPTION
<!-- Thank you for making a PR! Bug fixes are always welcome, but if you're adding a new feature or changing an existing one, we'd really appreciate if you open an issue, post on the forum, or drop in on Discord -->

## Checks
- [x] I am happy for maintainers to push small adjustments to this PR, to speed up the review cycle
- [x] I have checked that there are no existing pull requests for the same thing

Hi there! Just a small thing I noticed; I self-host an Atuin server via Docker and have started bumping my compose dependencies with Renovate. They have a feature that pulls the changelog and displays it in-line in the PR, which is handy when it works! - but currently this doesn't work for Atuin. According to [their documentation](https://docs.renovatebot.com/modules/datasource/docker/#description), the `org.opencontainers.image.source` label needs to point to the repository for them to grab release notes. Renovate cites their Dockerfile as an example, so I took a look at [the actual Dockerfile](https://github.com/renovatebot/renovate/blob/main/tools/docker/Dockerfile) to see if they had any other labels, and figured I'd pop those in as well.

No particularly strong feelings on the labeling itself, styling, etc; so free free to make any changes deemed necessary :)