### PR TITLE
feat: record shell per history entry

### DIFF
--- a/crates/atuin-ai/src/history_format.rs
+++ b/crates/atuin-ai/src/history_format.rs
@@ -98,6 +98,7 @@ mod tests {
             hostname: String::new(),
             author: String::new(),
             intent: None,
+            shell: None,
             deleted_at: None,
         }
     }

--- a/crates/atuin-client/migrations/20260604000000_history_shell.sql
+++ b/crates/atuin-client/migrations/20260604000000_history_shell.sql
@@ -1,0 +1,1 @@
+ALTER TABLE history ADD COLUMN shell TEXT;

--- a/crates/atuin-client/src/database.rs
+++ b/crates/atuin-client/src/database.rs
@@ -239,8 +239,8 @@ impl Sqlite {
 
     async fn save_raw(tx: &mut sqlx::Transaction<'_, sqlx::Sqlite>, h: &History) -> Result<()> {
         sqlx::query(
-            "insert or ignore into history(id, timestamp, duration, exit, command, cwd, session, hostname, author, intent, deleted_at)
-                values(?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11)",
+            "insert or ignore into history(id, timestamp, duration, exit, command, cwd, session, hostname, shell, author, intent, deleted_at)
+                values(?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12)",
         )
         .bind(h.id.0.as_str())
         .bind(h.timestamp.unix_timestamp_nanos() as i64)
@@ -250,6 +250,7 @@ impl Sqlite {
         .bind(h.cwd.as_str())
         .bind(h.session.as_str())
         .bind(h.hostname.as_str())
+        .bind(h.shell.as_deref())
         .bind(h.author.as_str())
         .bind(h.intent.as_deref())
         .bind(h.deleted_at.map(|t|t.unix_timestamp_nanos() as i64))
@@ -274,6 +275,8 @@ impl Sqlite {
     fn query_history(row: SqliteRow) -> History {
         let deleted_at: Option<i64> = row.get("deleted_at");
         let hostname: String = row.get("hostname");
+        let shell: Option<String> = row.try_get("shell").ok().flatten();
+        let shell = shell.filter(|s| !s.trim().is_empty());
         let author: Option<String> = row.try_get("author").ok().flatten();
         let author = author
             .filter(|author| !author.trim().is_empty())
@@ -293,6 +296,7 @@ impl Sqlite {
             .cwd(row.get("cwd"))
             .session(row.get("session"))
             .hostname(hostname)
+            .shell(shell)
             .author(author)
             .intent(intent)
             .deleted_at(
@@ -345,7 +349,7 @@ impl Database for Sqlite {
 
         sqlx::query(
             "update history
-                set timestamp = ?2, duration = ?3, exit = ?4, command = ?5, cwd = ?6, session = ?7, hostname = ?8, author = ?9, intent = ?10, deleted_at = ?11
+                set timestamp = ?2, duration = ?3, exit = ?4, command = ?5, cwd = ?6, session = ?7, hostname = ?8, shell = ?9, author = ?10, intent = ?11, deleted_at = ?12
                 where id = ?1",
         )
         .bind(h.id.0.as_str())
@@ -356,6 +360,7 @@ impl Database for Sqlite {
         .bind(h.cwd.as_str())
         .bind(h.session.as_str())
         .bind(h.hostname.as_str())
+        .bind(h.shell.as_deref())
         .bind(h.author.as_str())
         .bind(h.intent.as_deref())
         .bind(h.deleted_at.map(|t|t.unix_timestamp_nanos() as i64))

--- a/crates/atuin-client/src/encryption.rs
+++ b/crates/atuin-client/src/encryption.rs
@@ -255,6 +255,7 @@ fn decode(bytes: &[u8]) -> Result<History> {
         hostname: hostname.to_owned(),
         author: History::author_from_hostname(hostname),
         intent: None,
+        shell: None,
         deleted_at: deleted_at
             .map(|t| OffsetDateTime::parse(t, &Rfc3339))
             .transpose()?,
@@ -337,6 +338,7 @@ mod test {
             hostname: "fvfg936c0kpf:conrad.ludgate".to_owned(),
             author: "conrad.ludgate".to_owned(),
             intent: None,
+            shell: None,
             deleted_at: None,
         };
 
@@ -360,6 +362,7 @@ mod test {
             hostname: "fvfg936c0kpf:conrad.ludgate".to_owned(),
             author: "conrad.ludgate".to_owned(),
             intent: None,
+            shell: None,
             deleted_at: Some(datetime!(2023-05-28 18:35:40.633872 +00:00)),
         };
 
@@ -393,6 +396,7 @@ mod test {
             hostname: "fvfg936c0kpf:conrad.ludgate".to_owned(),
             author: "conrad.ludgate".to_owned(),
             intent: None,
+            shell: None,
             deleted_at: None,
         };
 

--- a/crates/atuin-client/src/history.rs
+++ b/crates/atuin-client/src/history.rs
@@ -656,6 +656,7 @@ mod tests {
             hostname: "fvfg936c0kpf:conrad.ludgate".to_owned(),
             author: "conrad.ludgate".to_owned(),
             intent: None,
+            shell: None,
             deleted_at: None,
         };
 
@@ -684,6 +685,7 @@ mod tests {
             hostname: "fvfg936c0kpf:conrad.ludgate".to_owned(),
             author: "conrad.ludgate".to_owned(),
             intent: None,
+            shell: None,
             deleted_at: Some(datetime!(2023-11-19 20:18 +00:00)),
         };
 
@@ -708,6 +710,7 @@ mod tests {
             hostname: "fvfg936c0kpf:conrad.ludgate".to_owned(),
             author: "claude".to_owned(),
             intent: Some("check repository status".to_owned()),
+            shell: None,
             deleted_at: None,
         };
 
@@ -750,6 +753,7 @@ mod tests {
             hostname: "fvfg936c0kpf:conrad.ludgate".to_owned(),
             author: "conrad.ludgate".to_owned(),
             intent: None,
+            shell: None,
             deleted_at: None,
         };
 

--- a/crates/atuin-client/src/history.rs
+++ b/crates/atuin-client/src/history.rs
@@ -93,6 +93,8 @@ pub struct History {
     pub session: String,
     /// The hostname of the machine the command was run on.
     pub hostname: String,
+    /// The shell in which the command was run (e.g. "bash", "zsh", "fish").
+    pub shell: Option<String>,
     /// Who wrote this command (human user or automation/agent identity).
     pub author: String,
     /// Optional rationale for why the command was executed.
@@ -148,6 +150,7 @@ impl History {
         duration: i64,
         session: Option<String>,
         hostname: Option<String>,
+        shell: Option<String>,
         author: Option<String>,
         intent: Option<String>,
         deleted_at: Option<OffsetDateTime>,
@@ -156,6 +159,7 @@ impl History {
             .or_else(|| env::var("ATUIN_SESSION").ok())
             .unwrap_or_else(|| uuid_v7().as_simple().to_string());
         let hostname = hostname.unwrap_or_else(get_host_user);
+        let shell = Self::normalize_optional_field(shell);
         let author = Self::normalize_optional_field(author)
             .or_else(|| Self::normalize_optional_field(env::var(HISTORY_AUTHOR_ENV).ok()))
             .unwrap_or_else(|| Self::author_from_hostname(hostname.as_str()));
@@ -171,6 +175,7 @@ impl History {
             duration,
             session,
             hostname,
+            shell,
             author,
             intent,
             deleted_at,
@@ -287,6 +292,7 @@ impl History {
             cwd: cwd.to_owned(),
             session: session.to_owned(),
             hostname: hostname.to_owned(),
+            shell: None,
             author: Self::author_from_hostname(hostname),
             intent: None,
             deleted_at: deleted_at
@@ -358,6 +364,7 @@ impl History {
             cwd: cwd.to_owned(),
             session: session.to_owned(),
             hostname: hostname.to_owned(),
+            shell: None,
             author: author.unwrap_or_else(|| Self::author_from_hostname(hostname)),
             intent,
             deleted_at: deleted_at

--- a/crates/atuin-client/src/history/builder.rs
+++ b/crates/atuin-client/src/history/builder.rs
@@ -21,6 +21,8 @@ pub struct HistoryImported {
     #[builder(default, setter(strip_option, into))]
     hostname: Option<String>,
     #[builder(default, setter(strip_option, into))]
+    shell: Option<String>,
+    #[builder(default, setter(strip_option, into))]
     author: Option<String>,
     #[builder(default, setter(strip_option, into))]
     intent: Option<String>,
@@ -36,6 +38,7 @@ impl From<HistoryImported> for History {
             imported.duration,
             imported.session,
             imported.hostname,
+            imported.shell,
             imported.author,
             imported.intent,
             None,
@@ -56,6 +59,8 @@ pub struct HistoryCaptured {
     #[builder(setter(into))]
     cwd: String,
     #[builder(default, setter(strip_option, into))]
+    shell: Option<String>,
+    #[builder(default, setter(strip_option, into))]
     author: Option<String>,
     #[builder(default, setter(strip_option, into))]
     intent: Option<String>,
@@ -71,6 +76,7 @@ impl From<HistoryCaptured> for History {
             -1,
             None,
             None,
+            captured.shell,
             captured.author,
             captured.intent,
             None,
@@ -91,6 +97,8 @@ pub struct HistoryFromDb {
     duration: i64,
     session: String,
     hostname: String,
+    #[builder(default)]
+    shell: Option<String>,
     author: String,
     intent: Option<String>,
     deleted_at: Option<time::OffsetDateTime>,
@@ -107,6 +115,7 @@ impl From<HistoryFromDb> for History {
             duration: from_db.duration,
             session: from_db.session,
             hostname: from_db.hostname,
+            shell: from_db.shell,
             author: from_db.author,
             intent: from_db.intent,
             deleted_at: from_db.deleted_at,
@@ -131,6 +140,8 @@ pub struct HistoryDaemonCapture {
     #[builder(setter(into))]
     hostname: String,
     #[builder(default, setter(strip_option, into))]
+    shell: Option<String>,
+    #[builder(default, setter(strip_option, into))]
     author: Option<String>,
     #[builder(default, setter(strip_option, into))]
     intent: Option<String>,
@@ -146,6 +157,7 @@ impl From<HistoryDaemonCapture> for History {
             -1,
             Some(captured.session),
             Some(captured.hostname),
+            captured.shell,
             captured.author,
             captured.intent,
             None,

--- a/crates/atuin-client/src/history/store.rs
+++ b/crates/atuin-client/src/history/store.rs
@@ -392,6 +392,7 @@ mod tests {
             hostname: "boop:ellie".to_owned(),
             author: "ellie".to_owned(),
             intent: None,
+            shell: None,
             deleted_at: None,
         };
 

--- a/crates/atuin-client/src/history/store.rs
+++ b/crates/atuin-client/src/history/store.rs
@@ -20,6 +20,7 @@ pub struct HistoryStore {
 }
 
 #[derive(Debug, Eq, PartialEq, Clone)]
+#[allow(clippy::large_enum_variant)]
 pub enum HistoryRecord {
     Create(History),   // Create a history record
     Delete(HistoryId), // Delete a history record, identified by ID

--- a/crates/atuin-daemon/src/components/semantic.rs
+++ b/crates/atuin-daemon/src/components/semantic.rs
@@ -639,6 +639,7 @@ mod tests {
             hostname: String::new(),
             author: String::new(),
             intent: None,
+            shell: None,
             deleted_at: None,
         }
     }

--- a/crates/atuin/src/command/client/history.rs
+++ b/crates/atuin/src/command/client/history.rs
@@ -51,6 +51,10 @@ pub enum Cmd {
         #[arg(long = "command-from-env", hide = true)]
         cmd_env: bool,
 
+        /// The shell in which this command was run (e.g. bash, zsh, fish)
+        #[arg(long)]
+        shell: Option<String>,
+
         /// Author of this command, eg `ellie`, `claude`, or `copilot`
         #[arg(long)]
         author: Option<String>,
@@ -374,7 +378,16 @@ fn parse_fmt(format: &str) -> ParsedFmt<'_> {
     }
 }
 
-fn apply_start_metadata(history: &mut History, author: Option<&str>, intent: Option<&str>) {
+fn apply_start_metadata(
+    history: &mut History,
+    shell: Option<&str>,
+    author: Option<&str>,
+    intent: Option<&str>,
+) {
+    if let Some(shell) = shell.map(str::trim).filter(|s| !s.is_empty()) {
+        history.shell = Some(shell.to_owned());
+    }
+
     if let Some(author) = author.map(str::trim).filter(|author| !author.is_empty()) {
         author.clone_into(&mut history.author);
     }
@@ -414,6 +427,7 @@ async fn handle_start(
     db: &impl Database,
     settings: &Settings,
     command: &str,
+    shell: Option<&str>,
     author: Option<&str>,
     intent: Option<&str>,
 ) -> Result<Option<String>> {
@@ -428,7 +442,7 @@ async fn handle_start(
         .cwd(cwd)
         .build()
         .into();
-    apply_start_metadata(&mut h, author, intent);
+    apply_start_metadata(&mut h, shell, author, intent);
 
     if !h.should_save(settings) {
         return Ok(None);
@@ -449,6 +463,7 @@ async fn handle_start(
 async fn handle_daemon_start(
     settings: &Settings,
     command: &str,
+    shell: Option<&str>,
     author: Option<&str>,
     intent: Option<&str>,
 ) -> Result<Option<String>> {
@@ -463,7 +478,7 @@ async fn handle_daemon_start(
         .cwd(cwd)
         .build()
         .into();
-    apply_start_metadata(&mut h, author, intent);
+    apply_start_metadata(&mut h, shell, author, intent);
 
     if !h.should_save(settings) {
         return Ok(None);
@@ -565,17 +580,18 @@ async fn handle_daemon_end(
 pub(super) async fn start_history_entry(
     settings: &Settings,
     command: &str,
+    shell: Option<&str>,
     author: Option<&str>,
     intent: Option<&str>,
 ) -> Result<Option<String>> {
     #[cfg(feature = "daemon")]
     if settings.daemon.enabled {
-        return handle_daemon_start(settings, command, author, intent).await;
+        return handle_daemon_start(settings, command, shell, author, intent).await;
     }
 
     let db_path = PathBuf::from(settings.db_path.as_str());
     let db = Sqlite::new(db_path, settings.local_timeout).await?;
-    handle_start(&db, settings, command, author, intent).await
+    handle_start(&db, settings, command, shell, author, intent).await
 }
 
 pub(super) async fn end_history_entry(
@@ -1097,6 +1113,7 @@ impl Cmd {
         match self {
             Self::Start {
                 cmd_env,
+                shell,
                 author,
                 intent,
                 command,
@@ -1107,9 +1124,14 @@ impl Cmd {
                     command.join(" ")
                 };
 
-                if let Some(id) =
-                    start_history_entry(settings, &command, author.as_deref(), intent.as_deref())
-                        .await?
+                if let Some(id) = start_history_entry(
+                    settings,
+                    &command,
+                    shell.as_deref(),
+                    author.as_deref(),
+                    intent.as_deref(),
+                )
+                .await?
                 {
                     println!("{id}");
                 }
@@ -1251,7 +1273,7 @@ mod tests {
         let db = Sqlite::new("sqlite::memory:", 2.0).await.unwrap();
         let settings = Settings::utc();
 
-        handle_start(&db, &settings, "ls   \t", None, None)
+        handle_start(&db, &settings, "ls   \t", None, None, None)
             .await
             .unwrap();
 
@@ -1272,7 +1294,7 @@ mod tests {
             ..Settings::utc()
         };
 
-        handle_start(&db, &settings, "ls   \t", None, None)
+        handle_start(&db, &settings, "ls   \t", None, None, None)
             .await
             .unwrap();
 

--- a/crates/atuin/src/command/client/history.rs
+++ b/crates/atuin/src/command/client/history.rs
@@ -697,6 +697,7 @@ impl TailEvent {
                 hostname: history.hostname,
                 author: history.author,
                 intent: normalize_optional_field(&history.intent),
+                shell: None,
                 deleted_at: None,
             },
         })
@@ -1338,6 +1339,7 @@ mod tests {
                 hostname: "host:ellie".to_owned(),
                 author: "claude".to_owned(),
                 intent: Some("inspect repository state".to_owned()),
+                shell: None,
                 deleted_at: None,
             },
         }

--- a/crates/atuin/src/command/client/hook.rs
+++ b/crates/atuin/src/command/client/hook.rs
@@ -211,6 +211,7 @@ async fn handle(agent_name: &str, settings: &Settings) -> Result<()> {
             if let Some(history_id) = history::start_history_entry(
                 settings,
                 &command,
+                None,
                 Some(agent.actor_name()),
                 intent.as_deref(),
             )

--- a/crates/atuin/src/command/client/search/inspector.rs
+++ b/crates/atuin/src/command/client/search/inspector.rs
@@ -357,6 +357,7 @@ mod tests {
             hostname: "hostn".to_string(),
             author: "hostn".to_string(),
             intent: None,
+            shell: None,
             deleted_at: None,
         };
         let next = History {
@@ -370,6 +371,7 @@ mod tests {
             hostname: "hostn".to_string(),
             author: "hostn".to_string(),
             intent: None,
+            shell: None,
             deleted_at: None,
         };
         let prev = History {
@@ -383,6 +385,7 @@ mod tests {
             hostname: "hostn".to_string(),
             author: "hostn".to_string(),
             intent: None,
+            shell: None,
             deleted_at: None,
         };
         let stats = HistoryStats {


### PR DESCRIPTION
Closes #608.

## Changes

Adds a nullable `shell` column to history so each command carries the shell it was run in.

### Database (`atuin-client`)
- New migration `20260604000000_history_shell.sql`: `ALTER TABLE history ADD COLUMN shell TEXT`
- `history.rs`: `shell: Option<String>` field on `History`; `new()` wires it through
- `history/builder.rs`: `shell` in all four builders (`from_db`, `from_db_with_prefix`, `new`, `import`)
- `database.rs`: `shell` column in `INSERT` / `UPDATE` / `query_history` `SELECT`

### CLI (`atuin`)
- `atuin history start --shell <SHELL>` flag added; threaded through `handle_start` → `apply_start_metadata` → `History::new`

## Example

```sh
atuin history start --shell zsh "git status"
```

The stored entry will have `shell = "zsh"`. Legacy entries without the column default to `NULL`.