### PR TITLE
fix(xonsh): Ignore empty $ATUIN_HISTORY_ID in postcommand

### DIFF
--- a/crates/atuin/src/shell/atuin.xsh
+++ b/crates/atuin/src/shell/atuin.xsh
@@ -21,7 +21,7 @@ def _atuin_precommand(cmd: str):
 
 @events.on_postcommand
 def _atuin_postcommand(cmd: str, rtn: int, out, ts):
-    if "ATUIN_HISTORY_ID" not in ${...}:
+    if not ${...}.get("ATUIN_HISTORY_ID"):
         return
 
     duration = ts[1] - ts[0]


### PR DESCRIPTION
This PR makes xonsh behavior consistent with other shells: `atuin history end` should ignore $ATUIN_HISTORY_ID being undefined OR empty.

$ATUIN_HISTORY_ID can be empty if `atuin history start` fails, which happened to me in #3561.

## Checks
- [x] I am happy for maintainers to push small adjustments to this PR, to speed up the review cycle
- [x] I have checked that there are no existing pull requests for the same thing
