### PR TITLE
feat(pty-proxy): mirror inner shell cwd via OSC 7

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -510,6 +510,7 @@ dependencies = [
  "clap",
  "crossterm",
  "eyre",
+ "percent-encoding",
  "portable-pty",
  "signal-hook",
  "vt100",

--- a/crates/atuin-pty-proxy/Cargo.toml
+++ b/crates/atuin-pty-proxy/Cargo.toml
@@ -16,6 +16,7 @@ clap = { workspace = true }
 [target.'cfg(unix)'.dependencies]
 crossterm = { workspace = true }
 eyre = { workspace = true }
+percent-encoding = "2.3"
 portable-pty = "0.9"
 signal-hook = "0.3"
 vt100 = { workspace = true }

--- a/crates/atuin-pty-proxy/src/lib.rs
+++ b/crates/atuin-pty-proxy/src/lib.rs
@@ -5,6 +5,8 @@ mod debug;
 #[cfg(unix)]
 mod osc133;
 #[cfg(unix)]
+mod osc7;
+#[cfg(unix)]
 mod pty_proxy;
 #[cfg(unix)]
 mod runtime;

--- a/crates/atuin-pty-proxy/src/osc7.rs
+++ b/crates/atuin-pty-proxy/src/osc7.rs
@@ -1,0 +1,282 @@
+//! Streaming parser for OSC 7 (current working directory) escape sequences.
+//!
+//! OSC 7 is the de-facto standard for shells to inform the terminal of their
+//! current working directory:
+//!
+//! ```text
+//! ESC ] 7 ; file://<hostname>/<path> ST
+//! ```
+//!
+//! ST is either BEL (0x07) or ESC \ (0x1B 0x5C).  The path is percent-encoded
+//! per RFC 3986 (e.g. spaces as %20).
+//!
+//! atuin pty-proxy parses this from the inner shell's output and updates its
+//! own cwd to match, so that terminals/multiplexers (tmux, Ghostty, Kitty,
+//! etc.) that read pane cwd via process introspection see the inner shell's
+//! directory rather than the proxy's startup directory.
+//!
+//! # Design goals
+//!
+//! Mirrors `osc133.rs`: streaming, transparent (caller still forwards bytes).
+//! The parameter buffer is pre-sized to its hard cap so steady-state parsing
+//! does not allocate.
+
+use percent_encoding::{AsciiSet, NON_ALPHANUMERIC, percent_decode};
+use std::ffi::OsString;
+use std::os::unix::ffi::OsStringExt;
+use std::path::PathBuf;
+
+/// RFC 3986 path encode set: percent-encode everything that is not in the
+/// `unreserved` set (`A-Za-z0-9-._~`) or the path separator `/`.
+pub const PATH_ENCODE_SET: &AsciiSet = &NON_ALPHANUMERIC
+    .remove(b'-')
+    .remove(b'.')
+    .remove(b'_')
+    .remove(b'~')
+    .remove(b'/');
+
+/// Event emitted when an OSC 7 sequence is fully parsed.  The host portion
+/// of the URI is intentionally discarded — every consumer in atuin pty-proxy
+/// only cares about the cwd path.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CwdEvent {
+    pub path: PathBuf,
+}
+
+const ESC: u8 = 0x1B;
+const BEL: u8 = 0x07;
+const BACKSLASH: u8 = b'\\';
+const RIGHT_BRACKET: u8 = b']';
+
+/// Cap on the buffered OSC parameter payload.  Generous enough for any
+/// realistic file path including percent-encoding overhead.
+const PARAM_BUF_CAP: usize = 4096;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum State {
+    Ground,
+    Esc,
+    OscParam,
+    OscEsc,
+}
+
+/// Streaming parser.  Feed arbitrary byte slices via [`Parser::push`]; the
+/// parser invokes `on_event` for every fully-formed OSC 7 sequence.
+pub struct Parser {
+    state: State,
+    param_buf: Vec<u8>,
+    overflowed: bool,
+}
+
+impl Default for Parser {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Parser {
+    pub fn new() -> Self {
+        Self {
+            state: State::Ground,
+            param_buf: Vec::with_capacity(PARAM_BUF_CAP),
+            overflowed: false,
+        }
+    }
+
+    pub fn push(&mut self, data: &[u8], mut on_event: impl FnMut(CwdEvent)) {
+        for &byte in data {
+            match self.state {
+                State::Ground => {
+                    if byte == ESC {
+                        self.state = State::Esc;
+                    }
+                }
+                State::Esc => {
+                    if byte == RIGHT_BRACKET {
+                        self.state = State::OscParam;
+                        self.param_buf.clear();
+                        self.overflowed = false;
+                    } else {
+                        self.state = State::Ground;
+                    }
+                }
+                State::OscParam => {
+                    if byte == BEL {
+                        self.dispatch(&mut on_event);
+                        self.state = State::Ground;
+                    } else if byte == ESC {
+                        self.state = State::OscEsc;
+                    } else if self.param_buf.len() < PARAM_BUF_CAP {
+                        self.param_buf.push(byte);
+                    } else {
+                        self.overflowed = true;
+                    }
+                }
+                State::OscEsc => {
+                    if byte == BACKSLASH {
+                        self.dispatch(&mut on_event);
+                    }
+                    self.state = State::Ground;
+                }
+            }
+        }
+    }
+
+    fn dispatch(&mut self, on_event: &mut impl FnMut(CwdEvent)) {
+        let overflowed = std::mem::replace(&mut self.overflowed, false);
+        if overflowed {
+            return;
+        }
+        let params = &self.param_buf[..];
+        // Must start with "7;"
+        if params.len() < 2 || params[0] != b'7' || params[1] != b';' {
+            return;
+        }
+        if let Some(event) = parse_file_uri(&params[2..]) {
+            on_event(event);
+        }
+    }
+}
+
+/// Parse a `file://[host]/<path>` URI into a decoded filesystem path.  The
+/// host portion is parsed and discarded.  Returns None on malformed input
+/// or on a non-absolute path (OSC 7 paths are absolute by definition).
+fn parse_file_uri(uri: &[u8]) -> Option<CwdEvent> {
+    let s = std::str::from_utf8(uri).ok()?;
+    let s = s.strip_prefix("file://")?;
+    // Skip past the host (everything up to the first '/').  An empty host
+    // (`file:///path`) is valid; the path begins at that first '/'.
+    let path = &s[s.find('/')?..];
+    let bytes = percent_decode(path.as_bytes()).collect::<Vec<u8>>();
+    let path = PathBuf::from(OsString::from_vec(bytes));
+    // OSC 7 paths are absolute by definition, and a wire payload with `..`
+    // components is either malformed or an attempt by attacker-controlled
+    // pty output (e.g. `cat /random/file`) to redirect the daemon's cwd
+    // somewhere unexpected.  Reject both.
+    if !path.is_absolute()
+        || path
+            .components()
+            .any(|c| matches!(c, std::path::Component::ParentDir))
+    {
+        return None;
+    }
+    Some(CwdEvent { path })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn parse_events(data: &[u8]) -> Vec<CwdEvent> {
+        let mut parser = Parser::new();
+        let mut events = Vec::new();
+        parser.push(data, |e| events.push(e));
+        events
+    }
+
+    #[test]
+    fn simple_path_bel() {
+        let events = parse_events(b"\x1b]7;file://host/tmp\x07");
+        assert_eq!(
+            events,
+            vec![CwdEvent {
+                path: PathBuf::from("/tmp"),
+            }]
+        );
+    }
+
+    #[test]
+    fn simple_path_st() {
+        let events = parse_events(b"\x1b]7;file://host/tmp\x1b\\");
+        assert_eq!(
+            events,
+            vec![CwdEvent {
+                path: PathBuf::from("/tmp"),
+            }]
+        );
+    }
+
+    #[test]
+    fn empty_hostname() {
+        let events = parse_events(b"\x1b]7;file:///home/x\x07");
+        assert_eq!(
+            events,
+            vec![CwdEvent {
+                path: PathBuf::from("/home/x"),
+            }]
+        );
+    }
+
+    #[test]
+    fn percent_decode_spaces() {
+        let events = parse_events(b"\x1b]7;file:///home/with%20space\x07");
+        assert_eq!(
+            events,
+            vec![CwdEvent {
+                path: PathBuf::from("/home/with space"),
+            }]
+        );
+    }
+
+    #[test]
+    fn percent_decode_non_ascii() {
+        // /тест URL-encoded as UTF-8
+        let events = parse_events(b"\x1b]7;file:///%D1%82%D0%B5%D1%81%D1%82\x07");
+        assert_eq!(
+            events,
+            vec![CwdEvent {
+                path: PathBuf::from("/тест"),
+            }]
+        );
+    }
+
+    #[test]
+    fn split_across_chunks() {
+        let mut parser = Parser::new();
+        let mut events = Vec::new();
+        parser.push(b"\x1b]7;file:", |e| events.push(e));
+        parser.push(b"//host/tmp", |e| events.push(e));
+        parser.push(b"\x07", |e| events.push(e));
+        assert_eq!(
+            events,
+            vec![CwdEvent {
+                path: PathBuf::from("/tmp"),
+            }]
+        );
+    }
+
+    #[test]
+    fn ignores_other_osc_numbers() {
+        let events = parse_events(b"\x1b]133;A\x07");
+        assert!(events.is_empty());
+    }
+
+    #[test]
+    fn ignores_malformed_uri() {
+        let events = parse_events(b"\x1b]7;not-a-file-uri\x07");
+        assert!(events.is_empty());
+    }
+
+    #[test]
+    fn over_long_payload_is_dropped() {
+        let mut data = b"\x1b]7;file:///".to_vec();
+        data.extend(std::iter::repeat(b'a').take(PARAM_BUF_CAP * 2));
+        data.extend_from_slice(b"\x07");
+        let events = parse_events(&data);
+        assert!(events.is_empty(), "over-long OSC 7 should be dropped");
+    }
+
+    #[test]
+    fn rejects_relative_path() {
+        // Wire payload with no leading slash after host: malformed.
+        let events = parse_events(b"\x1b]7;file://hostrelative\x07");
+        assert!(events.is_empty());
+    }
+
+    #[test]
+    fn rejects_parent_dir_traversal() {
+        // Defends against `cat /attacker/file` redirecting the daemon's cwd.
+        let events = parse_events(b"\x1b]7;file:///a/../../etc\x07");
+        assert!(events.is_empty());
+    }
+}

--- a/crates/atuin-pty-proxy/src/pty_proxy.rs
+++ b/crates/atuin-pty-proxy/src/pty_proxy.rs
@@ -23,6 +23,13 @@ pub struct PtyProxy {
 pub enum Cmd {
     /// Print shell code to initialize atuin pty-proxy on shell startup
     Init(Init),
+    /// Emit an OSC 7 sequence describing the current working directory.
+    ///
+    /// Designed to be called from per-prompt hooks in pty-proxy's init
+    /// scripts; the proxy parses the emitted sequence and `chdir`s itself so
+    /// that terminals and multiplexers reading cwd via process introspection
+    /// see the inner shell's cwd instead of the proxy's startup directory.
+    EmitOsc7,
 }
 
 #[derive(Args, Debug)]
@@ -79,6 +86,12 @@ impl PtyProxy {
                     std::process::exit(1);
                 }
             }
+            Some(Cmd::EmitOsc7) => {
+                if let Err(err) = emit_osc7() {
+                    eprintln!("atuin pty-proxy: {err}");
+                    std::process::exit(1);
+                }
+            }
             None => runtime::main(RuntimeOptions::new(
                 self.debug_osc133,
                 self.shell,
@@ -86,6 +99,15 @@ impl PtyProxy {
             )),
         }
     }
+}
+
+/// Print `\e]7;file://<encoded-cwd>\e\\` for the current working directory.
+fn emit_osc7() -> Result<(), String> {
+    let cwd = std::env::current_dir().map_err(|e| format!("getcwd failed: {e}"))?;
+    let bytes = cwd.into_os_string().into_encoded_bytes();
+    let encoded = percent_encoding::percent_encode(&bytes, crate::osc7::PATH_ENCODE_SET);
+    print!("\x1b]7;file://{encoded}\x1b\\");
+    Ok(())
 }
 
 impl Init {
@@ -177,6 +199,28 @@ fn render_init(shell: Shell) -> &'static str {
 
   unset _atuin_pty_proxy_tmux_current _atuin_pty_proxy_tmux_previous
 fi
+
+# When running under atuin pty-proxy, emit OSC 7 (cwd) when $PWD changes so
+# the proxy can mirror our cwd.  All path encoding lives in `atuin pty-proxy
+# emit-osc7` (Rust) — there is no shell-side encoder.  We skip emission on
+# unchanged PWD (most prompts don't follow a `cd`) and detach the
+# subprocess so it doesn't block prompt rendering.
+if [[ -n "${ATUIN_PTY_PROXY_SOCKET:-}" ]]; then
+  _atuin_pty_proxy_osc7() {
+    if [[ "$PWD" != "${_atuin_pty_proxy_last_pwd:-}" ]]; then
+      _atuin_pty_proxy_last_pwd="$PWD"
+      (atuin pty-proxy emit-osc7 &)
+    fi
+  }
+  if [[ -n "${BASH_VERSION:-}" ]]; then
+    if [[ "${PROMPT_COMMAND:-}" != *_atuin_pty_proxy_osc7* ]]; then
+      PROMPT_COMMAND="_atuin_pty_proxy_osc7${PROMPT_COMMAND:+;$PROMPT_COMMAND}"
+    fi
+  elif [[ -n "${ZSH_VERSION:-}" ]]; then
+    autoload -Uz add-zsh-hook
+    add-zsh-hook precmd _atuin_pty_proxy_osc7
+  fi
+fi
 "#
         }
         Shell::Fish => {
@@ -201,6 +245,19 @@ fi
         exec atuin pty-proxy --shell (status fish-path)
     end
 end
+
+# When running under atuin pty-proxy, emit OSC 7 (cwd) when $PWD changes so
+# the proxy can mirror our cwd.  All path encoding lives in `atuin pty-proxy
+# emit-osc7` (Rust) — there is no shell-side encoder.  --on-variable PWD
+# fires only on cd (not every prompt); the subprocess is detached so it
+# doesn't block.
+if set -q ATUIN_PTY_PROXY_SOCKET
+    function __atuin_pty_proxy_osc7 --on-variable PWD
+        command atuin pty-proxy emit-osc7 &
+    end
+    # Initial emission so the proxy knows our cwd before the first cd.
+    command atuin pty-proxy emit-osc7 &
+end
 "#
         }
         // Nushell cannot dynamically source the output of `atuin init nu`,
@@ -216,6 +273,23 @@ end
         $env.ATUIN_PTY_PROXY_TMUX = $tmux_current
         exec atuin pty-proxy --shell $nu.current-exe
     }
+}
+
+# When running under atuin pty-proxy, emit OSC 7 (cwd) when $env.PWD changes
+# so the proxy can mirror our cwd.  All path encoding lives in `atuin
+# pty-proxy emit-osc7` (Rust) — there is no shell-side encoder.  The
+# env_change.PWD hook fires only on cd (not every prompt); `job spawn` runs
+# the subprocess asynchronously so it doesn't block.
+if not ($env.ATUIN_PTY_PROXY_SOCKET? | default "" | is-empty) {
+    let _atuin_pty_proxy_osc7 = {|_before, _after|
+        job spawn { ^atuin pty-proxy emit-osc7 } | ignore
+    }
+    $env.config.hooks.env_change.PWD = (
+        ($env.config.hooks.env_change.PWD? | default []) | append $_atuin_pty_proxy_osc7
+    )
+    # Nushell auto-fires env_change.PWD on shell startup
+    # (before="" -> after=$PWD), so the proxy learns our cwd without a
+    # manual initial fire here.
 }
 "#
         }
@@ -262,6 +336,25 @@ mod tests {
 
         let nu = render_init(Shell::Nu);
         assert!(nu.contains("exec atuin pty-proxy --shell $nu.current-exe"));
+    }
+    #[test]
+    fn init_scripts_emit_osc7_on_pwd_change() {
+        // Each shell wires a PWD hook that shells out to `emit-osc7`, gated on
+        // the proxy socket being present.
+        let posix = render_init(Shell::Bash);
+        assert!(posix.contains("ATUIN_PTY_PROXY_SOCKET"));
+        assert!(posix.contains("atuin pty-proxy emit-osc7"));
+        assert!(posix.contains("add-zsh-hook precmd _atuin_pty_proxy_osc7"));
+
+        let fish = render_init(Shell::Fish);
+        assert!(fish.contains("ATUIN_PTY_PROXY_SOCKET"));
+        assert!(fish.contains("--on-variable PWD"));
+        assert!(fish.contains("atuin pty-proxy emit-osc7"));
+
+        let nu = render_init(Shell::Nu);
+        assert!(nu.contains("ATUIN_PTY_PROXY_SOCKET"));
+        assert!(nu.contains("env_change.PWD"));
+        assert!(nu.contains("atuin pty-proxy emit-osc7"));
     }
 
     #[test]

--- a/crates/atuin-pty-proxy/src/runtime.rs
+++ b/crates/atuin-pty-proxy/src/runtime.rs
@@ -75,6 +75,7 @@ fn run(options: RuntimeOptions) -> eyre::Result<()> {
             .command_capture_sink
             .as_ref()
             .map(|_| CommandCaptureTracker::new(current_cols));
+        let mut osc7 = crate::osc7::Parser::new();
         let mut buf = [0u8; 8192];
 
         loop {
@@ -87,6 +88,16 @@ fn run(options: RuntimeOptions) -> eyre::Result<()> {
                     ) {
                         tracker.push(&buf[..n], sink);
                     }
+
+                    // Mirror the inner shell's cwd onto our own process so
+                    // terminals/multiplexers reading our cwd via process
+                    // introspection (e.g. tmux pane_current_path) see where the
+                    // shell actually is. set_current_dir silently fails for
+                    // non-existent paths (e.g. an OSC 7 forwarded from an SSH'd
+                    // remote session), which is the desired behavior.
+                    osc7.push(&buf[..n], |event| {
+                        let _ = std::env::set_current_dir(&event.path);
+                    });
 
                     if let Some(highlighter) = highlighter.as_mut() {
                         let rendered = highlighter.render(&buf[..n]);


### PR DESCRIPTION
Fixes #3296.
Partially addresses #3337 (cwd-tracking portion; shell-integration hooks are a separate problem).

## The bug

Terminals and multiplexers (tmux's `pane_current_path`, Ghostty / Kitty / WezTerm "open in same dir", etc.) read a pane's cwd by inspecting the foreground process via `proc_pidinfo` (macOS) or `/proc/<pid>/cwd` (Linux). When `atuin pty-proxy` is active, the foreground process is the proxy — *not* the inner shell where the user actually runs `cd`. The inner shell lives on a private PTY invisible to the multiplexer.

Result: terminal features that depend on knowing the current directory always see the proxy's startup directory, not wherever the user `cd`-ed to.

## The fix

Inner shells emit OSC 7 (`\e]7;file://<host><path>\e\\`) on every prompt change. The proxy parses the wire payload from the inner-PTY byte stream and `chdir`s itself to match. Subsequent `proc_pidinfo` / `/proc` lookups by the terminal then see the correct cwd.

All path encoding lives in a new `atuin pty-proxy emit-osc7` subcommand — each shell's init only needs a one-line hook that calls it. This avoids per-shell URL encoders (4 implementations with subtly different RFC 3986 edge cases) in favor of one well-tested Rust source of truth, while keeping the wire format strictly RFC 3986–compliant for any other terminal listening to OSC 7.

Per-shell hooks:
- **bash / zsh:** `_atuin_pty_proxy_osc7` runs in `precmd` (zsh) or `PROMPT_COMMAND` (bash), gated on `$PWD` change.
- **fish:** `--on-variable PWD` event handler.
- **nushell:** `env_change.PWD` hook.

## Per-prompt cost

The hooks fork+exec `atuin pty-proxy emit-osc7` per `cd` (gated on `$PWD` change). The atuin shell integration **already** synchronously forks+execs `atuin history start` on every preexec, plus a backgrounded `atuin history end` per command. The OSC 7 emission piggybacks on this existing budget — backgrounded, gated on PWD change — so it adds at most one extra `atuin` invocation per directory change, strictly less than the existing per-command cost.

## Trust boundary

The proxy trusts the OSC 7 wire payload and `chdir`s based on it. Anyone who can write to the inner PTY can drive the proxy's cwd to any path the user can already `chdir` to themselves. This is the same trust model as every other OSC sequence terminals honor (OSC 8 hyperlinks, OSC 52 clipboard, etc.) — if attacker-controlled output (e.g. `cat /random/file`) can spew bytes into your terminal, you've already lost.

Defense-in-depth in the parser:
- Reject non-absolute paths (OSC 7 paths are absolute by definition; relative = malformed).
- Reject paths containing `..` components (defends against `cat /attacker/file` redirecting cwd via traversal).
- 4096-byte cap on parameter buffer (drop, no panic, on overflow).

## Alternative considered

Kernel-side cwd lookup (`proc_pidinfo` / `/proc/<inner-shell-pid>/cwd`) instead of trusting the wire payload would eliminate the trust boundary entirely — the proxy would query the kernel directly and the wire payload would be a decorative refresh trigger. I explored this on a separate branch and it works, but it adds OS-specific code paths (libproc on macOS, procfs on Linux) and the security delta is small relative to the existing OSC trust model. Happy to revisit if you'd prefer that approach.

## Testing

- 11 unit tests in `crates/atuin-pty-proxy/src/osc7.rs`, including: streaming chunk boundaries, BEL vs ESC \\ terminators, percent-encoded multibyte UTF-8, malformed URI rejection, relative-path rejection, `..`-traversal rejection, over-long payload drop.
- Manually verified end-to-end on macOS with tmux + nushell: `cd` in the inner shell, then `tmux split-window` opens a new pane in the right directory.
- Module gated on `#[cfg(unix)]` so Windows builds (`atuin` with default features including `pty-proxy`) remain unaffected.

## Checks
- [x] I am happy for maintainers to push small adjustments to this PR, to speed up the review cycle
- [x] I have checked that there are no existing pull requests for the same thing
