### PR TITLE
fix(atuin-nucleo): duplicated "the" in utf32_str/lib doc-comments

### DIFF
--- a/crates/atuin-nucleo/matcher/src/utf32_str.rs
+++ b/crates/atuin-nucleo/matcher/src/utf32_str.rs
@@ -82,7 +82,7 @@ fn has_ascii_graphemes(string: &str) -> bool {
 /// encoded variant for rendering. In the (dominant) case of ASCII-only text
 /// we don't require a copy. Furthermore fuzzy matching usually is applied while
 /// the user is typing on the fly so the same item is potentially matched many
-/// times (making the the up-front cost more worth it). That means that its
+/// times (making the up-front cost more worth it). That means that its
 /// basically always worth it to pre-segment the string.
 ///
 /// For usecases that only match (a lot of) strings once its possible to keep

--- a/crates/atuin-nucleo/src/lib.rs
+++ b/crates/atuin-nucleo/src/lib.rs
@@ -375,7 +375,7 @@ impl<T: Sync + Send + 'static> Nucleo<T> {
         }
     }
 
-    /// Restart the the item stream. Removes all items and disconnects all
+    /// Restart the item stream. Removes all items and disconnects all
     /// previously created injectors from this instance. If `clear_snapshot`
     /// is `true` then all items and matched are removed from the [`Snapshot`]
     /// immediately. Otherwise the snapshot will keep the current matches until


### PR DESCRIPTION
Two one-line typo fixes for duplicated "the" in atuin-nucleo doc-comments:
- `crates/atuin-nucleo/matcher/src/utf32_str.rs` — "/// times (making the the up-front cost more worth it). That means that its" → "...making the up-front cost more worth it..."
- `crates/atuin-nucleo/src/lib.rs` — "/// Restart the the item stream. Removes all items and disconnects all" → "/// Restart the item stream. Removes all items and disconnects all"

No code/behavior change.