### PR TITLE
docs(hex): use psub in Fish init so the test -t 0 check passes

### DIFF
--- a/docs/docs/reference/hex.md
+++ b/docs/docs/reference/hex.md
@@ -29,10 +29,15 @@ Atuin Hex needs to be initialized separately from your existing Atuin config. Pl
     Add
 
     ```shell
-    atuin hex init fish | source
+    source (atuin hex init fish | psub)
     ```
 
-    to your `is-interactive` block in your `~/.config/fish/config.fish` file
+    to your `is-interactive` block in your `~/.config/fish/config.fish` file.
+
+    Hex's init checks `test -t 0` before activating, so `psub` is
+    used here instead of `| source`: piping would redirect stdin to
+    the pipe for the duration of the source, the check would fail,
+    and Hex would silently skip activation.
 
 === "Nushell"
 


### PR DESCRIPTION
Closes #3458.

The Fish quickstart in `docs/docs/reference/hex.md` recommends:

```fish
atuin hex init fish | source
```

That line silently no-ops. The Hex Fish init guards `exec atuin hex` with `status is-interactive; and test -t 0; and test -t 1` ([crates/atuin-hex/src/lib.rs:112](https://github.com/atuinsh/atuin/blob/main/crates/atuin-hex/src/lib.rs#L112)). When `source` reads from a pipe, fd 0 is redirected to the pipe for the duration of the source, so `test -t 0` returns false and the body is skipped. `is-interactive` doesn't help here because the shell still considers itself interactive while sourcing the piped input.

`exec atuin hex` couldn't recover even without the guard: the new process would inherit the pipe as fd 0 instead of the terminal, breaking the PTY proxy as soon as it tried to read user input.

Switching the docs to `source (atuin hex init fish | psub)` materializes the script to a temp file path, so `source` reads from a file and fd 0 stays attached to the terminal. The Bash and Zsh examples already work because `eval "$(...)"` doesn't redirect stdin — this brings Fish into line.

Reproduction (from #3458):

```fish
> cat foo.fish
#!/bin/env fish
test -t 0 && echo true || echo false

> source foo.fish
true

> cat foo.fish | source
false
```

Repro reporter: @mati865 (Fish 4.0+, CachyOS).