### PR TITLE
fix: create output dir (if not exists) for `gen_completions` command

### DIFF
--- a/crates/atuin/src/command/gen_completions.rs
+++ b/crates/atuin/src/command/gen_completions.rs
@@ -67,6 +67,7 @@ impl Cmd {
 
         match out_dir {
             Some(out_dir) => {
+                fs_err::create_dir_all(&out_dir)?;
                 generate_to(shell, &mut cli, env!("CARGO_PKG_NAME"), &out_dir)?;
             }
             None => {


### PR DESCRIPTION
this follows standard *nix behavior. i.e. if the folder doesn't exist usually in *nix environments in this case, the folder is created automatically.

 - If the directory already exists, it succeeds and does nothing.
 - If parent directories are missing, it creates them.
 - If the path exists but is a file, it returns an error.
 - If permissions prevent creating/accessing it, it returns an error.

<!-- Thank you for making a PR! Bug fixes are always welcome, but if you're adding a new feature or changing an existing one, we'd really appreciate if you open an issue, post on the forum, or drop in on Discord -->

## Checks
- [ x] I am happy for maintainers to push small adjustments to this PR, to speed up the review cycle
- [ x] I have checked that there are no existing pull requests for the same thing
