### PR TITLE
fix: atuin update on windows

### DIFF
--- a/crates/atuin-client/src/plugin.rs
+++ b/crates/atuin-client/src/plugin.rs
@@ -42,7 +42,7 @@ impl OfficialPluginRegistry {
                 "Update atuin to the latest version",
                 "The 'atuin update' command is provided by the atuin-update plugin.\n\
                  It is only installed if you used the install script\n  \
-                 If you used a package manager (brew, apt, etc), please continue to use it for updates"
+                 If you used a package manager (brew, apt, etc), please continue to use it for updates",
             ),
         );
     }
@@ -65,6 +65,55 @@ impl OfficialPluginRegistry {
 impl Default for OfficialPluginRegistry {
     fn default() -> Self {
         Self::new()
+    }
+}
+
+pub struct PluginContext {
+    #[cfg(windows)]
+    _update_on_windows: Option<UpdateOnWindowsContext>,
+}
+
+impl PluginContext {
+    pub fn new(_subcommand: &str) -> Self {
+        PluginContext {
+            #[cfg(windows)]
+            _update_on_windows: (_subcommand == "update").then(UpdateOnWindowsContext::new),
+        }
+    }
+}
+
+#[cfg(windows)]
+struct UpdateOnWindowsContext {
+    initial_exe: Option<std::path::PathBuf>,
+}
+
+#[cfg(windows)]
+impl UpdateOnWindowsContext {
+    const OLD_FILE_NAME: &'static str = "atuin.old";
+
+    pub fn new() -> Self {
+        // Windows doesn't let you overwrite a running exe, but it lets you rename it,
+        // so make some room for atuin-update to install the new version.
+        let initial_exe = std::env::current_exe().ok().and_then(|exe| {
+            std::fs::rename(&exe, exe.with_file_name(Self::OLD_FILE_NAME)).ok()?;
+            Some(exe)
+        });
+
+        Self { initial_exe }
+    }
+}
+
+#[cfg(windows)]
+impl Drop for UpdateOnWindowsContext {
+    fn drop(&mut self) {
+        if let Some(exe) = &self.initial_exe
+            && !exe.exists()
+        {
+            // The update failed, roll back the current exe to its initial name.
+            std::fs::rename(exe.with_file_name(Self::OLD_FILE_NAME), exe).unwrap_or_else(|e| {
+                eprintln!("Failed to roll back the update, you may need to reinstall Atuin: {e}");
+            });
+        }
     }
 }
 

--- a/crates/atuin-client/src/plugin.rs
+++ b/crates/atuin-client/src/plugin.rs
@@ -82,6 +82,10 @@ impl PluginContext {
     }
 }
 
+impl Drop for PluginContext {
+    fn drop(&mut self) {}
+}
+
 #[cfg(windows)]
 struct UpdateOnWindowsContext {
     initial_exe: Option<std::path::PathBuf>,

--- a/crates/atuin/src/command/client/daemon.rs
+++ b/crates/atuin/src/command/client/daemon.rs
@@ -331,6 +331,7 @@ async fn wait_until_ready(settings: &Settings, timeout: Duration) -> Result<Hist
     }
 }
 
+#[allow(clippy::unnecessary_wraps)]
 fn ensure_autostart_supported(settings: &Settings) -> Result<()> {
     #[cfg(unix)]
     if settings.daemon.systemd_socket {

--- a/crates/atuin/src/command/external.rs
+++ b/crates/atuin/src/command/external.rs
@@ -3,7 +3,7 @@ use std::process::Command;
 use std::{io, process};
 
 #[cfg(feature = "client")]
-use atuin_client::plugin::OfficialPluginRegistry;
+use atuin_client::plugin::{OfficialPluginRegistry, PluginContext};
 use clap::CommandFactory;
 use clap::builder::{StyledStr, Styles};
 use eyre::Result;
@@ -15,6 +15,8 @@ pub fn run(args: &[String]) -> Result<()> {
     let bin = format!("atuin-{subcommand}");
     let mut cmd = Command::new(&bin);
     cmd.args(&args[1..]);
+
+    let context = PluginContext::new(subcommand);
 
     let spawn_result = match cmd.spawn() {
         Ok(child) => Ok(child),
@@ -33,11 +35,13 @@ pub fn run(args: &[String]) -> Result<()> {
             if status.success() {
                 Ok(())
             } else {
+                drop(context);
                 process::exit(status.code().unwrap_or(1));
             }
         }
         Err(e) => {
             eprintln!("{}", e.ansi());
+            drop(context);
             process::exit(1);
         }
     }

--- a/crates/atuin/src/command/external.rs
+++ b/crates/atuin/src/command/external.rs
@@ -16,6 +16,7 @@ pub fn run(args: &[String]) -> Result<()> {
     let mut cmd = Command::new(&bin);
     cmd.args(&args[1..]);
 
+    #[cfg(feature = "client")]
     let context = PluginContext::new(subcommand);
 
     let spawn_result = match cmd.spawn() {
@@ -35,13 +36,18 @@ pub fn run(args: &[String]) -> Result<()> {
             if status.success() {
                 Ok(())
             } else {
+                #[cfg(feature = "client")]
                 drop(context);
+
                 process::exit(status.code().unwrap_or(1));
             }
         }
         Err(e) => {
             eprintln!("{}", e.ansi());
+
+            #[cfg(feature = "client")]
             drop(context);
+
             process::exit(1);
         }
     }


### PR DESCRIPTION
This fixes the `atuin update` command on Windows.

Windows doesn't let you overwrite a running exe, but it lets you rename it. This PR special-cases the official `update` plugin by renaming the running `atuin.exe` to `atuin.old` before the update, and rolling it back if the update fails.

Note that the `atuin.old` file is left behind on success, which shouldn't be a problem in practice: it will be overwritten on the next call to `atuin update` (also deleted if there's no update available), and is located in `~/.atuin/bin`, which is an isolated location specific to Atuin.

Fixes #3451

## Checks
- [x] I am happy for maintainers to push small adjustments to this PR, to speed up the review cycle
- [x] I have checked that there are no existing pull requests for the same thing
