### PR TITLE
chore: Generate LLM-optimized docs

### DIFF
--- a/docs/docs/ai/introduction.md
+++ b/docs/docs/ai/introduction.md
@@ -4,6 +4,8 @@ Atuin AI is a subcommand that enables shell command generation and other informa
 
 Atuin AI requires an account on [Atuin Hub](https://hub.atuin.sh/), and you'll be prompted to login upon first use of the binary.
 
+Usage of Atuin AI is currently free.
+
 ## Getting Started
 
 Atuin AI currently supports zsh, bash, and fish shells. Your shell's usual `atuin init` call will automatically bind the question mark key to the Atuin AI UI (only when the prompt is empty).

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -43,6 +43,64 @@ plugins:
       paths: ["mkdocs.yml", "docs/index.md", "docs/stylesheets/*"]
       yml_file: mkdocs.yml
       branch: mkt/docs-migration
+  - llmstxt:
+      base_url: https://docs.atuin.sh/cli
+      full_output: llms-full.txt
+      markdown_description: |
+        Atuin replaces your shell's built-in history with a SQLite database, adding context
+        (cwd, exit code, duration, hostname) and optionally syncing across machines with
+        end-to-end encryption. These docs cover the CLI tool - installation, configuration,
+        usage, self-hosting, and AI features.
+      sections:
+        Overview:
+          - index.md: Getting started with Atuin - quickstart, supported shells, and links.
+        Guide:
+          - guide/getting-started.md: First steps - install, import history, and start using Atuin.
+          - guide/installation.md: Install via script, Homebrew, WinGet, Cargo, Nix, or from source.
+          - guide/sync.md: Register an account and set up end-to-end encrypted history sync.
+          - guide/import.md: Import existing shell history from bash, zsh, fish, and others.
+          - guide/basic-usage.md: What Atuin records, how to use the TUI, and common config tweaks.
+          - guide/advanced-usage.md: Filter modes (global, host, session, directory, workspace) and search modes (fuzzy, full-text, skim).
+          - guide/shell-integration.md: How shell hooks work, environment variables, embedded terminals, and excluding commands.
+          - guide/agent-hooks.md: Capture commands from AI coding agents (Claude Code, Codex, pi) and filter by author.
+          - guide/delete-history.md: Delete single entries, bulk delete by query, remove duplicates, or wipe everything.
+          - guide/dotfiles.md: Sync shell aliases and environment variables across machines.
+          - guide/theming.md: Customize the TUI with color themes.
+        Configuration:
+          - configuration/config.md: Complete reference for ~/.config/atuin/config.toml - all settings with defaults and examples.
+          - configuration/key-binding.md: Custom up-arrow filter mode, disable up-arrow or ctrl-r, vim mode.
+          - configuration/advanced-key-binding.md: Full keymap customization with emacs, vim-normal, vim-insert, and inspector modes.
+        Reference:
+          - reference/config.md: The `atuin config` command - get, set, list, and resolve configuration values.
+          - reference/daemon.md: Background daemon for faster writes, auto-sync, and in-memory fuzzy search.
+          - reference/doctor.md: Diagnose common problems and dump system info for bug reports.
+          - reference/gen-completions.md: Generate shell completions for bash, fish, zsh, nushell, powershell, elvish.
+          - reference/hex.md: Experimental PTY proxy with popup rendering over existing terminal output.
+          - reference/import.md: Import history from bash, fish, zsh, replxx, mcfly, resh, and xonsh.
+          - reference/info.md: Show config file paths, env vars, and version info.
+          - reference/list.md: List history entries with formatting, filtering by cwd/session, and custom output templates.
+          - reference/prune.md: Delete entries matching history_filter config (useful after updating filters).
+          - reference/search.md: Search history with wildcards, filters (cwd, exit code, before/after), and delete mode.
+          - reference/stats.md: Compute stats for a time period - most used command, command count, unique commands.
+          - reference/sync.md: Sync commands - register, login, manual sync, and account management.
+        Self Hosting:
+          - self-hosting/server-setup.md: Run your own Atuin sync server with PostgreSQL or SQLite.
+          - self-hosting/usage.md: Configure the client to use a self-hosted server.
+          - self-hosting/docker.md: Deploy with Docker or Docker Compose.
+          - self-hosting/kubernetes.md: Full Kubernetes deployment with Postgres, secrets, and ingress.
+          - self-hosting/systemd.md: Systemd service unit with hardening options.
+        AI:
+          - ai/introduction.md: Atuin AI - command generation and lookup via LLM from your terminal.
+          - ai/settings.md: AI configuration in config.toml - enabled, endpoint, session timeout.
+          - ai/user-context.md: Send additional context to the LLM via TERMINAL.md files and dynamic shell substitution.
+          - ai/skills.md: Reusable instruction sets (skills) for Atuin AI - playbooks, conventions, workflows.
+          - ai/tools-permissions.md: Tools the AI can use (shell, filesystem) and permission files to control access.
+        Misc:
+          - known-issues.md: Known issues with ZFS and network filesystems.
+          - integrations.md: Integrations with zsh-autosuggestions, zsh-vi-mode, ble.sh, and mcfly.
+          - faq.md: Frequently asked questions - IDE terminals, history filtering, up-arrow, uninstalling.
+          - uninstall.md: How to uninstall Atuin and remove all data.
+          - sync-v2.md: Upgrading from sync v1 to v2 - faster, more reliable, less bandwidth.
 
 markdown_extensions:
   - pymdownx.highlight:

--- a/docs/pyproject.toml
+++ b/docs/pyproject.toml
@@ -9,6 +9,7 @@ dependencies = [
   "mkdocs-git-revision-date-localized-plugin>=1.2",
   "mkdocs-glightbox>=0.4",
   "mkdocs-redirects>=1.2.2",
+  "mkdocs-llmstxt>=0.5",
 ]
 
 [tool.uv]

--- a/docs/uv.lock
+++ b/docs/uv.lock
@@ -12,6 +12,7 @@ source = { virtual = "." }
 dependencies = [
     { name = "mkdocs-git-revision-date-localized-plugin" },
     { name = "mkdocs-glightbox" },
+    { name = "mkdocs-llmstxt" },
     { name = "mkdocs-material" },
     { name = "mkdocs-multirepo-plugin" },
     { name = "mkdocs-redirects" },
@@ -21,6 +22,7 @@ dependencies = [
 requires-dist = [
     { name = "mkdocs-git-revision-date-localized-plugin", specifier = ">=1.2" },
     { name = "mkdocs-glightbox", specifier = ">=0.4" },
+    { name = "mkdocs-llmstxt", specifier = ">=0.5" },
     { name = "mkdocs-material", specifier = ">=9.5" },
     { name = "mkdocs-multirepo-plugin", git = "https://github.com/atuinsh/mkdocs-multirepo-plugin?rev=mkt%2Fimported_repo" },
     { name = "mkdocs-redirects", specifier = ">=1.2.2" },
@@ -50,6 +52,19 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/eb/95/7118e935b0b0bd3f94dfec2d852fd4e4f4f9757bdb49850519acd245cd3a/backrefs-6.1-py313-none-any.whl", hash = "sha256:4c9d3dc1e2e558965202c012304f33d4e0e477e1c103663fd2c3cc9bb18b0d05", size = 400726, upload-time = "2025-11-15T14:52:04.093Z" },
     { url = "https://files.pythonhosted.org/packages/1d/72/6296bad135bfafd3254ae3648cd152980a424bd6fed64a101af00cc7ba31/backrefs-6.1-py314-none-any.whl", hash = "sha256:13eafbc9ccd5222e9c1f0bec563e6d2a6d21514962f11e7fc79872fd56cbc853", size = 412584, upload-time = "2025-11-15T14:52:05.233Z" },
     { url = "https://files.pythonhosted.org/packages/02/e3/a4fa1946722c4c7b063cc25043a12d9ce9b4323777f89643be74cef2993c/backrefs-6.1-py39-none-any.whl", hash = "sha256:a9e99b8a4867852cad177a6430e31b0f6e495d65f8c6c134b68c14c3c95bf4b0", size = 381058, upload-time = "2025-11-15T14:52:06.698Z" },
+]
+
+[[package]]
+name = "beautifulsoup4"
+version = "4.14.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "soupsieve" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c3/b0/1c6a16426d389813b48d95e26898aff79abbde42ad353958ad95cc8c9b21/beautifulsoup4-4.14.3.tar.gz", hash = "sha256:6292b1c5186d356bba669ef9f7f051757099565ad9ada5dd630bd9de5fa7fb86", size = 627737, upload-time = "2025-11-30T15:08:26.084Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1a/39/47f9197bdd44df24d67ac8893641e16f386c984a0619ef2ee4c51fbbc019/beautifulsoup4-4.14.3-py3-none-any.whl", hash = "sha256:0918bfe44902e6ad8d57732ba310582e98da931428d231a5ecb9e7c703a735bb", size = 107721, upload-time = "2025-11-30T15:08:24.087Z" },
 ]
 
 [[package]]
@@ -231,6 +246,31 @@ wheels = [
 ]
 
 [[package]]
+name = "markdown-it-py"
+version = "3.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mdurl" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/38/71/3b932df36c1a044d397a1f92d1cf91ee0a503d91e470cbd670aa66b07ed0/markdown-it-py-3.0.0.tar.gz", hash = "sha256:e3f60a94fa066dc52ec76661e37c851cb232d92f9886b15cb560aaada2df8feb", size = 74596, upload-time = "2023-06-03T06:41:14.443Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/42/d7/1ec15b46af6af88f19b8e5ffea08fa375d433c998b8a7639e76935c14f1f/markdown_it_py-3.0.0-py3-none-any.whl", hash = "sha256:355216845c60bd96232cd8d8c40e8f9765cc86f46880e43a8fd22dc1a1a8cab1", size = 87528, upload-time = "2023-06-03T06:41:11.019Z" },
+]
+
+[[package]]
+name = "markdownify"
+version = "1.2.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "beautifulsoup4" },
+    { name = "six" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/3f/bc/c8c8eea5335341306b0fa7e1cb33c5e1c8d24ef70ddd684da65f41c49c92/markdownify-1.2.2.tar.gz", hash = "sha256:b274f1b5943180b031b699b199cbaeb1e2ac938b75851849a31fd0c3d6603d09", size = 18816, upload-time = "2025-11-16T19:21:18.565Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/43/ce/f1e3e9d959db134cedf06825fae8d5b294bd368aacdd0831a3975b7c4d55/markdownify-1.2.2-py3-none-any.whl", hash = "sha256:3f02d3cc52714084d6e589f70397b6fc9f2f3a8531481bf35e8cc39f975e186a", size = 15724, upload-time = "2025-11-16T19:21:17.622Z" },
+]
+
+[[package]]
 name = "markupsafe"
 version = "3.0.3"
 source = { registry = "https://pypi.org/simple" }
@@ -305,6 +345,40 @@ wheels = [
 ]
 
 [[package]]
+name = "mdformat"
+version = "0.7.22"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markdown-it-py" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/fc/eb/b5cbf2484411af039a3d4aeb53a5160fae25dd8c84af6a4243bc2f3fedb3/mdformat-0.7.22.tar.gz", hash = "sha256:eef84fa8f233d3162734683c2a8a6222227a229b9206872e6139658d99acb1ea", size = 34610, upload-time = "2025-01-30T18:00:51.418Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f2/6f/94a7344f6d634fe3563bea8b33bccedee37f2726f7807e9a58440dc91627/mdformat-0.7.22-py3-none-any.whl", hash = "sha256:61122637c9e1d9be1329054f3fa216559f0d1f722b7919b060a8c2a4ae1850e5", size = 34447, upload-time = "2025-01-30T18:00:48.708Z" },
+]
+
+[[package]]
+name = "mdformat-tables"
+version = "1.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mdformat" },
+    { name = "wcwidth" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/64/fc/995ba209096bdebdeb8893d507c7b32b7e07d9a9f2cdc2ec07529947794b/mdformat_tables-1.0.0.tar.gz", hash = "sha256:a57db1ac17c4a125da794ef45539904bb8a9592e80557d525e1f169c96daa2c8", size = 6106, upload-time = "2024-08-23T23:41:33.413Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2a/37/d78e37d14323da3f607cd1af7daf262cb87fe614a245c15ad03bb03a2706/mdformat_tables-1.0.0-py3-none-any.whl", hash = "sha256:94cd86126141b2adc3b04c08d1441eb1272b36c39146bab078249a41c7240a9a", size = 5104, upload-time = "2024-08-23T23:41:31.863Z" },
+]
+
+[[package]]
+name = "mdurl"
+version = "0.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d6/54/cfe61301667036ec958cb99bd3efefba235e65cdeb9c84d24a8293ba1d90/mdurl-0.1.2.tar.gz", hash = "sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba", size = 8729, upload-time = "2022-08-14T12:40:10.846Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl", hash = "sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8", size = 9979, upload-time = "2022-08-14T12:40:09.779Z" },
+]
+
+[[package]]
 name = "mergedeep"
 version = "1.3.4"
 source = { registry = "https://pypi.org/simple" }
@@ -376,6 +450,21 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/8d/26/c793459622da8e31f954c6f5fb51e8f098143fdfc147b1e3c25bf686f4aa/mkdocs_glightbox-0.5.2.tar.gz", hash = "sha256:c7622799347c32310878e01ccf14f70648445561010911c80590cec0353370ac", size = 510586, upload-time = "2025-10-23T14:55:18.909Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/4e/ca/03624e017e5ee2d7ce8a08d89f81c1e535eb3c30d7b2dc4a435ea3fbbeae/mkdocs_glightbox-0.5.2-py3-none-any.whl", hash = "sha256:23a431ea802b60b1030c73323db2eed6ba859df1a0822ce575afa43e0ea3f47e", size = 26458, upload-time = "2025-10-23T14:55:17.43Z" },
+]
+
+[[package]]
+name = "mkdocs-llmstxt"
+version = "0.5.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "beautifulsoup4" },
+    { name = "markdownify" },
+    { name = "mdformat" },
+    { name = "mdformat-tables" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7f/f5/4c31cdffa7c09bf48d8c7a50d8342dc100abac98ac4150826bc11afc0c9f/mkdocs_llmstxt-0.5.0.tar.gz", hash = "sha256:b2fa9e6d68df41d7467e948a4745725b6c99434a36b36204857dbd7bb3dfe041", size = 33909, upload-time = "2025-11-20T14:02:24.861Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ad/2b/82928cc9e8d9269cd79e7ebf015efdc4945e6c646e86ec1d4dba1707f215/mkdocs_llmstxt-0.5.0-py3-none-any.whl", hash = "sha256:753c699913d2d619a9072604b26b6dc9f5fb6d257d9b107857f80c8a0b787533", size = 12040, upload-time = "2025-11-20T14:02:23.483Z" },
 ]
 
 [[package]]
@@ -677,6 +766,15 @@ wheels = [
 ]
 
 [[package]]
+name = "soupsieve"
+version = "2.8.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7b/ae/2d9c981590ed9999a0d91755b47fc74f74de286b0f5cee14c9269041e6c4/soupsieve-2.8.3.tar.gz", hash = "sha256:3267f1eeea4251fb42728b6dfb746edc9acaffc4a45b27e19450b676586e8349", size = 118627, upload-time = "2026-01-20T04:27:02.457Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/46/2c/1462b1d0a634697ae9e55b3cecdcb64788e8b7d63f54d923fcd0bb140aed/soupsieve-2.8.3-py3-none-any.whl", hash = "sha256:ed64f2ba4eebeab06cc4962affce381647455978ffc1e36bb79a545b91f45a95", size = 37016, upload-time = "2026-01-20T04:27:01.012Z" },
+]
+
+[[package]]
 name = "text-unidecode"
 version = "1.3"
 source = { registry = "https://pypi.org/simple" }
@@ -750,4 +848,13 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/07/f6/d0e5b343768e8bcb4cda79f0f2f55051bf26177ecd5651f84c07567461cf/watchdog-6.0.0-py3-none-win32.whl", hash = "sha256:07df1fdd701c5d4c8e55ef6cf55b8f0120fe1aef7ef39a1c6fc6bc2e606d517a", size = 79065, upload-time = "2024-11-01T14:07:09.525Z" },
     { url = "https://files.pythonhosted.org/packages/db/d9/c495884c6e548fce18a8f40568ff120bc3a4b7b99813081c8ac0c936fa64/watchdog-6.0.0-py3-none-win_amd64.whl", hash = "sha256:cbafb470cf848d93b5d013e2ecb245d4aa1c8fd0504e863ccefa32445359d680", size = 79070, upload-time = "2024-11-01T14:07:10.686Z" },
     { url = "https://files.pythonhosted.org/packages/33/e8/e40370e6d74ddba47f002a32919d91310d6074130fe4e17dabcafc15cbf1/watchdog-6.0.0-py3-none-win_ia64.whl", hash = "sha256:a1914259fa9e1454315171103c6a30961236f508b9b623eae470268bbcc6a22f", size = 79067, upload-time = "2024-11-01T14:07:11.845Z" },
+]
+
+[[package]]
+name = "wcwidth"
+version = "0.7.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/2c/ee/afaf0f85a9a18fe47a67f1e4422ed6cf1fe642f0ae0a2f81166231303c52/wcwidth-0.7.0.tar.gz", hash = "sha256:90e3a7ea092341c44b99562e75d09e4d5160fe7a3974c6fb842a101a95e7eed0", size = 182132, upload-time = "2026-05-02T16:04:12.653Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/41/52/e465037f5375f43533d1a80b6923955201596a99142ed524d77b571a1418/wcwidth-0.7.0-py3-none-any.whl", hash = "sha256:5d69154c429a82910e241c738cd0e2976fac8a2dd47a1a805f4afed1c0f136f2", size = 110825, upload-time = "2026-05-02T16:04:11.033Z" },
 ]


### PR DESCRIPTION
Generates markdown format docs for use by LLMs using the mkdocs `llmstxt` plugin. Generates `/cli/llms.txt`, `/cli/llms-full.txt`, and individual markdown files:

```
# Atuin CLI Docs

Atuin replaces your shell's built-in history with a SQLite database, adding context
(cwd, exit code, duration, hostname) and optionally syncing across machines with
end-to-end encryption. These docs cover the CLI tool - installation, configuration,
usage, self-hosting, and AI features.


## Overview

- [Home](https://docs.atuin.sh/cli/index.md): Getting started with Atuin - quickstart, supported shells, and links.

## Guide

- [Getting Started](https://docs.atuin.sh/cli/guide/getting-started/index.md): First steps - install, import history, and start using Atuin.
- [Installation](https://docs.atuin.sh/cli/guide/installation/index.md): Install via script, Homebrew, WinGet, Cargo, Nix, or from source.
- [Setting up sync](https://docs.atuin.sh/cli/guide/sync/index.md): Register an account and set up end-to-end encrypted history sync.
...
```