### PR TITLE
docs: update for new server binary

### DIFF
--- a/docs/docs/reference/sync.md
+++ b/docs/docs/reference/sync.md
@@ -4,7 +4,7 @@ Atuin can back up your history to a server, and use this to ensure multiple
 machines have the same shell history. This is all encrypted end-to-end, so the
 server operator can _never_ see your data!
 
-Anyone can host a server (try `atuin server start`, more docs to follow), but I
+Anyone can host a server (see the [self-hosting docs](../self-hosting/server-setup.md)), but I
 host one at https://api.atuin.sh. This is the default server address, which can
 be changed in the [config](../configuration/config.md#sync_address). Again, I _cannot_ see your data, and
 do not want to.

--- a/docs/docs/self-hosting/kubernetes.md
+++ b/docs/docs/self-hosting/kubernetes.md
@@ -105,7 +105,6 @@ spec:
     spec:
       containers:
         - args:
-            - server
             - start
           env:
             - name: ATUIN_DB_URI

--- a/docs/docs/self-hosting/server-setup.md
+++ b/docs/docs/self-hosting/server-setup.md
@@ -6,17 +6,25 @@ The requirements to do so are pretty minimal! You need to be able to run a binar
 
 Atuin also supports sqlite 3 and above.
 
-Any host with the `atuin` binary may also run a server, by running
+The server is distributed as a separate binary, `atuin-server`. Prebuilt binaries and an installer are published with every release on the [GitHub releases page](https://github.com/atuinsh/atuin/releases). For example, to install the latest release:
 
 ```shell
-atuin server start
+curl --proto '=https' --tlsv1.2 -LsSf https://github.com/atuinsh/atuin/releases/latest/download/atuin-server-installer.sh | sh
 ```
+
+Once installed, start the server with:
+
+```shell
+atuin-server start
+```
+
+!!! note
+    Prior to v18.12.0, the server was bundled into the main `atuin` binary and started with `atuin server start`. If you are upgrading from an older release, you will need to install the new `atuin-server` binary and update any service files (systemd, docker, k8s) to invoke `atuin-server` instead of `atuin server`. See the [release notes](https://github.com/atuinsh/atuin/releases) for details.
 
 ## Configuration
 
-The config for the server is kept separate from the config for the client, even
-though they are the same binary. Server config can be found at
-`~/.config/atuin/server.toml`.
+The server's config lives at `~/.config/atuin/server.toml`, separate from the
+client's config.
 
 It looks something like this for PostgreSQL:
 

--- a/docs/docs/self-hosting/systemd.md
+++ b/docs/docs/self-hosting/systemd.md
@@ -1,5 +1,11 @@
 # Systemd
 
+!!! note
+    These instructions assume the `atuin-server` binary is on your `PATH`. Since
+    v18.12.0, the server is distributed as a separate binary — install it from
+    the [releases page](https://github.com/atuinsh/atuin/releases) (see [Server
+    setup](./server-setup.md) for the installer).
+
 First, create the service unit file
 [`atuin-server.service`](https://github.com/atuinsh/atuin/raw/main/systemd/atuin-server.service) at
 `/etc/systemd/system/atuin-server.service` with contents like this:
@@ -11,7 +17,7 @@ After=network-online.target
 Wants=network-online.target systemd-networkd-wait-online.service
 
 [Service]
-ExecStart=atuin server start
+ExecStart=atuin-server start
 Restart=on-failure
 User=atuin
 Group=atuin


### PR DESCRIPTION
<!-- Thank you for making a PR! Bug fixes are always welcome, but if you're adding a new feature or changing an existing one, we'd really appreciate if you open an issue, post on the forum, or drop in on Discord -->

## Checks
- [ ] I am happy for maintainers to push small adjustments to this PR, to speed up the review cycle
- [ ] I have checked that there are no existing pull requests for the same thing

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Updates docs across four files to reflect the new `atuin-server` standalone binary (since v18.12.0), replacing references to `atuin server start` with `atuin-server start` and adding migration notes for upgraders.

<h3>Confidence Score: 5/5</h3>

Safe to merge — docs-only change with consistent updates across all relevant files.

All changes are straightforward documentation updates. The binary name, installer command, and migration notes are consistent across every affected file.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| docs/docs/self-hosting/server-setup.md | Explains new `atuin-server` binary, installer command, and migration note from v18.12.0 |
| docs/docs/self-hosting/systemd.md | Updates ExecStart to `atuin-server start` and adds migration note |
| docs/docs/self-hosting/kubernetes.md | Removes the `server` subcommand arg since the new binary takes `start` directly |
| docs/docs/reference/sync.md | Replaces stale `atuin server start` hint with a link to the self-hosting docs |

</details>

<sub>Reviews (1): Last reviewed commit: ["docs: update for new server binary"](https://github.com/atuinsh/atuin/commit/87df6bb9352367f3d52bf3a0074afffec8134625) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29222776)</sub>

<!-- /greptile_comment -->