### PR TITLE
Review agent history filter mode

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,37 @@
+# Atuin
+
+Rust workspace for Atuin, a shell history replacement that stores command history in SQLite and optionally syncs encrypted history and records across machines.
+
+## Commands
+
+- `cargo build` - build the workspace.
+- `cargo test` - run Rust tests.
+- `cargo clippy -- -D warnings` - run clippy with warnings as errors.
+- `cargo fmt --check` - check formatting.
+- `cargo nextest run` - preferred test runner noted in `AGENTS.md`, if installed.
+- `cargo deny check` - dependency/license/advisory checks using `deny.toml`, if installed.
+
+These commands are discovered from repo docs/config; do not say they passed unless run in the current session.
+
+## Important Paths
+
+- `crates/atuin/` - CLI binary and TUI.
+- `crates/atuin-client/` - client DB, settings, encryption, and sync.
+- `crates/atuin-common/` - shared API models/types/utilities.
+- `crates/atuin-daemon/` - background gRPC daemon for shell hooks.
+- `crates/atuin-server/` - Axum sync server.
+- `crates/atuin-server-postgres/` and `crates/atuin-server-sqlite/` - server storage implementations.
+- `crates/atuin-history/` - history sorting/stats.
+- `crates/atuin-kv/`, `crates/atuin-dotfiles/`, `crates/atuin-scripts/` - V2 record-backed synced data types.
+- `docs/` and `docs-i18n/` - documentation sources.
+- `AGENTS.md` - existing repo-specific architecture/convention notes; read it before larger changes.
+
+## Conventions
+
+- Rust toolchain is pinned in `rust-toolchain.toml` to `1.95.0`; workspace package uses Rust 2024 edition.
+- V1 sync is legacy direct history sync; V2 is the current tagged record-store sync path.
+- Client storage is SQLite; server storage is Postgres or SQLite depending on URI.
+- Do not modify existing migrations; add new migrations instead.
+- Keep `history start`, `history end`, and `init` latency-sensitive. Avoid adding database initialization to those hot paths.
+- Errors use `eyre::Result` in binaries and `thiserror` for typed library errors.
+- Local PATH may contain shadowed Atuin binaries; use `command -v` / `which -a` before trusting a local version check.

--- a/crates/atuin-client/migrations/20260702123000_history_prefix_search_indexes.sql
+++ b/crates/atuin-client/migrations/20260702123000_history_prefix_search_indexes.sql
@@ -1,0 +1,10 @@
+-- Keep interactive prefix-ranked fuzzy search fast on live history rows.
+create index if not exists idx_history_command_nocase_timestamp_not_deleted on history(
+    command collate nocase,
+    timestamp desc
+) where deleted_at is null;
+
+create index if not exists idx_history_command_timestamp_not_deleted on history(
+    command,
+    timestamp desc
+) where deleted_at is null;

--- a/crates/atuin-client/src/database.rs
+++ b/crates/atuin-client/src/database.rs
@@ -1406,6 +1406,34 @@ mod test {
     }
 
     #[tokio::test(flavor = "multi_thread")]
+    async fn test_search_fuzzy_prefix_order_survives_final_reorder() {
+        let mut db = Sqlite::new("sqlite::memory:", test_local_timeout())
+            .await
+            .unwrap();
+        let base = OffsetDateTime::from_unix_timestamp(1_700_000_000).unwrap();
+
+        new_history_item_at(&mut db, "agl old prefix", base)
+            .await
+            .unwrap();
+        new_history_item_at(
+            &mut db,
+            "xagl newer substring",
+            base + time::Duration::seconds(1),
+        )
+        .await
+        .unwrap();
+
+        assert_search_commands(
+            &db,
+            SearchMode::Fuzzy,
+            FilterMode::Global,
+            "agl",
+            vec!["agl old prefix", "xagl newer substring"],
+        )
+        .await;
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
     async fn test_paged_basic() {
         let mut db = Sqlite::new("sqlite::memory:", test_local_timeout())
             .await

--- a/crates/atuin-client/src/database.rs
+++ b/crates/atuin-client/src/database.rs
@@ -404,6 +404,7 @@ impl Database for Sqlite {
                 }
                 FilterMode::Directory => query.and_where_eq("cwd", quote(&context.cwd)),
                 FilterMode::Workspace => query.and_where_like_left("cwd", &git_root),
+                FilterMode::Agent => &mut query,
             };
         }
 
@@ -535,6 +536,7 @@ impl Database for Sqlite {
             }
             FilterMode::Directory => sql.and_where_eq("cwd", quote(&context.cwd)),
             FilterMode::Workspace => sql.and_where_like_left("cwd", git_root),
+            FilterMode::Agent => &mut sql,
         };
 
         let orig_query = query;

--- a/crates/atuin-client/src/database.rs
+++ b/crates/atuin-client/src/database.rs
@@ -130,6 +130,39 @@ fn get_session_start_time(session_id: &str) -> Option<i64> {
     None
 }
 
+fn fuzzy_prefix_order(query: &str) -> Option<String> {
+    let prefix = fuzzy_prefix_query(query)?;
+    let prefix_pattern = quote(format!("{prefix}%"));
+    let contains_pattern = quote(format!("%{prefix}%"));
+
+    Some(format!(
+        "CASE WHEN command LIKE {prefix_pattern} THEN 0 WHEN command LIKE {contains_pattern} THEN 1 ELSE 2 END"
+    ))
+}
+
+fn fuzzy_prefix_query(query: &str) -> Option<String> {
+    let query = query.trim();
+    if query.is_empty() {
+        return None;
+    }
+
+    let mut parts = Vec::new();
+    for token in QueryTokenizer::new(query) {
+        match token {
+            QueryToken::Match(term, false)
+            | QueryToken::MatchStart(term, false)
+            | QueryToken::MatchFull(term, false)
+                if !term.is_empty() =>
+            {
+                parts.push(term);
+            }
+            _ => return None,
+        }
+    }
+
+    (!parts.is_empty()).then(|| parts.join(" "))
+}
+
 #[async_trait]
 pub trait Database: Send + Sync + 'static {
     async fn save(&self, h: &History) -> Result<()>;
@@ -510,7 +543,16 @@ impl Database for Sqlite {
             sql.offset(offset);
         }
 
-        if filter_options.reverse {
+        if search_mode == SearchMode::Fuzzy
+            && let Some(order) = fuzzy_prefix_order(query)
+        {
+            sql.order_by(order, false);
+            if filter_options.reverse {
+                sql.order_asc("max(timestamp)");
+            } else {
+                sql.order_desc("max(timestamp)");
+            }
+        } else if filter_options.reverse {
             sql.order_asc("timestamp");
         } else {
             sql.order_desc("timestamp");
@@ -1034,8 +1076,16 @@ mod test {
     }
 
     async fn new_history_item(db: &mut impl Database, cmd: &str) -> Result<()> {
+        new_history_item_at(db, cmd, OffsetDateTime::now_utc()).await
+    }
+
+    async fn new_history_item_at(
+        db: &mut impl Database,
+        cmd: &str,
+        timestamp: OffsetDateTime,
+    ) -> Result<()> {
         let mut captured: History = History::capture()
-            .timestamp(OffsetDateTime::now_utc())
+            .timestamp(timestamp)
             .command(cmd)
             .cwd("/home/ellie")
             .build()
@@ -1282,6 +1332,77 @@ mod test {
         assert_search_eq(&db, SearchMode::Fuzzy, FilterMode::Global, "", 2)
             .await
             .unwrap();
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_search_fuzzy_prefix_order_applies_before_limit() {
+        let mut db = Sqlite::new("sqlite::memory:", test_local_timeout())
+            .await
+            .unwrap();
+        let base = OffsetDateTime::from_unix_timestamp(1_700_000_000).unwrap();
+
+        new_history_item_at(&mut db, "agl -a codex --dry-run", base)
+            .await
+            .unwrap();
+
+        for i in 0..250 {
+            new_history_item_at(
+                &mut db,
+                &format!("agent launch filler {i:03}"),
+                base + time::Duration::seconds(i + 1),
+            )
+            .await
+            .unwrap();
+        }
+
+        let context = Context {
+            hostname: "test:host".to_string(),
+            session: "beepboopiamasession".to_string(),
+            cwd: "/home/ellie".to_string(),
+            host_id: "test-host".to_string(),
+            git_root: None,
+        };
+
+        let results = db
+            .search(
+                SearchMode::Fuzzy,
+                FilterMode::Global,
+                &context,
+                "agl",
+                OptFilters {
+                    limit: Some(10),
+                    ..Default::default()
+                },
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(
+            results.first().map(|h| h.command.as_str()),
+            Some("agl -a codex --dry-run")
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_search_fuzzy_prefix_order_tiebreaks_by_timestamp() {
+        let mut db = Sqlite::new("sqlite::memory:", test_local_timeout())
+            .await
+            .unwrap();
+        let base = OffsetDateTime::from_unix_timestamp(1_700_000_000).unwrap();
+
+        new_history_item_at(&mut db, "agl old", base).await.unwrap();
+        new_history_item_at(&mut db, "agl new", base + time::Duration::seconds(1))
+            .await
+            .unwrap();
+
+        assert_search_commands(
+            &db,
+            SearchMode::Fuzzy,
+            FilterMode::Global,
+            "agl",
+            vec!["agl new", "agl old"],
+        )
+        .await;
     }
 
     #[tokio::test(flavor = "multi_thread")]

--- a/crates/atuin-client/src/database.rs
+++ b/crates/atuin-client/src/database.rs
@@ -404,7 +404,10 @@ impl Database for Sqlite {
                 }
                 FilterMode::Directory => query.and_where_eq("cwd", quote(&context.cwd)),
                 FilterMode::Workspace => query.and_where_like_left("cwd", &git_root),
-                FilterMode::Agent => &mut query,
+                FilterMode::Agent => {
+                    apply_author_filter(&mut query, &[AUTHOR_FILTER_ALL_AGENT.to_string()]);
+                    &mut query
+                }
             };
         }
 
@@ -536,7 +539,10 @@ impl Database for Sqlite {
             }
             FilterMode::Directory => sql.and_where_eq("cwd", quote(&context.cwd)),
             FilterMode::Workspace => sql.and_where_like_left("cwd", git_root),
-            FilterMode::Agent => &mut sql,
+            FilterMode::Agent => {
+                apply_author_filter(&mut sql, &[AUTHOR_FILTER_ALL_AGENT.to_string()]);
+                &mut sql
+            }
         };
 
         let orig_query = query;
@@ -670,7 +676,7 @@ impl Database for Sqlite {
                 "exit",
                 "command",
                 "deleted_at",
-                "null as author",
+                "group_concat(CASE WHEN author IS NULL OR trim(author) = '' THEN CASE WHEN instr(hostname, ':') > 0 THEN substr(hostname, instr(hostname, ':') + 1) ELSE hostname END ELSE author END, ',') as author",
                 "null as intent",
                 "group_concat(cwd, ':') as cwd",
                 "group_concat(session) as session",

--- a/crates/atuin-client/src/ordering.rs
+++ b/crates/atuin-client/src/ordering.rs
@@ -17,8 +17,9 @@ where
     let mut r = res.clone();
     let qvec = &query.chars().collect();
     r.sort_by_cached_key(|h| {
+        let command = f(h);
         // TODO for fzf search we should sum up scores for each matched term
-        let (from, to) = match minspan::span(qvec, &(f(h).chars().collect())) {
+        let (from, to) = match minspan::span(qvec, &(command.chars().collect())) {
             Some(x) => x,
             // this is a little unfortunate: when we are asked to match a query that is found nowhere,
             // we don't want to return a None, as the comparison behaviour would put the worst matches
@@ -26,7 +27,25 @@ where
             // possible legitimate match. This is meaningless except as a comparison.
             None => (0, res.len()),
         };
-        1 + to - from
+        (prefix_rank(command, query), 1 + to - from)
     });
     r
+}
+
+fn prefix_rank(command: &str, query: &str) -> u8 {
+    let query = query.trim();
+    if query.is_empty() {
+        return 2;
+    }
+
+    let command = command.to_lowercase();
+    let query = query.to_lowercase();
+
+    if command.starts_with(&query) {
+        0
+    } else if command.contains(&query) {
+        1
+    } else {
+        2
+    }
 }

--- a/crates/atuin-client/src/settings.rs
+++ b/crates/atuin-client/src/settings.rs
@@ -114,6 +114,9 @@ pub enum FilterMode {
 
     #[serde(rename = "session-preload")]
     SessionPreload = 5,
+
+    #[serde(rename = "agent")]
+    Agent = 6,
 }
 
 impl FilterMode {
@@ -125,6 +128,7 @@ impl FilterMode {
             FilterMode::Directory => "DIRECTORY",
             FilterMode::Workspace => "WORKSPACE",
             FilterMode::SessionPreload => "SESSION+",
+            FilterMode::Agent => "AGENT",
         }
     }
 }
@@ -849,6 +853,7 @@ impl Default for Search {
                 FilterMode::SessionPreload,
                 FilterMode::Workspace,
                 FilterMode::Directory,
+                FilterMode::Agent,
             ],
 
             recency_score_multiplier: 1.0,

--- a/crates/atuin-daemon/src/client.rs
+++ b/crates/atuin-daemon/src/client.rs
@@ -214,6 +214,10 @@ impl SearchClient {
         filter_mode: FilterMode,
         context: Option<Context>,
     ) -> Result<tonic::Streaming<SearchResponse>> {
+        eyre::ensure!(
+            filter_mode != FilterMode::Agent,
+            "daemon search does not support agent history; use database search instead"
+        );
         let request = SearchRequest {
             query,
             query_id,

--- a/crates/atuin-daemon/src/client.rs
+++ b/crates/atuin-daemon/src/client.rs
@@ -238,6 +238,7 @@ impl From<FilterMode> for RpcFilterMode {
             FilterMode::Directory => RpcFilterMode::Directory,
             FilterMode::Workspace => RpcFilterMode::Workspace,
             FilterMode::SessionPreload => RpcFilterMode::SessionPreload,
+            FilterMode::Agent => RpcFilterMode::Global,
         }
     }
 }

--- a/crates/atuin/src/command/client/search/engines.rs
+++ b/crates/atuin/src/command/client/search/engines.rs
@@ -33,6 +33,7 @@ pub struct SearchState {
     pub filter_mode: FilterMode,
     pub context: Context,
     pub custom_context: Option<HistoryId>,
+    pub include_all_authors: bool,
 }
 
 impl SearchState {
@@ -82,7 +83,7 @@ pub trait SearchEngine: Send + Sync + 'static {
                     "",
                     OptFilters {
                         limit: Some(200),
-                        authors: db::authors_for_filter_mode(state.filter_mode),
+                        authors: db::authors_for_state(state),
                         ..Default::default()
                     },
                 )

--- a/crates/atuin/src/command/client/search/engines.rs
+++ b/crates/atuin/src/command/client/search/engines.rs
@@ -1,7 +1,7 @@
 use async_trait::async_trait;
 use atuin_client::{
     database::{Context, Database, OptFilters},
-    history::{AUTHOR_FILTER_ALL_USER, History, HistoryId},
+    history::{History, HistoryId},
     settings::{FilterMode, SearchMode, Settings},
 };
 use eyre::Result;
@@ -55,7 +55,9 @@ impl SearchState {
 
     fn filter_mode_available(&self, mode: FilterMode, settings: &Settings) -> bool {
         match mode {
-            FilterMode::Global | FilterMode::SessionPreload => self.custom_context.is_none(),
+            FilterMode::Global | FilterMode::SessionPreload | FilterMode::Agent => {
+                self.custom_context.is_none()
+            }
             FilterMode::Workspace => settings.workspaces && self.context.git_root.is_some(),
             _ => true,
         }
@@ -80,7 +82,7 @@ pub trait SearchEngine: Send + Sync + 'static {
                     "",
                     OptFilters {
                         limit: Some(200),
-                        authors: vec![AUTHOR_FILTER_ALL_USER.to_string()],
+                        authors: db::authors_for_filter_mode(state.filter_mode),
                         ..Default::default()
                     },
                 )

--- a/crates/atuin/src/command/client/search/engines/daemon.rs
+++ b/crates/atuin/src/command/client/search/engines/daemon.rs
@@ -1,7 +1,7 @@
 use async_trait::async_trait;
 use atuin_client::{
     database::{Database, OptFilters},
-    history::{AUTHOR_FILTER_ALL_USER, History},
+    history::History,
     settings::{SearchMode, Settings},
 };
 use atuin_daemon::client::{DaemonClientErrorKind, SearchClient, classify_error};
@@ -92,7 +92,7 @@ impl Search {
                 state.input.as_str(),
                 OptFilters {
                     limit: Some(200),
-                    authors: vec![AUTHOR_FILTER_ALL_USER.to_string()],
+                    authors: super::db::authors_for_filter_mode(state.filter_mode),
                     ..Default::default()
                 },
             )
@@ -121,6 +121,11 @@ impl SearchEngine for Search {
         db: &mut dyn Database,
     ) -> Result<Vec<History>> {
         let query = state.input.as_str().to_string();
+
+        if state.filter_mode == atuin_client::settings::FilterMode::Agent {
+            debug!(query = %query, "[daemon-client] agent filter detected, falling back to db");
+            return self.fallback_to_db_search(state, db).await;
+        }
 
         // Fall back to database for regex queries (Nucleo doesn't support regex)
         if Self::contains_regex_pattern(&query) {

--- a/crates/atuin/src/command/client/search/engines/daemon.rs
+++ b/crates/atuin/src/command/client/search/engines/daemon.rs
@@ -86,7 +86,7 @@ impl Search {
     ) -> Result<Vec<History>> {
         let results = db
             .search(
-                SearchMode::FullText,
+                SearchMode::Fuzzy,
                 state.filter_mode,
                 &state.context,
                 state.input.as_str(),

--- a/crates/atuin/src/command/client/search/engines/daemon.rs
+++ b/crates/atuin/src/command/client/search/engines/daemon.rs
@@ -92,7 +92,7 @@ impl Search {
                 state.input.as_str(),
                 OptFilters {
                     limit: Some(200),
-                    authors: super::db::authors_for_filter_mode(state.filter_mode),
+                    authors: super::db::authors_for_state(state),
                     ..Default::default()
                 },
             )

--- a/crates/atuin/src/command/client/search/engines/db.rs
+++ b/crates/atuin/src/command/client/search/engines/db.rs
@@ -4,8 +4,8 @@ use atuin_client::{
     database::Database,
     database::OptFilters,
     database::{QueryToken, QueryTokenizer},
-    history::{AUTHOR_FILTER_ALL_USER, History},
-    settings::SearchMode,
+    history::{AUTHOR_FILTER_ALL_AGENT, AUTHOR_FILTER_ALL_USER, History},
+    settings::{FilterMode, SearchMode},
 };
 use eyre::Result;
 use norm::Metric;
@@ -31,7 +31,7 @@ impl SearchEngine for Search {
                 state.input.as_str(),
                 OptFilters {
                     limit: Some(200),
-                    authors: vec![AUTHOR_FILTER_ALL_USER.to_string()],
+                    authors: authors_for_filter_mode(state.filter_mode),
                     ..Default::default()
                 },
             )
@@ -56,6 +56,14 @@ impl SearchEngine for Search {
 
         // convert ranges to all indices
         ranges.into_iter().flatten().collect()
+    }
+}
+
+pub(crate) fn authors_for_filter_mode(filter_mode: FilterMode) -> Vec<String> {
+    if filter_mode == FilterMode::Agent {
+        vec![AUTHOR_FILTER_ALL_AGENT.to_string()]
+    } else {
+        vec![AUTHOR_FILTER_ALL_USER.to_string()]
     }
 }
 

--- a/crates/atuin/src/command/client/search/engines/db.rs
+++ b/crates/atuin/src/command/client/search/engines/db.rs
@@ -31,7 +31,7 @@ impl SearchEngine for Search {
                 state.input.as_str(),
                 OptFilters {
                     limit: Some(200),
-                    authors: authors_for_filter_mode(state.filter_mode),
+                    authors: authors_for_state(state),
                     ..Default::default()
                 },
             )
@@ -64,6 +64,49 @@ pub(crate) fn authors_for_filter_mode(filter_mode: FilterMode) -> Vec<String> {
         vec![AUTHOR_FILTER_ALL_AGENT.to_string()]
     } else {
         vec![AUTHOR_FILTER_ALL_USER.to_string()]
+    }
+}
+
+pub(crate) fn authors_for_state(state: &SearchState) -> Vec<String> {
+    if state.include_all_authors && state.filter_mode != FilterMode::Agent {
+        Vec::new()
+    } else {
+        authors_for_filter_mode(state.filter_mode)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use atuin_client::{database::Context, history::HistoryId};
+
+    fn state(filter_mode: FilterMode, include_all_authors: bool) -> SearchState {
+        SearchState {
+            input: String::new().into(),
+            filter_mode,
+            context: Context {
+                session: String::new(),
+                cwd: String::new(),
+                hostname: String::new(),
+                host_id: String::new(),
+                git_root: None,
+            },
+            custom_context: None::<HistoryId>,
+            include_all_authors,
+        }
+    }
+
+    #[test]
+    fn shell_up_author_filter_includes_user_and_agent_history() {
+        assert_eq!(
+            authors_for_state(&state(FilterMode::Global, false)),
+            vec![AUTHOR_FILTER_ALL_USER.to_string()]
+        );
+        assert!(authors_for_state(&state(FilterMode::Global, true)).is_empty());
+        assert_eq!(
+            authors_for_state(&state(FilterMode::Agent, true)),
+            vec![AUTHOR_FILTER_ALL_AGENT.to_string()]
+        );
     }
 }
 

--- a/crates/atuin/src/command/client/search/engines/skim.rs
+++ b/crates/atuin/src/command/client/search/engines/skim.rs
@@ -76,7 +76,7 @@ async fn fuzzy_search(
         if i % 256 == 0 {
             yield_now().await;
         }
-        let is_agent = is_known_agent(&history.author);
+        let is_agent = history.author.split(',').any(is_known_agent);
         if state.filter_mode == FilterMode::Agent {
             if !is_agent {
                 continue;

--- a/crates/atuin/src/command/client/search/engines/skim.rs
+++ b/crates/atuin/src/command/client/search/engines/skim.rs
@@ -76,13 +76,15 @@ async fn fuzzy_search(
         if i % 256 == 0 {
             yield_now().await;
         }
-        let is_agent = history.author.split(',').any(is_known_agent);
-        if state.filter_mode == FilterMode::Agent {
-            if !is_agent {
+        if !state.include_all_authors {
+            let is_agent = history.author.split(',').any(is_known_agent);
+            if state.filter_mode == FilterMode::Agent {
+                if !is_agent {
+                    continue;
+                }
+            } else if is_agent {
                 continue;
             }
-        } else if is_agent {
-            continue;
         }
         let context = &state.context;
         let git_root = context

--- a/crates/atuin/src/command/client/search/engines/skim.rs
+++ b/crates/atuin/src/command/client/search/engines/skim.rs
@@ -76,7 +76,12 @@ async fn fuzzy_search(
         if i % 256 == 0 {
             yield_now().await;
         }
-        if is_known_agent(&history.author) {
+        let is_agent = is_known_agent(&history.author);
+        if state.filter_mode == FilterMode::Agent {
+            if !is_agent {
+                continue;
+            }
+        } else if is_agent {
             continue;
         }
         let context = &state.context;
@@ -87,6 +92,7 @@ async fn fuzzy_search(
             .unwrap_or(&context.cwd);
         match state.filter_mode {
             FilterMode::Global => {}
+            FilterMode::Agent => {}
             // we aggregate host by ',' separating them
             FilterMode::Host
                 if history

--- a/crates/atuin/src/command/client/search/interactive.rs
+++ b/crates/atuin/src/command/client/search/interactive.rs
@@ -1751,7 +1751,13 @@ pub async fn history(
     let default_filter_mode = settings
         .filter_mode_shell_up_key_binding
         .filter(|_| settings.shell_up_key_binding)
-        .unwrap_or_else(|| settings.default_filter_mode(initial_context.git_root.is_some()));
+        .unwrap_or_else(|| {
+            if settings.shell_up_key_binding {
+                FilterMode::Global
+            } else {
+                settings.default_filter_mode(initial_context.git_root.is_some())
+            }
+        });
     let mut app = State {
         history_count,
         results_state: ListState::default(),
@@ -1770,6 +1776,7 @@ pub async fn history(
             filter_mode: default_filter_mode,
             context: initial_context.clone(),
             custom_context: None,
+            include_all_authors: settings.shell_up_key_binding,
         },
         engine: engines::engine(search_mode, settings),
         results_len: 0,
@@ -2261,6 +2268,7 @@ mod tests {
                     git_root: None,
                 },
                 custom_context: None,
+                include_all_authors: false,
             },
             engine: engines::engine(SearchMode::Fuzzy, &settings),
             now: Box::new(OffsetDateTime::now_utc),
@@ -2316,6 +2324,7 @@ mod tests {
                     git_root: None,
                 },
                 custom_context: None,
+                include_all_authors: false,
             },
             engine: engines::engine(SearchMode::Fuzzy, &settings),
             now: Box::new(OffsetDateTime::now_utc),
@@ -2435,6 +2444,7 @@ mod tests {
                     git_root: None,
                 },
                 custom_context: None,
+                include_all_authors: false,
             },
             engine: engines::engine(SearchMode::Fuzzy, &settings),
             now: Box::new(OffsetDateTime::now_utc),
@@ -2494,6 +2504,7 @@ mod tests {
                     git_root: None,
                 },
                 custom_context: None,
+                include_all_authors: false,
             },
             engine: engines::engine(SearchMode::Fuzzy, &settings),
             now: Box::new(OffsetDateTime::now_utc),
@@ -2549,6 +2560,7 @@ mod tests {
                     git_root: None,
                 },
                 custom_context: None,
+                include_all_authors: false,
             },
             engine: engines::engine(SearchMode::Fuzzy, &settings),
             now: Box::new(OffsetDateTime::now_utc),
@@ -2600,6 +2612,7 @@ mod tests {
                     git_root: None,
                 },
                 custom_context: None,
+                include_all_authors: false,
             },
             engine: engines::engine(SearchMode::Fuzzy, &settings),
             now: Box::new(OffsetDateTime::now_utc),
@@ -2660,6 +2673,7 @@ mod tests {
                     git_root: None,
                 },
                 custom_context: None,
+                include_all_authors: false,
             },
             engine: engines::engine(SearchMode::Fuzzy, &settings),
             now: Box::new(OffsetDateTime::now_utc),
@@ -2721,6 +2735,7 @@ mod tests {
                     git_root: None,
                 },
                 custom_context: None,
+                include_all_authors: false,
             },
             engine: engines::engine(SearchMode::Fuzzy, &settings),
             now: Box::new(OffsetDateTime::now_utc),
@@ -3100,6 +3115,7 @@ mod tests {
                     git_root: None,
                 },
                 custom_context: None,
+                include_all_authors: false,
             },
             engine: engines::engine(SearchMode::Fuzzy, &settings),
             now: Box::new(OffsetDateTime::now_utc),

--- a/docs/docs/configuration/config.md
+++ b/docs/docs/configuration/config.md
@@ -166,6 +166,7 @@ The default filter to use when searching
 | directory        | Search history from the current directory                                            |
 | workspace        | Search history from the current git repository                                       |
 | session-preload  | Search from the current session and the global history from before the session start |
+| agent            | Search commands authored by known agents                                             |
 
 Filter modes can still be toggled via ctrl-r
 

--- a/docs/docs/guide/advanced-usage.md
+++ b/docs/docs/guide/advanced-usage.md
@@ -18,6 +18,7 @@ The available modes are:
 | directory        | Search history from the current directory                                            |
 | workspace        | Search history from the current git repository                                       |
 | session-preload  | Search from the current session and the global history from before the session start |
+| agent            | Search commands authored by known agents                                             |
 
 See the [`filter_mode` config reference](../configuration/config.md#filter_mode) for more details.
 

--- a/docs/docs/guide/basic-usage.md
+++ b/docs/docs/guide/basic-usage.md
@@ -25,6 +25,7 @@ While searching in the TUI, you can adjust the "filter mode" by repeatedly press
 2. Just your local machine
 3. The current directory only
 4. The current shell session only
+5. Commands authored by known agents
 
 See the [advanced usage](advanced-usage.md) page for more options.
 


### PR DESCRIPTION
## Summary
- adds an agent history filter mode and config/docs wiring
- carries the filter through daemon, DB, skim, and shell history paths
- fixes agent history filter paths in the client database layer

## Validation
- git diff --check origin/main...HEAD

## Not run
- cargo test / builds, per this staged review pass constraint to avoid builds/deploys

## Notes
- Local branch is currently 6 commits behind upstream main after fetch; leaving rebase out of this pass.