### PR TITLE
Fix/zsh count multiline

### DIFF
--- a/crates/atuin-client/src/import/zsh.rs
+++ b/crates/atuin-client/src/import/zsh.rs
@@ -198,6 +198,19 @@ mod test {
     }
 
     #[tokio::test]
+    async fn test_count_entries_multilines() {
+        let bytes = r"ls
+    pwd
+    date
+    export ATUIN_RECORD_STORE_PATH=/tmp/atuin_records.db # path to primary record store \
+    export ATUIN_META__DB_PATH=/tmp/atuin_meta.db        # path to meta database
+    "
+        .as_bytes()
+        .to_owned();
+        let mut zsh = Zsh { bytes };
+        assert_eq!(zsh.entries().await.unwrap(), 4);
+    }
+    #[tokio::test]
     async fn test_parse_file() {
         let bytes = r": 1613322469:0;cargo install atuin
 : 1613322469:10;cargo install atuin; \\

--- a/crates/atuin-client/src/import/zsh.rs
+++ b/crates/atuin-client/src/import/zsh.rs
@@ -54,7 +54,19 @@ impl Importer for Zsh {
     }
 
     async fn entries(&mut self) -> Result<usize> {
-        Ok(super::count_lines(&self.bytes))
+        let mut counter = 0;
+        for b in unix_byte_lines(&self.bytes) {
+            let s = match unmetafy(b) {
+                Some(s) => s,
+                _ => continue,
+            };
+
+            if s.strip_suffix('\\').is_none() {
+                counter += 1;
+            }
+        }
+
+        Ok(counter)
     }
 
     async fn load(self, h: &mut impl Loader) -> Result<()> {
@@ -196,7 +208,7 @@ cargo update
         .to_owned();
 
         let mut zsh = Zsh { bytes };
-        assert_eq!(zsh.entries().await.unwrap(), 4);
+        assert_eq!(zsh.entries().await.unwrap(), 3);
 
         let mut loader = TestLoader::default();
         zsh.load(&mut loader).await.unwrap();

--- a/crates/atuin-client/src/import/zsh.rs
+++ b/crates/atuin-client/src/import/zsh.rs
@@ -199,12 +199,12 @@ mod test {
 
     #[tokio::test]
     async fn test_count_entries_multilines() {
-        let bytes = r"ls
-    pwd
-    date
-    export ATUIN_RECORD_STORE_PATH=/tmp/atuin_records.db # path to primary record store \
-    export ATUIN_META__DB_PATH=/tmp/atuin_meta.db        # path to meta database
-    "
+        let bytes = "ls
+pwd
+date
+export FOO=bar \\
+export BAZ=qux
+"
         .as_bytes()
         .to_owned();
         let mut zsh = Zsh { bytes };


### PR DESCRIPTION
<!-- Thank you for making a PR! Bug fixes are always welcome, but if you're adding a new feature or changing an existing one, we'd really appreciate if you open an issue, post on the forum, or drop in on Discord -->
### Problem
when importing zsh_history, if there are multi-line commands, the progress bar displays an incorrect count. This happens because entries() counts physical lines via count_lines and not the commands. 

### Fix  
.entries() now counts joined commands instead of lines.Same complexity,  no extra traversal (it already walked the whole file)

### Test plan
test_parse_file updated and passing; new test (test_count_lines_multiline  does this check more explicitly)


Closes #3008 


## Checks
- [x] I am happy for maintainers to push small adjustments to this PR, to speed up the review cycle
- [x] I have checked that there are no existing pull requests for the same thing
