### PR TITLE
chore(release): prepare for release 18.16.0-beta.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,47 @@
 
 All notable changes to this project will be documented in this file.
 
+## [unreleased]
+
+### Features
+
+- AI tool rendering overhaul + edit_file tool ([#3423](https://github.com/atuinsh/atuin/issues/3423))
+- Implement write_file tool with overwrite safety ([#3432](https://github.com/atuinsh/atuin/issues/3432))
+- Shell tool execution timeouts ([#3437](https://github.com/atuinsh/atuin/issues/3437))
+- Send user-defined context with `TERMINAL.md` ([#3443](https://github.com/atuinsh/atuin/issues/3443))
+- Add skill discovery, loading, and invocation ([#3444](https://github.com/atuinsh/atuin/issues/3444))
+
+
+### Bug Fixes
+
+- Shell tool preview stuck as Running after completion ([#3436](https://github.com/atuinsh/atuin/issues/3436))
+- Require all subcommands covered for shell allow rules ([#3440](https://github.com/atuinsh/atuin/issues/3440))
+- Minor issues with fish's vim mode(s) ([#3362](https://github.com/atuinsh/atuin/issues/3362))
+
+
+### Documentation
+
+- Document show_numeric_shortcuts ([#3433](https://github.com/atuinsh/atuin/issues/3433))
+- Update for new server binary ([#3439](https://github.com/atuinsh/atuin/issues/3439))
+
+
+### Miscellaneous Tasks
+
+- Update to rust 1.95 ([#3426](https://github.com/atuinsh/atuin/issues/3426))
+- Clarified note about regular expressions matching in path. ([#3427](https://github.com/atuinsh/atuin/issues/3427))
+- Use cat -n format for read_file tool ([#3435](https://github.com/atuinsh/atuin/issues/3435))
+- Update to eye_declare 0.5.1 ([#3449](https://github.com/atuinsh/atuin/issues/3449))
+
+
+### Performance
+
+- Reduce AI TUI rendering overhead for long conversations ([#3447](https://github.com/atuinsh/atuin/issues/3447))
+
+
+### Refactor
+
+- Replace ad-hoc dispatch with FSM + driver architecture ([#3434](https://github.com/atuinsh/atuin/issues/3434))
+
 ## 18.15.2
 
 ### Bug Fixes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -214,7 +214,7 @@ checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "atuin"
-version = "18.15.2"
+version = "18.16.0-beta.1"
 dependencies = [
  "arboard",
  "async-trait",
@@ -274,7 +274,7 @@ dependencies = [
 
 [[package]]
 name = "atuin-ai"
-version = "18.15.2"
+version = "18.16.0-beta.1"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -326,7 +326,7 @@ dependencies = [
 
 [[package]]
 name = "atuin-client"
-version = "18.15.2"
+version = "18.16.0-beta.1"
 dependencies = [
  "async-trait",
  "atuin-common",
@@ -381,7 +381,7 @@ dependencies = [
 
 [[package]]
 name = "atuin-common"
-version = "18.15.2"
+version = "18.16.0-beta.1"
 dependencies = [
  "base64",
  "directories",
@@ -401,7 +401,7 @@ dependencies = [
 
 [[package]]
 name = "atuin-daemon"
-version = "18.15.2"
+version = "18.16.0-beta.1"
 dependencies = [
  "atuin-client",
  "atuin-common",
@@ -434,7 +434,7 @@ dependencies = [
 
 [[package]]
 name = "atuin-dotfiles"
-version = "18.15.2"
+version = "18.16.0-beta.1"
 dependencies = [
  "atuin-client",
  "atuin-common",
@@ -448,7 +448,7 @@ dependencies = [
 
 [[package]]
 name = "atuin-hex"
-version = "18.15.2"
+version = "18.16.0-beta.1"
 dependencies = [
  "clap",
  "crossterm",
@@ -460,7 +460,7 @@ dependencies = [
 
 [[package]]
 name = "atuin-history"
-version = "18.15.2"
+version = "18.16.0-beta.1"
 dependencies = [
  "atuin-client",
  "crossterm",
@@ -473,7 +473,7 @@ dependencies = [
 
 [[package]]
 name = "atuin-kv"
-version = "18.15.2"
+version = "18.16.0-beta.1"
 dependencies = [
  "atuin-client",
  "atuin-common",
@@ -516,7 +516,7 @@ dependencies = [
 
 [[package]]
 name = "atuin-scripts"
-version = "18.15.2"
+version = "18.16.0-beta.1"
 dependencies = [
  "atuin-client",
  "atuin-common",
@@ -538,7 +538,7 @@ dependencies = [
 
 [[package]]
 name = "atuin-server"
-version = "18.15.2"
+version = "18.16.0-beta.1"
 dependencies = [
  "argon2",
  "atuin-common",
@@ -567,7 +567,7 @@ dependencies = [
 
 [[package]]
 name = "atuin-server-database"
-version = "18.15.2"
+version = "18.16.0-beta.1"
 dependencies = [
  "async-trait",
  "atuin-common",
@@ -580,7 +580,7 @@ dependencies = [
 
 [[package]]
 name = "atuin-server-postgres"
-version = "18.15.2"
+version = "18.16.0-beta.1"
 dependencies = [
  "async-trait",
  "atuin-common",
@@ -598,7 +598,7 @@ dependencies = [
 
 [[package]]
 name = "atuin-server-sqlite"
-version = "18.15.2"
+version = "18.16.0-beta.1"
 dependencies = [
  "async-trait",
  "atuin-common",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ resolver = "2"
 exclude = ["ui/backend", "crates/atuin-nucleo/matcher/fuzz"]
 
 [workspace.package]
-version = "18.15.2"
+version = "18.16.0-beta.1"
 authors = ["Ellie Huxtable <ellie@atuin.sh>"]
 rust-version = "1.95.0"
 license = "MIT"
@@ -19,17 +19,17 @@ readme = "README.md"
 
 [workspace.dependencies]
 async-trait = "0.1.58"
-atuin-client = { path = "crates/atuin-client", version = "18.15.2" }
-atuin-common = { path = "crates/atuin-common", version = "18.15.2" }
-atuin-daemon = { path = "crates/atuin-daemon", version = "18.15.2" }
-atuin-dotfiles = { path = "crates/atuin-dotfiles", version = "18.15.2" }
-atuin-history = { path = "crates/atuin-history", version = "18.15.2" }
-atuin-kv = { path = "crates/atuin-kv", version = "18.15.2" }
-atuin-scripts = { path = "crates/atuin-scripts", version = "18.15.2" }
-atuin-server = { path = "crates/atuin-server", version = "18.15.2" }
-atuin-server-database = { path = "crates/atuin-server-database", version = "18.15.2" }
-atuin-server-postgres = { path = "crates/atuin-server-postgres", version = "18.15.2" }
-atuin-server-sqlite = { path = "crates/atuin-server-sqlite", version = "18.15.2" }
+atuin-client = { path = "crates/atuin-client", version = "18.16.0-beta.1" }
+atuin-common = { path = "crates/atuin-common", version = "18.16.0-beta.1" }
+atuin-daemon = { path = "crates/atuin-daemon", version = "18.16.0-beta.1" }
+atuin-dotfiles = { path = "crates/atuin-dotfiles", version = "18.16.0-beta.1" }
+atuin-history = { path = "crates/atuin-history", version = "18.16.0-beta.1" }
+atuin-kv = { path = "crates/atuin-kv", version = "18.16.0-beta.1" }
+atuin-scripts = { path = "crates/atuin-scripts", version = "18.16.0-beta.1" }
+atuin-server = { path = "crates/atuin-server", version = "18.16.0-beta.1" }
+atuin-server-database = { path = "crates/atuin-server-database", version = "18.16.0-beta.1" }
+atuin-server-postgres = { path = "crates/atuin-server-postgres", version = "18.16.0-beta.1" }
+atuin-server-sqlite = { path = "crates/atuin-server-sqlite", version = "18.16.0-beta.1" }
 atuin-nucleo = { path = "crates/atuin-nucleo", version = "0.6.0" }
 atuin-nucleo-matcher = { path = "crates/atuin-nucleo/matcher", version = "0.3.1" }
 base64 = "0.22"

--- a/crates/atuin-client/Cargo.toml
+++ b/crates/atuin-client/Cargo.toml
@@ -20,7 +20,7 @@ daemon = []
 check-update = []
 
 [dependencies]
-atuin-common = { path = "../atuin-common", version = "18.15.2" }
+atuin-common = { path = "../atuin-common", version = "18.16.0-beta.1" }
 
 log = { workspace = true }
 base64 = { workspace = true }

--- a/crates/atuin-daemon/Cargo.toml
+++ b/crates/atuin-daemon/Cargo.toml
@@ -14,10 +14,10 @@ readme.workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-atuin-client = { path = "../atuin-client", version = "18.15.2" }
-atuin-common = { path = "../atuin-common", version = "18.15.2" }
-atuin-dotfiles = { path = "../atuin-dotfiles", version = "18.15.2" }
-atuin-history = { path = "../atuin-history", version = "18.15.2" }
+atuin-client = { path = "../atuin-client", version = "18.16.0-beta.1" }
+atuin-common = { path = "../atuin-common", version = "18.16.0-beta.1" }
+atuin-dotfiles = { path = "../atuin-dotfiles", version = "18.16.0-beta.1" }
+atuin-history = { path = "../atuin-history", version = "18.16.0-beta.1" }
 
 time = { workspace = true }
 uuid = { workspace = true }

--- a/crates/atuin-dotfiles/Cargo.toml
+++ b/crates/atuin-dotfiles/Cargo.toml
@@ -14,8 +14,8 @@ readme.workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-atuin-common = { path = "../atuin-common", version = "18.15.2" }
-atuin-client = { path = "../atuin-client", version = "18.15.2" }
+atuin-common = { path = "../atuin-common", version = "18.16.0-beta.1" }
+atuin-client = { path = "../atuin-client", version = "18.16.0-beta.1" }
 
 eyre = { workspace = true }
 tokio = { workspace = true }

--- a/crates/atuin-history/Cargo.toml
+++ b/crates/atuin-history/Cargo.toml
@@ -14,7 +14,7 @@ readme.workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-atuin-client = { path = "../atuin-client", version = "18.15.2" }
+atuin-client = { path = "../atuin-client", version = "18.16.0-beta.1" }
 
 time = { workspace = true }
 serde = { workspace = true }

--- a/crates/atuin-kv/Cargo.toml
+++ b/crates/atuin-kv/Cargo.toml
@@ -14,8 +14,8 @@ readme.workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-atuin-client = { path = "../atuin-client", version = "18.15.2" }
-atuin-common = { path = "../atuin-common", version = "18.15.2" }
+atuin-client = { path = "../atuin-client", version = "18.16.0-beta.1" }
+atuin-common = { path = "../atuin-common", version = "18.16.0-beta.1" }
 
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }

--- a/crates/atuin-scripts/Cargo.toml
+++ b/crates/atuin-scripts/Cargo.toml
@@ -14,8 +14,8 @@ readme.workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-atuin-client = { path = "../atuin-client", version = "18.15.2" }
-atuin-common = { path = "../atuin-common", version = "18.15.2" }
+atuin-client = { path = "../atuin-client", version = "18.16.0-beta.1" }
+atuin-common = { path = "../atuin-common", version = "18.16.0-beta.1" }
 
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }

--- a/crates/atuin-server-database/Cargo.toml
+++ b/crates/atuin-server-database/Cargo.toml
@@ -10,7 +10,7 @@ homepage = { workspace = true }
 repository = { workspace = true }
 
 [dependencies]
-atuin-common = { path = "../atuin-common", version = "18.15.2" }
+atuin-common = { path = "../atuin-common", version = "18.16.0-beta.1" }
 
 tracing = { workspace = true }
 time = { workspace = true }

--- a/crates/atuin-server-postgres/Cargo.toml
+++ b/crates/atuin-server-postgres/Cargo.toml
@@ -10,8 +10,8 @@ homepage = { workspace = true }
 repository = { workspace = true }
 
 [dependencies]
-atuin-common = { path = "../atuin-common", version = "18.15.2" }
-atuin-server-database = { path = "../atuin-server-database", version = "18.15.2" }
+atuin-common = { path = "../atuin-common", version = "18.16.0-beta.1" }
+atuin-server-database = { path = "../atuin-server-database", version = "18.16.0-beta.1" }
 
 eyre = { workspace = true }
 tracing = { workspace = true }

--- a/crates/atuin-server-sqlite/Cargo.toml
+++ b/crates/atuin-server-sqlite/Cargo.toml
@@ -10,8 +10,8 @@ homepage = { workspace = true }
 repository = { workspace = true }
 
 [dependencies]
-atuin-common = { path = "../atuin-common", version = "18.15.2" }
-atuin-server-database = { path = "../atuin-server-database", version = "18.15.2" }
+atuin-common = { path = "../atuin-common", version = "18.16.0-beta.1" }
+atuin-server-database = { path = "../atuin-server-database", version = "18.16.0-beta.1" }
 
 eyre = { workspace = true }
 tracing = { workspace = true }

--- a/crates/atuin/Cargo.toml
+++ b/crates/atuin/Cargo.toml
@@ -43,13 +43,13 @@ clipboard = ["arboard"]
 check-update = ["atuin-client/check-update"]
 
 [dependencies]
-atuin-ai = { path = "../atuin-ai", version = "18.15.2", optional = true, default-features = false }
-atuin-client = { path = "../atuin-client", version = "18.15.2", optional = true, default-features = false }
+atuin-ai = { path = "../atuin-ai", version = "18.16.0-beta.1", optional = true, default-features = false }
+atuin-client = { path = "../atuin-client", version = "18.16.0-beta.1", optional = true, default-features = false }
 atuin-common = { workspace = true }
 atuin-dotfiles = { workspace = true }
 atuin-history = { workspace = true }
-atuin-daemon = { path = "../atuin-daemon", version = "18.15.2", optional = true, default-features = false }
-atuin-hex = { path = "../atuin-hex", version = "18.15.2", optional = true, default-features = false }
+atuin-daemon = { path = "../atuin-daemon", version = "18.16.0-beta.1", optional = true, default-features = false }
+atuin-hex = { path = "../atuin-hex", version = "18.16.0-beta.1", optional = true, default-features = false }
 atuin-scripts = { workspace = true }
 atuin-kv = { workspace = true }
 
@@ -109,7 +109,7 @@ daemonize = "0.5.0"
 # compiles cleanly. tree-sitter 0.26's portable/endian.h fails on illumos,
 # Windows cross-compiles, and potentially other exotic targets.
 [target.'cfg(any(target_os = "linux", target_os = "macos"))'.dependencies]
-atuin-ai = { path = "../atuin-ai", version = "18.15.2", optional = true, default-features = false, features = ["tree-sitter"] }
+atuin-ai = { path = "../atuin-ai", version = "18.16.0-beta.1", optional = true, default-features = false, features = ["tree-sitter"] }
 
 [target.'cfg(windows)'.dependencies]
 windows-sys = { version = "0.61.2", features = ["Win32_System_Console"] }


### PR DESCRIPTION

### Features

- AI tool rendering overhaul + edit_file tool ([#3423](https://github.com/atuinsh/atuin/issues/3423))
- Implement write_file tool with overwrite safety ([#3432](https://github.com/atuinsh/atuin/issues/3432))
- Shell tool execution timeouts ([#3437](https://github.com/atuinsh/atuin/issues/3437))
- Send user-defined context with `TERMINAL.md` ([#3443](https://github.com/atuinsh/atuin/issues/3443))
- Add skill discovery, loading, and invocation ([#3444](https://github.com/atuinsh/atuin/issues/3444))


### Bug Fixes

- Shell tool preview stuck as Running after completion ([#3436](https://github.com/atuinsh/atuin/issues/3436))
- Require all subcommands covered for shell allow rules ([#3440](https://github.com/atuinsh/atuin/issues/3440))
- Minor issues with fish's vim mode(s) ([#3362](https://github.com/atuinsh/atuin/issues/3362))


### Documentation

- Document show_numeric_shortcuts ([#3433](https://github.com/atuinsh/atuin/issues/3433))
- Update for new server binary ([#3439](https://github.com/atuinsh/atuin/issues/3439))


### Miscellaneous Tasks

- Update to rust 1.95 ([#3426](https://github.com/atuinsh/atuin/issues/3426))
- Clarified note about regular expressions matching in path. ([#3427](https://github.com/atuinsh/atuin/issues/3427))
- Use cat -n format for read_file tool ([#3435](https://github.com/atuinsh/atuin/issues/3435))
- Update to eye_declare 0.5.1 ([#3449](https://github.com/atuinsh/atuin/issues/3449))


### Performance

- Reduce AI TUI rendering overhead for long conversations ([#3447](https://github.com/atuinsh/atuin/issues/3447))


### Refactor

- Replace ad-hoc dispatch with FSM + driver architecture ([#3434](https://github.com/atuinsh/atuin/issues/3434))