### PR TITLE
Fix command example typo in documentation

### DIFF
--- a/docs/docs/guide/agent-hooks.md
+++ b/docs/docs/guide/agent-hooks.md
@@ -106,10 +106,10 @@ After installing hooks and restarting your agent, run a command through the agen
 
 ```shell
 # Show all history including agent commands
-atuin search --authors '' -- ''
+atuin search --author '' -- ''
 
 # Show only agent commands
-atuin search --authors '$all-agent' -- ''
+atuin search --author '$all-agent' -- ''
 ```
 
 You can also check the agent's config file directly to confirm the hooks are registered:


### PR DESCRIPTION
This one took a moment to realize since undefined flags don't actually throw an error e.g.
```sh
> atuin search --banana '$all-agent'
2026-06-18 14:05:01     atuin search --banana '$all-agent'      0s
```

## Checks
- [x] I am happy for maintainers to push small adjustments to this PR, to speed up the review cycle
- [x] I have checked that there are no existing pull requests for the same thing
