### PR TITLE
docs(zinit): fix bpick pattern, add wait/lucid ices, zcompile

### DIFF
--- a/docs/docs/guide/installation.md
+++ b/docs/docs/guide/installation.md
@@ -124,10 +124,10 @@ If you don't wish to use the installer, the manual installation steps are as fol
     Atuin is installable from github-releases directly:
 
     ```shell
-    # line 1: `atuin` binary as command, from github release, only look at .tar.gz files, use the `atuin` file from the extracted archive
+    # line 1: `atuin` binary as command, from github release, only look at .tar.gz files (excluding server), use the `atuin` file from the extracted archive
     # line 2: setup at clone(create init.zsh, completion)
     # line 3: pull behavior same as clone, source init.zsh
-    zinit ice as"command" from"gh-r" bpick"atuin-*.tar.gz" mv"atuin*/atuin -> atuin" \
+    zinit ice wait lucid as"command" from"gh-r" bpick"atuin-*.tar.gz~*server*" mv"atuin*/atuin -> atuin" \
         atclone"./atuin init zsh > init.zsh; ./atuin gen-completions --shell zsh > _atuin" \
         atpull"%atclone" src"init.zsh"
     zinit light atuinsh/atuin

--- a/docs/docs/guide/installation.md
+++ b/docs/docs/guide/installation.md
@@ -126,7 +126,8 @@ If you don't wish to use the installer, the manual installation steps are as fol
     ```shell
     # line 1: `atuin` binary as command, from github release, only look at .tar.gz files (excluding server), use the `atuin` file from the extracted archive
     # line 2: setup at clone(create init.zsh, completion)
-    # line 3: pull behavior same as clone, source init.zsh
+    # line 3: zcompile init.zsh for faster startup (zsh auto-loads .zwc)
+    # line 4: pull behavior same as clone, source init.zsh
     zinit ice wait lucid as"command" from"gh-r" bpick"atuin-*.tar.gz~*server*" mv"atuin*/atuin -> atuin" \
         atclone"./atuin init zsh > init.zsh && zcompile init.zsh && ./atuin gen-completions --shell zsh > _atuin" \
         atpull"%atclone" src"init.zsh"

--- a/docs/docs/guide/installation.md
+++ b/docs/docs/guide/installation.md
@@ -128,7 +128,7 @@ If you don't wish to use the installer, the manual installation steps are as fol
     # line 2: setup at clone(create init.zsh, completion)
     # line 3: pull behavior same as clone, source init.zsh
     zinit ice wait lucid as"command" from"gh-r" bpick"atuin-*.tar.gz~*server*" mv"atuin*/atuin -> atuin" \
-        atclone"./atuin init zsh > init.zsh; ./atuin gen-completions --shell zsh > _atuin" \
+        atclone"./atuin init zsh > init.zsh && zcompile init.zsh && ./atuin gen-completions --shell zsh > _atuin" \
         atpull"%atclone" src"init.zsh"
     zinit light atuinsh/atuin
     ```

--- a/docs/docs/guide/installation.md
+++ b/docs/docs/guide/installation.md
@@ -125,9 +125,8 @@ If you don't wish to use the installer, the manual installation steps are as fol
 
     ```shell
     # line 1: `atuin` binary as command, from github release, only look at .tar.gz files (excluding server), use the `atuin` file from the extracted archive
-    # line 2: setup at clone(create init.zsh, completion)
-    # line 3: zcompile init.zsh for faster startup (zsh auto-loads .zwc)
-    # line 4: pull behavior same as clone, source init.zsh
+    # line 2: setup at clone(create init.zsh, completion); zcompile init.zsh for faster startup (zsh auto-loads .zwc)
+    # line 3: pull behavior same as clone, source init.zsh
     zinit ice wait lucid as"command" from"gh-r" bpick"atuin-*.tar.gz~*server*" mv"atuin*/atuin -> atuin" \
         atclone"./atuin init zsh > init.zsh && zcompile init.zsh && ./atuin gen-completions --shell zsh > _atuin" \
         atpull"%atclone" src"init.zsh"


### PR DESCRIPTION
The zinit installation docs at https://docs.atuin.sh/cli/guide/installation/ have two issues:

### 1. `bpick` pattern matches server binary

The current pattern `bpick"atuin-*.tar.gz"` matches both the client binary (`atuin-x86_64-unknown-linux-gnu.tar.gz`) and the server binary (`atuin-server-x86_64-unknown-linux-gnu.tar.gz`). Since GitHub releases returns the server asset first alphabetically, users get the wrong binary:

```
[ziextract] Unpacking the files from: `atuin-server-x86_64-unknown-linux-gnu.tar.gz'...
Warning: mv ice didn't match any file. [atuin*/atuin -> atuin]
Available files: atuin-server-x86_64-unknown-linux-gnu
(eval):1: no such file or directory: ./atuin
```

**Fix:** Use zsh glob exclusion to skip server artifacts:

```diff
-bpick"atuin-*.tar.gz"
+bpick"atuin-*.tar.gz~*server*"
```

### 2. Missing `wait` and `lucid` ices

The current zinit example loads synchronously during `.zshrc` processing. For a binary plugin that doesn't need to be available until after the prompt, `wait` (turbo mode) and `lucid` (suppress "Loaded" message) are recommended:

```diff
-zinit ice as"command" from"gh-r" bpick"atuin-*.tar.gz" mv"atuin*/atuin -> atuin" \
+zinit ice wait lucid as"command" from"gh-r" bpick"atuin-*.tar.gz~*server*" mv"atuin*/atuin -> atuin" \
```

### 3. Add `zcompile` for faster startup

Compiling `init.zsh` to `.zwc` with `zcompile` gives faster startup times since zsh auto-loads the compiled bytecode:

```diff
-    atclone"./atuin init zsh > init.zsh; ./atuin gen-completions --shell zsh > _atuin" \
+    atclone"./atuin init zsh > init.zsh && zcompile init.zsh && ./atuin gen-completions --shell zsh > _atuin" \
```

### Proposed corrected example

```zsh
zinit ice wait lucid as"command" from"gh-r" bpick"atuin-*.tar.gz~*server*" mv"atuin*/atuin -> atuin" \
    atclone"./atuin init zsh > init.zsh && zcompile init.zsh && ./atuin gen-completions --shell zsh > _atuin" \
    atpull"%atclone" src"init.zsh"
zinit light atuinsh/atuin
```