### PR TITLE
chore: Update to eye_declare 0.5.1

### DIFF
--- a/.atuin/skills/release/SKILL.md
+++ b/.atuin/skills/release/SKILL.md
@@ -28,6 +28,8 @@ Verify these tools are installed: `git`, `gsed`, `cargo`, `gh`, `git-cliff`.
 
 Use `command -v` for each. If any are missing, report which ones and stop.
 
+Remember to use `gsed`, or else macOS flags to regular `sed`, later in the workflow.
+
 ---
 
 ## Step 2 — Determine Version
@@ -78,8 +80,9 @@ ALL subsequent Bash commands run from `$WORKDIR`.
 
 4. Show `git diff --stat` and the version-related lines from the diff:
    ```bash
-   git diff --unified=0 -- '*.toml' | grep -E '^\+.*version' | grep -v '^\+\+\+'
+   git diff --unified=0 -- '*.toml' | grep '^\+.*version' | grep -vF '+++'
    ```
+   Remember to use macOS grep arguments on macOS systems.
 
 5. Verify the workspace version was actually updated by re-reading it
    from `Cargo.toml`.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1551,9 +1551,9 @@ dependencies = [
 
 [[package]]
 name = "eye_declare"
-version = "0.5.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "960fe0e307c26cfaf176a1d0b5c355ea0a641596e1b57676fb4a67718969fe5a"
+checksum = "1e4caff9f5574315258489ecb2d27aad2cc057521f4b0bc6819a1cd82a648f40"
 dependencies = [
  "crossterm",
  "eye_declare_macros",
@@ -1567,9 +1567,9 @@ dependencies = [
 
 [[package]]
 name = "eye_declare_macros"
-version = "0.5.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c973cc0ad5038f4d248fd949384b9610edacffec3959ec81926a34bf277bbb9f"
+checksum = "cb8ac27b19f79b61a8afc0a55a3148eb2dafc2aaec66c1103432e3e76e7c25af"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/crates/atuin-ai/Cargo.toml
+++ b/crates/atuin-ai/Cargo.toml
@@ -45,7 +45,7 @@ async-stream = "0.3"
 uuid = { workspace = true }
 tui-textarea-2 = "0.10.2"
 unicode-width = "0.2"
-eye_declare = "0.5"
+eye_declare = "0.5.1"
 ratatui-core = "0.1"
 ratatui-widgets = "0.3"
 thiserror = { workspace = true }


### PR DESCRIPTION
Fixes the burst output issue. See https://github.com/atuinsh/eye-declare/pull/33

Also includes some unrelated release script changes