### PR TITLE
fix(nu): use `char -u 1b` for ESC in OSC 133 sequences

### DIFF
--- a/crates/atuin/src/shell/atuin.nu
+++ b/crates/atuin/src/shell/atuin.nu
@@ -22,7 +22,7 @@ def _atuin_osc133_command_executed [] {
         return
     }
 
-    print -n $"(char esc)]133;C(char bel)"
+    print -n $"(char -u '1b')]133;C(char bel)"
 }
 
 def _atuin_osc133_command_finished [exit_code: int] {
@@ -33,7 +33,7 @@ def _atuin_osc133_command_finished [exit_code: int] {
         return
     }
 
-    print -n $"(char esc)]133;D;($exit_code);history_id=($env.ATUIN_HISTORY_ID);session_id=($env.ATUIN_SESSION)(char bel)"
+    print -n $"(char -u '1b')]133;D;($exit_code);history_id=($env.ATUIN_HISTORY_ID);session_id=($env.ATUIN_SESSION)(char bel)"
 }
 
 # Magic token to make sure we don't record commands run by keybindings


### PR DESCRIPTION
## Problem

The OSC 133 helpers added to `crates/atuin/src/shell/atuin.nu` in #3510 call `(char esc)`, but `esc` is **not a valid named character in Nushell** — it has never existed in the `char` command's named-character map. The map goes `bel` → `backspace` → `file_separator`, with no entry for ESC (`\x1b`).

As a result, `_atuin_osc133_command_executed` and `_atuin_osc133_command_finished` error on **every** Nushell version when the pty-proxy is active:

```
Error: nu::shell::type_mismatch

  × Type mismatch.
     print -n $"(char esc)]133;C(char bel)"
                      ^^^ error finding named character
```

You can confirm `esc` is absent from the available names with `char --list`.

## Fix

Emit ESC by its Unicode codepoint via `char -u 1b` (`char --unicode`), which is supported across Nushell versions. `(char bel)` is left as-is since `bel` *is* a valid named character.

## Testing

`atuin init nu` output now sources without error, and OSC 133 command/finished markers are emitted correctly.