### PR TITLE
fix(nu): ignore missing history id in pre-prompt

### DIFF
--- a/crates/atuin/src/shell/atuin.nu
+++ b/crates/atuin/src/shell/atuin.nu
@@ -69,7 +69,7 @@ let _atuin_pre_prompt = {||
         }
 
     }
-    hide-env ATUIN_HISTORY_ID
+    hide-env -i ATUIN_HISTORY_ID
 }
 
 def _atuin_search_cmd [...flags: string] {


### PR DESCRIPTION
Fixes #3520.

This changes the Nushell pre-prompt hook to use `hide-env -i ATUIN_HISTORY_ID`, matching the startup cleanup above it. That keeps overlay/subshell prompts from erroring when `ATUIN_HISTORY_ID` is already absent.

## Checks
- [x] I am happy for maintainers to push small adjustments to this PR, to speed up the review cycle
- [x] I have checked that there are no existing pull requests for the same thing

Verification:
- `git diff --check`
- `nu` was not available in this runner, so I could not run a local Nushell source smoke test.
