### PR TITLE
feat: Allow overriding model with env var

### DIFF
--- a/crates/atuin-ai/src/stream.rs
+++ b/crates/atuin-ai/src/stream.rs
@@ -137,6 +137,13 @@ pub(crate) fn create_chat_stream(
             }
         }
 
+        if let Ok(model) = std::env::var("ATUIN_AI__MODEL")
+            && !model.is_empty() {
+                config["model"] = serde_json::json!(model);
+
+        }
+
+
         let mut request_body = serde_json::json!({
             "messages": request.messages,
             "context": context,

--- a/crates/atuin-ai/src/stream.rs
+++ b/crates/atuin-ai/src/stream.rs
@@ -138,8 +138,8 @@ pub(crate) fn create_chat_stream(
         }
 
         if let Ok(model) = std::env::var("ATUIN_AI__MODEL")
-            && !model.is_empty() {
-                config["model"] = serde_json::json!(model);
+            && !model.trim().is_empty() {
+                config["model"] = serde_json::json!(model.trim());
 
         }
 


### PR DESCRIPTION
This PR allows overriding the Atuin AI model for feature-flagged users with the `ATUIN_AI__MODEL` environment variable. Any OpenRouter model is accepted; it's recommended to include an explicit `openrouter:` provider prefix, so models with colons in their names are interpreted correctly, e.g. `ATUIN_AI__MODEL=openrouter:deepseek/deepseek-v4-flash:free`.

Note that this capability is not currently generally available.