### PR TITLE
fix: add annotations to Docker workflow

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -59,3 +59,4 @@ jobs:
             GitCommit=${{ github.sha }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          annotations: ${{ steps.meta.outputs.annotations }}

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -36,6 +36,8 @@ jobs:
       - name: Docker meta
         id: meta
         uses: docker/metadata-action@v5
+        env:
+          DOCKER_METADATA_ANNOTATIONS_LEVELS: manifest,index
         with:
           images: ghcr.io/${{ env.REPO_OWNER }}/atuin
           flavor: |


### PR DESCRIPTION
Labels were added a while back to the docker image, but since the image is being built for multiple architectures, annotations need to be set in order for tools like renovate to pick up the OCI metadata.

https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-container-registry#labelling-container-images

## Checks
- [X] I am happy for maintainers to push small adjustments to this PR, to speed up the review cycle
- [X] I have checked that there are no existing pull requests for the same thing
