### PR TITLE
fix: correct grammar in 'history last' help text

### DIFF
--- a/crates/atuin/src/command/client/history.rs
+++ b/crates/atuin/src/command/client/history.rs
@@ -114,7 +114,7 @@ pub enum Cmd {
         format: Option<String>,
     },
 
-    /// Get the last command ran
+    /// Get the last command that was run
     Last {
         #[arg(long)]
         human: bool,


### PR DESCRIPTION
## Summary

Fixes the help text for `atuin history last` from "Get the last command ran" to "Get the last command that was run".

Closes #3324

The previous phrasing was grammatically incorrect — "ran" is the simple past tense, which doesn't work as a past participle in this sentence structure.