### PR TITLE
fix: shell tool preview stuck as Running after completion

### DIFF
--- a/crates/atuin-ai/src/fsm/mod.rs
+++ b/crates/atuin-ai/src/fsm/mod.rs
@@ -447,11 +447,24 @@ impl AgentFsm {
                 },
             ) => {
                 if let Some(tracked) = self.ctx.tools.get_mut(&tool_id) {
-                    tracked.preview = Some(tools::ToolPreviewData::Shell {
-                        lines,
-                        exit_code,
-                        interrupted: false,
-                    });
+                    if tracked.is_resolved() {
+                        // Tool already completed — a late preview update raced with
+                        // ToolExecutionDone. Update lines (they may carry the final
+                        // screen) but preserve the finalized exit_code/interrupted.
+                        if let Some(tools::ToolPreviewData::Shell {
+                            lines: existing_lines,
+                            ..
+                        }) = &mut tracked.preview
+                        {
+                            *existing_lines = lines;
+                        }
+                    } else {
+                        tracked.preview = Some(tools::ToolPreviewData::Shell {
+                            lines,
+                            exit_code,
+                            interrupted: false,
+                        });
+                    }
                 }
                 vec![]
             }
@@ -799,8 +812,30 @@ impl AgentFsm {
         }
 
         tracked.state = ToolState::Completed;
-        if preview.is_some() {
-            tracked.preview = preview;
+
+        // Merge shell preview: the final ToolExecutionDone carries exit_code/interrupted
+        // but has empty lines (the live lines were accumulated via ToolPreviewUpdate).
+        // Preserve the accumulated lines and fold in the terminal metadata.
+        match (&mut tracked.preview, preview) {
+            (
+                Some(tools::ToolPreviewData::Shell {
+                    exit_code,
+                    interrupted,
+                    ..
+                }),
+                Some(tools::ToolPreviewData::Shell {
+                    exit_code: final_exit,
+                    interrupted: final_interrupted,
+                    ..
+                }),
+            ) => {
+                *exit_code = final_exit;
+                *interrupted = final_interrupted;
+            }
+            (_, Some(p)) => {
+                tracked.preview = Some(p);
+            }
+            _ => {}
         }
 
         let content = outcome.format_for_llm();


### PR DESCRIPTION
## Summary
- Shell command previews showed "Running" with "[Ctrl+C] Interrupt" even after the command finished, because `ToolPreviewUpdate` (live output lines) and `ToolExecutionDone` (exit code) arrive from separate async tasks and can race
- `handle_tool_done` now merges the final exit_code/interrupted into the existing preview, preserving accumulated output lines
- Late `ToolPreviewUpdate` on a resolved tool updates only lines, preserving the finalized exit_code/interrupted

## Test plan
- [x] Run a fast command (e.g. `ls`) — should show "Ran:" with exit code and output lines
- [x] Run a piped command (e.g. `cat README.md | grep Atuin`) should show "Ran:" with exit code and output lines
- [x] Run a slow command — verify live preview updates, then shows completed state
- [x] Interrupt a running command with Ctrl+C — verify "Interrupted" footer
- [x] 157 existing tests pass