### PR TITLE
fix: Tab doesn't insert suggested command

### DIFF
--- a/crates/atuin-ai/src/tui/components/atuin_ai.rs
+++ b/crates/atuin-ai/src/tui/components/atuin_ai.rs
@@ -90,6 +90,16 @@ fn atuin_ai(
             return EventResult::Consumed;
         }
 
+        if *code == KeyCode::Tab
+            && matches!(props.mode, AppMode::Input)
+            && modifiers.contains(KeyModifiers::NONE)
+            && props.has_command
+            && props.is_input_blank
+        {
+            let _ = tx.send(AiTuiEvent::InsertCommand);
+            return EventResult::Consumed;
+        }
+
         EventResult::Ignored
     });
 
@@ -110,13 +120,6 @@ fn atuin_ai(
 
         match props.mode {
             AppMode::Input => match code {
-                KeyCode::Tab => {
-                    if props.has_command && props.is_input_blank {
-                        let _ = tx.send(AiTuiEvent::InsertCommand);
-                        return EventResult::Consumed;
-                    }
-                    EventResult::Ignored
-                }
                 KeyCode::Enter => {
                     if props.has_command && props.is_input_blank {
                         let _ = tx.send(AiTuiEvent::ExecuteCommand);


### PR DESCRIPTION
Broken by #3418 — moves the tab key handling back to the capture phase.