### PR TITLE
Exclude AI agent commands from zsh-autosuggestions

### DIFF
--- a/crates/atuin/src/shell/atuin.zsh
+++ b/crates/atuin/src/shell/atuin.zsh
@@ -16,7 +16,7 @@ zmodload zsh/datetime 2>/dev/null
 # in your .zshrc
 _zsh_autosuggest_strategy_atuin() {
     # silence errors, since we don't want to spam the terminal prompt while typing.
-    suggestion=$(ATUIN_QUERY="$1" atuin search --cmd-only --limit 1 --search-mode prefix 2>/dev/null)
+    suggestion=$(ATUIN_QUERY="$1" atuin search --cmd-only --author '$all-user' --limit 1 --search-mode prefix 2>/dev/null)
 }
 
 if [ -n "${ZSH_AUTOSUGGEST_STRATEGY:-}" ]; then


### PR DESCRIPTION
Without this, commands from AI agents will pollute the suggestions passed to `zsh-autosuggestions` (which is used by live users).

This touches the same code as #2903, but this PR should be a less controversial simple bugfix.

## Checks
- [x] I am happy for maintainers to push small adjustments to this PR, to speed up the review cycle
- [x] I have checked that there are no existing pull requests for the same thing
