### PR TITLE
fix(pty-proxy): forward terminal pixel size to the child pty

### DIFF
--- a/crates/atuin-pty-proxy/src/runtime.rs
+++ b/crates/atuin-pty-proxy/src/runtime.rs
@@ -19,16 +19,31 @@ pub(crate) fn main(options: RuntimeOptions) {
     }
 }
 
+/// Terminal size including pixel dimensions: `(cols, rows, pixel_width, pixel_height)`.
+///
+/// We forward the controlling terminal's pixel width/height to the child pty so
+/// programs inside (e.g. image.nvim) can derive the cell size in pixels via
+/// TIOCGWINSZ. `terminal::size()` only returns cols/rows, which would leave the
+/// child's `ws_xpixel`/`ws_ypixel` at 0 — making HiDPI terminals look like an
+/// 8x16 cell and render inline images too small. `window_size()` includes the
+/// pixels; fall back to cols/rows (pixels 0) on terminals that don't report them.
+fn query_size() -> (u16, u16, u16, u16) {
+    match terminal::window_size() {
+        Ok(ws) => (ws.columns, ws.rows, ws.width, ws.height),
+        Err(_) => terminal::size().map_or((80, 24, 0, 0), |(c, r)| (c, r, 0, 0)),
+    }
+}
+
 fn run(options: RuntimeOptions) -> eyre::Result<()> {
-    let (cols, rows) = terminal::size()?;
+    let (cols, rows, pixel_width, pixel_height) = query_size();
 
     let pty_system = native_pty_system();
     let pair = pty_system
         .openpty(PtySize {
             rows,
             cols,
-            pixel_width: 0,
-            pixel_height: 0,
+            pixel_width,
+            pixel_height,
         })
         .map_err(|e| eyre::eyre!("{e:#}"))?;
 
@@ -146,16 +161,15 @@ fn spawn_resize_handler(
 
     std::thread::spawn(move || {
         for _ in signals.forever() {
-            if let Ok((cols, rows)) = terminal::size() {
-                current_cols.store(cols.max(1), Ordering::Relaxed);
-                let _ = master.resize(PtySize {
-                    rows,
-                    cols,
-                    pixel_width: 0,
-                    pixel_height: 0,
-                });
-                let _ = resize_tx.try_send(Msg::Resize { rows, cols });
-            }
+            let (cols, rows, pixel_width, pixel_height) = query_size();
+            current_cols.store(cols.max(1), Ordering::Relaxed);
+            let _ = master.resize(PtySize {
+                rows,
+                cols,
+                pixel_width,
+                pixel_height,
+            });
+            let _ = resize_tx.try_send(Msg::Resize { rows, cols });
         }
     });
 


### PR DESCRIPTION
## What

Forward the controlling terminal's pixel dimensions to the child pty in
`atuin pty-proxy`.

The pty was created (and resized on `SIGWINCH`) with `pixel_width: 0` /
`pixel_height: 0`, because `crossterm::terminal::size()` only reports
columns/rows. With zero pixel dimensions, programs inside the proxy that query
`TIOCGWINSZ` (e.g. `image.nvim`) fall back to an assumed ~8×16 cell, so inline
images render far too small on HiDPI terminals.

This switches to `terminal::window_size()`, which includes `ws_xpixel` /
`ws_ypixel`, and forwards those to the child pty both at startup and on every
resize. It falls back to cols/rows (pixels `0`) on terminals that don't report
pixel size.

## Why

Zero pixel dimensions break inline image rendering for terminal programs that
rely on the kernel-reported cell pixel size.

## Testing

- `cargo build` / `cargo test` / `cargo clippy` for `atuin-pty-proxy` (all pass).
- Manually verified inline images (image.nvim) render at the correct size inside
  `atuin pty-proxy` on a HiDPI terminal.

## Checks
- [x] I am happy for maintainers to push small adjustments to this PR, to speed up the review cycle
- [x] I have checked that there are no existing pull requests for the same thing
