### PR TITLE
fix(install): pin bash-preexec to 0.6.0 release

### DIFF
--- a/docs-i18n/zh-CN/README.md
+++ b/docs-i18n/zh-CN/README.md
@@ -200,7 +200,7 @@ zinit load ellie/atuin
 我们需要设置一些钩子（hooks）, 所以首先需要安装 bash-preexec :
 
 ```
-curl https://raw.githubusercontent.com/rcaloras/bash-preexec/master/bash-preexec.sh -o ~/.bash-preexec.sh
+curl https://raw.githubusercontent.com/rcaloras/bash-preexec/0.6.0/bash-preexec.sh -o ~/.bash-preexec.sh
 echo '[[ -f ~/.bash-preexec.sh ]] && source ~/.bash-preexec.sh' >> ~/.bashrc
 ```
 

--- a/docs/docs/guide/installation.md
+++ b/docs/docs/guide/installation.md
@@ -225,7 +225,7 @@ After installing, remember to restart your shell.
         To use bash-preexec, download and initialize it
 
         ```shell
-        curl https://raw.githubusercontent.com/rcaloras/bash-preexec/master/bash-preexec.sh -o ~/.bash-preexec.sh
+        curl https://raw.githubusercontent.com/rcaloras/bash-preexec/0.6.0/bash-preexec.sh -o ~/.bash-preexec.sh
         echo '[[ -f ~/.bash-preexec.sh ]] && source ~/.bash-preexec.sh' >> ~/.bashrc
         ```
 

--- a/install.sh
+++ b/install.sh
@@ -62,7 +62,7 @@ fi
 # shellcheck disable=SC2016
 
 if ! grep -q "atuin init bash" ~/.bashrc; then
-  curl --proto '=https' --tlsv1.2 -LsSf https://raw.githubusercontent.com/rcaloras/bash-preexec/master/bash-preexec.sh -o ~/.bash-preexec.sh
+  curl --proto '=https' --tlsv1.2 -LsSf https://raw.githubusercontent.com/rcaloras/bash-preexec/0.6.0/bash-preexec.sh -o ~/.bash-preexec.sh
   printf '\n[[ -f ~/.bash-preexec.sh ]] && source ~/.bash-preexec.sh\n' >> ~/.bashrc
   echo 'eval "$(atuin init bash)"' >> ~/.bashrc
 fi


### PR DESCRIPTION
## What

`install.sh` and the bash install docs fetch `bash-preexec.sh` from `master` instead of a release tag. This PR pins all three call sites to the `0.6.0` tag.

## Why

A commit landed on `master` after the `0.6.0` release that adds a PS0 based preexec hook for bash 5.3+ using the new "command substitution that has no value" syntax:

```sh
PS0=${PS0-}'${ __bp_invoke_preexec_from_ps0 "$_" >&2; }'
```

Ubuntu 26.04 ships bash 5.3.9, which activates that branch. Under some shell environments the funsub body is printed verbatim before each command instead of being suppressed cleanly, producing the `__bp_invoke_preexec_from_ps0 "..." >&2; }` text the issue reports.

I can reproduce the literal leak locally with bash 5.3.9 by sourcing the `master` file with `promptvars` off:

```
$ echo HELLO
${ __bp_invoke_preexec_from_ps0 "$_" >&2; }HELLO
```

The reporters in #3456 have `promptvars on`, so something else in their `~/.bashrc` flips the funsub from "fires silently" to "prints body", and I haven't pinned down the exact environmental trigger from the issue alone. What's clear is that `0.6.0` doesn't set `PS0` at all, so pinning to that tag sidesteps the whole code path regardless of which environment trigger is at play.

I'm not 100% sure this matches every report in the thread (one user noted `ble.sh` fixed the history symptom but not the gibberish), but the gibberish signature is unambiguously the PS0 hook from `master`, and pinning a release tag is the right move either way for a fetched dependency.

## History capture

`0.6.0` still installs the DEBUG-trap preexec path, which fires `__atuin_preexec` on every command, so atuin history capture continues to work on bash 5.3.9.

## Files changed

- `install.sh` line 65 (the actual install path users hit)
- `docs/docs/guide/installation.md` (English docs `bash-preexec` manual setup instructions)
- `docs-i18n/zh-CN/README.md` (Simplified Chinese mirror of the same)

## Long term

The underlying bug belongs upstream in `bash-preexec`. Pinning here protects new atuin installs in the meantime; a future bump to a new `bash-preexec` release that fixes the PS0 funsub is a small follow-up.

Refs #3456