### PR TITLE
refactor: pull `fn into_utc` into atuin-server-database crate

### DIFF
--- a/crates/atuin-server-database/src/lib.rs
+++ b/crates/atuin-server-database/src/lib.rs
@@ -16,7 +16,7 @@ use self::{
 use async_trait::async_trait;
 use atuin_common::record::{EncryptedData, HostId, Record, RecordIdx, RecordStatus};
 use serde::{Deserialize, Serialize};
-use time::{Date, Duration, Month, OffsetDateTime, Time, UtcOffset};
+use time::{Date, Duration, Month, OffsetDateTime, PrimitiveDateTime, Time, UtcOffset};
 use tracing::instrument;
 
 #[derive(Debug)]
@@ -237,5 +237,32 @@ pub trait Database: Sized + Clone + Send + Sync + 'static {
         }
 
         Ok(ret)
+    }
+}
+
+pub fn into_utc(x: OffsetDateTime) -> PrimitiveDateTime {
+    let x = x.to_offset(UtcOffset::UTC);
+    PrimitiveDateTime::new(x.date(), x.time())
+}
+
+#[cfg(test)]
+mod tests {
+    use time::macros::datetime;
+
+    use crate::into_utc;
+
+    #[test]
+    fn utc() {
+        let dt = datetime!(2023-09-26 15:11:02 +05:30);
+        assert_eq!(into_utc(dt), datetime!(2023-09-26 09:41:02));
+        assert_eq!(into_utc(dt).assume_utc(), dt);
+
+        let dt = datetime!(2023-09-26 15:11:02 -07:00);
+        assert_eq!(into_utc(dt), datetime!(2023-09-26 22:11:02));
+        assert_eq!(into_utc(dt).assume_utc(), dt);
+
+        let dt = datetime!(2023-09-26 15:11:02 +00:00);
+        assert_eq!(into_utc(dt), datetime!(2023-09-26 15:11:02));
+        assert_eq!(into_utc(dt).assume_utc(), dt);
     }
 }

--- a/crates/atuin-server-postgres/src/lib.rs
+++ b/crates/atuin-server-postgres/src/lib.rs
@@ -6,12 +6,12 @@ use rand::Rng;
 use async_trait::async_trait;
 use atuin_common::record::{EncryptedData, HostId, Record, RecordIdx, RecordStatus};
 use atuin_server_database::models::{History, NewHistory, NewSession, NewUser, Session, User};
-use atuin_server_database::{Database, DbError, DbResult, DbSettings};
+use atuin_server_database::{Database, DbError, DbResult, DbSettings, into_utc};
 use futures_util::TryStreamExt;
 use sqlx::Row;
 use sqlx::postgres::PgPoolOptions;
 
-use time::{OffsetDateTime, PrimitiveDateTime, UtcOffset};
+use time::OffsetDateTime;
 use tracing::instrument;
 use uuid::Uuid;
 use wrappers::{DbHistory, DbRecord, DbSession, DbUser};
@@ -577,32 +577,5 @@ impl Database for Postgres {
         }
 
         Ok(status)
-    }
-}
-
-fn into_utc(x: OffsetDateTime) -> PrimitiveDateTime {
-    let x = x.to_offset(UtcOffset::UTC);
-    PrimitiveDateTime::new(x.date(), x.time())
-}
-
-#[cfg(test)]
-mod tests {
-    use time::macros::datetime;
-
-    use crate::into_utc;
-
-    #[test]
-    fn utc() {
-        let dt = datetime!(2023-09-26 15:11:02 +05:30);
-        assert_eq!(into_utc(dt), datetime!(2023-09-26 09:41:02));
-        assert_eq!(into_utc(dt).assume_utc(), dt);
-
-        let dt = datetime!(2023-09-26 15:11:02 -07:00);
-        assert_eq!(into_utc(dt), datetime!(2023-09-26 22:11:02));
-        assert_eq!(into_utc(dt).assume_utc(), dt);
-
-        let dt = datetime!(2023-09-26 15:11:02 +00:00);
-        assert_eq!(into_utc(dt), datetime!(2023-09-26 15:11:02));
-        assert_eq!(into_utc(dt).assume_utc(), dt);
     }
 }

--- a/crates/atuin-server-sqlite/src/lib.rs
+++ b/crates/atuin-server-sqlite/src/lib.rs
@@ -3,7 +3,7 @@ use std::str::FromStr;
 use async_trait::async_trait;
 use atuin_common::record::{EncryptedData, HostId, Record, RecordIdx, RecordStatus};
 use atuin_server_database::{
-    Database, DbError, DbResult, DbSettings,
+    Database, DbError, DbResult, DbSettings, into_utc,
     models::{History, NewHistory, NewSession, NewUser, Session, User},
 };
 use futures_util::TryStreamExt;
@@ -12,7 +12,6 @@ use sqlx::{
     sqlite::{SqliteConnectOptions, SqliteJournalMode, SqlitePoolOptions},
     types::Uuid,
 };
-use time::{OffsetDateTime, PrimitiveDateTime, UtcOffset};
 use tracing::instrument;
 use wrappers::{DbHistory, DbRecord, DbSession, DbUser};
 
@@ -428,9 +427,4 @@ impl Database for Sqlite {
         .map_err(Into::into)
         .map(|DbHistory(h)| h)
     }
-}
-
-fn into_utc(x: OffsetDateTime) -> PrimitiveDateTime {
-    let x = x.to_offset(UtcOffset::UTC);
-    PrimitiveDateTime::new(x.date(), x.time())
 }


### PR DESCRIPTION
The `fn into_utc` was defined in both `atuin-server-postgres` and `atuin-server-sqlite`, with tests being in the postgres crate.  This pulls the function into the `atuin-server-database` crate along with the tests and references it from both crates.

## Checks
- [X] I am happy for maintainers to push small adjustments to this PR, to speed up the review cycle
- [X] I have checked that there are no existing pull requests for the same thing
