### PR TITLE
fix: ensure local key matches remote data before syncing

### DIFF
--- a/crates/atuin-client/src/record/sync.rs
+++ b/crates/atuin-client/src/record/sync.rs
@@ -340,7 +340,7 @@ async fn check_encryption_key(
     let sample = remote_index
         .hosts
         .iter()
-        .flat_map(|(host, tags)| tags.iter().map(move |(tag, _)| (*host, tag.clone())))
+        .flat_map(|(host, tags)| tags.keys().map(move |tag| (*host, tag.clone())))
         .next();
 
     let Some((host, tag)) = sample else {

--- a/crates/atuin-client/src/record/sync.rs
+++ b/crates/atuin-client/src/record/sync.rs
@@ -4,7 +4,7 @@ use std::{cmp::Ordering, fmt::Write};
 use eyre::Result;
 use thiserror::Error;
 
-use super::store::Store;
+use super::{encryption::PASETO_V4, store::Store};
 use crate::{api_client::Client, settings::Settings};
 
 use atuin_common::record::{Diff, HostId, RecordId, RecordIdx, RecordStatus};
@@ -26,6 +26,14 @@ pub enum SyncError {
 
     #[error("a request to the sync server failed: {msg:?}")]
     RemoteRequestError { msg: String },
+
+    #[error(
+        "the encryption key on this machine does not match the data on the server. \
+         this usually means a new machine was set up without copying the existing key. \
+         to fix: run `atuin key` on a machine that already syncs correctly, then run \
+         `atuin store rekey <key>` on this machine with the value from the other machine"
+    )]
+    WrongKey,
 }
 
 #[derive(Debug, Eq, PartialEq)]
@@ -324,11 +332,58 @@ pub async fn sync_remote(
     Ok((uploaded, downloaded))
 }
 
+async fn check_encryption_key(
+    settings: &Settings,
+    remote_index: &RecordStatus,
+    encryption_key: &[u8; 32],
+) -> Result<(), SyncError> {
+    let sample = remote_index
+        .hosts
+        .iter()
+        .flat_map(|(host, tags)| tags.iter().map(move |(tag, _)| (*host, tag.clone())))
+        .next();
+
+    let Some((host, tag)) = sample else {
+        return Ok(());
+    };
+
+    let client = Client::new(
+        &settings.sync_address,
+        settings
+            .sync_auth_token()
+            .await
+            .map_err(|e| SyncError::RemoteRequestError { msg: e.to_string() })?,
+        settings.network_connect_timeout,
+        settings.network_timeout,
+    )
+    .map_err(|e| SyncError::OperationalError { msg: e.to_string() })?;
+
+    let records = client
+        .next_records(host, tag, 0, 1)
+        .await
+        .map_err(|e| SyncError::RemoteRequestError { msg: e.to_string() })?;
+
+    let Some(record) = records.into_iter().next() else {
+        return Ok(());
+    };
+
+    record
+        .decrypt::<PASETO_V4>(encryption_key)
+        .map_err(|_| SyncError::WrongKey)?;
+
+    Ok(())
+}
+
 pub async fn sync(
     settings: &Settings,
     store: &impl Store,
+    encryption_key: &[u8; 32],
 ) -> Result<(i64, Vec<RecordId>), SyncError> {
-    let (diff, _) = diff(settings, store).await?;
+    let (diff, remote_index) = diff(settings, store).await?;
+
+    // Bail before mutating either side if the local key can't read the remote.
+    check_encryption_key(settings, &remote_index, encryption_key).await?;
+
     let operations = operations(diff, store).await?;
     let (uploaded, downloaded) = sync_remote(operations, store, settings, 100).await?;
 

--- a/crates/atuin-client/src/record/sync.rs
+++ b/crates/atuin-client/src/record/sync.rs
@@ -57,7 +57,7 @@ pub enum Operation {
     },
 }
 
-async fn build_client(settings: &Settings) -> Result<Client<'_>, SyncError> {
+pub async fn build_client(settings: &Settings) -> Result<Client<'_>, SyncError> {
     Client::new(
         &settings.sync_address,
         settings
@@ -70,7 +70,7 @@ async fn build_client(settings: &Settings) -> Result<Client<'_>, SyncError> {
     .map_err(|e| SyncError::OperationalError { msg: e.to_string() })
 }
 
-async fn diff_inner(
+pub async fn diff(
     client: &Client<'_>,
     store: &impl Store,
 ) -> Result<(Vec<Diff>, RecordStatus), SyncError> {
@@ -87,14 +87,6 @@ async fn diff_inner(
     let diff = local_index.diff(&remote_index);
 
     Ok((diff, remote_index))
-}
-
-pub async fn diff(
-    settings: &Settings,
-    store: &impl Store,
-) -> Result<(Vec<Diff>, RecordStatus), SyncError> {
-    let client = build_client(settings).await?;
-    diff_inner(&client, store).await
 }
 
 // Take a diff, along with a local store, and resolve it into a set of operations.
@@ -290,7 +282,7 @@ async fn sync_download(
     Ok(ret)
 }
 
-async fn sync_remote_inner(
+pub async fn sync_remote(
     client: &Client<'_>,
     operations: Vec<Operation>,
     local_store: &impl Store,
@@ -319,8 +311,7 @@ async fn sync_remote_inner(
                 remote,
             } => {
                 let mut d =
-                    sync_download(local_store, client, host, tag, local, remote, page_size)
-                        .await?;
+                    sync_download(local_store, client, host, tag, local, remote, page_size).await?;
                 downloaded.append(&mut d)
             }
 
@@ -331,17 +322,7 @@ async fn sync_remote_inner(
     Ok((uploaded, downloaded))
 }
 
-pub async fn sync_remote(
-    operations: Vec<Operation>,
-    local_store: &impl Store,
-    settings: &Settings,
-    page_size: u64,
-) -> Result<(i64, Vec<RecordId>), SyncError> {
-    let client = build_client(settings).await?;
-    sync_remote_inner(&client, operations, local_store, page_size).await
-}
-
-async fn check_encryption_key_inner(
+pub async fn check_encryption_key(
     client: &Client<'_>,
     remote_index: &RecordStatus,
     encryption_key: &[u8; 32],
@@ -372,31 +353,19 @@ async fn check_encryption_key_inner(
     Ok(())
 }
 
-pub async fn check_encryption_key(
-    settings: &Settings,
-    encryption_key: &[u8; 32],
-) -> Result<(), SyncError> {
-    let client = build_client(settings).await?;
-    let remote_index = client
-        .record_status()
-        .await
-        .map_err(|e| SyncError::RemoteRequestError { msg: e.to_string() })?;
-    check_encryption_key_inner(&client, &remote_index, encryption_key).await
-}
-
 pub async fn sync(
     settings: &Settings,
     store: &impl Store,
     encryption_key: &[u8; 32],
 ) -> Result<(i64, Vec<RecordId>), SyncError> {
     let client = build_client(settings).await?;
-    let (diff, remote_index) = diff_inner(&client, store).await?;
+    let (diff, remote_index) = diff(&client, store).await?;
 
     // Bail before mutating either side if the local key can't read the remote.
-    check_encryption_key_inner(&client, &remote_index, encryption_key).await?;
+    check_encryption_key(&client, &remote_index, encryption_key).await?;
 
     let operations = operations(diff, store).await?;
-    let (uploaded, downloaded) = sync_remote_inner(&client, operations, store, 100).await?;
+    let (uploaded, downloaded) = sync_remote(&client, operations, store, 100).await?;
 
     Ok((uploaded, downloaded))
 }

--- a/crates/atuin-client/src/record/sync.rs
+++ b/crates/atuin-client/src/record/sync.rs
@@ -57,11 +57,8 @@ pub enum Operation {
     },
 }
 
-pub async fn diff(
-    settings: &Settings,
-    store: &impl Store,
-) -> Result<(Vec<Diff>, RecordStatus), SyncError> {
-    let client = Client::new(
+async fn build_client(settings: &Settings) -> Result<Client<'_>, SyncError> {
+    Client::new(
         &settings.sync_address,
         settings
             .sync_auth_token()
@@ -70,8 +67,13 @@ pub async fn diff(
         settings.network_connect_timeout,
         settings.network_timeout,
     )
-    .map_err(|e| SyncError::OperationalError { msg: e.to_string() })?;
+    .map_err(|e| SyncError::OperationalError { msg: e.to_string() })
+}
 
+async fn diff_inner(
+    client: &Client<'_>,
+    store: &impl Store,
+) -> Result<(Vec<Diff>, RecordStatus), SyncError> {
     let local_index = store
         .status()
         .await
@@ -85,6 +87,14 @@ pub async fn diff(
     let diff = local_index.diff(&remote_index);
 
     Ok((diff, remote_index))
+}
+
+pub async fn diff(
+    settings: &Settings,
+    store: &impl Store,
+) -> Result<(Vec<Diff>, RecordStatus), SyncError> {
+    let client = build_client(settings).await?;
+    diff_inner(&client, store).await
 }
 
 // Take a diff, along with a local store, and resolve it into a set of operations.
@@ -280,23 +290,12 @@ async fn sync_download(
     Ok(ret)
 }
 
-pub async fn sync_remote(
+async fn sync_remote_inner(
+    client: &Client<'_>,
     operations: Vec<Operation>,
     local_store: &impl Store,
-    settings: &Settings,
     page_size: u64,
 ) -> Result<(i64, Vec<RecordId>), SyncError> {
-    let client = Client::new(
-        &settings.sync_address,
-        settings
-            .sync_auth_token()
-            .await
-            .map_err(|e| SyncError::RemoteRequestError { msg: e.to_string() })?,
-        settings.network_connect_timeout,
-        settings.network_timeout,
-    )
-    .expect("failed to create client");
-
     let mut uploaded = 0;
     let mut downloaded = Vec::new();
 
@@ -310,7 +309,7 @@ pub async fn sync_remote(
                 remote,
             } => {
                 uploaded +=
-                    sync_upload(local_store, &client, host, tag, local, remote, page_size).await?
+                    sync_upload(local_store, client, host, tag, local, remote, page_size).await?
             }
 
             Operation::Download {
@@ -320,7 +319,7 @@ pub async fn sync_remote(
                 remote,
             } => {
                 let mut d =
-                    sync_download(local_store, &client, host, tag, local, remote, page_size)
+                    sync_download(local_store, client, host, tag, local, remote, page_size)
                         .await?;
                 downloaded.append(&mut d)
             }
@@ -332,26 +331,21 @@ pub async fn sync_remote(
     Ok((uploaded, downloaded))
 }
 
-pub async fn check_encryption_key(
+pub async fn sync_remote(
+    operations: Vec<Operation>,
+    local_store: &impl Store,
     settings: &Settings,
+    page_size: u64,
+) -> Result<(i64, Vec<RecordId>), SyncError> {
+    let client = build_client(settings).await?;
+    sync_remote_inner(&client, operations, local_store, page_size).await
+}
+
+async fn check_encryption_key_inner(
+    client: &Client<'_>,
+    remote_index: &RecordStatus,
     encryption_key: &[u8; 32],
 ) -> Result<(), SyncError> {
-    let client = Client::new(
-        &settings.sync_address,
-        settings
-            .sync_auth_token()
-            .await
-            .map_err(|e| SyncError::RemoteRequestError { msg: e.to_string() })?,
-        settings.network_connect_timeout,
-        settings.network_timeout,
-    )
-    .map_err(|e| SyncError::OperationalError { msg: e.to_string() })?;
-
-    let remote_index = client
-        .record_status()
-        .await
-        .map_err(|e| SyncError::RemoteRequestError { msg: e.to_string() })?;
-
     let sample = remote_index
         .hosts
         .iter()
@@ -378,17 +372,31 @@ pub async fn check_encryption_key(
     Ok(())
 }
 
+pub async fn check_encryption_key(
+    settings: &Settings,
+    encryption_key: &[u8; 32],
+) -> Result<(), SyncError> {
+    let client = build_client(settings).await?;
+    let remote_index = client
+        .record_status()
+        .await
+        .map_err(|e| SyncError::RemoteRequestError { msg: e.to_string() })?;
+    check_encryption_key_inner(&client, &remote_index, encryption_key).await
+}
+
 pub async fn sync(
     settings: &Settings,
     store: &impl Store,
     encryption_key: &[u8; 32],
 ) -> Result<(i64, Vec<RecordId>), SyncError> {
-    // Bail before mutating either side if the local key can't read the remote.
-    check_encryption_key(settings, encryption_key).await?;
+    let client = build_client(settings).await?;
+    let (diff, remote_index) = diff_inner(&client, store).await?;
 
-    let (diff, _) = diff(settings, store).await?;
+    // Bail before mutating either side if the local key can't read the remote.
+    check_encryption_key_inner(&client, &remote_index, encryption_key).await?;
+
     let operations = operations(diff, store).await?;
-    let (uploaded, downloaded) = sync_remote(operations, store, settings, 100).await?;
+    let (uploaded, downloaded) = sync_remote_inner(&client, operations, store, 100).await?;
 
     Ok((uploaded, downloaded))
 }

--- a/crates/atuin-client/src/record/sync.rs
+++ b/crates/atuin-client/src/record/sync.rs
@@ -332,21 +332,10 @@ pub async fn sync_remote(
     Ok((uploaded, downloaded))
 }
 
-async fn check_encryption_key(
+pub async fn check_encryption_key(
     settings: &Settings,
-    remote_index: &RecordStatus,
     encryption_key: &[u8; 32],
 ) -> Result<(), SyncError> {
-    let sample = remote_index
-        .hosts
-        .iter()
-        .flat_map(|(host, tags)| tags.keys().map(move |tag| (*host, tag.clone())))
-        .next();
-
-    let Some((host, tag)) = sample else {
-        return Ok(());
-    };
-
     let client = Client::new(
         &settings.sync_address,
         settings
@@ -357,6 +346,21 @@ async fn check_encryption_key(
         settings.network_timeout,
     )
     .map_err(|e| SyncError::OperationalError { msg: e.to_string() })?;
+
+    let remote_index = client
+        .record_status()
+        .await
+        .map_err(|e| SyncError::RemoteRequestError { msg: e.to_string() })?;
+
+    let sample = remote_index
+        .hosts
+        .iter()
+        .flat_map(|(host, tags)| tags.keys().map(move |tag| (*host, tag.clone())))
+        .next();
+
+    let Some((host, tag)) = sample else {
+        return Ok(());
+    };
 
     let records = client
         .next_records(host, tag, 0, 1)
@@ -379,11 +383,10 @@ pub async fn sync(
     store: &impl Store,
     encryption_key: &[u8; 32],
 ) -> Result<(i64, Vec<RecordId>), SyncError> {
-    let (diff, remote_index) = diff(settings, store).await?;
-
     // Bail before mutating either side if the local key can't read the remote.
-    check_encryption_key(settings, &remote_index, encryption_key).await?;
+    check_encryption_key(settings, encryption_key).await?;
 
+    let (diff, _) = diff(settings, store).await?;
     let operations = operations(diff, store).await?;
     let (uploaded, downloaded) = sync_remote(operations, store, settings, 100).await?;
 

--- a/crates/atuin-daemon/src/components/sync.rs
+++ b/crates/atuin-daemon/src/components/sync.rs
@@ -213,7 +213,7 @@ async fn do_sync_tick(
     }
 
     // Perform the sync
-    let res = sync::sync(settings, handle.store()).await;
+    let res = sync::sync(settings, handle.store(), handle.encryption_key()).await;
 
     match res {
         Err(e) => {

--- a/crates/atuin/src/command/client/account/login.rs
+++ b/crates/atuin/src/command/client/account/login.rs
@@ -9,6 +9,7 @@ use atuin_client::{
     encryption::{Key, decode_key, encode_key, load_key},
     record::sqlite_store::SqliteStore,
     record::store::Store,
+    record::sync::{self, SyncError},
     settings::{Settings, SyncAuth},
 };
 use rpassword::prompt_password;
@@ -62,10 +63,12 @@ impl Cmd {
         }
 
         if settings.is_hub_sync() {
-            self.run_hub_login(settings, store).await
+            self.run_hub_login(settings, store).await?;
         } else {
-            self.run_legacy_login(settings, store).await
+            self.run_legacy_login(settings, store).await?;
         }
+
+        verify_key_against_remote(settings).await
     }
 
     /// Hub login: use the browser flow unless the username was provided for headless use.
@@ -266,6 +269,36 @@ impl Cmd {
         }
 
         Ok(())
+    }
+}
+
+async fn verify_key_against_remote(settings: &Settings) -> Result<()> {
+    let key: [u8; 32] = load_key(settings)
+        .context("could not load encryption key for verification")?
+        .into();
+
+    match sync::check_encryption_key(settings, &key).await {
+        Ok(()) => Ok(()),
+        Err(SyncError::WrongKey) => {
+            // Roll back the saved session so the user is not left in a
+            // half-authenticated state with a key that can't read the data.
+            if let Ok(meta) = Settings::meta_store().await {
+                let _ = meta.delete_session().await;
+                let _ = meta.delete_hub_session().await;
+            }
+            bail!(
+                "The provided encryption key does not match the data on the server. \
+                 You have been logged out — please run `atuin login` again with the correct key. \
+                 Find it by running `atuin key` on a machine that already syncs successfully."
+            );
+        }
+        Err(e) => {
+            // Non-key error (e.g. transient network issue). Don't fail the
+            // login — the user is authenticated and can sync later when the
+            // network recovers.
+            tracing::warn!("could not verify encryption key against remote: {e}");
+            Ok(())
+        }
     }
 }
 

--- a/crates/atuin/src/command/client/account/login.rs
+++ b/crates/atuin/src/command/client/account/login.rs
@@ -277,7 +277,16 @@ async fn verify_key_against_remote(settings: &Settings) -> Result<()> {
         .context("could not load encryption key for verification")?
         .into();
 
-    match sync::check_encryption_key(settings, &key).await {
+    let client = sync::build_client(settings).await?;
+    let remote_index = match client.record_status().await {
+        Ok(idx) => idx,
+        Err(e) => {
+            tracing::warn!("could not fetch remote status to verify key: {e}");
+            return Ok(());
+        }
+    };
+
+    match sync::check_encryption_key(&client, &remote_index, &key).await {
         Ok(()) => Ok(()),
         Err(SyncError::WrongKey) => {
             // Roll back the saved session so the user is not left in a

--- a/crates/atuin/src/command/client/history.rs
+++ b/crates/atuin/src/command/client/history.rs
@@ -531,7 +531,8 @@ async fn handle_end(
         #[cfg(feature = "sync")]
         {
             if settings.sync.records {
-                let (_, downloaded) = record::sync::sync(settings, &store).await?;
+                let (_, downloaded) =
+                    record::sync::sync(settings, &store, &history_store.encryption_key).await?;
                 Settings::save_sync_time().await?;
 
                 crate::sync::build(settings, &store, db, Some(&downloaded)).await?;

--- a/crates/atuin/src/command/client/store/pull.rs
+++ b/crates/atuin/src/command/client/store/pull.rs
@@ -46,7 +46,8 @@ impl Pull {
         // 3. Filter operations by
         //  a) are they a download op?
         //  b) are they for the host/tag we are pushing here?
-        let (diff, _) = sync::diff(settings, &store).await?;
+        let client = sync::build_client(settings).await?;
+        let (diff, _) = sync::diff(&client, &store).await?;
         let operations = sync::operations(diff, &store).await?;
 
         let operations = operations
@@ -72,7 +73,7 @@ impl Pull {
             })
             .collect();
 
-        let (_, downloaded) = sync::sync_remote(operations, &store, settings, self.page).await?;
+        let (_, downloaded) = sync::sync_remote(&client, operations, &store, self.page).await?;
 
         println!("Downloaded {} records", downloaded.len());
 

--- a/crates/atuin/src/command/client/store/pull.rs
+++ b/crates/atuin/src/command/client/store/pull.rs
@@ -3,6 +3,7 @@ use eyre::Result;
 
 use atuin_client::{
     database::Database,
+    encryption::load_key,
     record::store::Store,
     record::sync::Operation,
     record::{sqlite_store::SqliteStore, sync},
@@ -47,7 +48,14 @@ impl Pull {
         //  a) are they a download op?
         //  b) are they for the host/tag we are pushing here?
         let client = sync::build_client(settings).await?;
-        let (diff, _) = sync::diff(&client, &store).await?;
+        let (diff, remote_index) = sync::diff(&client, &store).await?;
+
+        // Skip on --force: local was already wiped above, mismatch is the user's call.
+        if !self.force {
+            let key: [u8; 32] = load_key(settings)?.into();
+            sync::check_encryption_key(&client, &remote_index, &key).await?;
+        }
+
         let operations = sync::operations(diff, &store).await?;
 
         let operations = operations

--- a/crates/atuin/src/command/client/store/push.rs
+++ b/crates/atuin/src/command/client/store/push.rs
@@ -58,7 +58,8 @@ impl Push {
         // 3. Filter operations by
         //  a) are they an upload op?
         //  b) are they for the host/tag we are pushing here?
-        let (diff, _) = sync::diff(settings, &store).await?;
+        let client = sync::build_client(settings).await?;
+        let (diff, _) = sync::diff(&client, &store).await?;
         let operations = sync::operations(diff, &store).await?;
 
         let operations = operations
@@ -92,7 +93,7 @@ impl Push {
             })
             .collect();
 
-        let (uploaded, _) = sync::sync_remote(operations, &store, settings, self.page).await?;
+        let (uploaded, _) = sync::sync_remote(&client, operations, &store, self.page).await?;
 
         println!("Uploaded {uploaded} records");
 

--- a/crates/atuin/src/command/client/store/push.rs
+++ b/crates/atuin/src/command/client/store/push.rs
@@ -5,6 +5,7 @@ use uuid::Uuid;
 
 use atuin_client::{
     api_client::Client,
+    encryption::load_key,
     record::sync::Operation,
     record::{sqlite_store::SqliteStore, sync},
     settings::Settings,
@@ -59,7 +60,14 @@ impl Push {
         //  a) are they an upload op?
         //  b) are they for the host/tag we are pushing here?
         let client = sync::build_client(settings).await?;
-        let (diff, _) = sync::diff(&client, &store).await?;
+        let (diff, remote_index) = sync::diff(&client, &store).await?;
+
+        // Skip on --force: that path intentionally replaces remote with local.
+        if !self.force {
+            let key: [u8; 32] = load_key(settings)?.into();
+            sync::check_encryption_key(&client, &remote_index, &key).await?;
+        }
+
         let operations = sync::operations(diff, &store).await?;
 
         let operations = operations

--- a/crates/atuin/src/command/client/sync.rs
+++ b/crates/atuin/src/command/client/sync.rs
@@ -88,7 +88,7 @@ async fn run(
         let host_id = Settings::host_id().await?;
         let history_store = HistoryStore::new(store.clone(), host_id, encryption_key);
 
-        let (uploaded, downloaded) = sync::sync(settings, &store).await?;
+        let (uploaded, downloaded) = sync::sync(settings, &store, &encryption_key).await?;
 
         crate::sync::build(settings, &store, db, Some(&downloaded)).await?;
 
@@ -111,7 +111,7 @@ async fn run(
             println!("Re-running sync due to new records locally");
 
             // we'll want to run sync once more, as there will now be stuff to upload
-            let (uploaded, downloaded) = sync::sync(settings, &store).await?;
+            let (uploaded, downloaded) = sync::sync(settings, &store, &encryption_key).await?;
 
             crate::sync::build(settings, &store, db, Some(&downloaded)).await?;
 


### PR DESCRIPTION
We rely on the user to manage their keys. This is ok, and is intentionally part of our security model

However. If the user messes up, they corrupt their remote store. It is possible to work around and fix, but not without difficulty. This change ensures that if the local key does not match the remote data, no data is synced and the user has a chance to fix it before breaking things.

## Checks
- [ ] I am happy for maintainers to push small adjustments to this PR, to speed up the review cycle
- [ ] I have checked that there are no existing pull requests for the same thing
