### PR TITLE
fix: doctor resiliency fo runknown platforms + openbsd warning

### DIFF
--- a/crates/atuin/src/command/client/doctor.rs
+++ b/crates/atuin/src/command/client/doctor.rs
@@ -167,18 +167,31 @@ impl ShellInfo {
             .collect()
     }
 
+    fn unknown() -> Self {
+        let name = Shell::Unknown.to_string();
+        let default = Shell::default_shell().unwrap_or(Shell::Unknown).to_string();
+        let preexec = Self::detect_preexec_framework(name.as_str());
+
+        Self {
+            name,
+            default,
+            plugins: Vec::new(),
+            preexec,
+        }
+    }
+
     pub fn new() -> Self {
         // TODO: rework to use atuin_common::Shell
 
         let sys = System::new_all();
 
-        let process = sys
-            .process(get_current_pid().expect("Failed to get current PID"))
-            .expect("Process with current pid does not exist");
+        let Some(process) = get_current_pid().ok().and_then(|pid| sys.process(pid)) else {
+            return Self::unknown();
+        };
 
-        let parent = sys
-            .process(process.parent().expect("Atuin running with no parent!"))
-            .expect("Process with parent pid does not exist");
+        let Some(parent) = process.parent().and_then(|pid| sys.process(pid)) else {
+            return Self::unknown();
+        };
 
         let name = shell_name(Some(parent));
 
@@ -383,6 +396,11 @@ fn checks(info: &DoctorDump) {
     let zfs_error = "[Filesystem] ZFS is known to have some issues with SQLite. Atuin uses SQLite heavily. If you are having poor performance, there are some workarounds here: https://github.com/atuinsh/atuin/issues/952".bold().red();
     let bash_plugin_error = "[Shell] If you are using Bash, Atuin requires that either bash-preexec or ble.sh (>= 0.4) be installed. An older ble.sh may not be detected. so ignore this if you have ble.sh >= 0.4 set up! Read more here: https://docs.atuin.sh/guide/installation/#bash".bold().red();
     let blesh_integration_error = "[Shell] Atuin and ble.sh seem to be loaded in the session, but the integration does not seem to be working. Please check the setup in .bashrc.".bold().red();
+    let openbsd_warning = "[System] OpenBSD is not officially supported.".bold().red();
+
+    if cfg!(target_os = "openbsd") {
+        println!("{openbsd_warning}");
+    }
 
     // ZFS: https://github.com/atuinsh/atuin/issues/952
     if info.system.disks.iter().any(|d| d.filesystem == "zfs") {


### PR DESCRIPTION
Resolve #3527

I do not have access to OpenBSD, so cannot do a more specific solution. I am very open to PRs improving our OpenBSD support

This change improves our resiliency on platforms where our usual detection does not work, and also includes a warning for openbsd

## Checks
- [ ] I am happy for maintainers to push small adjustments to this PR, to speed up the review cycle
- [ ] I have checked that there are no existing pull requests for the same thing
