### PR TITLE
feat: Cache user contexts on load until `/reload`

### DIFF
--- a/crates/atuin-ai/src/commands/inline.rs
+++ b/crates/atuin-ai/src/commands/inline.rs
@@ -267,6 +267,7 @@ async fn run_inline_tui(
         edit_permissions,
         snapshot_store,
         skill_registry,
+        user_context_cache: Default::default(),
     };
 
     // ─── Channel + Application ──────────────────────────────────

--- a/crates/atuin-ai/src/driver.rs
+++ b/crates/atuin-ai/src/driver.rs
@@ -963,12 +963,18 @@ async fn run_stream_bridge(
 
     // User context files (TERMINAL.md) are gathered and interpolated on the
     // first request, then served from the cache until `/reload`.
+    //
+    // Watch for cancellation during the gather: interpolation commands can
+    // be slow, and a cancelled (or replaced) bridge must not populate the
+    // cache — its result may predate a gather a newer bridge already stored.
     let shell = client_ctx.shell.as_deref().unwrap_or("sh");
     let start_dir = std::env::current_dir().unwrap_or_default();
     let global_ctx_path = crate::user_context::global_context_path();
-    let user_contexts = user_context_cache
-        .get_or_gather(&start_dir, Some(&global_ctx_path), shell)
-        .await;
+    let user_contexts = tokio::select! {
+        biased;
+        _ = cancel_rx.changed() => return,
+        contexts = user_context_cache.get_or_gather(&start_dir, Some(&global_ctx_path), shell) => contexts,
+    };
 
     let stream = create_chat_stream(
         app_ctx.endpoint.clone(),

--- a/crates/atuin-ai/src/driver.rs
+++ b/crates/atuin-ai/src/driver.rs
@@ -349,6 +349,7 @@ fn translate_tui_event(
 /// Resolve a slash command to its output content.
 /// If the input starts with `/`, check whether the command name matches a
 /// registered skill. Returns `Some((skill_name, arguments))` if it does.
+/// Built-in slash commands take precedence: a skill can't shadow them.
 fn resolve_skill_name(input: &str, handle: &Handle<ViewState>) -> Option<(String, Option<String>)> {
     let after_slash = input.trim_start_matches('/');
     let cmd_name = after_slash.split_whitespace().next()?.to_string();
@@ -356,7 +357,7 @@ fn resolve_skill_name(input: &str, handle: &Handle<ViewState>) -> Option<(String
     let is_skill = handle
         .fetch({
             let cmd_name = cmd_name.clone();
-            move |vs| vs.skill_names.contains(&cmd_name)
+            move |vs| vs.skill_names.contains(&cmd_name) && !vs.slash_registry.contains(&cmd_name)
         })
         .blocking_recv()
         .unwrap_or(false);

--- a/crates/atuin-ai/src/driver.rs
+++ b/crates/atuin-ai/src/driver.rs
@@ -57,6 +57,7 @@ pub(crate) struct IoContext {
     pub edit_permissions: EditPermissionCache,
     pub snapshot_store: Option<crate::snapshots::SnapshotStore>,
     pub skill_registry: crate::skills::SkillRegistry,
+    pub user_context_cache: crate::user_context::UserContextCache,
 }
 
 // ============================================================================
@@ -180,7 +181,7 @@ pub(crate) fn run_driver(
             }
             DriverEvent::Tui(tui_event) => {
                 tracing::trace!(?tui_event, state = ?fsm.state, "TUI event");
-                translate_tui_event(tui_event, &handle)
+                translate_tui_event(tui_event, &handle, &io)
             }
         };
 
@@ -234,7 +235,11 @@ pub(crate) fn run_driver(
 
 /// Translate a TUI event into an FSM event.
 /// Returns None for events handled directly (e.g. InputUpdated).
-fn translate_tui_event(event: AiTuiEvent, handle: &Handle<ViewState>) -> Option<Event> {
+fn translate_tui_event(
+    event: AiTuiEvent,
+    handle: &Handle<ViewState>,
+    io: &IoContext,
+) -> Option<Event> {
     match event {
         AiTuiEvent::SubmitInput(input) => {
             // Clear slash state and reset is_input_blank (the InputBox clears
@@ -257,7 +262,7 @@ fn translate_tui_event(event: AiTuiEvent, handle: &Handle<ViewState>) -> Option<
                         arguments,
                     })
                 } else {
-                    let content = resolve_slash_command(&input, handle);
+                    let content = resolve_slash_command(&input, handle, io);
                     Some(Event::SlashCommand {
                         command: input,
                         content,
@@ -331,7 +336,7 @@ fn translate_tui_event(event: AiTuiEvent, handle: &Handle<ViewState>) -> Option<
                     arguments,
                 })
             } else {
-                let content = resolve_slash_command(&cmd, handle);
+                let content = resolve_slash_command(&cmd, handle, io);
                 Some(Event::SlashCommand {
                     command: cmd,
                     content,
@@ -369,8 +374,12 @@ fn resolve_skill_name(input: &str, handle: &Handle<ViewState>) -> Option<(String
     Some((cmd_name, args))
 }
 
-fn resolve_slash_command(command: &str, handle: &Handle<ViewState>) -> String {
+fn resolve_slash_command(command: &str, handle: &Handle<ViewState>, io: &IoContext) -> String {
     match command.trim() {
+        "/reload" => {
+            io.user_context_cache.invalidate();
+            "Context files will be reloaded on the next request.".to_string()
+        }
         "/help" => {
             let commands = handle
                 .fetch(|vs| {
@@ -487,6 +496,7 @@ fn execute_effect(effect: &Effect, ctx: DriverContext) {
             let tx = tx.clone();
             let app = io.app_ctx.clone();
             let cc = io.client_ctx.clone();
+            let user_context_cache = io.user_context_cache.clone();
             let (skill_summaries, skill_overflow) = io.skill_registry.server_skills();
             let request = ChatRequest::new(
                 messages.clone(),
@@ -504,6 +514,7 @@ fn execute_effect(effect: &Effect, ctx: DriverContext) {
                     cancel_rx,
                     skill_summaries,
                     skill_overflow,
+                    user_context_cache,
                 )
                 .await;
             });
@@ -935,6 +946,7 @@ async fn load_skill_content(
 // Stream bridge
 // ============================================================================
 
+#[allow(clippy::too_many_arguments)]
 async fn run_stream_bridge(
     request: ChatRequest,
     app_ctx: AppContext,
@@ -943,16 +955,19 @@ async fn run_stream_bridge(
     mut cancel_rx: tokio::sync::watch::Receiver<()>,
     skill_summaries: Vec<crate::skills::SkillSummary>,
     skill_overflow: Option<String>,
+    user_context_cache: crate::user_context::UserContextCache,
 ) {
     use crate::stream::{StreamContent, StreamControl, StreamFrame, create_chat_stream};
     use futures::StreamExt;
 
-    // Gather user context files (TERMINAL.md) and interpolate commands.
+    // User context files (TERMINAL.md) are gathered and interpolated on the
+    // first request, then served from the cache until `/reload`.
     let shell = client_ctx.shell.as_deref().unwrap_or("sh");
     let start_dir = std::env::current_dir().unwrap_or_default();
     let global_ctx_path = crate::user_context::global_context_path();
-    let user_contexts =
-        crate::user_context::gather(&start_dir, Some(&global_ctx_path), shell).await;
+    let user_contexts = user_context_cache
+        .get_or_gather(&start_dir, Some(&global_ctx_path), shell)
+        .await;
 
     let stream = create_chat_stream(
         app_ctx.endpoint.clone(),

--- a/crates/atuin-ai/src/tui/slash.rs
+++ b/crates/atuin-ai/src/tui/slash.rs
@@ -73,6 +73,10 @@ impl Default for SlashCommandRegistry {
             "new",
             "Start a new conversation, archiving the current one",
         ));
+        registry.register(SlashCommand::new(
+            "reload",
+            "Reload context files (TERMINAL.md) on the next request",
+        ));
 
         registry
     }

--- a/crates/atuin-ai/src/tui/slash.rs
+++ b/crates/atuin-ai/src/tui/slash.rs
@@ -40,6 +40,10 @@ impl SlashCommandRegistry {
         &self.commands
     }
 
+    pub fn contains(&self, name: &str) -> bool {
+        self.commands.iter().any(|c| c.name == name)
+    }
+
     pub fn search_fuzzy(&self, query: &str) -> Vec<SlashCommandSearchResult> {
         let query_lower = query.to_lowercase();
 

--- a/crates/atuin-ai/src/user_context/mod.rs
+++ b/crates/atuin-ai/src/user_context/mod.rs
@@ -1,14 +1,17 @@
 //! User-authored context files (`TERMINAL.md`).
 //!
 //! Context files are markdown documents that can embed shell commands for
-//! dynamic content. Before each API request, context files are discovered
-//! by walking the filesystem, commands are executed, and the interpolated
-//! content is sent to the server as `config.user_contexts`.
+//! dynamic content. On the first API request of an invocation, context files
+//! are discovered by walking the filesystem, commands are executed, and the
+//! interpolated content is sent to the server as `config.user_contexts`.
+//! The result is cached for the rest of the invocation; `/reload` clears
+//! the cache so the next request re-gathers.
 
 pub(crate) mod interpolate;
 mod walker;
 
 use std::path::Path;
+use std::sync::{Arc, Mutex};
 
 pub(crate) use walker::global_context_path;
 
@@ -19,6 +22,50 @@ pub(crate) struct UserContext {
     pub path: String,
     /// The interpolated content.
     pub data: String,
+}
+
+/// Process-lifetime cache of gathered user contexts.
+///
+/// Context files are walked and interpolated once per invocation; subsequent
+/// requests reuse the cached result. `/reload` invalidates the cache so the
+/// next request re-gathers.
+#[derive(Debug, Clone, Default)]
+pub(crate) struct UserContextCache {
+    inner: Arc<Mutex<Option<Vec<UserContext>>>>,
+}
+
+impl UserContextCache {
+    /// Return the cached contexts, gathering them first if the cache is empty.
+    pub async fn get_or_gather(
+        &self,
+        start: &Path,
+        global_path: Option<&Path>,
+        shell: &str,
+    ) -> Vec<UserContext> {
+        if let Some(contexts) = self.lock().clone() {
+            return contexts;
+        }
+
+        // Concurrent callers may both gather here; streams run one at a
+        // time so this stays simpler than holding a lock across .await.
+        let contexts = gather(start, global_path, shell).await;
+        *self.lock() = Some(contexts.clone());
+        contexts
+    }
+
+    /// Drop the cached contexts so the next request re-gathers them.
+    pub fn invalidate(&self) {
+        self.lock().take();
+    }
+
+    /// A poisoned lock means another thread panicked while holding it, but
+    /// the cached value is only ever replaced wholesale — it can't be torn.
+    /// Recover with the inner value rather than propagating the panic.
+    fn lock(&self) -> std::sync::MutexGuard<'_, Option<Vec<UserContext>>> {
+        self.inner
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+    }
 }
 
 /// Discover context files and interpolate embedded commands.
@@ -65,4 +112,36 @@ pub(crate) async fn gather(
     }
 
     contexts
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn find<'a>(contexts: &'a [UserContext], path: &Path) -> Option<&'a UserContext> {
+        let path = path.to_string_lossy();
+        contexts.iter().find(|c| c.path == path)
+    }
+
+    #[tokio::test]
+    async fn cache_serves_stale_until_invalidated() {
+        let dir = tempfile::tempdir().unwrap();
+        let file = dir.path().join("TERMINAL.md");
+        tokio::fs::write(&file, "version one").await.unwrap();
+
+        let cache = UserContextCache::default();
+
+        let contexts = cache.get_or_gather(dir.path(), None, "sh").await;
+        assert_eq!(find(&contexts, &file).unwrap().data, "version one");
+
+        tokio::fs::write(&file, "version two").await.unwrap();
+
+        let contexts = cache.get_or_gather(dir.path(), None, "sh").await;
+        assert_eq!(find(&contexts, &file).unwrap().data, "version one");
+
+        cache.invalidate();
+
+        let contexts = cache.get_or_gather(dir.path(), None, "sh").await;
+        assert_eq!(find(&contexts, &file).unwrap().data, "version two");
+    }
 }

--- a/crates/atuin-ai/src/user_context/mod.rs
+++ b/crates/atuin-ai/src/user_context/mod.rs
@@ -31,7 +31,15 @@ pub(crate) struct UserContext {
 /// next request re-gathers.
 #[derive(Debug, Clone, Default)]
 pub(crate) struct UserContextCache {
-    inner: Arc<Mutex<Option<Vec<UserContext>>>>,
+    inner: Arc<Mutex<CacheSlot>>,
+}
+
+#[derive(Debug, Default)]
+struct CacheSlot {
+    /// Bumped on every invalidation, so a gather that raced with `/reload`
+    /// can detect its result is stale and decline to cache it.
+    epoch: u64,
+    contexts: Option<Vec<UserContext>>,
 }
 
 impl UserContextCache {
@@ -42,26 +50,39 @@ impl UserContextCache {
         global_path: Option<&Path>,
         shell: &str,
     ) -> Vec<UserContext> {
-        if let Some(contexts) = self.lock().clone() {
-            return contexts;
-        }
+        // The lock is not held across the gather; streams run one at a time
+        // so duplicate gathers aren't a concern.
+        let epoch = {
+            let slot = self.lock();
+            if let Some(contexts) = slot.contexts.clone() {
+                return contexts;
+            }
+            slot.epoch
+        };
 
-        // Concurrent callers may both gather here; streams run one at a
-        // time so this stays simpler than holding a lock across .await.
         let contexts = gather(start, global_path, shell).await;
-        *self.lock() = Some(contexts.clone());
+
+        // If `/reload` arrived mid-gather, this result predates it: return
+        // it for the in-flight request but leave the cache empty so the
+        // next request re-gathers.
+        let mut slot = self.lock();
+        if slot.epoch == epoch {
+            slot.contexts = Some(contexts.clone());
+        }
         contexts
     }
 
     /// Drop the cached contexts so the next request re-gathers them.
     pub fn invalidate(&self) {
-        self.lock().take();
+        let mut slot = self.lock();
+        slot.epoch += 1;
+        slot.contexts = None;
     }
 
     /// A poisoned lock means another thread panicked while holding it, but
     /// the cached value is only ever replaced wholesale — it can't be torn.
     /// Recover with the inner value rather than propagating the panic.
-    fn lock(&self) -> std::sync::MutexGuard<'_, Option<Vec<UserContext>>> {
+    fn lock(&self) -> std::sync::MutexGuard<'_, CacheSlot> {
         self.inner
             .lock()
             .unwrap_or_else(std::sync::PoisonError::into_inner)
@@ -143,5 +164,38 @@ mod tests {
 
         let contexts = cache.get_or_gather(dir.path(), None, "sh").await;
         assert_eq!(find(&contexts, &file).unwrap().data, "version two");
+    }
+
+    #[tokio::test]
+    async fn invalidate_during_gather_is_not_lost() {
+        let dir = tempfile::tempdir().unwrap();
+        let file = dir.path().join("TERMINAL.md");
+        // The embedded sleep holds the gather open while we invalidate.
+        tokio::fs::write(&file, "!`sleep 0.5 && echo one`")
+            .await
+            .unwrap();
+
+        let cache = UserContextCache::default();
+
+        let in_flight = tokio::spawn({
+            let cache = cache.clone();
+            let start = dir.path().to_path_buf();
+            async move { cache.get_or_gather(&start, None, "sh").await }
+        });
+
+        // Let the gather read its epoch and start interpolating, then
+        // invalidate mid-flight.
+        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+        cache.invalidate();
+        tokio::fs::write(&file, "!`echo two`").await.unwrap();
+
+        // The in-flight request still gets its pre-reload result...
+        let contexts = in_flight.await.unwrap();
+        assert_eq!(find(&contexts, &file).unwrap().data.trim(), "one");
+
+        // ...but it must not repopulate the cache: the next request
+        // re-gathers and sees the new content.
+        let contexts = cache.get_or_gather(dir.path(), None, "sh").await;
+        assert_eq!(find(&contexts, &file).unwrap().data.trim(), "two");
     }
 }

--- a/crates/atuin-ai/src/user_context/mod.rs
+++ b/crates/atuin-ai/src/user_context/mod.rs
@@ -64,9 +64,10 @@ impl UserContextCache {
 
         // If `/reload` arrived mid-gather, this result predates it: return
         // it for the in-flight request but leave the cache empty so the
-        // next request re-gathers.
+        // next request re-gathers. Likewise, never overwrite a result a
+        // concurrent gather stored first — ours may be the older read.
         let mut slot = self.lock();
-        if slot.epoch == epoch {
+        if slot.epoch == epoch && slot.contexts.is_none() {
             slot.contexts = Some(contexts.clone());
         }
         contexts
@@ -195,6 +196,39 @@ mod tests {
 
         // ...but it must not repopulate the cache: the next request
         // re-gathers and sees the new content.
+        let contexts = cache.get_or_gather(dir.path(), None, "sh").await;
+        assert_eq!(find(&contexts, &file).unwrap().data.trim(), "two");
+    }
+
+    #[tokio::test]
+    async fn slow_gather_does_not_overwrite_concurrent_result() {
+        let dir = tempfile::tempdir().unwrap();
+        let file = dir.path().join("TERMINAL.md");
+        tokio::fs::write(&file, "!`sleep 0.5 && echo one`")
+            .await
+            .unwrap();
+
+        let cache = UserContextCache::default();
+
+        // First gather reads the old file and is held open by the sleep.
+        let slow = tokio::spawn({
+            let cache = cache.clone();
+            let start = dir.path().to_path_buf();
+            async move { cache.get_or_gather(&start, None, "sh").await }
+        });
+
+        // While it runs, the file changes and a second request gathers
+        // and caches the new content.
+        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+        tokio::fs::write(&file, "!`echo two`").await.unwrap();
+        let contexts = cache.get_or_gather(dir.path(), None, "sh").await;
+        assert_eq!(find(&contexts, &file).unwrap().data.trim(), "two");
+
+        // The slow gather finishes last with its older read...
+        let contexts = slow.await.unwrap();
+        assert_eq!(find(&contexts, &file).unwrap().data.trim(), "one");
+
+        // ...but must not replace the newer cached result.
         let contexts = cache.get_or_gather(dir.path(), None, "sh").await;
         assert_eq!(find(&contexts, &file).unwrap().data.trim(), "two");
     }

--- a/docs/docs/ai/user-context.md
+++ b/docs/docs/ai/user-context.md
@@ -37,6 +37,10 @@ git status --short
 ```
 ````
 
+## Caching
+
+`TERMINAL.md` files are cached after they are first loaded; if you make changes to them mid-session, use the `/reload` slash command to refresh the data. This will invalidate the server cache on the next request, increasing the latency and token usage for that request.
+
 ## Why not `AGENTS.md`?
 
 Most agent files are optimized for _coding_ agents: patterns, tools, coding style, and so on. This is great for coding agents, but not as useful for general-purpose agents. By using `TERMINAL.md` instead, we can provide a more flexible way to send additional context that is not tied to coding-specific patterns. This allows users to provide any kind of context they want, without being constrained by the structure of an agent file.


### PR DESCRIPTION
This PR adds a cache for user contexts (`TERMINAL.md` files) that is populated on first load and reused across requests. This allows the server to cache requests that include them. The user can use the new `/reload` slash command to refresh this client-side cache, which will invalidate the next server request. This is called out in the docs.