### PR TITLE
Add 'opencode' to KNOWN_AGENTS list

### DIFF
--- a/crates/atuin-client/src/history.rs
+++ b/crates/atuin-client/src/history.rs
@@ -19,7 +19,7 @@ mod builder;
 pub mod store;
 
 /// Known AI agent author values. Used to expand `$all-agent` and `$all-user` filters.
-pub const KNOWN_AGENTS: &[&str] = &["claude-code", "codex", "copilot", "pi"];
+pub const KNOWN_AGENTS: &[&str] = &["claude-code", "codex", "copilot", "opencode", "pi"];
 pub const AUTHOR_FILTER_ALL_USER: &str = "$all-user";
 pub const AUTHOR_FILTER_ALL_AGENT: &str = "$all-agent";
 

--- a/docs/docs/configuration/config.md
+++ b/docs/docs/configuration/config.md
@@ -597,7 +597,7 @@ Special values:
 | `$all-user` | Commands from any author that is **not** a known AI agent |
 | `$all-agent` | Commands from any known AI agent |
 
-You can also use literal author names like `"claude-code"`, `"codex"`, or `"pi"`.
+You can also use literal author names like `"claude-code"`, `"codex"`, `"opencode"`, or `"pi"`.
 
 ```toml
 [search]

--- a/docs/docs/guide/agent-hooks.md
+++ b/docs/docs/guide/agent-hooks.md
@@ -70,7 +70,7 @@ atuin search -- ''
 atuin search --author '$all-agent' -- ''
 ```
 
-Currently recognized agent names are: `claude-code`, `codex`, `copilot`, and `pi`.
+Currently recognized agent names are: `claude-code`, `codex`, `copilot`, `opencode`, and `pi`.
 
 ## Supported Agents
 


### PR DESCRIPTION
Fixes #3532

Atuin's interactive search now has agent hooks for other CLIs (claude-code, codex, copilot, pi) so users can filter agent commands with `--author $all-user`. OpenCode lacks a built-in agent hook, so users with a custom atuin plugin who record their agent's commands under `author = "opencode"` are unable to filter them.

Adding `"opencode"` to `KNOWN_AGENTS` ensures those commands are properly excluded when using the `--author $all-user` filter.

**Changes:**
* `crates/atuin-client/src/history.rs`: Add `"opencode"` to `KNOWN_AGENTS`
* `docs/docs/guide/agent-hooks.md`: Update recognized agent names list
* `docs/docs/configuration/config.md`: Add `"opencode"` to literal author names example