### PR TITLE
fix(sync): skip records that fail to decrypt or decode instead of failing the whole store

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -445,6 +445,7 @@ dependencies = [
  "rmp",
  "serde",
  "tokio",
+ "tracing",
 ]
 
 [[package]]

--- a/crates/atuin-client/src/history/store.rs
+++ b/crates/atuin-client/src/history/store.rs
@@ -207,19 +207,36 @@ impl HistoryStore {
         // Not ideal as that is potentially quite a lot, although history will be small.
         let records = self.store.all_tagged(HISTORY_TAG).await?;
         let mut ret = Vec::with_capacity(records.len());
+        let mut skipped = 0;
 
         for record in records.into_iter() {
-            let hist = match record.version.as_str() {
-                HISTORY_VERSION_V0 | HISTORY_VERSION => {
-                    let version = record.version.clone();
-                    let decrypted = record.decrypt::<PASETO_V4>(&self.encryption_key)?;
+            let id = record.id;
+            let version = record.version.clone();
 
-                    HistoryRecord::deserialize(&decrypted.data, version.as_str())
+            // A record we can't decrypt or decode must not block the rest of the store -
+            // skip it, and load everything else.
+            let hist = match version.as_str() {
+                HISTORY_VERSION_V0 | HISTORY_VERSION => record
+                    .decrypt::<PASETO_V4>(&self.encryption_key)
+                    .and_then(|decrypted| {
+                        HistoryRecord::deserialize(&decrypted.data, version.as_str())
+                    }),
+                version => Err(eyre!("unknown history version {version:?}")),
+            };
+
+            match hist {
+                Ok(hist) => ret.push(hist),
+                Err(e) => {
+                    warn!("failed to decode history record {}, skipping: {e}", id.0);
+                    skipped += 1;
                 }
-                version => bail!("unknown history version {version:?}"),
-            }?;
+            }
+        }
 
-            ret.push(hist);
+        if skipped > 0 {
+            eprintln!(
+                "Warning: skipped {skipped} history records that could not be decrypted or decoded.\nRun `atuin store verify` to check your store, and `atuin store purge` to remove broken records locally."
+            );
         }
 
         Ok(ret)
@@ -273,12 +290,23 @@ impl HistoryStore {
             }
 
             let version = record.version.clone();
-            let decrypted = record.decrypt::<PASETO_V4>(&self.encryption_key)?;
+
+            // Skip records we can't decrypt or decode, rather than failing the entire build.
             let record = match version.as_str() {
-                HISTORY_VERSION_V0 | HISTORY_VERSION => {
-                    HistoryRecord::deserialize(&decrypted.data, version.as_str())?
+                HISTORY_VERSION_V0 | HISTORY_VERSION => record
+                    .decrypt::<PASETO_V4>(&self.encryption_key)
+                    .and_then(|decrypted| {
+                        HistoryRecord::deserialize(&decrypted.data, version.as_str())
+                    }),
+                version => Err(eyre!("unknown history version {version:?}")),
+            };
+
+            let record = match record {
+                Ok(record) => record,
+                Err(e) => {
+                    warn!("failed to decode history record {}, skipping: {e}", id.0);
+                    continue;
                 }
-                version => bail!("unknown history version {version:?}"),
             };
 
             match record {
@@ -361,10 +389,14 @@ impl HistoryStore {
 
 #[cfg(test)]
 mod tests {
-    use atuin_common::record::DecryptedData;
+    use atuin_common::record::{DecryptedData, Host, HostId, Record};
     use time::macros::datetime;
 
-    use crate::history::{HISTORY_VERSION, store::HistoryRecord};
+    use crate::{
+        history::{HISTORY_TAG, HISTORY_VERSION, store::HistoryRecord, store::HistoryStore},
+        record::{encryption::PASETO_V4, sqlite_store::SqliteStore, store::Store},
+        settings::test_local_timeout,
+    };
 
     use super::History;
 
@@ -430,5 +462,52 @@ mod tests {
             HistoryRecord::deserialize(&DecryptedData(Vec::from(bytes)), HISTORY_VERSION)
                 .expect("failed to deserialize HistoryRecord");
         assert_eq!(deserialized, record);
+    }
+
+    #[tokio::test]
+    async fn test_history_skips_corrupt_records() {
+        let store = SqliteStore::new(":memory:", test_local_timeout())
+            .await
+            .unwrap();
+        let host_id = HostId(atuin_common::utils::uuid_v7());
+        let key = [0u8; 32];
+
+        let history_store = HistoryStore::new(store.clone(), host_id, key);
+
+        let history = History {
+            id: "018cd4fe81757cd2aee65cd7861f9c81".to_owned().into(),
+            timestamp: datetime!(2024-01-04 00:00:00.000000 +00:00),
+            duration: 100,
+            exit: 0,
+            command: "ls".to_owned(),
+            cwd: "/".to_owned(),
+            session: "018cd4fead897597852527a31c998059".to_owned(),
+            hostname: "test:test".to_owned(),
+            author: "test".to_owned(),
+            intent: None,
+            deleted_at: None,
+        };
+
+        history_store.push(history.clone()).await.unwrap();
+
+        // a record in the history tag encrypted with a different key - the store is corrupt,
+        // or "mixed". it should be skipped, rather than breaking loading entirely.
+        let corrupt = Record::builder()
+            .host(Host::new(host_id))
+            .version(HISTORY_VERSION.to_string())
+            .tag(HISTORY_TAG.to_string())
+            .idx(1)
+            .data(DecryptedData(vec![1, 2, 3]))
+            .build();
+
+        store
+            .push(&corrupt.encrypt::<PASETO_V4>(&[1u8; 32]))
+            .await
+            .unwrap();
+
+        let records = history_store.history().await.unwrap();
+
+        assert_eq!(records.len(), 1);
+        assert_eq!(records[0], HistoryRecord::Create(history));
     }
 }

--- a/crates/atuin-client/src/history/store.rs
+++ b/crates/atuin-client/src/history/store.rs
@@ -234,8 +234,9 @@ impl HistoryStore {
         }
 
         if skipped > 0 {
-            eprintln!(
-                "Warning: skipped {skipped} history records that could not be decrypted or decoded.\nRun `atuin store verify` to check your store, and `atuin store purge` to remove broken records locally."
+            // library code that may run under the TUI or shell hooks, so no stderr here
+            warn!(
+                "skipped {skipped} history records that could not be decrypted or decoded. Run `atuin store verify` to check your store, and `atuin store purge` to remove broken records locally."
             );
         }
 

--- a/crates/atuin-dotfiles/Cargo.toml
+++ b/crates/atuin-dotfiles/Cargo.toml
@@ -19,6 +19,7 @@ atuin-client = { path = "../atuin-client", version = "18.16.1" }
 
 eyre = { workspace = true }
 tokio = { workspace = true }
+tracing = { workspace = true }
 rmp = { version = "0.8.14" }
 rand = { workspace = true }
 serde = { workspace = true }

--- a/crates/atuin-dotfiles/src/store.rs
+++ b/crates/atuin-dotfiles/src/store.rs
@@ -298,16 +298,29 @@ impl AliasStore {
 
         // this is sorted, oldest to newest
         let tagged = self.store.all_tagged(CONFIG_SHELL_ALIAS_TAG).await?;
+        let mut skipped = 0;
 
         for record in tagged {
             let version = record.version.clone();
 
-            let decrypted = match version.as_str() {
-                CONFIG_SHELL_ALIAS_VERSION => record.decrypt::<PASETO_V4>(&self.encryption_key)?,
-                version => bail!("unknown version {version:?}"),
+            // Skip records we can't decrypt or decode, rather than failing the entire build.
+            let ar = match version.as_str() {
+                CONFIG_SHELL_ALIAS_VERSION => record
+                    .decrypt::<PASETO_V4>(&self.encryption_key)
+                    .and_then(|decrypted| {
+                        AliasRecord::deserialize(&decrypted.data, version.as_str())
+                    }),
+                version => Err(eyre!("unknown version {version:?}")),
             };
 
-            let ar = AliasRecord::deserialize(&decrypted.data, version.as_str())?;
+            let ar = match ar {
+                Ok(ar) => ar,
+                Err(e) => {
+                    tracing::warn!("failed to decode alias record, skipping: {e}");
+                    skipped += 1;
+                    continue;
+                }
+            };
 
             match ar {
                 AliasRecord::Create(a) => {
@@ -317,6 +330,13 @@ impl AliasStore {
                     build.remove(&d);
                 }
             }
+        }
+
+        if skipped > 0 {
+            // aliases() runs during shell init, so this must not write to stderr
+            tracing::warn!(
+                "skipped {skipped} alias records that could not be decrypted or decoded"
+            );
         }
 
         Ok(build.into_values().collect())
@@ -417,5 +437,50 @@ alias k='kubectl'
 alias kgap='kubectl get pods --all-namespaces'
 "
         )
+    }
+
+    #[tokio::test]
+    async fn build_aliases_skips_corrupt_records() {
+        use atuin_client::record::{encryption::PASETO_V4, store::Store};
+        use atuin_common::record::{DecryptedData, Host};
+
+        use super::CONFIG_SHELL_ALIAS_TAG;
+
+        let store = SqliteStore::new(":memory:", test_local_timeout())
+            .await
+            .unwrap();
+        let key: [u8; 32] = XSalsa20Poly1305::generate_key(&mut OsRng).into();
+        let host_id = atuin_common::record::HostId(atuin_common::utils::uuid_v7());
+
+        let alias = AliasStore::new(store.clone(), host_id, key);
+
+        alias.set("k", "kubectl").await.unwrap();
+
+        // a record in the alias tag encrypted with a different key - the store is corrupt,
+        // or "mixed". it should be skipped, rather than breaking the build entirely.
+        let corrupt_key: [u8; 32] = XSalsa20Poly1305::generate_key(&mut OsRng).into();
+        let corrupt = atuin_common::record::Record::builder()
+            .host(Host::new(host_id))
+            .version(CONFIG_SHELL_ALIAS_VERSION.to_string())
+            .tag(CONFIG_SHELL_ALIAS_TAG.to_string())
+            .idx(1)
+            .data(DecryptedData(vec![1, 2, 3]))
+            .build();
+
+        store
+            .push(&corrupt.encrypt::<PASETO_V4>(&corrupt_key))
+            .await
+            .unwrap();
+
+        let aliases = alias.aliases().await.unwrap();
+
+        assert_eq!(aliases.len(), 1);
+        assert_eq!(
+            aliases[0],
+            Alias {
+                name: String::from("k"),
+                value: String::from("kubectl")
+            }
+        );
     }
 }

--- a/crates/atuin-dotfiles/src/store/var.rs
+++ b/crates/atuin-dotfiles/src/store/var.rs
@@ -351,12 +351,15 @@ impl VarStore {
             let version = record.version.clone();
 
             // Skip records we can't decrypt or decode, rather than failing the entire build.
-            let ar = match version.as_str() {
-                DOTFILES_VAR_VERSION => record
-                    .decrypt::<PASETO_V4>(&self.encryption_key)
-                    .and_then(|decrypted| VarRecord::deserialize(&decrypted.data, version.as_str())),
-                version => Err(eyre!("unknown version {version:?}")),
-            };
+            let ar =
+                match version.as_str() {
+                    DOTFILES_VAR_VERSION => record
+                        .decrypt::<PASETO_V4>(&self.encryption_key)
+                        .and_then(|decrypted| {
+                            VarRecord::deserialize(&decrypted.data, version.as_str())
+                        }),
+                    version => Err(eyre!("unknown version {version:?}")),
+                };
 
             let ar = match ar {
                 Ok(ar) => ar,

--- a/crates/atuin-dotfiles/src/store/var.rs
+++ b/crates/atuin-dotfiles/src/store/var.rs
@@ -345,16 +345,27 @@ impl VarStore {
 
         // this is sorted, oldest to newest
         let tagged = self.store.all_tagged(DOTFILES_VAR_TAG).await?;
+        let mut skipped = 0;
 
         for record in tagged {
             let version = record.version.clone();
 
-            let decrypted = match version.as_str() {
-                DOTFILES_VAR_VERSION => record.decrypt::<PASETO_V4>(&self.encryption_key)?,
-                version => bail!("unknown version {version:?}"),
+            // Skip records we can't decrypt or decode, rather than failing the entire build.
+            let ar = match version.as_str() {
+                DOTFILES_VAR_VERSION => record
+                    .decrypt::<PASETO_V4>(&self.encryption_key)
+                    .and_then(|decrypted| VarRecord::deserialize(&decrypted.data, version.as_str())),
+                version => Err(eyre!("unknown version {version:?}")),
             };
 
-            let ar = VarRecord::deserialize(&decrypted.data, version.as_str())?;
+            let ar = match ar {
+                Ok(ar) => ar,
+                Err(e) => {
+                    tracing::warn!("failed to decode var record, skipping: {e}");
+                    skipped += 1;
+                    continue;
+                }
+            };
 
             match ar {
                 VarRecord::Create(a) => {
@@ -364,6 +375,11 @@ impl VarStore {
                     build.remove(&d);
                 }
             }
+        }
+
+        if skipped > 0 {
+            // vars() runs during shell init, so this must not write to stderr
+            tracing::warn!("skipped {skipped} var records that could not be decrypted or decoded");
         }
 
         Ok(build.into_values().collect())

--- a/crates/atuin-kv/src/store.rs
+++ b/crates/atuin-kv/src/store.rs
@@ -1,6 +1,6 @@
 use std::collections::HashSet;
 
-use eyre::{Result, bail};
+use eyre::{Result, eyre};
 
 use atuin_client::record::sqlite_store::SqliteStore;
 use atuin_client::record::{encryption::PASETO_V4, store::Store};
@@ -114,16 +114,28 @@ impl KvStore {
         let cached = self.kv_db.list(None).await?;
 
         let mut visited = HashSet::new();
+        let mut skipped = 0;
 
         // Iterate through all KV records from newest to oldest;
         // only visit each KV once, inserting or deleting based on the first time we see it
         for record in tagged {
-            let decrypted = match record.version.as_str() {
-                "v0" | KV_VERSION => record.decrypt::<PASETO_V4>(&self.encryption_key)?,
-                version => bail!("unknown version {version:?}"),
+            // Skip records we can't decrypt or decode, rather than failing the entire build.
+            let kv = match record.version.as_str() {
+                "v0" | KV_VERSION => record
+                    .decrypt::<PASETO_V4>(&self.encryption_key)
+                    .and_then(|decrypted| KvRecord::deserialize(&decrypted.data, &decrypted.version)),
+                version => Err(eyre!("unknown version {version:?}")),
             };
 
-            let kv = KvRecord::deserialize(&decrypted.data, &decrypted.version)?;
+            let kv = match kv {
+                Ok(kv) => kv,
+                Err(e) => {
+                    tracing::warn!("failed to decode kv record, skipping: {e}");
+                    skipped += 1;
+                    continue;
+                }
+            };
+
             let uniq_id = format!("{}.{}", kv.namespace, kv.key);
 
             if visited.insert(uniq_id) {
@@ -157,6 +169,12 @@ impl KvStore {
                     .delete(kv.namespace.as_str(), kv.key.as_str())
                     .await?;
             }
+        }
+
+        if skipped > 0 {
+            eprintln!(
+                "Warning: skipped {skipped} kv records that could not be decrypted or decoded"
+            );
         }
 
         Ok(())

--- a/crates/atuin-kv/src/store.rs
+++ b/crates/atuin-kv/src/store.rs
@@ -175,9 +175,8 @@ impl KvStore {
         }
 
         if skipped > 0 {
-            eprintln!(
-                "Warning: skipped {skipped} kv records that could not be decrypted or decoded"
-            );
+            // library code that may run under the TUI or shell hooks, so no stderr here
+            tracing::warn!("skipped {skipped} kv records that could not be decrypted or decoded");
         }
 
         Ok(())

--- a/crates/atuin-kv/src/store.rs
+++ b/crates/atuin-kv/src/store.rs
@@ -120,12 +120,15 @@ impl KvStore {
         // only visit each KV once, inserting or deleting based on the first time we see it
         for record in tagged {
             // Skip records we can't decrypt or decode, rather than failing the entire build.
-            let kv = match record.version.as_str() {
-                "v0" | KV_VERSION => record
-                    .decrypt::<PASETO_V4>(&self.encryption_key)
-                    .and_then(|decrypted| KvRecord::deserialize(&decrypted.data, &decrypted.version)),
-                version => Err(eyre!("unknown version {version:?}")),
-            };
+            let kv =
+                match record.version.as_str() {
+                    "v0" | KV_VERSION => record
+                        .decrypt::<PASETO_V4>(&self.encryption_key)
+                        .and_then(|decrypted| {
+                            KvRecord::deserialize(&decrypted.data, &decrypted.version)
+                        }),
+                    version => Err(eyre!("unknown version {version:?}")),
+                };
 
             let kv = match kv {
                 Ok(kv) => kv,

--- a/crates/atuin-scripts/src/store.rs
+++ b/crates/atuin-scripts/src/store.rs
@@ -78,9 +78,13 @@ impl ScriptStore {
         for record in records.into_iter() {
             // Skip records we can't decrypt or decode, rather than failing the entire build.
             let script = match record.version.as_str() {
-                SCRIPT_VERSION => record
-                    .decrypt::<PASETO_V4>(&self.encryption_key)
-                    .and_then(|decrypted| ScriptRecord::deserialize(&decrypted.data, SCRIPT_VERSION)),
+                SCRIPT_VERSION => {
+                    record
+                        .decrypt::<PASETO_V4>(&self.encryption_key)
+                        .and_then(|decrypted| {
+                            ScriptRecord::deserialize(&decrypted.data, SCRIPT_VERSION)
+                        })
+                }
                 version => Err(eyre!("unknown script version {version:?}")),
             };
 

--- a/crates/atuin-scripts/src/store.rs
+++ b/crates/atuin-scripts/src/store.rs
@@ -98,8 +98,9 @@ impl ScriptStore {
         }
 
         if skipped > 0 {
-            eprintln!(
-                "Warning: skipped {skipped} script records that could not be decrypted or decoded"
+            // library code that may run under the TUI or shell hooks, so no stderr here
+            tracing::warn!(
+                "skipped {skipped} script records that could not be decrypted or decoded"
             );
         }
 

--- a/crates/atuin-scripts/src/store.rs
+++ b/crates/atuin-scripts/src/store.rs
@@ -1,4 +1,4 @@
-use eyre::{Result, bail};
+use eyre::{Result, eyre};
 
 use atuin_client::record::sqlite_store::SqliteStore;
 use atuin_client::record::{encryption::PASETO_V4, store::Store};
@@ -73,18 +73,30 @@ impl ScriptStore {
     pub async fn scripts(&self) -> Result<Vec<ScriptRecord>> {
         let records = self.store.all_tagged(SCRIPT_TAG).await?;
         let mut ret = Vec::with_capacity(records.len());
+        let mut skipped = 0;
 
         for record in records.into_iter() {
+            // Skip records we can't decrypt or decode, rather than failing the entire build.
             let script = match record.version.as_str() {
-                SCRIPT_VERSION => {
-                    let decrypted = record.decrypt::<PASETO_V4>(&self.encryption_key)?;
+                SCRIPT_VERSION => record
+                    .decrypt::<PASETO_V4>(&self.encryption_key)
+                    .and_then(|decrypted| ScriptRecord::deserialize(&decrypted.data, SCRIPT_VERSION)),
+                version => Err(eyre!("unknown script version {version:?}")),
+            };
 
-                    ScriptRecord::deserialize(&decrypted.data, SCRIPT_VERSION)
+            match script {
+                Ok(script) => ret.push(script),
+                Err(e) => {
+                    tracing::warn!("failed to decode script record, skipping: {e}");
+                    skipped += 1;
                 }
-                version => bail!("unknown history version {version:?}"),
-            }?;
+            }
+        }
 
-            ret.push(script);
+        if skipped > 0 {
+            eprintln!(
+                "Warning: skipped {skipped} script records that could not be decrypted or decoded"
+            );
         }
 
         Ok(ret)

--- a/crates/atuin/src/sync.rs
+++ b/crates/atuin/src/sync.rs
@@ -37,14 +37,30 @@ pub async fn build(
     let kv_store = KvStore::new(store.clone(), kv_db, host_id, encryption_key);
     let script_store = ScriptStore::new(store.clone(), host_id, encryption_key);
 
-    history_store.incremental_build(db, downloaded).await?;
+    // A failure in one store should not stop the others from building - build as much as
+    // possible, and warn about the rest.
+    if let Err(e) = history_store.incremental_build(db, downloaded).await {
+        eprintln!("Warning: failed to build history: {e}");
+    }
 
-    alias_store.build().await?;
-    var_store.build().await?;
-    kv_store.build().await?;
+    if let Err(e) = alias_store.build().await {
+        eprintln!("Warning: failed to build aliases: {e}");
+    }
+
+    if let Err(e) = var_store.build().await {
+        eprintln!("Warning: failed to build vars: {e}");
+    }
+
+    if let Err(e) = kv_store.build().await {
+        eprintln!("Warning: failed to build kv: {e}");
+    }
 
     let script_db =
         atuin_scripts::database::Database::new(settings.scripts.db_path.clone(), 1.0).await?;
-    script_store.build(script_db).await?;
+
+    if let Err(e) = script_store.build(script_db).await {
+        eprintln!("Warning: failed to build scripts: {e}");
+    }
+
     Ok(())
 }


### PR DESCRIPTION
Previously, we chose to fail loudly when there was a key mismatch in a users store. However, in the past, we did not check the key at login, so users could easily end up in a state where they inserted an invalid key, and then broke their store. 

This PR ensures that even with a partially invalid store, the user can still sync their data. 

This does not mean that users will be able to introduce new invalid keys, and simply makes things better for older users (pre key-checking). We still need to figure out a more straightforward way for a user to repair their entire record store if they have somehow mixed up keys, other than the `purge` + `push/pull --force` steps.

## Checks
- [ ] I am happy for maintainers to push small adjustments to this PR, to speed up the review cycle
- [ ] I have checked that there are no existing pull requests for the same thing
