### PR TITLE
fix: respect `store_failed` when using daemon

### DIFF
--- a/crates/atuin-daemon/proto/history.proto
+++ b/crates/atuin-daemon/proto/history.proto
@@ -18,6 +18,11 @@ message EndHistoryRequest {
   uint64 duration = 3;
 }
 
+// Cancel an in-progress history entry without adding it to the database.
+message CancelHistoryRequest {
+  string id = 1;
+}
+
 message StartHistoryReply {
   string id = 1;
   string version = 2;
@@ -29,6 +34,11 @@ message EndHistoryReply {
   uint64 idx = 2;
   string version = 3;
   uint32 protocol = 4;
+}
+
+message CancelHistoryReply {
+  string version = 1;
+  uint32 protocol = 2;
 }
 
 message StatusRequest {}
@@ -75,6 +85,7 @@ message TailHistoryReply {
 service History {
   rpc StartHistory(StartHistoryRequest) returns (StartHistoryReply);
   rpc EndHistory(EndHistoryRequest) returns (EndHistoryReply);
+  rpc CancelHistory(CancelHistoryRequest) returns (CancelHistoryReply);
   rpc TailHistory(TailHistoryRequest) returns (stream TailHistoryReply);
   rpc Status(StatusRequest) returns (StatusReply);
   rpc Shutdown(ShutdownRequest) returns (ShutdownReply);

--- a/crates/atuin-daemon/src/client.rs
+++ b/crates/atuin-daemon/src/client.rs
@@ -22,9 +22,9 @@ use crate::control::{
 };
 use crate::events::DaemonEvent;
 use crate::history::{
-    EndHistoryReply, EndHistoryRequest, ShutdownRequest, StartHistoryReply, StartHistoryRequest,
-    StatusReply, StatusRequest, TailHistoryReply, TailHistoryRequest,
-    history_client::HistoryClient as HistoryServiceClient,
+    CancelHistoryReply, CancelHistoryRequest, EndHistoryReply, EndHistoryRequest, ShutdownRequest,
+    StartHistoryReply, StartHistoryRequest, StatusReply, StatusRequest, TailHistoryReply,
+    TailHistoryRequest, history_client::HistoryClient as HistoryServiceClient,
 };
 use crate::search::{
     FilterMode as RpcFilterMode, SearchContext as RpcSearchContext, SearchRequest, SearchResponse,
@@ -139,6 +139,12 @@ impl HistoryClient {
         let req = EndHistoryRequest { id, duration, exit };
 
         Ok(self.client.end_history(req).await?.into_inner())
+    }
+
+    pub async fn cancel_history(&mut self, id: String) -> Result<CancelHistoryReply> {
+        let req = CancelHistoryRequest { id };
+
+        Ok(self.client.cancel_history(req).await?.into_inner())
     }
 
     pub async fn status(&mut self) -> Result<StatusReply> {

--- a/crates/atuin-daemon/src/components/history.rs
+++ b/crates/atuin-daemon/src/components/history.rs
@@ -20,9 +20,9 @@ use crate::{
     daemon::{Component, DaemonHandle},
     events::DaemonEvent,
     history::{
-        EndHistoryReply, EndHistoryRequest, HistoryEntry, HistoryEventKind, ShutdownReply,
-        ShutdownRequest, StartHistoryReply, StartHistoryRequest, StatusReply, StatusRequest,
-        TailHistoryReply, TailHistoryRequest,
+        CancelHistoryReply, CancelHistoryRequest, EndHistoryReply, EndHistoryRequest, HistoryEntry,
+        HistoryEventKind, ShutdownReply, ShutdownRequest, StartHistoryReply, StartHistoryRequest,
+        StatusReply, StatusRequest, TailHistoryReply, TailHistoryRequest,
         history_server::{History as HistorySvc, HistoryServer},
     },
 };
@@ -245,6 +245,25 @@ impl HistorySvc for HistoryGrpcService {
         Err(Status::not_found(format!(
             "could not find history with id: {id}"
         )))
+    }
+
+    #[instrument(skip_all, level = Level::INFO)]
+    async fn cancel_history(
+        &self,
+        request: Request<CancelHistoryRequest>,
+    ) -> Result<Response<CancelHistoryReply>, Status> {
+        let req = request.into_inner();
+        let id = HistoryId(req.id);
+        if self.inner.running.remove(&id).is_some() {
+            Ok(Response::new(CancelHistoryReply {
+                version: env!("CARGO_PKG_VERSION").to_string(),
+                protocol: DAEMON_PROTOCOL_VERSION,
+            }))
+        } else {
+            Err(Status::not_found(format!(
+                "could not find history with id: {id}"
+            )))
+        }
     }
 
     #[instrument(skip_all, level = Level::INFO)]

--- a/crates/atuin-daemon/src/history/mod.rs
+++ b/crates/atuin-daemon/src/history/mod.rs
@@ -4,3 +4,27 @@
 
 // Include the generated proto code
 tonic::include_proto!("history");
+
+/// Trait for reply types that include the daemon version and protocol version.
+pub trait VersionedReply {
+    fn version(&self) -> &str;
+    fn protocol(&self) -> u32;
+}
+
+macro_rules! impl_versioned_reply {
+    ($($name:ident),* $(,)?) => {
+        $(
+            impl VersionedReply for $name {
+                fn version(&self) -> &str {
+                    &self.version
+                }
+
+                fn protocol(&self) -> u32 {
+                    self.protocol
+                }
+            }
+        )*
+    };
+}
+
+impl_versioned_reply!(StartHistoryReply, EndHistoryReply, CancelHistoryReply);

--- a/crates/atuin/src/command/client/daemon.rs
+++ b/crates/atuin/src/command/client/daemon.rs
@@ -406,11 +406,22 @@ fn ensure_reply_compatible(settings: &Settings, version: &str, protocol: u32) ->
     bail!("{message}. Enable `daemon.autostart = true` or restart the daemon manually");
 }
 
+#[derive(Clone, Copy)]
+struct TryWithRestartOptions {
+    /// Whether to resend the command if the daemon isn't the expected version.
+    pub retry_on_version_mismatch: bool,
+}
+
 /// Try to send a request to the daemon, restarting it and retrying if necessary.
 ///
 /// `context` will be passed to the closure. Compared to capturing the needed context in the
 /// closure, this may reduce the number of required clones.
-async fn try_with_restart<C, F, R>(settings: &Settings, context: C, send_request: F) -> Result<R>
+async fn try_with_restart<C, F, R>(
+    settings: &Settings,
+    send_request: F,
+    context: C,
+    options: TryWithRestartOptions,
+) -> Result<R>
 where
     C: Clone + Sync,
     F: AsyncFn(&mut HistoryClient, C) -> Result<R> + Sync,
@@ -429,6 +440,13 @@ where
                     daemon_mismatch_message(resp.version(), resp.protocol())
                 ));
             }
+
+            if !options.retry_on_version_mismatch {
+                // We don't need to retry the request, so only restart to make subsequent hook calls
+                // target the expected version.
+                let _ = restart_daemon(settings).await;
+                return Ok(resp);
+            }
         }
         Err(err) if !settings.daemon.autostart => return Err(err),
         Err(err) if !should_retry_after_error(&err) => return Err(err),
@@ -441,25 +459,40 @@ where
 }
 
 pub async fn start_history(settings: &Settings, history: History) -> Result<String> {
-    let resp = try_with_restart(settings, history, async |client, history| {
-        client.start_history(history).await
-    })
+    let resp = try_with_restart(
+        settings,
+        async |client, history| client.start_history(history).await,
+        history,
+        TryWithRestartOptions {
+            retry_on_version_mismatch: true,
+        },
+    )
     .await?;
     Ok(resp.id)
 }
 
 pub async fn end_history(settings: &Settings, id: String, duration: u64, exit: i64) -> Result<()> {
-    try_with_restart(settings, id, async |client, id| {
-        client.end_history(id, duration, exit).await
-    })
+    try_with_restart(
+        settings,
+        async |client, id| client.end_history(id, duration, exit).await,
+        id,
+        TryWithRestartOptions {
+            retry_on_version_mismatch: false,
+        },
+    )
     .await?;
     Ok(())
 }
 
 pub async fn cancel_history(settings: &Settings, id: String) -> Result<()> {
-    try_with_restart(settings, id, async |client, id| {
-        client.cancel_history(id).await
-    })
+    try_with_restart(
+        settings,
+        async |client, id| client.cancel_history(id).await,
+        id,
+        TryWithRestartOptions {
+            retry_on_version_mismatch: false,
+        },
+    )
     .await?;
     Ok(())
 }

--- a/crates/atuin/src/command/client/daemon.rs
+++ b/crates/atuin/src/command/client/daemon.rs
@@ -406,24 +406,27 @@ fn ensure_reply_compatible(settings: &Settings, version: &str, protocol: u32) ->
     bail!("{message}. Enable `daemon.autostart = true` or restart the daemon manually");
 }
 
-pub async fn start_history(settings: &Settings, history: History) -> Result<String> {
-    match async {
-        connect_client(settings)
-            .await?
-            .start_history(history.clone())
-            .await
-    }
-    .await
+/// Try to send a request to the daemon, restarting it and retrying if necessary.
+///
+/// `context` will be passed to the closure. Compared to capturing the needed context in the
+/// closure, this may reduce the number of required clones.
+async fn try_with_restart<C, F, R>(settings: &Settings, context: C, send_request: F) -> Result<R>
+where
+    C: Clone + Sync,
+    F: AsyncFn(&mut HistoryClient, C) -> Result<R> + Sync,
+    R: atuin_daemon::history::VersionedReply,
+{
+    match async { send_request(&mut connect_client(settings).await?, context.clone()).await }.await
     {
         Ok(resp) => {
-            if daemon_matches_expected(&resp.version, resp.protocol) {
-                return Ok(resp.id);
+            if daemon_matches_expected(resp.version(), resp.protocol()) {
+                return Ok(resp);
             }
 
             if !settings.daemon.autostart {
                 return Err(eyre!(
                     "{}. Enable `daemon.autostart = true` or restart the daemon manually",
-                    daemon_mismatch_message(&resp.version, resp.protocol)
+                    daemon_mismatch_message(resp.version(), resp.protocol())
                 ));
             }
         }
@@ -432,50 +435,32 @@ pub async fn start_history(settings: &Settings, history: History) -> Result<Stri
         Err(_) => {}
     }
 
-    let resp = restart_daemon(settings)
-        .await?
-        .start_history(history)
-        .await?;
-    ensure_reply_compatible(settings, &resp.version, resp.protocol)?;
+    let resp = send_request(&mut restart_daemon(settings).await?, context).await?;
+    ensure_reply_compatible(settings, resp.version(), resp.protocol())?;
+    Ok(resp)
+}
+
+pub async fn start_history(settings: &Settings, history: History) -> Result<String> {
+    let resp = try_with_restart(settings, history, async |client, history| {
+        client.start_history(history).await
+    })
+    .await?;
     Ok(resp.id)
 }
 
 pub async fn end_history(settings: &Settings, id: String, duration: u64, exit: i64) -> Result<()> {
-    match async {
-        connect_client(settings)
-            .await?
-            .end_history(id.clone(), duration, exit)
-            .await
-    }
-    .await
-    {
-        Ok(resp) => {
-            if daemon_matches_expected(&resp.version, resp.protocol) {
-                return Ok(());
-            }
+    try_with_restart(settings, id, async |client, id| {
+        client.end_history(id, duration, exit).await
+    })
+    .await?;
+    Ok(())
+}
 
-            if !settings.daemon.autostart {
-                return Err(eyre!(
-                    "{}. Enable `daemon.autostart = true` or restart the daemon manually",
-                    daemon_mismatch_message(&resp.version, resp.protocol)
-                ));
-            }
-
-            // End succeeded on the running daemon, so avoid replaying it.
-            // We only restart to make subsequent hook calls target the expected version.
-            let _ = restart_daemon(settings).await;
-            return Ok(());
-        }
-        Err(err) if !settings.daemon.autostart => return Err(err),
-        Err(err) if !should_retry_after_error(&err) => return Err(err),
-        Err(_) => {}
-    }
-
-    let resp = restart_daemon(settings)
-        .await?
-        .end_history(id, duration, exit)
-        .await?;
-    ensure_reply_compatible(settings, &resp.version, resp.protocol)?;
+pub async fn cancel_history(settings: &Settings, id: String) -> Result<()> {
+    try_with_restart(settings, id, async |client, id| {
+        client.cancel_history(id).await
+    })
+    .await?;
     Ok(())
 }
 

--- a/crates/atuin/src/command/client/history.rs
+++ b/crates/atuin/src/command/client/history.rs
@@ -557,7 +557,12 @@ async fn handle_daemon_end(
     exit: i64,
     duration: Option<u64>,
 ) -> Result<()> {
-    daemon::end_history(settings, id.to_string(), duration.unwrap_or(0), exit).await?;
+    if !settings.store_failed && exit > 0 {
+        debug!("history has non-zero exit code, and store_failed is false");
+        daemon::cancel_history(settings, id.to_string()).await?;
+    } else {
+        daemon::end_history(settings, id.to_string(), duration.unwrap_or(0), exit).await?;
+    }
 
     Ok(())
 }


### PR DESCRIPTION
Currently, when using the daemon, the `store_failed` setting is ignored and unconditionally treated as true. This PR fixes the issue.

Fixes #3564.