### PR TITLE
fix: Double input on arrow keys in AI setup prompt on Windows

### DIFF
--- a/crates/atuin-ai/src/commands/inline.rs
+++ b/crates/atuin-ai/src/commands/inline.rs
@@ -426,7 +426,7 @@ enum SetupChoice {
 fn prompt_ai_setup() -> Result<SetupChoice> {
     use crossterm::{
         cursor,
-        event::{self, Event, KeyCode},
+        event::{self, Event, KeyCode, KeyEventKind},
         terminal,
     };
 
@@ -460,6 +460,9 @@ fn prompt_ai_setup() -> Result<SetupChoice> {
         crossterm::execute!(stdout, cursor::MoveUp(options.len() as u16))?;
 
         if let Event::Key(key) = ev {
+            if key.kind != KeyEventKind::Press {
+                continue;
+            }
             match key.code {
                 KeyCode::Up | KeyCode::Char('k') => {
                     selected = selected.saturating_sub(1);


### PR DESCRIPTION
<!-- Thank you for making a PR! Bug fixes are always welcome, but if you're adding a new feature or changing an existing one, we'd really appreciate if you open an issue, post on the forum, or drop in on Discord -->


## Checks
- [x] I am happy for maintainers to push small adjustments to this PR, to speed up the review cycle
- [x] I have checked that there are no existing pull requests for the same thing

## Description

When pressing the Up/Down arrow keys in the Atuin AI setup prompt (`?`) on Windows (e.g., Git Bash / msys2), the cursor moves twice per physical keystroke.

This prevents the user from selecting the `Disable ? Keybind` option, which is located in the middle of the list.

```sh
~

  Atuin AI is not yet configured.

  > Enable Atuin AI
    Disable ? Keybind
    Cancel
```

## To Reproduce

1. Open Git Bash / msys2 on Windows.
2. Press `?` to trigger the AI setup prompt.
3. Press the Down arrow key once.
4. The cursor jumps two lines instead of one.

## Fix

This is a [known `crossterm` behavior on Windows](https://github.com/crossterm-rs/crossterm/issues/797). Since `crossterm` 0.26, it emits both `KeyEventKind::Press` and `KeyEventKind::Release` events on Windows. 

In `prompt_ai_setup`, the event loop ignores `KeyEventKind`. Both the press and release events trigger the cursor movement.

So the fix is: Filter for `KeyEventKind::Press` in the event loop.
