### PR TITLE
chore(release): prepare for release 18.15.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,26 @@
 
 All notable changes to this project will be documented in this file.
 
+## 18.15.0
+
+### Bug Fixes
+
+- Install script incorrectly tries to install opencode hooks ([#3410](https://github.com/atuinsh/atuin/issues/3410))
+- Dependency fix ([#3414](https://github.com/atuinsh/atuin/issues/3414))
+- Loss of loading spinners + tokio panic on exit ([#3415](https://github.com/atuinsh/atuin/issues/3415))
+
+
+### Features
+
+- Add OCI standard labels to Dockerfile ([#3412](https://github.com/atuinsh/atuin/issues/3412))
+- Enable atuin hex for illumos ([#3413](https://github.com/atuinsh/atuin/issues/3413))
+- Allow resuming previous AI sessions ([#3407](https://github.com/atuinsh/atuin/issues/3407))
+
+
+### Miscellaneous Tasks
+
+- Add release script ([#3411](https://github.com/atuinsh/atuin/issues/3411))
+
 ## 18.14.1
 
 ### Bug Fixes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -208,7 +208,7 @@ checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "atuin"
-version = "18.14.1"
+version = "18.15.0"
 dependencies = [
  "arboard",
  "async-trait",
@@ -268,7 +268,7 @@ dependencies = [
 
 [[package]]
 name = "atuin-ai"
-version = "18.14.1"
+version = "18.15.0"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -316,7 +316,7 @@ dependencies = [
 
 [[package]]
 name = "atuin-client"
-version = "18.14.1"
+version = "18.15.0"
 dependencies = [
  "async-trait",
  "atuin-common",
@@ -371,7 +371,7 @@ dependencies = [
 
 [[package]]
 name = "atuin-common"
-version = "18.14.1"
+version = "18.15.0"
 dependencies = [
  "base64",
  "directories",
@@ -391,7 +391,7 @@ dependencies = [
 
 [[package]]
 name = "atuin-daemon"
-version = "18.14.1"
+version = "18.15.0"
 dependencies = [
  "atuin-client",
  "atuin-common",
@@ -424,7 +424,7 @@ dependencies = [
 
 [[package]]
 name = "atuin-dotfiles"
-version = "18.14.1"
+version = "18.15.0"
 dependencies = [
  "atuin-client",
  "atuin-common",
@@ -438,7 +438,7 @@ dependencies = [
 
 [[package]]
 name = "atuin-hex"
-version = "18.14.1"
+version = "18.15.0"
 dependencies = [
  "clap",
  "crossterm",
@@ -450,7 +450,7 @@ dependencies = [
 
 [[package]]
 name = "atuin-history"
-version = "18.14.1"
+version = "18.15.0"
 dependencies = [
  "atuin-client",
  "crossterm",
@@ -463,7 +463,7 @@ dependencies = [
 
 [[package]]
 name = "atuin-kv"
-version = "18.14.1"
+version = "18.15.0"
 dependencies = [
  "atuin-client",
  "atuin-common",
@@ -506,7 +506,7 @@ dependencies = [
 
 [[package]]
 name = "atuin-scripts"
-version = "18.14.1"
+version = "18.15.0"
 dependencies = [
  "atuin-client",
  "atuin-common",
@@ -528,7 +528,7 @@ dependencies = [
 
 [[package]]
 name = "atuin-server"
-version = "18.14.1"
+version = "18.15.0"
 dependencies = [
  "argon2",
  "atuin-common",
@@ -557,7 +557,7 @@ dependencies = [
 
 [[package]]
 name = "atuin-server-database"
-version = "18.14.1"
+version = "18.15.0"
 dependencies = [
  "async-trait",
  "atuin-common",
@@ -570,7 +570,7 @@ dependencies = [
 
 [[package]]
 name = "atuin-server-postgres"
-version = "18.14.1"
+version = "18.15.0"
 dependencies = [
  "async-trait",
  "atuin-common",
@@ -588,7 +588,7 @@ dependencies = [
 
 [[package]]
 name = "atuin-server-sqlite"
-version = "18.14.1"
+version = "18.15.0"
 dependencies = [
  "async-trait",
  "atuin-common",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ resolver = "2"
 exclude = ["ui/backend", "crates/atuin-nucleo/matcher/fuzz"]
 
 [workspace.package]
-version = "18.14.1"
+version = "18.15.0"
 authors = ["Ellie Huxtable <ellie@atuin.sh>"]
 rust-version = "1.94.0"
 license = "MIT"
@@ -19,17 +19,17 @@ readme = "README.md"
 
 [workspace.dependencies]
 async-trait = "0.1.58"
-atuin-client = { path = "crates/atuin-client", version = "18.14.1" }
-atuin-common = { path = "crates/atuin-common", version = "18.14.1" }
-atuin-daemon = { path = "crates/atuin-daemon", version = "18.14.1" }
-atuin-dotfiles = { path = "crates/atuin-dotfiles", version = "18.14.1" }
-atuin-history = { path = "crates/atuin-history", version = "18.14.1" }
-atuin-kv = { path = "crates/atuin-kv", version = "18.14.1" }
-atuin-scripts = { path = "crates/atuin-scripts", version = "18.14.1" }
-atuin-server = { path = "crates/atuin-server", version = "18.14.1" }
-atuin-server-database = { path = "crates/atuin-server-database", version = "18.14.1" }
-atuin-server-postgres = { path = "crates/atuin-server-postgres", version = "18.14.1" }
-atuin-server-sqlite = { path = "crates/atuin-server-sqlite", version = "18.14.1" }
+atuin-client = { path = "crates/atuin-client", version = "18.15.0" }
+atuin-common = { path = "crates/atuin-common", version = "18.15.0" }
+atuin-daemon = { path = "crates/atuin-daemon", version = "18.15.0" }
+atuin-dotfiles = { path = "crates/atuin-dotfiles", version = "18.15.0" }
+atuin-history = { path = "crates/atuin-history", version = "18.15.0" }
+atuin-kv = { path = "crates/atuin-kv", version = "18.15.0" }
+atuin-scripts = { path = "crates/atuin-scripts", version = "18.15.0" }
+atuin-server = { path = "crates/atuin-server", version = "18.15.0" }
+atuin-server-database = { path = "crates/atuin-server-database", version = "18.15.0" }
+atuin-server-postgres = { path = "crates/atuin-server-postgres", version = "18.15.0" }
+atuin-server-sqlite = { path = "crates/atuin-server-sqlite", version = "18.15.0" }
 atuin-nucleo = { path = "crates/atuin-nucleo", version = "0.6.0" }
 atuin-nucleo-matcher = { path = "crates/atuin-nucleo/matcher", version = "0.3.1" }
 base64 = "0.22"

--- a/crates/atuin-client/Cargo.toml
+++ b/crates/atuin-client/Cargo.toml
@@ -20,7 +20,7 @@ daemon = []
 check-update = []
 
 [dependencies]
-atuin-common = { path = "../atuin-common", version = "18.14.1" }
+atuin-common = { path = "../atuin-common", version = "18.15.0" }
 
 log = { workspace = true }
 base64 = { workspace = true }

--- a/crates/atuin-daemon/Cargo.toml
+++ b/crates/atuin-daemon/Cargo.toml
@@ -14,10 +14,10 @@ readme.workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-atuin-client = { path = "../atuin-client", version = "18.14.1" }
-atuin-common = { path = "../atuin-common", version = "18.14.1" }
-atuin-dotfiles = { path = "../atuin-dotfiles", version = "18.14.1" }
-atuin-history = { path = "../atuin-history", version = "18.14.1" }
+atuin-client = { path = "../atuin-client", version = "18.15.0" }
+atuin-common = { path = "../atuin-common", version = "18.15.0" }
+atuin-dotfiles = { path = "../atuin-dotfiles", version = "18.15.0" }
+atuin-history = { path = "../atuin-history", version = "18.15.0" }
 
 time = { workspace = true }
 uuid = { workspace = true }

--- a/crates/atuin-dotfiles/Cargo.toml
+++ b/crates/atuin-dotfiles/Cargo.toml
@@ -14,8 +14,8 @@ readme.workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-atuin-common = { path = "../atuin-common", version = "18.14.1" }
-atuin-client = { path = "../atuin-client", version = "18.14.1" }
+atuin-common = { path = "../atuin-common", version = "18.15.0" }
+atuin-client = { path = "../atuin-client", version = "18.15.0" }
 
 eyre = { workspace = true }
 tokio = { workspace = true }

--- a/crates/atuin-history/Cargo.toml
+++ b/crates/atuin-history/Cargo.toml
@@ -14,7 +14,7 @@ readme.workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-atuin-client = { path = "../atuin-client", version = "18.14.1" }
+atuin-client = { path = "../atuin-client", version = "18.15.0" }
 
 time = { workspace = true }
 serde = { workspace = true }

--- a/crates/atuin-kv/Cargo.toml
+++ b/crates/atuin-kv/Cargo.toml
@@ -14,8 +14,8 @@ readme.workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-atuin-client = { path = "../atuin-client", version = "18.14.1" }
-atuin-common = { path = "../atuin-common", version = "18.14.1" }
+atuin-client = { path = "../atuin-client", version = "18.15.0" }
+atuin-common = { path = "../atuin-common", version = "18.15.0" }
 
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }

--- a/crates/atuin-scripts/Cargo.toml
+++ b/crates/atuin-scripts/Cargo.toml
@@ -14,8 +14,8 @@ readme.workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-atuin-client = { path = "../atuin-client", version = "18.14.1" }
-atuin-common = { path = "../atuin-common", version = "18.14.1" }
+atuin-client = { path = "../atuin-client", version = "18.15.0" }
+atuin-common = { path = "../atuin-common", version = "18.15.0" }
 
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }

--- a/crates/atuin-server-database/Cargo.toml
+++ b/crates/atuin-server-database/Cargo.toml
@@ -10,7 +10,7 @@ homepage = { workspace = true }
 repository = { workspace = true }
 
 [dependencies]
-atuin-common = { path = "../atuin-common", version = "18.14.1" }
+atuin-common = { path = "../atuin-common", version = "18.15.0" }
 
 tracing = { workspace = true }
 time = { workspace = true }

--- a/crates/atuin-server-postgres/Cargo.toml
+++ b/crates/atuin-server-postgres/Cargo.toml
@@ -10,8 +10,8 @@ homepage = { workspace = true }
 repository = { workspace = true }
 
 [dependencies]
-atuin-common = { path = "../atuin-common", version = "18.14.1" }
-atuin-server-database = { path = "../atuin-server-database", version = "18.14.1" }
+atuin-common = { path = "../atuin-common", version = "18.15.0" }
+atuin-server-database = { path = "../atuin-server-database", version = "18.15.0" }
 
 eyre = { workspace = true }
 tracing = { workspace = true }

--- a/crates/atuin-server-sqlite/Cargo.toml
+++ b/crates/atuin-server-sqlite/Cargo.toml
@@ -10,8 +10,8 @@ homepage = { workspace = true }
 repository = { workspace = true }
 
 [dependencies]
-atuin-common = { path = "../atuin-common", version = "18.14.1" }
-atuin-server-database = { path = "../atuin-server-database", version = "18.14.1" }
+atuin-common = { path = "../atuin-common", version = "18.15.0" }
+atuin-server-database = { path = "../atuin-server-database", version = "18.15.0" }
 
 eyre = { workspace = true }
 tracing = { workspace = true }

--- a/crates/atuin/Cargo.toml
+++ b/crates/atuin/Cargo.toml
@@ -43,13 +43,13 @@ clipboard = ["arboard"]
 check-update = ["atuin-client/check-update"]
 
 [dependencies]
-atuin-ai = { path = "../atuin-ai", version = "18.14.1", optional = true, default-features = false }
-atuin-client = { path = "../atuin-client", version = "18.14.1", optional = true, default-features = false }
+atuin-ai = { path = "../atuin-ai", version = "18.15.0", optional = true, default-features = false }
+atuin-client = { path = "../atuin-client", version = "18.15.0", optional = true, default-features = false }
 atuin-common = { workspace = true }
 atuin-dotfiles = { workspace = true }
 atuin-history = { workspace = true }
-atuin-daemon = { path = "../atuin-daemon", version = "18.14.1", optional = true, default-features = false }
-atuin-hex = { path = "../atuin-hex", version = "18.14.1", optional = true, default-features = false }
+atuin-daemon = { path = "../atuin-daemon", version = "18.15.0", optional = true, default-features = false }
+atuin-hex = { path = "../atuin-hex", version = "18.15.0", optional = true, default-features = false }
 atuin-scripts = { workspace = true }
 atuin-kv = { workspace = true }
 
@@ -109,7 +109,7 @@ daemonize = "0.5.0"
 # compiles cleanly. tree-sitter 0.26's portable/endian.h fails on illumos,
 # Windows cross-compiles, and potentially other exotic targets.
 [target.'cfg(any(target_os = "linux", target_os = "macos"))'.dependencies]
-atuin-ai = { path = "../atuin-ai", version = "18.14.1", optional = true, default-features = false, features = ["tree-sitter"] }
+atuin-ai = { path = "../atuin-ai", version = "18.15.0", optional = true, default-features = false, features = ["tree-sitter"] }
 
 [target.'cfg(windows)'.dependencies]
 windows-sys = { version = "0.61.2", features = ["Win32_System_Console"] }


### PR DESCRIPTION
### Bug Fixes

- Install script incorrectly tries to install opencode hooks ([#3410](https://github.com/atuinsh/atuin/issues/3410))
- Dependency fix ([#3414](https://github.com/atuinsh/atuin/issues/3414))
- Loss of loading spinners + tokio panic on exit ([#3415](https://github.com/atuinsh/atuin/issues/3415))


### Features

- Add OCI standard labels to Dockerfile ([#3412](https://github.com/atuinsh/atuin/issues/3412))
- Enable atuin hex for illumos ([#3413](https://github.com/atuinsh/atuin/issues/3413))
- Allow resuming previous AI sessions ([#3407](https://github.com/atuinsh/atuin/issues/3407))


### Miscellaneous Tasks

- Add release script ([#3411](https://github.com/atuinsh/atuin/issues/3411))