### PR TITLE
fix(pty-proxy): set $SHELL to the spawned shell

### DIFF
--- a/crates/atuin-pty-proxy/src/runtime.rs
+++ b/crates/atuin-pty-proxy/src/runtime.rs
@@ -40,6 +40,13 @@ fn run(options: RuntimeOptions) -> eyre::Result<()> {
         None => CommandBuilder::new_default_prog(),
     };
     cmd.cwd(std::env::current_dir()?);
+    // Reflect the shell we actually spawn in `$SHELL` so the child — and
+    // anything it execs via `$SHELL -c` (e.g. fzf's `become`) — sees the
+    // shell the user asked for instead of a stale value inherited from the
+    // parent environment.
+    if let Some(ref path) = options.shell {
+        cmd.env("SHELL", path);
+    }
     cmd.env("ATUIN_PTY_PROXY_SOCKET", sock_path.as_os_str());
     cmd.env("ATUIN_PTY_PROXY_ACTIVE", "1");
 


### PR DESCRIPTION
The proxy spawns the inner shell (optionally overridden via --shell) but only sets ATUIN_PTY_PROXY_{SOCKET,ACTIVE} on it, never SHELL. So the child — and anything it execs via `$SHELL -c` such as fzf's `become` — inherits whatever SHELL leaked down the parent/login chain rather than the shell actually running. Set SHELL to the --shell path so downstream tools resolve the correct interpreter.

<!-- Thank you for making a PR! Bug fixes are always welcome, but if you're adding a new feature or changing an existing one, we'd really appreciate if you open an issue, post on the forum, or drop in on Discord -->

## Checks
- [x] I am happy for maintainers to push small adjustments to this PR, to speed up the review cycle
- [x] I have checked that there are no existing pull requests for the same thing
