### PR TITLE
fix(search): add enhanced_keyboard option to fix IME Enter commit

### DIFF
--- a/crates/atuin-client/config.toml
+++ b/crates/atuin-client/config.toml
@@ -171,6 +171,12 @@
 ## This applies for new installs. Old installs will keep the old behaviour unless configured otherwise.
 enter_accept = true
 
+## Defaults to true. Enables the kitty keyboard enhancement protocol for the search TUI,
+## which makes modifier and F-key reporting unambiguous. If you use a CJK input method
+## (Chinese/Japanese/Korean) in iTerm2 and pressing Enter runs a command instead of
+## committing your input into the search box, set this to false.
+# enhanced_keyboard = true
+
 ## Defaults to false. If enabled, when triggered after &&, || or |, Atuin will complete commands to chain rather than replace the current line.
 # command_chaining = false
 

--- a/crates/atuin-client/src/settings.rs
+++ b/crates/atuin-client/src/settings.rs
@@ -1133,6 +1133,7 @@ pub struct Settings {
     pub network_timeout: u64,
     pub local_timeout: f64,
     pub enter_accept: bool,
+    pub enhanced_keyboard: bool,
     pub smart_sort: bool,
     pub command_chaining: bool,
 
@@ -1531,6 +1532,7 @@ impl Settings {
             // muscle memory.
             // New users will get the new default, that is more similar to what they are used to.
             .set_default("enter_accept", false)?
+            .set_default("enhanced_keyboard", true)?
             .set_default("sync.records", true)?
             .set_default("keys.scroll_exits", true)?
             .set_default("keys.accept_past_line_end", true)?

--- a/crates/atuin/src/command/client/search/interactive.rs
+++ b/crates/atuin/src/command/client/search/interactive.rs
@@ -1493,10 +1493,11 @@ struct Stdout {
     writer: TerminalWriter,
     inline_mode: bool,
     no_mouse: bool,
+    enhanced_keyboard: bool,
 }
 
 impl Stdout {
-    pub fn new(inline_mode: bool, no_mouse: bool) -> std::io::Result<Self> {
+    pub fn new(inline_mode: bool, no_mouse: bool, enhanced_keyboard: bool) -> std::io::Result<Self> {
         terminal::enable_raw_mode()?;
 
         let mut writer = TerminalWriter::new()?;
@@ -1511,29 +1512,38 @@ impl Stdout {
 
         execute!(writer, event::EnableBracketedPaste)?;
 
-        #[cfg(not(target_os = "windows"))]
-        execute!(
-            writer,
-            PushKeyboardEnhancementFlags(
-                KeyboardEnhancementFlags::DISAMBIGUATE_ESCAPE_CODES
-                    | KeyboardEnhancementFlags::REPORT_ALL_KEYS_AS_ESCAPE_CODES
-                    | KeyboardEnhancementFlags::REPORT_ALTERNATE_KEYS
-            ),
-        )?;
+        // The kitty keyboard enhancement protocol makes modifier/F-key reporting
+        // unambiguous, but on some terminals (e.g. iTerm2) it causes Enter during
+        // an active IME composition to be reported to us instead of committing the
+        // IME text. `enhanced_keyboard = false` restores normal IME handling.
+        if enhanced_keyboard {
+            #[cfg(not(target_os = "windows"))]
+            execute!(
+                writer,
+                PushKeyboardEnhancementFlags(
+                    KeyboardEnhancementFlags::DISAMBIGUATE_ESCAPE_CODES
+                        | KeyboardEnhancementFlags::REPORT_ALL_KEYS_AS_ESCAPE_CODES
+                        | KeyboardEnhancementFlags::REPORT_ALTERNATE_KEYS
+                ),
+            )?;
+        }
 
         Ok(Self {
             writer,
             inline_mode,
             no_mouse,
+            enhanced_keyboard,
         })
     }
 }
 
 impl Drop for Stdout {
     fn drop(&mut self) {
-        #[cfg(not(target_os = "windows"))]
-        if let Err(e) = execute!(self.writer, PopKeyboardEnhancementFlags) {
-            tracing::error!(?e, "Failed to pop keyboard enhancement flags");
+        if self.enhanced_keyboard {
+            #[cfg(not(target_os = "windows"))]
+            if let Err(e) = execute!(self.writer, PopKeyboardEnhancementFlags) {
+                tracing::error!(?e, "Failed to pop keyboard enhancement flags");
+            }
         }
 
         if !self.inline_mode
@@ -1683,7 +1693,7 @@ pub async fn history(
 
     let popup_mode = saved_screen.is_some();
 
-    let stdout = Stdout::new(inline_height > 0, settings.no_mouse)?;
+    let stdout = Stdout::new(inline_height > 0, settings.no_mouse, settings.enhanced_keyboard)?;
 
     // In popup mode, clear the popup region on the physical terminal before
     // ratatui takes over. Ratatui's diff-based rendering compares against an

--- a/docs/docs/configuration/config.md
+++ b/docs/docs/configuration/config.md
@@ -468,8 +468,6 @@ change to be the default for everyone in a later release.
 
 ### `enhanced_keyboard`
 
-Atuin version: >= 18.17
-
 Default: `true`
 
 Enables the [kitty keyboard enhancement

--- a/docs/docs/configuration/config.md
+++ b/docs/docs/configuration/config.md
@@ -466,6 +466,22 @@ This technically defaults to true for new users, but false for existing. We
 have set `enter_accept = true` in the default config file. This is likely to
 change to be the default for everyone in a later release.
 
+### `enhanced_keyboard`
+
+Atuin version: >= 18.17
+
+Default: `true`
+
+Enables the [kitty keyboard enhancement
+protocol](https://sw.kovidgoyal.net/kitty/keyboard-protocol/) in the interactive
+search TUI. This makes modifier keys (including `Cmd`/`Super`) and F1-F24 keys
+report unambiguously. On some terminals (notably iTerm2), this protocol changes
+how keys are delivered so that pressing Enter while a CJK input method (Chinese,
+Japanese, Korean, etc.) is composing will run the highlighted command instead of
+committing the composed text into the search box. If you use such an input method
+and find that Enter is being captured, set this to `false` to restore normal IME
+handling.
+
 ### `keymap_mode`
 
 Atuin version: >= 18.0


### PR DESCRIPTION
Fixes #3558.

## Summary

The interactive search TUI enables the [kitty keyboard enhancement protocol](https://sw.kovidgoyal.net/kitty/keyboard-protocol/). On terminals that implement it (e.g. iTerm2), this causes **Enter during an active IME composition to be reported to Atuin instead of committing the composed text** into the search box. CJK users (Chinese / Japanese / Korean) who type a search term and press Enter see the highlighted command run instead, and the typed letters are lost. A normal shell prompt is unaffected because it does not enable the protocol.

This PR adds a new `enhanced_keyboard` setting (default `true`, preserving existing behavior) that gates the `PushKeyboardEnhancementFlags` / `PopKeyboardEnhancementFlags` calls. Setting `enhanced_keyboard = false` restores the terminal's normal key handling so IME commits on Enter work again.

## Changes

- `atuin-client/src/settings.rs`: add `enhanced_keyboard: bool` with default `true`.
- `command/client/search/interactive.rs`: thread the setting into `Stdout`, and only push/pop the keyboard enhancement flags when it is enabled (so we never pop a level we did not push).
- `atuin-client/config.toml` template + `docs/docs/configuration/config.md`: document the new option.

## Trade-off

With `enhanced_keyboard = false`, modifier keys that rely on the kitty protocol (`Cmd` / `Super`) and F1-F24 keys are not reported in the search TUI. Normal Ctrl / letter / arrow keys are unaffected. This only applies to users who explicitly set the option to `false`; the default behavior is unchanged.

## Testing

- `cargo check` passes on `main`.
- Built and ran locally; confirmed `atuin config get enhanced_keyboard --resolved` reflects the configured value and that the search TUI starts normally with `enhanced_keyboard = false`.
- The change disables exactly the protocol identified as the root cause in #3558. I am confirming the end-to-end IME behavior in iTerm2 + macOS Pinyin and will update here once verified.
