### PR TITLE
Add agent history filter mode

### DIFF
--- a/crates/atuin-client/src/database.rs
+++ b/crates/atuin-client/src/database.rs
@@ -404,6 +404,7 @@ impl Database for Sqlite {
                 }
                 FilterMode::Directory => query.and_where_eq("cwd", quote(&context.cwd)),
                 FilterMode::Workspace => query.and_where_like_left("cwd", &git_root),
+                FilterMode::Agent => &mut query,
             };
         }
 
@@ -535,6 +536,7 @@ impl Database for Sqlite {
             }
             FilterMode::Directory => sql.and_where_eq("cwd", quote(&context.cwd)),
             FilterMode::Workspace => sql.and_where_like_left("cwd", git_root),
+            FilterMode::Agent => &mut sql,
         };
 
         let orig_query = query;

--- a/crates/atuin-client/src/settings.rs
+++ b/crates/atuin-client/src/settings.rs
@@ -114,6 +114,9 @@ pub enum FilterMode {
 
     #[serde(rename = "session-preload")]
     SessionPreload = 5,
+
+    #[serde(rename = "agent")]
+    Agent = 6,
 }
 
 impl FilterMode {
@@ -125,6 +128,7 @@ impl FilterMode {
             FilterMode::Directory => "DIRECTORY",
             FilterMode::Workspace => "WORKSPACE",
             FilterMode::SessionPreload => "SESSION+",
+            FilterMode::Agent => "AGENT",
         }
     }
 }
@@ -849,6 +853,7 @@ impl Default for Search {
                 FilterMode::SessionPreload,
                 FilterMode::Workspace,
                 FilterMode::Directory,
+                FilterMode::Agent,
             ],
 
             recency_score_multiplier: 1.0,

--- a/crates/atuin-daemon/src/client.rs
+++ b/crates/atuin-daemon/src/client.rs
@@ -238,6 +238,7 @@ impl From<FilterMode> for RpcFilterMode {
             FilterMode::Directory => RpcFilterMode::Directory,
             FilterMode::Workspace => RpcFilterMode::Workspace,
             FilterMode::SessionPreload => RpcFilterMode::SessionPreload,
+            FilterMode::Agent => RpcFilterMode::Global,
         }
     }
 }

--- a/crates/atuin/src/command/client/search/engines.rs
+++ b/crates/atuin/src/command/client/search/engines.rs
@@ -1,7 +1,7 @@
 use async_trait::async_trait;
 use atuin_client::{
     database::{Context, Database, OptFilters},
-    history::{AUTHOR_FILTER_ALL_USER, History, HistoryId},
+    history::{History, HistoryId},
     settings::{FilterMode, SearchMode, Settings},
 };
 use eyre::Result;
@@ -55,7 +55,9 @@ impl SearchState {
 
     fn filter_mode_available(&self, mode: FilterMode, settings: &Settings) -> bool {
         match mode {
-            FilterMode::Global | FilterMode::SessionPreload => self.custom_context.is_none(),
+            FilterMode::Global | FilterMode::SessionPreload | FilterMode::Agent => {
+                self.custom_context.is_none()
+            }
             FilterMode::Workspace => settings.workspaces && self.context.git_root.is_some(),
             _ => true,
         }
@@ -80,7 +82,7 @@ pub trait SearchEngine: Send + Sync + 'static {
                     "",
                     OptFilters {
                         limit: Some(200),
-                        authors: vec![AUTHOR_FILTER_ALL_USER.to_string()],
+                        authors: db::authors_for_filter_mode(state.filter_mode),
                         ..Default::default()
                     },
                 )

--- a/crates/atuin/src/command/client/search/engines/daemon.rs
+++ b/crates/atuin/src/command/client/search/engines/daemon.rs
@@ -1,7 +1,7 @@
 use async_trait::async_trait;
 use atuin_client::{
     database::{Database, OptFilters},
-    history::{AUTHOR_FILTER_ALL_USER, History},
+    history::History,
     settings::{SearchMode, Settings},
 };
 use atuin_daemon::client::{DaemonClientErrorKind, SearchClient, classify_error};
@@ -92,7 +92,7 @@ impl Search {
                 state.input.as_str(),
                 OptFilters {
                     limit: Some(200),
-                    authors: vec![AUTHOR_FILTER_ALL_USER.to_string()],
+                    authors: super::db::authors_for_filter_mode(state.filter_mode),
                     ..Default::default()
                 },
             )
@@ -121,6 +121,11 @@ impl SearchEngine for Search {
         db: &mut dyn Database,
     ) -> Result<Vec<History>> {
         let query = state.input.as_str().to_string();
+
+        if state.filter_mode == atuin_client::settings::FilterMode::Agent {
+            debug!(query = %query, "[daemon-client] agent filter detected, falling back to db");
+            return self.fallback_to_db_search(state, db).await;
+        }
 
         // Fall back to database for regex queries (Nucleo doesn't support regex)
         if Self::contains_regex_pattern(&query) {

--- a/crates/atuin/src/command/client/search/engines/db.rs
+++ b/crates/atuin/src/command/client/search/engines/db.rs
@@ -4,8 +4,8 @@ use atuin_client::{
     database::Database,
     database::OptFilters,
     database::{QueryToken, QueryTokenizer},
-    history::{AUTHOR_FILTER_ALL_USER, History},
-    settings::SearchMode,
+    history::{AUTHOR_FILTER_ALL_AGENT, AUTHOR_FILTER_ALL_USER, History},
+    settings::{FilterMode, SearchMode},
 };
 use eyre::Result;
 use norm::Metric;
@@ -31,7 +31,7 @@ impl SearchEngine for Search {
                 state.input.as_str(),
                 OptFilters {
                     limit: Some(200),
-                    authors: vec![AUTHOR_FILTER_ALL_USER.to_string()],
+                    authors: authors_for_filter_mode(state.filter_mode),
                     ..Default::default()
                 },
             )
@@ -56,6 +56,14 @@ impl SearchEngine for Search {
 
         // convert ranges to all indices
         ranges.into_iter().flatten().collect()
+    }
+}
+
+pub(crate) fn authors_for_filter_mode(filter_mode: FilterMode) -> Vec<String> {
+    if filter_mode == FilterMode::Agent {
+        vec![AUTHOR_FILTER_ALL_AGENT.to_string()]
+    } else {
+        vec![AUTHOR_FILTER_ALL_USER.to_string()]
     }
 }
 

--- a/crates/atuin/src/command/client/search/engines/skim.rs
+++ b/crates/atuin/src/command/client/search/engines/skim.rs
@@ -76,7 +76,12 @@ async fn fuzzy_search(
         if i % 256 == 0 {
             yield_now().await;
         }
-        if is_known_agent(&history.author) {
+        let is_agent = is_known_agent(&history.author);
+        if state.filter_mode == FilterMode::Agent {
+            if !is_agent {
+                continue;
+            }
+        } else if is_agent {
             continue;
         }
         let context = &state.context;
@@ -87,6 +92,7 @@ async fn fuzzy_search(
             .unwrap_or(&context.cwd);
         match state.filter_mode {
             FilterMode::Global => {}
+            FilterMode::Agent => {}
             // we aggregate host by ',' separating them
             FilterMode::Host
                 if history

--- a/docs/docs/configuration/config.md
+++ b/docs/docs/configuration/config.md
@@ -166,6 +166,7 @@ The default filter to use when searching
 | directory        | Search history from the current directory                                            |
 | workspace        | Search history from the current git repository                                       |
 | session-preload  | Search from the current session and the global history from before the session start |
+| agent            | Search commands authored by known agents                                             |
 
 Filter modes can still be toggled via ctrl-r
 

--- a/docs/docs/guide/advanced-usage.md
+++ b/docs/docs/guide/advanced-usage.md
@@ -18,6 +18,7 @@ The available modes are:
 | directory        | Search history from the current directory                                            |
 | workspace        | Search history from the current git repository                                       |
 | session-preload  | Search from the current session and the global history from before the session start |
+| agent            | Search commands authored by known agents                                             |
 
 See the [`filter_mode` config reference](../configuration/config.md#filter_mode) for more details.
 

--- a/docs/docs/guide/basic-usage.md
+++ b/docs/docs/guide/basic-usage.md
@@ -25,6 +25,7 @@ While searching in the TUI, you can adjust the "filter mode" by repeatedly press
 2. Just your local machine
 3. The current directory only
 4. The current shell session only
+5. Commands authored by known agents
 
 See the [advanced usage](advanced-usage.md) page for more options.
 


### PR DESCRIPTION
## Summary
- add an agent filter mode to interactive history search
- filter user vs known-agent history consistently across DB, daemon fallback, and skim paths
- document the new filter mode

## Tests
- cargo fmt --check
- cargo test -p atuin-history sort