### PR TITLE
feat: Implement write_file tool with overwrite safety

### DIFF
--- a/crates/atuin-ai/src/diff.rs
+++ b/crates/atuin-ai/src/diff.rs
@@ -101,6 +101,40 @@ impl EditPreview {
     }
 }
 
+/// Maximum lines to show in a write preview.
+const WRITE_PREVIEW_LINES: usize = 20;
+
+/// A content preview for a write_file operation.
+///
+/// Shows the first N lines of the written content plus a count of
+/// remaining lines if truncated.
+#[derive(Debug, Clone)]
+pub(crate) struct WritePreview {
+    /// First lines of content (up to WRITE_PREVIEW_LINES).
+    pub lines: Vec<String>,
+    /// Total number of lines in the written file.
+    pub total_lines: usize,
+}
+
+impl WritePreview {
+    /// Create a preview from file content.
+    pub fn from_content(content: &str) -> Self {
+        let all_lines: Vec<&str> = content.lines().collect();
+        let total_lines = all_lines.len();
+        let lines = all_lines
+            .into_iter()
+            .take(WRITE_PREVIEW_LINES)
+            .map(String::from)
+            .collect();
+        WritePreview { lines, total_lines }
+    }
+
+    /// Number of lines not shown in the preview.
+    pub fn remaining_lines(&self) -> usize {
+        self.total_lines.saturating_sub(self.lines.len())
+    }
+}
+
 /// Build a single DiffHunk from a group of adjacent raw hunks.
 fn build_hunk(group: &[&imara_diff::Hunk], input: &InternedInput<&str>) -> DiffHunk {
     let first = group.first().unwrap();

--- a/crates/atuin-ai/src/diff.rs
+++ b/crates/atuin-ai/src/diff.rs
@@ -102,7 +102,7 @@ impl EditPreview {
 }
 
 /// Maximum lines to show in a write preview.
-const WRITE_PREVIEW_LINES: usize = 20;
+const WRITE_PREVIEW_LINES: usize = 10;
 
 /// A content preview for a write_file operation.
 ///

--- a/crates/atuin-ai/src/tools/mod.rs
+++ b/crates/atuin-ai/src/tools/mod.rs
@@ -796,6 +796,9 @@ impl WriteToolCall {
             );
         }
 
+        // Capture before the write — after atomic_write the file always exists.
+        let existed = resolved_path.exists();
+
         // Write atomically
         let content_bytes = self.content.as_bytes().to_vec();
         if let Err(e) = crate::snapshots::atomic_write_file(resolved_path, &content_bytes) {
@@ -803,11 +806,7 @@ impl WriteToolCall {
         }
 
         let line_count = self.content.lines().count();
-        let verb = if self.overwrite && resolved_path.exists() {
-            "Overwrote"
-        } else {
-            "Created"
-        };
+        let verb = if existed { "Overwrote" } else { "Created" };
         (
             ToolOutcome::Success(format!(
                 "{verb} {} ({line_count} lines).",

--- a/crates/atuin-ai/src/tools/mod.rs
+++ b/crates/atuin-ai/src/tools/mod.rs
@@ -171,6 +171,8 @@ pub(crate) struct TrackedTool {
     pub abort_tx: Option<tokio::sync::oneshot::Sender<()>>,
     /// Diff preview for completed edit tool calls.
     pub edit_preview: Option<crate::diff::EditPreview>,
+    /// Content preview for completed write tool calls.
+    pub write_preview: Option<crate::diff::WritePreview>,
 }
 
 impl TrackedTool {
@@ -237,6 +239,7 @@ impl ToolTracker {
             phase: ToolPhase::CheckingPermissions,
             abort_tx: None,
             edit_preview: None,
+            write_preview: None,
         });
     }
 
@@ -724,10 +727,10 @@ impl PermissableToolCall for EditToolCall {
 }
 
 #[derive(Debug, Clone)]
-#[expect(dead_code)]
 pub(crate) struct WriteToolCall {
     pub path: PathBuf,
     pub content: String,
+    pub overwrite: bool,
 }
 
 impl TryFrom<&serde_json::Value> for WriteToolCall {
@@ -735,19 +738,83 @@ impl TryFrom<&serde_json::Value> for WriteToolCall {
 
     fn try_from(value: &serde_json::Value) -> Result<Self, Self::Error> {
         let path = value
-            .get("path")
+            .get("file_path")
             .and_then(|v| v.as_str())
-            .ok_or(eyre::eyre!("Missing path"))?;
+            .ok_or(eyre::eyre!("Missing file_path"))?;
 
         let content = value
             .get("content")
             .and_then(|v| v.as_str())
             .ok_or(eyre::eyre!("Missing content"))?;
 
+        let overwrite = value
+            .get("overwrite")
+            .and_then(|v| v.as_bool())
+            .unwrap_or(false);
+
         Ok(WriteToolCall {
             path: expand_path(path),
             content: content.to_string(),
+            overwrite,
         })
+    }
+}
+
+impl WriteToolCall {
+    /// Resolve the write path to an absolute path.
+    pub fn resolved_path(&self) -> PathBuf {
+        if self.path.is_relative() {
+            std::env::current_dir()
+                .map(|cwd| cwd.join(&self.path))
+                .unwrap_or_else(|_| self.path.clone())
+        } else {
+            self.path.clone()
+        }
+    }
+
+    /// Execute the write operation.
+    ///
+    /// Creates a new file or overwrites an existing one (if `overwrite` is set).
+    /// Returns the outcome and the written bytes (for tracker updates).
+    pub fn execute(&self, resolved_path: &Path) -> (ToolOutcome, Option<Vec<u8>>) {
+        if resolved_path.is_dir() {
+            return (
+                ToolOutcome::Error(format!(
+                    "Error: path is a directory, not a file: {}",
+                    resolved_path.display()
+                )),
+                None,
+            );
+        }
+        if resolved_path.exists() && !self.overwrite {
+            return (
+                ToolOutcome::Error(format!(
+                    "File already exists: {}. Set overwrite to true to replace it, or use edit_file to make targeted changes.",
+                    resolved_path.display()
+                )),
+                None,
+            );
+        }
+
+        // Write atomically
+        let content_bytes = self.content.as_bytes().to_vec();
+        if let Err(e) = crate::snapshots::atomic_write_file(resolved_path, &content_bytes) {
+            return (ToolOutcome::Error(format!("Error writing file: {e}")), None);
+        }
+
+        let line_count = self.content.lines().count();
+        let verb = if self.overwrite && resolved_path.exists() {
+            "Overwrote"
+        } else {
+            "Created"
+        };
+        (
+            ToolOutcome::Success(format!(
+                "{verb} {} ({line_count} lines).",
+                resolved_path.display()
+            )),
+            Some(content_bytes),
+        )
     }
 }
 
@@ -1235,6 +1302,7 @@ mod tests {
         WriteToolCall {
             path: expand_path(path),
             content: String::new(),
+            overwrite: false,
         }
     }
 
@@ -1732,6 +1800,107 @@ mod tests {
             let json = cache.to_json().unwrap();
             let restored = EditPermissionCache::from_json(&json).unwrap();
             assert!(restored.has_valid_grant(&path));
+        }
+    }
+
+    // ── write_file execution tests ──
+
+    mod write {
+        use super::*;
+
+        #[test]
+        fn creates_new_file() {
+            let dir = tempfile::tempdir().unwrap();
+            let path = dir.path().join("new_file.txt");
+
+            let call = WriteToolCall {
+                path: path.clone(),
+                content: "hello\nworld\n".to_string(),
+                overwrite: false,
+            };
+            let (outcome, new_bytes) = call.execute(&path);
+
+            assert!(matches!(outcome, ToolOutcome::Success(ref s) if s.contains("Created")));
+            assert!(new_bytes.is_some());
+            assert_eq!(std::fs::read_to_string(&path).unwrap(), "hello\nworld\n");
+        }
+
+        #[test]
+        fn error_file_exists_without_overwrite() {
+            let dir = tempfile::tempdir().unwrap();
+            let path = dir.path().join("existing.txt");
+            std::fs::write(&path, "original").unwrap();
+
+            let call = WriteToolCall {
+                path: path.clone(),
+                content: "new content".to_string(),
+                overwrite: false,
+            };
+            let (outcome, new_bytes) = call.execute(&path);
+
+            assert!(new_bytes.is_none());
+            match outcome {
+                ToolOutcome::Error(msg) => {
+                    assert!(msg.contains("already exists"), "got: {msg}");
+                    assert!(msg.contains("overwrite"), "got: {msg}");
+                }
+                _ => panic!("expected error"),
+            }
+            // Original preserved
+            assert_eq!(std::fs::read_to_string(&path).unwrap(), "original");
+        }
+
+        #[test]
+        fn overwrites_existing_file_when_flag_set() {
+            let dir = tempfile::tempdir().unwrap();
+            let path = dir.path().join("existing.txt");
+            std::fs::write(&path, "original").unwrap();
+
+            let call = WriteToolCall {
+                path: path.clone(),
+                content: "replaced content\n".to_string(),
+                overwrite: true,
+            };
+            let (outcome, new_bytes) = call.execute(&path);
+
+            assert!(matches!(outcome, ToolOutcome::Success(_)));
+            assert!(new_bytes.is_some());
+            assert_eq!(
+                std::fs::read_to_string(&path).unwrap(),
+                "replaced content\n"
+            );
+        }
+
+        #[test]
+        fn creates_parent_directories() {
+            let dir = tempfile::tempdir().unwrap();
+            let path = dir.path().join("sub").join("dir").join("file.txt");
+
+            let call = WriteToolCall {
+                path: path.clone(),
+                content: "nested\n".to_string(),
+                overwrite: false,
+            };
+            let (outcome, _) = call.execute(&path);
+
+            assert!(matches!(outcome, ToolOutcome::Success(_)));
+            assert_eq!(std::fs::read_to_string(&path).unwrap(), "nested\n");
+        }
+
+        #[test]
+        fn error_path_is_directory() {
+            let dir = tempfile::tempdir().unwrap();
+            let path = dir.path().to_path_buf();
+
+            let call = WriteToolCall {
+                path: path.clone(),
+                content: "content".to_string(),
+                overwrite: false,
+            };
+            let (outcome, new_bytes) = call.execute(&path);
+
+            assert!(new_bytes.is_none());
+            assert!(matches!(outcome, ToolOutcome::Error(ref msg) if msg.contains("directory")));
         }
     }
 

--- a/crates/atuin-ai/src/tui/dispatch.rs
+++ b/crates/atuin-ai/src/tui/dispatch.rs
@@ -408,17 +408,17 @@ fn execute_write_tool(
         let resolved = write_call.resolved_path();
 
         // 1. Snapshot the existing file before overwriting (if it exists).
-        if resolved.exists() {
-            if let Ok(original_content) = std::fs::read(&resolved) {
-                let snap_path = resolved.clone();
-                h.update(move |state| {
-                    if let Some(ref mut store) = state.snapshot_store {
-                        if let Err(e) = store.ensure_snapshot(&snap_path, &original_content) {
-                            tracing::warn!("failed to create file snapshot: {e}");
-                        }
-                    }
-                });
-            }
+        if resolved.exists()
+            && let Ok(original_content) = std::fs::read(&resolved)
+        {
+            let snap_path = resolved.clone();
+            h.update(move |state| {
+                if let Some(ref mut store) = state.snapshot_store
+                    && let Err(e) = store.ensure_snapshot(&snap_path, &original_content)
+                {
+                    tracing::warn!("failed to create file snapshot: {e}");
+                }
+            });
         }
 
         // 2. Execute: check exists/overwrite, atomic write
@@ -434,17 +434,17 @@ fn execute_write_tool(
         // 4. Update tracker, store preview, and finish
         let tc_id = tool_id;
         h.update(move |state| {
-            if let Some(ref new_bytes) = new_bytes {
-                if let Ok(mtime) = std::fs::metadata(&resolved).and_then(|m| m.modified()) {
-                    state
-                        .file_tracker
-                        .update_after_edit(&resolved, new_bytes, mtime);
-                }
+            if let Some(ref new_bytes) = new_bytes
+                && let Ok(mtime) = std::fs::metadata(&resolved).and_then(|m| m.modified())
+            {
+                state
+                    .file_tracker
+                    .update_after_edit(&resolved, new_bytes, mtime);
             }
-            if let Some(preview) = write_preview {
-                if let Some(tracked) = state.tool_tracker.get_mut(&tc_id) {
-                    tracked.write_preview = Some(preview);
-                }
+            if let Some(preview) = write_preview
+                && let Some(tracked) = state.tool_tracker.get_mut(&tc_id)
+            {
+                tracked.write_preview = Some(preview);
             }
             state.finish_tool_call(&tc_id, outcome);
             if !state.tool_tracker.has_pending() {

--- a/crates/atuin-ai/src/tui/dispatch.rs
+++ b/crates/atuin-ai/src/tui/dispatch.rs
@@ -232,6 +232,10 @@ fn execute_tool(
             let edit_call = edit_call.clone();
             execute_edit_tool(handle, tx, tool_id, edit_call);
         }
+        ClientToolCall::Write(write_call) => {
+            let write_call = write_call.clone();
+            execute_write_tool(handle, tx, tool_id, write_call);
+        }
         _ => {
             execute_simple_tool(handle, tx, tool_id, tool, db);
         }
@@ -378,6 +382,69 @@ fn execute_edit_tool(
                 && let Some(tracked) = state.tool_tracker.get_mut(&tc_id)
             {
                 tracked.edit_preview = Some(preview);
+            }
+            state.finish_tool_call(&tc_id, outcome);
+            if !state.tool_tracker.has_pending() {
+                let _ = tx.send(AiTuiEvent::ContinueAfterTools);
+            }
+        });
+    });
+}
+
+/// Execute a write_file tool call.
+///
+/// Snapshots the existing file (if any) before overwriting, writes atomically,
+/// stores a content preview on the tracker, and updates the file tracker.
+fn execute_write_tool(
+    handle: &Handle<Session>,
+    tx: &mpsc::Sender<AiTuiEvent>,
+    tool_id: String,
+    write_call: crate::tools::WriteToolCall,
+) {
+    let h = handle.clone();
+    let tx = tx.clone();
+
+    tokio::spawn(async move {
+        let resolved = write_call.resolved_path();
+
+        // 1. Snapshot the existing file before overwriting (if it exists).
+        if resolved.exists() {
+            if let Ok(original_content) = std::fs::read(&resolved) {
+                let snap_path = resolved.clone();
+                h.update(move |state| {
+                    if let Some(ref mut store) = state.snapshot_store {
+                        if let Err(e) = store.ensure_snapshot(&snap_path, &original_content) {
+                            tracing::warn!("failed to create file snapshot: {e}");
+                        }
+                    }
+                });
+            }
+        }
+
+        // 2. Execute: check exists/overwrite, atomic write
+        let (outcome, new_bytes) = write_call.execute(&resolved);
+
+        // 3. Build content preview on success
+        let write_preview = if new_bytes.is_some() {
+            Some(crate::diff::WritePreview::from_content(&write_call.content))
+        } else {
+            None
+        };
+
+        // 4. Update tracker, store preview, and finish
+        let tc_id = tool_id;
+        h.update(move |state| {
+            if let Some(ref new_bytes) = new_bytes {
+                if let Ok(mtime) = std::fs::metadata(&resolved).and_then(|m| m.modified()) {
+                    state
+                        .file_tracker
+                        .update_after_edit(&resolved, new_bytes, mtime);
+                }
+            }
+            if let Some(preview) = write_preview {
+                if let Some(tracked) = state.tool_tracker.get_mut(&tc_id) {
+                    tracked.write_preview = Some(preview);
+                }
             }
             state.finish_tool_call(&tc_id, outcome);
             if !state.tool_tracker.has_pending() {

--- a/crates/atuin-ai/src/tui/view/mod.rs
+++ b/crates/atuin-ai/src/tui/view/mod.rs
@@ -175,7 +175,7 @@ fn tool_call_view(tool_call: &TrackedTool, in_git_project: bool) -> Elements {
 /// keep the standard set.
 fn permission_options_for_tool(tool: &ClientToolCall, in_git_project: bool) -> Vec<SelectOption> {
     match tool {
-        ClientToolCall::Edit(_) => vec![
+        ClientToolCall::Edit(_) | ClientToolCall::Write(_) => vec![
             SelectOption::builder()
                 .label("Allow")
                 .value(PermissionResult::Allow.as_value_str())

--- a/crates/atuin-ai/src/tui/view/mod.rs
+++ b/crates/atuin-ai/src/tui/view/mod.rs
@@ -296,8 +296,8 @@ fn agent_turn_view(events: &[turn::UiEvent], busy: bool) -> Elements {
                                     turn::ToolRenderData::FileEdit { path, preview } => {
                                         file_edit_tool_view(&tool_key, &details.status, path, preview.as_ref())
                                     },
-                                    turn::ToolRenderData::FileWrite { path } => {
-                                        file_write_tool_view(&details.status, path)
+                                    turn::ToolRenderData::FileWrite { path, preview } => {
+                                        file_write_tool_view(&tool_key, &details.status, path, preview.as_ref())
                                     },
                                     turn::ToolRenderData::Remote => {
                                         tool_status_view(&details.name, &details.status)
@@ -577,10 +577,16 @@ fn file_edit_tool_view(
     }
 }
 
-/// Render a file write tool call status with the target path.
-fn file_write_tool_view(status: &turn::ToolResultStatus, path: &std::path::Path) -> Elements {
-    let display_path = path.display();
-    match status {
+/// Render a file write tool call with content preview.
+fn file_write_tool_view(
+    key: &str,
+    status: &turn::ToolResultStatus,
+    path: &std::path::Path,
+    preview: Option<&crate::diff::WritePreview>,
+) -> Elements {
+    let display_path = format_path_for_display(path);
+
+    let status_line = match status {
         turn::ToolResultStatus::Pending => {
             element! {
                 Spinner(
@@ -591,16 +597,60 @@ fn file_write_tool_view(status: &turn::ToolResultStatus, path: &std::path::Path)
             }
         }
         turn::ToolResultStatus::Success => {
+            let line_info = preview
+                .map(|p| format!(" ({} lines)", p.total_lines))
+                .unwrap_or_default();
             element! {
-                Spinner(label: format!("Wrote: {display_path}"), done: true)
+                Spinner(label: format!("Wrote: {display_path}{line_info}"), done: true)
             }
         }
         turn::ToolResultStatus::Error => {
             element! {
                 Text {
                     Span(text: "✗ ", style: Style::default().fg(Color::Red))
-                    Span(text: format!("Write {display_path}: denied"), style: Style::default().fg(Color::Red))
+                    Span(text: format!("Write {display_path}: failed"), style: Style::default().fg(Color::Red))
                 }
+            }
+        }
+    };
+
+    let Some(preview) = preview else {
+        return status_line;
+    };
+    if preview.lines.is_empty() {
+        return status_line;
+    }
+
+    let gutter_width = preview.total_lines.to_string().len().max(2) as u16 + 1;
+    let remaining = preview.remaining_lines();
+
+    element! {
+        View(key: key.to_string()) {
+            #(status_line)
+
+            View(key: format!("{key}-content"), padding_left: Cells::from(2)) {
+                #(for (idx, line) in preview.lines.iter().enumerate() {
+                    HStack(key: format!("{key}-line-{idx}")) {
+                        View(width: WidthConstraint::Fixed(gutter_width)) {
+                            Text { Span(
+                                text: format!("{:>width$}", idx + 1, width = (gutter_width - 1) as usize),
+                                style: Style::default().fg(Color::DarkGray)
+                            ) }
+                        }
+                        View {
+                            Text { Span(text: line, style: Style::default().fg(Color::DarkGray)) }
+                        }
+                    }
+                })
+
+                #(if remaining > 0 {
+                    Text {
+                        Span(
+                            text: format!("     ... +{remaining} more lines"),
+                            style: Style::default().fg(Color::DarkGray)
+                        )
+                    }
+                })
             }
         }
     }

--- a/crates/atuin-ai/src/tui/view/turn.rs
+++ b/crates/atuin-ai/src/tui/view/turn.rs
@@ -141,7 +141,10 @@ pub(crate) enum ToolRenderData {
         preview: Option<crate::diff::EditPreview>,
     },
     /// File write/create operation.
-    FileWrite { path: PathBuf },
+    FileWrite {
+        path: PathBuf,
+        preview: Option<crate::diff::WritePreview>,
+    },
     /// Atuin history search.
     HistorySearch {
         query: String,
@@ -449,6 +452,7 @@ impl<'a> TurnBuilder<'a> {
                 },
                 ClientToolCall::Write(write) => ToolRenderData::FileWrite {
                     path: write.path.clone(),
+                    preview: tracked.write_preview.clone(),
                 },
                 ClientToolCall::AtuinHistory(history) => ToolRenderData::HistorySearch {
                     query: history.query.clone(),


### PR DESCRIPTION
## Summary

Implements the `write_file` client-side tool — creates new files or overwrites existing ones with an explicit `overwrite` flag for safety.

- **Overwrite flag**: Writing to an existing file without `overwrite: true` returns an error directing the LLM to set the flag or use `edit_file` for targeted changes. Prevents accidental overwrites.
- **Snapshots**: Existing files are backed up before overwriting (same infrastructure as `edit_file`).
- **Content preview**: Completed writes show the first 10 lines in gray with line numbers, plus "+ N more lines" for longer files.
- **Atomic writes**: Uses `tempfile` + fsync + rename (same as `edit_file`).
- **File tracker update**: After writing, the file is registered in the tracker so subsequent `edit_file` calls work without a separate read.
- **Permission**: Shares the `"Write"` rule with `edit_file` — one permission covers both tools.

Also includes fixes from the edit_file PR review:
- **xxh3 hash**: Replaced non-deterministic `DefaultHasher` with `xxhash-rust` for file freshness tracking across process restarts
- **Windows fixes**: `sanitize_path` now encodes `\` and strips drive prefixes; tests use `TempDir` instead of `NamedTempFile` to avoid open-handle rename failures
- **Unified permissions**: Edit and Write share `"Write"` rule name; Write implies Read

## Test plan

- [x] 5 new write_file execution tests (create, exists-error, overwrite, parent dirs, is-directory)
- [x] 137 total tests passing
- [x] Server-side tool definition with tests (separate hub PR)
- [x] Manual test: create new file via Atuin AI
- [x] Manual test: overwrite existing file (verify snapshot created)
- [x] Manual test: attempt write without overwrite flag (verify error message)