### PR TITLE
fix: bound daemon history RPCs so a wedged daemon doesn't hang the shell

### DIFF
--- a/crates/atuin/src/command/client/daemon.rs
+++ b/crates/atuin/src/command/client/daemon.rs
@@ -16,7 +16,7 @@ use clap::Subcommand;
 use daemonize::Daemonize;
 use eyre::{Result, WrapErr, bail, eyre};
 use fs4::fs_std::FileExt;
-use tokio::time::sleep;
+use tokio::time::{sleep, timeout};
 
 #[derive(clap::Args, Debug)]
 pub struct Cmd {
@@ -232,15 +232,20 @@ async fn probe(settings: &Settings) -> Probe {
         Err(err) => return Probe::Unreachable(err),
     };
 
-    match client.status().await {
-        Ok(status) => {
+    let cap = rpc_timeout(settings);
+    match timeout(cap, client.status()).await {
+        Ok(Ok(status)) => {
             if daemon_matches_expected(&status.version, status.protocol) {
                 Probe::Ready(client)
             } else {
                 Probe::NeedsRestart(daemon_mismatch_message(&status.version, status.protocol))
             }
         }
-        Err(err) => Probe::Unreachable(err),
+        Ok(Err(err)) => Probe::Unreachable(err),
+        Err(_elapsed) => Probe::Unreachable(eyre!(
+            "daemon status request timed out after {}ms",
+            cap.as_millis()
+        )),
     }
 }
 
@@ -270,6 +275,15 @@ fn spawn_daemon_process() -> Result<()> {
 
 fn startup_timeout(settings: &Settings) -> Duration {
     Duration::from_secs_f64(settings.local_timeout.max(0.5) + 2.0)
+}
+
+// A daemon that accepts the socket but never responds (crash loop mid-boot,
+// systemd StartLimitBurst while the socket stays held) wedges gRPC with no
+// built-in deadline. Bound each shell-blocking RPC with the same cap the rest
+// of the client uses for local IO so the hook either gets an answer or fails
+// fast enough for the shell to continue.
+fn rpc_timeout(settings: &Settings) -> Duration {
+    Duration::from_secs_f64(settings.local_timeout.max(0.5))
 }
 
 #[cfg(unix)]
@@ -406,15 +420,17 @@ fn ensure_reply_compatible(settings: &Settings, version: &str, protocol: u32) ->
 }
 
 pub async fn start_history(settings: &Settings, history: History) -> Result<String> {
-    match async {
+    let cap = rpc_timeout(settings);
+    let attempt = timeout(cap, async {
         connect_client(settings)
             .await?
             .start_history(history.clone())
             .await
-    }
-    .await
-    {
-        Ok(resp) => {
+    })
+    .await;
+
+    match attempt {
+        Ok(Ok(resp)) => {
             if daemon_matches_expected(&resp.version, resp.protocol) {
                 return Ok(resp.id);
             }
@@ -426,29 +442,48 @@ pub async fn start_history(settings: &Settings, history: History) -> Result<Stri
                 ));
             }
         }
-        Err(err) if !settings.daemon.autostart => return Err(err),
-        Err(err) if !should_retry_after_error(&err) => return Err(err),
-        Err(_) => {}
+        Ok(Err(err)) if !settings.daemon.autostart => return Err(err),
+        Ok(Err(err)) if !should_retry_after_error(&err) => return Err(err),
+        Ok(Err(_)) => {}
+        Err(_elapsed) if !settings.daemon.autostart => {
+            return Err(eyre!(
+                "daemon start_history timed out after {}ms",
+                cap.as_millis()
+            ));
+        }
+        Err(_elapsed) => {
+            tracing::debug!(
+                "daemon start_history exceeded {}ms, restarting",
+                cap.as_millis()
+            );
+        }
     }
 
-    let resp = restart_daemon(settings)
-        .await?
-        .start_history(history)
-        .await?;
+    let mut client = restart_daemon(settings).await?;
+    let resp = timeout(cap, client.start_history(history))
+        .await
+        .map_err(|_| {
+            eyre!(
+                "daemon start_history timed out after {}ms following restart",
+                cap.as_millis()
+            )
+        })??;
     ensure_reply_compatible(settings, &resp.version, resp.protocol)?;
     Ok(resp.id)
 }
 
 pub async fn end_history(settings: &Settings, id: String, duration: u64, exit: i64) -> Result<()> {
-    match async {
+    let cap = rpc_timeout(settings);
+    let attempt = timeout(cap, async {
         connect_client(settings)
             .await?
             .end_history(id.clone(), duration, exit)
             .await
-    }
-    .await
-    {
-        Ok(resp) => {
+    })
+    .await;
+
+    match attempt {
+        Ok(Ok(resp)) => {
             if daemon_matches_expected(&resp.version, resp.protocol) {
                 return Ok(());
             }
@@ -465,15 +500,32 @@ pub async fn end_history(settings: &Settings, id: String, duration: u64, exit: i
             let _ = restart_daemon(settings).await;
             return Ok(());
         }
-        Err(err) if !settings.daemon.autostart => return Err(err),
-        Err(err) if !should_retry_after_error(&err) => return Err(err),
-        Err(_) => {}
+        Ok(Err(err)) if !settings.daemon.autostart => return Err(err),
+        Ok(Err(err)) if !should_retry_after_error(&err) => return Err(err),
+        Ok(Err(_)) => {}
+        Err(_elapsed) if !settings.daemon.autostart => {
+            return Err(eyre!(
+                "daemon end_history timed out after {}ms",
+                cap.as_millis()
+            ));
+        }
+        Err(_elapsed) => {
+            tracing::debug!(
+                "daemon end_history exceeded {}ms, restarting",
+                cap.as_millis()
+            );
+        }
     }
 
-    let resp = restart_daemon(settings)
-        .await?
-        .end_history(id, duration, exit)
-        .await?;
+    let mut client = restart_daemon(settings).await?;
+    let resp = timeout(cap, client.end_history(id, duration, exit))
+        .await
+        .map_err(|_| {
+            eyre!(
+                "daemon end_history timed out after {}ms following restart",
+                cap.as_millis()
+            )
+        })??;
     ensure_reply_compatible(settings, &resp.version, resp.protocol)?;
     Ok(())
 }


### PR DESCRIPTION
Fixes #3382.

The daemon-enabled `atuin history start` path calls into gRPC with no per-RPC deadline. When the socket is live but the daemon never replies (crash-restart mid-migration, or systemd holding the listen socket while the unit is in StartLimitBurst), the shell hook's preexec command substitution blocks on `atuin` forever. The reporter recovered by SSHing in without a TTY.

Fix: wrap the blocking RPC paths in `tokio::time::timeout` keyed to `settings.local_timeout` (2.0s default, floored at 500ms). Applies to `start_history`, `end_history`, and `probe`, plus the retry calls that follow `restart_daemon`. `handle_daemon_start`/`end` already swallow daemon errors and fall back to a locally-generated history id to avoid breaking the shell, so a timed-out call just routes through that existing fallback.

### Regression evidence

Listener that accepts but never responds (full script in the issue comment):

```
# before:  real 10.004s, exit 124 (external timeout killed it, shell would have hung forever)
# after:   real  2.015s, exit 0   (timeout hit, fallback returned id, shell continued)
```

Stock binary hangs to the external `timeout 10` cap with no output. Patched binary returns a local id in ~2s matching the `local_timeout` cap, which is what the shell hook expects.

### Why `local_timeout`

Reusing the existing setting keeps the user-facing surface area unchanged. If you'd rather have a dedicated `daemon.request_timeout`, I'm happy to plumb it through as a follow-up. Flagged that choice on the issue.

### Not included here

- Timeouts on `SearchClient`, `ControlClient`, and `tail_history`. Search happens from the interactive UI where hangs are recoverable (Ctrl-C). Control and tail are not called from the shell's critical path. Narrowed scope to the two RPCs that actually wedge the shell.
- A regression test. The hang requires a real accept-but-silent UnixListener, which means spawning a listener task in a test that doesn't touch the daemon binary. Happy to add one if you'd like; the repro in #3382 serves as the manual check.
