### PR TITLE
feat(doctor): add whether daemon is enabled to `doctor` output

### DIFF
--- a/crates/atuin/src/command/client/doctor.rs
+++ b/crates/atuin/src/command/client/doctor.rs
@@ -343,6 +343,8 @@ struct AtuinInfo {
 
     #[serde(skip)] // probably unnecessary to expose this
     pub setting_paths: SettingPaths,
+
+    pub daemon_enabled: bool,
 }
 
 impl AtuinInfo {
@@ -369,6 +371,7 @@ impl AtuinInfo {
             sync,
             sqlite_version,
             setting_paths: SettingPaths::new(settings),
+            daemon_enabled: cfg!(feature = "daemon") && settings.daemon.enabled,
         }
     }
 }


### PR DESCRIPTION
Add whether the daemon is enabled to the output of `atuin doctor`.