### PR TITLE
perf: deduplicate empty-query results in Rust instead of SQL

### DIFF
--- a/crates/atuin/src/command/client/search/engines.rs
+++ b/crates/atuin/src/command/client/search/engines.rs
@@ -72,6 +72,7 @@ pub trait SearchEngine: Send + Sync + 'static {
 
     async fn query(&mut self, state: &SearchState, db: &mut dyn Database) -> Result<Vec<History>> {
         if state.input.as_str().is_empty() {
+            let mut seen = std::collections::HashSet::new();
             Ok(db
                 .search(
                     SearchMode::FullText,
@@ -80,13 +81,15 @@ pub trait SearchEngine: Send + Sync + 'static {
                     "",
                     OptFilters {
                         limit: Some(200),
+                        include_duplicates: true,
                         authors: vec![AUTHOR_FILTER_ALL_USER.to_string()],
                         ..Default::default()
                     },
                 )
                 .await?
                 .into_iter()
-                .collect::<Vec<_>>())
+                .filter(|h| seen.insert(h.command.clone()))
+                .collect())
         } else {
             self.full_query(state, db).await
         }


### PR DESCRIPTION
Move deduplication from SQL `GROUP BY` to a Rust `HashSet` for the empty-input query path in `SearchEngine::query`. This avoids the very expensive SQL-level aggregate computation.

**NOTE**: The performance problem and the code was found and generated by AI (OpenCode Big Pickle), but I made sure to verify all edge cases I could think of.

## Behavior change

The `LIMIT 200` is now applied before deduplication (on raw rows), so results may differ when the most recent 200 rows contain fewer than 200 unique commands. The previous `GROUP BY` would deduplicate first, always returning up to 200 unique entries.
This could be somewhat mitigated by simply fetching more rows.  
I think most users won't even notice a difference, but there's room for discussion.

## Benchmarks
My personal 3 year old database:
- `history.db` is `130M`
- `atuin stats`:
```
[▮▮▮▮▮▮▮▮▮▮] 45929 vim
[▮▮▮▮▮▮▮▮▮ ] 44123 cd
[▮▮▮▮▮▮▮▮▮ ] 44099 ls
[▮▮▮       ] 15974 j
[▮▮        ]  9954 lazygit
[▮▮        ]  9633 sh
[▮         ]  8823 npm run
[▮         ]  8387 rm
[▮         ]  5871 bun
[▮         ]  5719 tsc
Total commands:   314471
Unique commands:  59018
```
Using `hyper --warmup 3 --min-runs 10` and a custom python script to start `atuin search -i` and exit after first displayed frame.  
CPU: `AMD Ryzen 7 5700G (16) @ 4.85 GHz`
Old `atuin 18.16.1`:
```
Time (mean ± σ):     402.1 ms ±   4.2 ms    [User: 276.8 ms, System: 125.1 ms]
Range (min … max):   397.6 ms … 411.6 ms    10 runs
```
New:
```
Time (mean ± σ):      48.8 ms ±   0.5 ms    [User: 31.8 ms, System: 18.1 ms]
Range (min … max):    47.7 ms …  50.0 ms    59 runs
```
About ~10x improvement

## Default or option toggle

Should this be put behind a config toggle?  
I think this should be enabled by default, but I'm open to adding a toggle that forces the old behavior.