### PR TITLE
docs(i18n): add Serbian, Croatian, Bosnian, Montenegrin localizations + fix Russian typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@
   <a href="https://twitter.com/atuinsh"><img src="https://img.shields.io/twitter/follow/atuinsh?style=social" /></a>
 </p>
 
-[English] | [简体中文]
+[English] | [简体中文] | [Srpski] | [Hrvatski] | [Bosanski] | [Crnogorski]
 
 Atuin replaces your existing shell history with a SQLite database, and records
 additional context for your commands. Additionally, it provides optional and
@@ -135,3 +135,7 @@ Made with [contrib.rocks](https://contrib.rocks).
 
 [English]: ./README.md
 [简体中文]: ./docs-i18n/zh-CN/README.md
+[Srpski]: ./docs-i18n/sr/
+[Hrvatski]: ./docs-i18n/hr/
+[Bosanski]: ./docs-i18n/bs/
+[Crnogorski]: ./docs-i18n/cnr/

--- a/docs-i18n/bs/config.md
+++ b/docs-i18n/bs/config.md
@@ -1,0 +1,146 @@
+# Konfiguracija
+
+Atuin koristi dva konfiguraciona fajla. Oni se nalaze u `~/.config/atuin/`. Podaci
+se skladište u `~/.local/share/atuin` (ukoliko nije drugačije definisano u XDG\_\*).
+
+Putanja do direktorijuma konfiguracije može biti promenjena postavljanjem
+parametra `ATUIN_CONFIG_DIR`. Na primer
+
+```
+export ATUIN_CONFIG_DIR = /home/ellie/.atuin
+```
+
+## Korisnička konfiguracija
+
+```
+~/.config/atuin/config.toml
+```
+
+Ovaj fajl se koristi kada klijent radi na lokalnoj mašini (ne na serveru).
+
+Primer možete pogledati u [config.toml](../../atuin-client/config.toml)
+
+### `dialect`
+
+Ovaj parametar kontroliše kako [stats](stats.md) komanda obrađuje podatke.
+Može imati jednu od dve dozvoljene vrednosti:
+
+```
+dialect = "uk"
+```
+
+ili
+
+```
+dialect = "us"
+```
+
+Podrazumevano je "us".
+
+### `auto_sync`
+
+Da li se automatski sinhronizovati ako je korisnik prijavljen. Podrazumevano je da (true)
+```
+auto_sync = true/false
+```
+
+### `sync_address`
+
+Adresa servera za sinhronizaciju. Podrazumevano je `https://api.atuin.sh`.
+
+```
+sync_address = "https://api.atuin.sh"
+```
+
+### `sync_frequency`
+
+Koliko često se klijent sinhronizuje sa serverom. Može biti navedeno u
+formatu čitljivom za ljude. Na primer, `10s`, `20m`, `1h`, itd.
+Podrazumevano je `1h`
+
+Ako je vrednost postavljena na 0, Atuin će se sinhronizovati nakon svake izvršene komande.
+Imajte na umu da serveri mogu imati ograničenje na broj poslatih zahteva.
+
+```
+sync_frequency = "1h"
+```
+
+### `db_path`
+
+Putanja do SQLite baze podataka. Podrazumevano je
+`~/.local/share/atuin/history.db`.
+
+```
+db_path = "~/.history.db"
+```
+
+### `key_path`
+
+Putanja do ključa za šifrovanje u Atuin-u. Podrazumevano je
+`~/.local/share/atuin/key`.
+
+```
+key = "~/.atuin-key"
+```
+
+### `session_path`
+
+Putanja do serverskog fajla sesije u Atuin-u. Podrazumevano je
+`~/.local/share/atuin/session`. U suštini, ovo je samo API token.
+
+```
+key = "~/.atuin-session"
+```
+
+### `search_mode`
+
+Određuje koji režim pretrage će biti korišćen. Atuin podržava "prefix",
+pretragu po celom tekstu (fulltext) i nepreciznu ("fuzzy") pretragu. Režim "prefix" pretražuje
+po "upit\*", "fulltext" po "\*upit\*", a "fuzzy" koristi
+[sledeći](#fuzzy-search-syntax) sintaksu.
+
+Podrazumevano je "fuzzy"
+
+### `filter_mode`
+
+Filter koji se podrazumevano koristi pri pretrazi
+
+| Vrednost         | Opis                                                               |
+|------------------|--------------------------------------------------------------------|
+| global (default) | Pretražuje istoriju komandi sa svih hostova, sesija i direktorijuma |
+| host             | Pretražuje istoriju komandi sa ovog hosta                           |
+| session          | Pretražuje istoriju komandi ove sesije                              |
+| directory        | Pretražuje istoriju komandi izvršenih u trenutnom direktorijumu     |
+
+Režimi pretrage mogu biti promenjeni preko ctrl-r
+
+
+```
+search_mode = "fulltext"
+```
+
+#### fuzzy search syntax
+
+Režim pretrage "fuzzy" zasnovan je na
+[fzf search syntax](https://github.com/junegunn/fzf#search-syntax).
+
+| Token     | Tip poklapanja               | Opis                                     |
+|-----------|------------------------------|------------------------------------------|
+| `sbtrkt`  | fuzzy-match                  | Sve što se poklapa sa `sbtrkt`           |
+| `'wild`   | exact-match (pod navodnicima)| Sve što sadrži `wild`                    |
+| `^music`  | prefix-exact-match           | Sve što počinje sa `music`               |
+| `.mp3$`   | suffix-exact-match           | Sve što se završava na `.mp3`            |
+| `!fire`   | inverse-exact-match          | Sve što ne sadrži `fire`                 |
+| `!^music` | inverse-prefix-exact-match   | Sve što ne počinje sa `music`            |
+| `!.mp3$`  | inverse-suffix-exact-match   | Sve što se ne završava na `.mp3`         |
+
+Znak vertikalne crte označava logičko ILI. Na primer, upit ispod vraća
+sve što počinje sa `core` i završava se na `go`, `rb` ili `py`.
+
+```
+^core go$ | rb$ | py$
+```
+
+## Serverska konfiguracija
+
+`// TODO`

--- a/docs-i18n/bs/import.md
+++ b/docs-i18n/bs/import.md
@@ -1,0 +1,27 @@
+# `atuin import`
+
+Atuin može da uveze istoriju iz "starog" fajla istorije
+
+`atuin import auto` pokušava da odredi tip komandnog interfejsa
+(preko \$SHELL) i pokreće odgovarajući skript za uvoz.
+
+Nažalost, ovi fajlovi ne sadrže toliko informacija koliko Atuin, tako da neće
+sve funkcije biti dostupne sa uvezenim podacima.
+
+# zsh
+
+```
+atuin import zsh
+```
+
+Ako imate HISTFILE, onda bi ova komanda trebalo da funkcioniše. U suprotnom, pokušajte
+
+```
+HISTFILE=/path/to/history/file atuin import zsh
+```
+
+Ovaj parametar podržava kako pojednostavljen, tako i pun format.
+
+# bash
+
+TODO

--- a/docs-i18n/bs/key-binding.md
+++ b/docs-i18n/bs/key-binding.md
@@ -1,0 +1,39 @@
+# Prečice na tastaturi
+
+Podrazumevano, Atuin će preusmeriti <kbd>Ctrl-r</kbd> i taster 'strelica nagore'.
+Ako to ne želite, postavite parametar ATUIN_NOBIND pre nego što pozovete `atuin init`
+
+Na primer,
+
+```
+export ATUIN_NOBIND="true"
+eval "$(atuin init zsh)"
+```
+
+Na ovaj način možete dozvoliti preusmeravanje tastera u Atuin-u, ako je to neophodno.
+Uradite to pre inicijalizacionog poziva.
+
+# zsh
+
+Atuin instalira ZLE widget "atuin-search"
+
+```
+export ATUIN_NOBIND="true"
+eval "$(atuin init zsh)"
+
+bindkey '^r' atuin-search
+
+# zavisi od režima terminala
+bindkey '^[[A' atuin-search
+bindkey '^[OA' atuin-search
+```
+
+# bash
+
+```
+export ATUIN_NOBIND="true"
+eval "$(atuin init bash)"
+
+# Predefinišite ctrl-r i bilo koje druge kombinacije prečica ovde
+bind -x '"\C-r": __atuin_history'
+```

--- a/docs-i18n/bs/list.md
+++ b/docs-i18n/bs/list.md
@@ -1,0 +1,11 @@
+# Prikaz istorije na ekranu
+
+```
+atuin history list
+```
+
+| Argument       | Opis                                                                                    |
+| -------------- | --------------------------------------------------------------------------------------- |
+| `--cwd/-c`     | Direktorijum čija istorija komandi treba da bude prikazana (podrazumevano svi direktorijumi) |
+| `--session/-s` | Prikazuje istoriju komandi samo trenutne sesije (podrazumevano false)                    |
+| `--human`      | Čitljiv format za vreme i vremenske periode (podrazumevano false)                       |

--- a/docs-i18n/bs/search.md
+++ b/docs-i18n/bs/search.md
@@ -1,0 +1,38 @@
+# `atuin search`
+
+```
+atuin search <query>
+```
+
+Pretraga u Atuin-u takođe podržava wildcards sa znacima `*` ili `%`.
+Podrazumevano, mora biti naveden prefiks (tj. svi upiti se automatski dopunjuju wildcard-ovima)
+
+| Argument           | Opis                                                                                         |
+| ------------------ | -------------------------------------------------------------------------------------------- |
+| `--cwd/-c`         | Direktorijum za koji se prikazuje istorija (podrazumevano svi direktorijumi)                 |
+| `--exclude-cwd`    | Isključuje komande koje su pokrenute u ovom direktorijumu (podrazumevano none)               |
+| `--exit/-e`        | Filtriranje po exit code (podrazumevano none)                                                |
+| `--exclude-exit`   | Isključuje komande koje su završene sa navedenom vrednošću (podrazumevano none)              |
+| `--before`         | Uključuje samo komande koje su pokrenute pre navedenog vremena (podrazumevano none)          |
+| `--after`          | Uključuje samo komande koje su pokrenute posle navedenog vremena (podrazumevano none)        |
+| `--interactive/-i` | Otvara interaktivni grafički interfejs za pretragu (podrazumevano false)                     |
+| `--human`          | Koristi čitljivo formatiranje za vreme i vremenske periode (podrazumevano false)             |
+
+## Primeri
+
+```
+# Pokreće interaktivnu pretragu sa tekstualnim korisničkim interfejsom
+atuin search -i
+
+# Pokreće interaktivnu pretragu sa tekstualnim korisničkim interfejsom i već unetim upitom
+atuin search -i atuin
+
+# Pretražuje sve komande koje počinju sa cargo i koje su uspešno završene
+atuin search --exit 0 cargo
+
+# Pretražuje sve komande koje su završene sa greškom, pokrenute u trenutnom direktorijumu i pre prvog aprila 2021
+atuin search --exclude-exit 0 --before 01/04/2021 --cwd .
+
+# Pretražuje sve komande koje počinju sa cargo, uspešno završene i pokrenute posle tri sata popodne juče
+atuin search --exit 0 --after "yesterday 3pm" cargo
+```

--- a/docs-i18n/bs/server.md
+++ b/docs-i18n/bs/server.md
@@ -1,0 +1,159 @@
+# `atuin server`
+
+Atuin vam omogućava da pokrenete sopstveni server za sinhronizaciju, ako
+ne želite da koristite podrazumevani :)
+
+Ovde postoji samo jedna podkomanda, `atuin server start`, koja pokreće
+Atuin http server za sinhronizaciju
+
+```
+USAGE:
+    atuin server start [OPTIONS]
+
+FLAGS:
+        --help       Prints help information
+    -V, --version    Prints version information
+
+OPTIONS:
+    -h, --host <host>
+    -p, --port <port>
+```
+
+## config
+
+Serverska konfiguracija se čuva odvojeno od korisničkog fajla konfiguracije, čak i ako
+je u pitanju isti binarni fajl. Serverska konfiguracija se nalazi u `~/.config/atuin/server.toml`.
+
+Ovaj fajl izgleda otprilike ovako:
+
+```toml
+host = "0.0.0.0"
+port = 8888
+open_registration = true
+db_uri="postgres://user:password@hostname/database"
+```
+
+Konfiguracija takođe može biti smeštena u promenljive okruženja.
+
+```sh
+ATUIN_HOST="0.0.0.0"
+ATUIN_PORT=8888
+ATUIN_OPEN_REGISTRATION=true
+ATUIN_DB_URI="postgres://user:password@hostname/database"
+```
+
+### host
+
+Adresa hosta na kojoj će Atuin server osluškivati.
+
+Podrazumevano je `127.0.0.1`.
+
+### port
+
+Port na kojem će Atuin server osluškivati.
+
+Podrazumevano je `8888`.
+
+### open_registration
+
+Ako je `true`, Atuin će dozvoliti registraciju novih korisnika.
+Postavite na `false` ako nakon kreiranja vašeg naloga ne želite da drugi
+koriste vaš server.
+
+Podrazumevano je `false`.
+
+### db_uri
+
+Validan postgres URI gde će biti sačuvan nalog korisnika i istorija.
+
+## Docker
+
+Podržan je Docker image kako bi se olakšalo pokretanje servera u kontejneru.
+
+```sh
+docker run -d -v "$USER/.config/atuin:/config" ghcr.io/ellie/atuin:latest server start
+```
+
+## Docker Compose
+
+Hostovanje sopstvenog Atuin servera pomoću vašeg docker-image-a može biti realizovano kroz
+docker-compose fajl.
+
+Kreirajte `.env` fajl pored `docker-compose.yml` sa sadržajem nalik ovom:
+
+```
+ATUIN_DB_USERNAME=atuin
+# Choose your own secure password
+ATUIN_DB_PASSWORD=really-insecure
+```
+
+Kreirajte `docker-compose.yml`:
+
+```yaml
+version: '3.5'
+services:
+  atuin:
+    restart: always
+    image: ghcr.io/ellie/atuin:main
+    command: server start
+    volumes:
+      - "./config:/config"
+    links:
+      - postgresql:db
+    ports:
+      - 8888:8888
+    environment:
+      ATUIN_HOST: "0.0.0.0"
+      ATUIN_OPEN_REGISTRATION: "true"
+      ATUIN_DB_URI: postgres://$ATUIN_DB_USERNAME:$ATUIN_DB_PASSWORD@db/atuin
+  postgresql:
+    image: postgres:14
+    restart: unless-stopped
+    volumes: # Don't remove permanent storage for index database files!
+      - "./database:/var/lib/postgresql/data/"
+    environment:
+      POSTGRES_USER: $ATUIN_DB_USERNAME
+      POSTGRES_PASSWORD: $ATUIN_DB_PASSWORD
+      POSTGRES_DB: atuin
+```
+
+Pokrenite servise pomoću `docker-compose`:
+
+```sh
+docker-compose up -d
+```
+
+### Korišćenje systemd za upravljanje Atuin serverom
+
+`systemd` unit za upravljanje servisima koje kontroliše `docker-compose`:
+
+```
+[Unit]
+Description=Docker Compose Atuin Service
+Requires=docker.service
+After=docker.service
+
+[Service]
+# Where the docker-compose file is located
+WorkingDirectory=/srv/atuin-server 
+ExecStart=/usr/bin/docker-compose up
+ExecStop=/usr/bin/docker-compose down
+TimeoutStartSec=0
+Restart=on-failure
+StartLimitBurst=3
+
+[Install]
+WantedBy=multi-user.target
+```
+
+Omogućite i pokrenite servis komandom:
+
+```sh
+systemctl enable --now atuin
+```
+
+Proverite da li radi:
+
+```sh
+systemctl status atuin
+```

--- a/docs-i18n/bs/shell-completions.md
+++ b/docs-i18n/bs/shell-completions.md
@@ -1,0 +1,20 @@
+# `atuin gen-completions`
+
+[Dopunjavanje komandi](https://en.wikipedia.org/wiki/Command-line_completion) za Atuin
+može biti generisano navođenjem direktorijuma za izlaz i željenog shell-a kroz podkomandu `gen-completions`.
+
+```
+$ atuin gen-completions --shell bash --out-dir $HOME
+
+Shell completion for BASH is generated in "/home/user"
+```
+
+Moguće vrednosti za argument `--shell` su sledeće:
+
+- `bash`
+- `fish`
+- `zsh`
+- `powershell`
+- `elvish`
+
+Takođe preporučujemo da pročitate [supported shells](./../../README.md#supported-shells).

--- a/docs-i18n/bs/stats.md
+++ b/docs-i18n/bs/stats.md
@@ -1,0 +1,39 @@
+# `atuin stats`
+
+Atuin takođe može da prikaže statistiku zasnovanu na istoriji. Za sada u veoma jednostavnom obliku,
+ali uskoro bi trebalo da bude više mogućnosti.
+
+Statistika se trenutno prikazuje samo na engleskom jeziku
+# TODO
+
+```
+$ atuin stats day last friday
+
++---------------------+------------+
+| Statistic           | Value      |
++---------------------+------------+
+| Most used command   | git status |
++---------------------+------------+
+| Commands ran        |        450 |
++---------------------+------------+
+| Unique commands ran |        213 |
++---------------------+------------+
+
+$ atuin stats day 01/01/21 # takođe prihvata apsolutne datume
+```
+
+Takođe, može biti prikazana statistika celokupne istorije poznate Atuin-u:
+
+```
+$ atuin stats all
+
++---------------------+-------+
+| Statistic           | Value |
++---------------------+-------+
+| Most used command   |    ls |
++---------------------+-------+
+| Commands ran        |  8190 |
++---------------------+-------+
+| Unique commands ran |  2996 |
++---------------------+-------+
+```

--- a/docs-i18n/bs/sync.md
+++ b/docs-i18n/bs/sync.md
@@ -1,0 +1,60 @@
+# `atuin sync`
+
+Atuin može da napravi rezervnu kopiju vaše istorije na serveru kako bi obezbedio korišćenje
+iste istorije na različitim računarima. Celokupna istorija će biti šifrovana dvostranim šifrovanjem,
+tako da server _nikada_ neće dobiti vaše podatke!
+
+Možete pokrenuti sopstveni server (pokretanjem `atuin server start`, o tome je napisano u drugim
+fajlovima dokumentacije), ali postoji i podrazumevani na https://api.atuin.sh. To je podrazumevana adresa servera
+koja može biti promenjena u [konfiguraciji](config.md). Još jednom, ja _ne mogu_ da pristupim vašim podacima
+i oni mi nisu potrebni.
+
+## Učestalost sinhronizacije
+
+Sinhronizacija će se odvijati automatski, ukoliko suprotno nije navedeno u konfiguraciji.
+Ovaj parametar možete podesiti u [konfiguraciji](config.md)
+
+## Sinhronizacija
+
+Sinhronizaciju takođe možete pokrenuti ručno, koristeći komandu `atuin sync`
+
+## Registracija
+
+Možete registrovati nalog za sinhronizaciju:
+
+```
+atuin register -u <USERNAME> -e <EMAIL> -p <PASSWORD>
+```
+
+Korisnička imena moraju biti jedinstvena, a elektronska pošta se koristi
+samo za hitna obaveštenja (promene politika, bezbednosni incidenti itd.)
+
+Nakon registracije, već ste prijavljeni na svoj nalog :) Od tog trenutka sinhronizacija
+će se odvijati automatski
+
+## Ključ
+
+Pošto se svi podaci šifruju, Atuin će prilikom rada generisati vaš ključ. On će biti sačuvan u
+direktorijumu sa podacima Atuin-a (`~/.local/share/atuin` na GNU/Linux sistemima)
+
+Takođe možete to uraditi sami:
+
+```
+atuin key
+```
+
+Nikada ne dajte nikome ovaj ključ!
+
+## Prijavljivanje
+
+Ako želite da se prijavite sa drugog računara, biće vam potreban bezbednosni ključ (`atuin key`).
+
+```
+atuin login -u <USERNAME> -p <PASSWORD> -k <KEY>
+```
+
+## Odjavljivanje
+
+```
+atuin logout
+```

--- a/docs-i18n/cnr/config.md
+++ b/docs-i18n/cnr/config.md
@@ -1,0 +1,146 @@
+# Konfiguracija
+
+Atuin koristi dva konfiguraciona fajla. Oni se nalaze u `~/.config/atuin/`. Podaci
+se skladište u `~/.local/share/atuin` (ukoliko nije drugačije definisano u XDG\_\*).
+
+Putanja do direktorijuma konfiguracije može biti promenjena postavljanjem
+parametra `ATUIN_CONFIG_DIR`. Na primer
+
+```
+export ATUIN_CONFIG_DIR = /home/ellie/.atuin
+```
+
+## Korisnička konfiguracija
+
+```
+~/.config/atuin/config.toml
+```
+
+Ovaj fajl se koristi kada klijent radi na lokalnoj mašini (ne na serveru).
+
+Primer možete pogledati u [config.toml](../../atuin-client/config.toml)
+
+### `dialect`
+
+Ovaj parametar kontroliše kako [stats](stats.md) komanda obrađuje podatke.
+Može imati jednu od dve dozvoljene vrednosti:
+
+```
+dialect = "uk"
+```
+
+ili
+
+```
+dialect = "us"
+```
+
+Podrazumevano je "us".
+
+### `auto_sync`
+
+Da li se automatski sinhronizovati ako je korisnik prijavljen. Podrazumevano je da (true)
+```
+auto_sync = true/false
+```
+
+### `sync_address`
+
+Adresa servera za sinhronizaciju. Podrazumevano je `https://api.atuin.sh`.
+
+```
+sync_address = "https://api.atuin.sh"
+```
+
+### `sync_frequency`
+
+Koliko često se klijent sinhronizuje sa serverom. Može biti navedeno u
+formatu čitljivom za ljude. Na primer, `10s`, `20m`, `1h`, itd.
+Podrazumevano je `1h`
+
+Ako je vrednost postavljena na 0, Atuin će se sinhronizovati nakon svake izvršene komande.
+Imajte na umu da serveri mogu imati ograničenje na broj poslatih zahteva.
+
+```
+sync_frequency = "1h"
+```
+
+### `db_path`
+
+Putanja do SQLite baze podataka. Podrazumevano je
+`~/.local/share/atuin/history.db`.
+
+```
+db_path = "~/.history.db"
+```
+
+### `key_path`
+
+Putanja do ključa za šifrovanje u Atuin-u. Podrazumevano je
+`~/.local/share/atuin/key`.
+
+```
+key = "~/.atuin-key"
+```
+
+### `session_path`
+
+Putanja do serverskog fajla sesije u Atuin-u. Podrazumevano je
+`~/.local/share/atuin/session`. U suštini, ovo je samo API token.
+
+```
+key = "~/.atuin-session"
+```
+
+### `search_mode`
+
+Određuje koji režim pretrage će biti korišćen. Atuin podržava "prefix",
+pretragu po celom tekstu (fulltext) i nepreciznu ("fuzzy") pretragu. Režim "prefix" pretražuje
+po "upit\*", "fulltext" po "\*upit\*", a "fuzzy" koristi
+[sledeći](#fuzzy-search-syntax) sintaksu.
+
+Podrazumevano je "fuzzy"
+
+### `filter_mode`
+
+Filter koji se podrazumevano koristi pri pretrazi
+
+| Vrednost         | Opis                                                               |
+|------------------|--------------------------------------------------------------------|
+| global (default) | Pretražuje istoriju komandi sa svih hostova, sesija i direktorijuma |
+| host             | Pretražuje istoriju komandi sa ovog hosta                           |
+| session          | Pretražuje istoriju komandi ove sesije                              |
+| directory        | Pretražuje istoriju komandi izvršenih u trenutnom direktorijumu     |
+
+Režimi pretrage mogu biti promenjeni preko ctrl-r
+
+
+```
+search_mode = "fulltext"
+```
+
+#### fuzzy search syntax
+
+Režim pretrage "fuzzy" zasnovan je na
+[fzf search syntax](https://github.com/junegunn/fzf#search-syntax).
+
+| Token     | Tip poklapanja               | Opis                                     |
+|-----------|------------------------------|------------------------------------------|
+| `sbtrkt`  | fuzzy-match                  | Sve što se poklapa sa `sbtrkt`           |
+| `'wild`   | exact-match (pod navodnicima)| Sve što sadrži `wild`                    |
+| `^music`  | prefix-exact-match           | Sve što počinje sa `music`               |
+| `.mp3$`   | suffix-exact-match           | Sve što se završava na `.mp3`            |
+| `!fire`   | inverse-exact-match          | Sve što ne sadrži `fire`                 |
+| `!^music` | inverse-prefix-exact-match   | Sve što ne počinje sa `music`            |
+| `!.mp3$`  | inverse-suffix-exact-match   | Sve što se ne završava na `.mp3`         |
+
+Znak vertikalne crte označava logičko ILI. Na primer, upit ispod vraća
+sve što počinje sa `core` i završava se na `go`, `rb` ili `py`.
+
+```
+^core go$ | rb$ | py$
+```
+
+## Serverska konfiguracija
+
+`// TODO`

--- a/docs-i18n/cnr/import.md
+++ b/docs-i18n/cnr/import.md
@@ -1,0 +1,27 @@
+# `atuin import`
+
+Atuin može da uveze istoriju iz "starog" fajla istorije
+
+`atuin import auto` pokušava da odredi tip komandnog interfejsa
+(preko \$SHELL) i pokreće odgovarajući skript za uvoz.
+
+Nažalost, ovi fajlovi ne sadrže toliko informacija koliko Atuin, tako da neće
+sve funkcije biti dostupne sa uvezenim podacima.
+
+# zsh
+
+```
+atuin import zsh
+```
+
+Ako imate HISTFILE, onda bi ova komanda trebalo da funkcioniše. U suprotnom, pokušajte
+
+```
+HISTFILE=/path/to/history/file atuin import zsh
+```
+
+Ovaj parametar podržava kako pojednostavljen, tako i pun format.
+
+# bash
+
+TODO

--- a/docs-i18n/cnr/key-binding.md
+++ b/docs-i18n/cnr/key-binding.md
@@ -1,0 +1,39 @@
+# Prečice na tastaturi
+
+Podrazumevano, Atuin će preusmeriti <kbd>Ctrl-r</kbd> i taster 'strelica nagore'.
+Ako to ne želite, postavite parametar ATUIN_NOBIND pre nego što pozovete `atuin init`
+
+Na primer,
+
+```
+export ATUIN_NOBIND="true"
+eval "$(atuin init zsh)"
+```
+
+Na ovaj način možete dozvoliti preusmeravanje tastera u Atuin-u, ako je to neophodno.
+Uradite to pre inicijalizacionog poziva.
+
+# zsh
+
+Atuin instalira ZLE widget "atuin-search"
+
+```
+export ATUIN_NOBIND="true"
+eval "$(atuin init zsh)"
+
+bindkey '^r' atuin-search
+
+# zavisi od režima terminala
+bindkey '^[[A' atuin-search
+bindkey '^[OA' atuin-search
+```
+
+# bash
+
+```
+export ATUIN_NOBIND="true"
+eval "$(atuin init bash)"
+
+# Predefinišite ctrl-r i bilo koje druge kombinacije prečica ovde
+bind -x '"\C-r": __atuin_history'
+```

--- a/docs-i18n/cnr/list.md
+++ b/docs-i18n/cnr/list.md
@@ -1,0 +1,11 @@
+# Prikaz istorije na ekranu
+
+```
+atuin history list
+```
+
+| Argument       | Opis                                                                                    |
+| -------------- | --------------------------------------------------------------------------------------- |
+| `--cwd/-c`     | Direktorijum čija istorija komandi treba da bude prikazana (podrazumevano svi direktorijumi) |
+| `--session/-s` | Prikazuje istoriju komandi samo trenutne sesije (podrazumevano false)                    |
+| `--human`      | Čitljiv format za vreme i vremenske periode (podrazumevano false)                       |

--- a/docs-i18n/cnr/search.md
+++ b/docs-i18n/cnr/search.md
@@ -1,0 +1,38 @@
+# `atuin search`
+
+```
+atuin search <query>
+```
+
+Pretraga u Atuin-u takođe podržava wildcards sa znacima `*` ili `%`.
+Podrazumevano, mora biti naveden prefiks (tj. svi upiti se automatski dopunjuju wildcard-ovima)
+
+| Argument           | Opis                                                                                         |
+| ------------------ | -------------------------------------------------------------------------------------------- |
+| `--cwd/-c`         | Direktorijum za koji se prikazuje istorija (podrazumevano svi direktorijumi)                 |
+| `--exclude-cwd`    | Isključuje komande koje su pokrenute u ovom direktorijumu (podrazumevano none)               |
+| `--exit/-e`        | Filtriranje po exit code (podrazumevano none)                                                |
+| `--exclude-exit`   | Isključuje komande koje su završene sa navedenom vrednošću (podrazumevano none)              |
+| `--before`         | Uključuje samo komande koje su pokrenute pre navedenog vremena (podrazumevano none)          |
+| `--after`          | Uključuje samo komande koje su pokrenute posle navedenog vremena (podrazumevano none)        |
+| `--interactive/-i` | Otvara interaktivni grafički interfejs za pretragu (podrazumevano false)                     |
+| `--human`          | Koristi čitljivo formatiranje za vreme i vremenske periode (podrazumevano false)             |
+
+## Primeri
+
+```
+# Pokreće interaktivnu pretragu sa tekstualnim korisničkim interfejsom
+atuin search -i
+
+# Pokreće interaktivnu pretragu sa tekstualnim korisničkim interfejsom i već unetim upitom
+atuin search -i atuin
+
+# Pretražuje sve komande koje počinju sa cargo i koje su uspešno završene
+atuin search --exit 0 cargo
+
+# Pretražuje sve komande koje su završene sa greškom, pokrenute u trenutnom direktorijumu i pre prvog aprila 2021
+atuin search --exclude-exit 0 --before 01/04/2021 --cwd .
+
+# Pretražuje sve komande koje počinju sa cargo, uspešno završene i pokrenute posle tri sata popodne juče
+atuin search --exit 0 --after "yesterday 3pm" cargo
+```

--- a/docs-i18n/cnr/server.md
+++ b/docs-i18n/cnr/server.md
@@ -1,0 +1,159 @@
+# `atuin server`
+
+Atuin vam omogućava da pokrenete sopstveni server za sinhronizaciju, ako
+ne želite da koristite podrazumevani :)
+
+Ovde postoji samo jedna podkomanda, `atuin server start`, koja pokreće
+Atuin http server za sinhronizaciju
+
+```
+USAGE:
+    atuin server start [OPTIONS]
+
+FLAGS:
+        --help       Prints help information
+    -V, --version    Prints version information
+
+OPTIONS:
+    -h, --host <host>
+    -p, --port <port>
+```
+
+## config
+
+Serverska konfiguracija se čuva odvojeno od korisničkog fajla konfiguracije, čak i ako
+je u pitanju isti binarni fajl. Serverska konfiguracija se nalazi u `~/.config/atuin/server.toml`.
+
+Ovaj fajl izgleda otprilike ovako:
+
+```toml
+host = "0.0.0.0"
+port = 8888
+open_registration = true
+db_uri="postgres://user:password@hostname/database"
+```
+
+Konfiguracija takođe može biti smeštena u promenljive okruženja.
+
+```sh
+ATUIN_HOST="0.0.0.0"
+ATUIN_PORT=8888
+ATUIN_OPEN_REGISTRATION=true
+ATUIN_DB_URI="postgres://user:password@hostname/database"
+```
+
+### host
+
+Adresa hosta na kojoj će Atuin server osluškivati.
+
+Podrazumevano je `127.0.0.1`.
+
+### port
+
+Port na kojem će Atuin server osluškivati.
+
+Podrazumevano je `8888`.
+
+### open_registration
+
+Ako je `true`, Atuin će dozvoliti registraciju novih korisnika.
+Postavite na `false` ako nakon kreiranja vašeg naloga ne želite da drugi
+koriste vaš server.
+
+Podrazumevano je `false`.
+
+### db_uri
+
+Validan postgres URI gde će biti sačuvan nalog korisnika i istorija.
+
+## Docker
+
+Podržan je Docker image kako bi se olakšalo pokretanje servera u kontejneru.
+
+```sh
+docker run -d -v "$USER/.config/atuin:/config" ghcr.io/ellie/atuin:latest server start
+```
+
+## Docker Compose
+
+Hostovanje sopstvenog Atuin servera pomoću vašeg docker-image-a može biti realizovano kroz
+docker-compose fajl.
+
+Kreirajte `.env` fajl pored `docker-compose.yml` sa sadržajem nalik ovom:
+
+```
+ATUIN_DB_USERNAME=atuin
+# Choose your own secure password
+ATUIN_DB_PASSWORD=really-insecure
+```
+
+Kreirajte `docker-compose.yml`:
+
+```yaml
+version: '3.5'
+services:
+  atuin:
+    restart: always
+    image: ghcr.io/ellie/atuin:main
+    command: server start
+    volumes:
+      - "./config:/config"
+    links:
+      - postgresql:db
+    ports:
+      - 8888:8888
+    environment:
+      ATUIN_HOST: "0.0.0.0"
+      ATUIN_OPEN_REGISTRATION: "true"
+      ATUIN_DB_URI: postgres://$ATUIN_DB_USERNAME:$ATUIN_DB_PASSWORD@db/atuin
+  postgresql:
+    image: postgres:14
+    restart: unless-stopped
+    volumes: # Don't remove permanent storage for index database files!
+      - "./database:/var/lib/postgresql/data/"
+    environment:
+      POSTGRES_USER: $ATUIN_DB_USERNAME
+      POSTGRES_PASSWORD: $ATUIN_DB_PASSWORD
+      POSTGRES_DB: atuin
+```
+
+Pokrenite servise pomoću `docker-compose`:
+
+```sh
+docker-compose up -d
+```
+
+### Korišćenje systemd za upravljanje Atuin serverom
+
+`systemd` unit za upravljanje servisima koje kontroliše `docker-compose`:
+
+```
+[Unit]
+Description=Docker Compose Atuin Service
+Requires=docker.service
+After=docker.service
+
+[Service]
+# Where the docker-compose file is located
+WorkingDirectory=/srv/atuin-server 
+ExecStart=/usr/bin/docker-compose up
+ExecStop=/usr/bin/docker-compose down
+TimeoutStartSec=0
+Restart=on-failure
+StartLimitBurst=3
+
+[Install]
+WantedBy=multi-user.target
+```
+
+Omogućite i pokrenite servis komandom:
+
+```sh
+systemctl enable --now atuin
+```
+
+Proverite da li radi:
+
+```sh
+systemctl status atuin
+```

--- a/docs-i18n/cnr/shell-completions.md
+++ b/docs-i18n/cnr/shell-completions.md
@@ -1,0 +1,20 @@
+# `atuin gen-completions`
+
+[Dopunjavanje komandi](https://en.wikipedia.org/wiki/Command-line_completion) za Atuin
+može biti generisano navođenjem direktorijuma za izlaz i željenog shell-a kroz podkomandu `gen-completions`.
+
+```
+$ atuin gen-completions --shell bash --out-dir $HOME
+
+Shell completion for BASH is generated in "/home/user"
+```
+
+Moguće vrednosti za argument `--shell` su sledeće:
+
+- `bash`
+- `fish`
+- `zsh`
+- `powershell`
+- `elvish`
+
+Takođe preporučujemo da pročitate [supported shells](./../../README.md#supported-shells).

--- a/docs-i18n/cnr/stats.md
+++ b/docs-i18n/cnr/stats.md
@@ -1,0 +1,39 @@
+# `atuin stats`
+
+Atuin takođe može da prikaže statistiku zasnovanu na istoriji. Za sada u veoma jednostavnom obliku,
+ali uskoro bi trebalo da bude više mogućnosti.
+
+Statistika se trenutno prikazuje samo na engleskom jeziku
+# TODO
+
+```
+$ atuin stats day last friday
+
++---------------------+------------+
+| Statistic           | Value      |
++---------------------+------------+
+| Most used command   | git status |
++---------------------+------------+
+| Commands ran        |        450 |
++---------------------+------------+
+| Unique commands ran |        213 |
++---------------------+------------+
+
+$ atuin stats day 01/01/21 # takođe prihvata apsolutne datume
+```
+
+Takođe, može biti prikazana statistika celokupne istorije poznate Atuin-u:
+
+```
+$ atuin stats all
+
++---------------------+-------+
+| Statistic           | Value |
++---------------------+-------+
+| Most used command   |    ls |
++---------------------+-------+
+| Commands ran        |  8190 |
++---------------------+-------+
+| Unique commands ran |  2996 |
++---------------------+-------+
+```

--- a/docs-i18n/cnr/sync.md
+++ b/docs-i18n/cnr/sync.md
@@ -1,0 +1,60 @@
+# `atuin sync`
+
+Atuin može da napravi rezervnu kopiju vaše istorije na serveru kako bi obezbedio korišćenje
+iste istorije na različitim računarima. Celokupna istorija će biti šifrovana dvostranim šifrovanjem,
+tako da server _nikada_ neće dobiti vaše podatke!
+
+Možete pokrenuti sopstveni server (pokretanjem `atuin server start`, o tome je napisano u drugim
+fajlovima dokumentacije), ali postoji i podrazumevani na https://api.atuin.sh. To je podrazumevana adresa servera
+koja može biti promenjena u [konfiguraciji](config.md). Još jednom, ja _ne mogu_ da pristupim vašim podacima
+i oni mi nisu potrebni.
+
+## Učestalost sinhronizacije
+
+Sinhronizacija će se odvijati automatski, ukoliko suprotno nije navedeno u konfiguraciji.
+Ovaj parametar možete podesiti u [konfiguraciji](config.md)
+
+## Sinhronizacija
+
+Sinhronizaciju takođe možete pokrenuti ručno, koristeći komandu `atuin sync`
+
+## Registracija
+
+Možete registrovati nalog za sinhronizaciju:
+
+```
+atuin register -u <USERNAME> -e <EMAIL> -p <PASSWORD>
+```
+
+Korisnička imena moraju biti jedinstvena, a elektronska pošta se koristi
+samo za hitna obaveštenja (promene politika, bezbednosni incidenti itd.)
+
+Nakon registracije, već ste prijavljeni na svoj nalog :) Od tog trenutka sinhronizacija
+će se odvijati automatski
+
+## Ključ
+
+Pošto se svi podaci šifruju, Atuin će prilikom rada generisati vaš ključ. On će biti sačuvan u
+direktorijumu sa podacima Atuin-a (`~/.local/share/atuin` na GNU/Linux sistemima)
+
+Takođe možete to uraditi sami:
+
+```
+atuin key
+```
+
+Nikada ne dajte nikome ovaj ključ!
+
+## Prijavljivanje
+
+Ako želite da se prijavite sa drugog računara, biće vam potreban bezbednosni ključ (`atuin key`).
+
+```
+atuin login -u <USERNAME> -p <PASSWORD> -k <KEY>
+```
+
+## Odjavljivanje
+
+```
+atuin logout
+```

--- a/docs-i18n/hr/config.md
+++ b/docs-i18n/hr/config.md
@@ -1,0 +1,146 @@
+# Konfiguracija
+
+Atuin koristi dvije konfiguracijske datoteke. One se nalaze u `~/.config/atuin/`. Podaci
+se skladište u `~/.local/share/atuin` (ukoliko nije drugačije definirano u XDG\_\*).
+
+Putanja do direktorija konfiguracije može biti promenjena postavljanjem
+parametra `ATUIN_CONFIG_DIR`. Na primer
+
+```
+export ATUIN_CONFIG_DIR = /home/ellie/.atuin
+```
+
+## Korisnička konfiguracija
+
+```
+~/.config/atuin/config.toml
+```
+
+Ova datoteka se koristi kada klijent radi na lokalnom stroju (ne na serveru).
+
+Primer možete pogledati u [config.toml](../../atuin-client/config.toml)
+
+### `dialect`
+
+Ovaj parametar kontroliše kako [stats](stats.md) naredba obrađuje podatke.
+Može imati jednu od dve dozvoljene vrednosti:
+
+```
+dialect = "uk"
+```
+
+ili
+
+```
+dialect = "us"
+```
+
+Zadano je "us".
+
+### `auto_sync`
+
+Da li se automatski sinkronizirati ako je korisnik prijavljen. Zadano je da (true)
+```
+auto_sync = true/false
+```
+
+### `sync_address`
+
+Adresa servera za sinkronizaciju. Zadano je `https://api.atuin.sh`.
+
+```
+sync_address = "https://api.atuin.sh"
+```
+
+### `sync_frequency`
+
+Koliko često se klijent sinkronizira sa serverom. Može biti navedeno u
+formatu čitljivom za ljude. Na primer, `10s`, `20m`, `1h`, itd.
+Zadano je `1h`
+
+Ako je vrednost postavljena na 0, Atuin će se sinkronizirati nakon svake izvršene naredbe.
+Imajte na umu da serveri mogu imati ograničenje na broj poslatih zahteva.
+
+```
+sync_frequency = "1h"
+```
+
+### `db_path`
+
+Putanja do SQLite baze podataka. Zadano je
+`~/.local/share/atuin/history.db`.
+
+```
+db_path = "~/.history.db"
+```
+
+### `key_path`
+
+Putanja do ključa za šifriranje u Atuin-u. Zadano je
+`~/.local/share/atuin/key`.
+
+```
+key = "~/.atuin-key"
+```
+
+### `session_path`
+
+Putanja do serverske datoteke sesije u Atuin-u. Zadano je
+`~/.local/share/atuin/session`. U suštini, ovo je samo API token.
+
+```
+key = "~/.atuin-session"
+```
+
+### `search_mode`
+
+Određuje koji režim pretrage će biti korišćen. Atuin podržava "prefix",
+pretragu po celom tekstu (fulltext) i nepreciznu ("fuzzy") pretragu. Režim "prefix" pretražuje
+po "upit\*", "fulltext" po "\*upit\*", a "fuzzy" koristi
+[sledeći](#fuzzy-search-syntax) sintaksu.
+
+Zadano je "fuzzy"
+
+### `filter_mode`
+
+Filter koji se zadano koristi pri pretrazi
+
+| Vrednost         | Opis                                                               |
+|------------------|--------------------------------------------------------------------|
+| global (default) | Pretražuje istoriju naredbi sa svih hostova, sesija i direktorija |
+| host             | Pretražuje istoriju naredbi sa ovog hosta                           |
+| session          | Pretražuje istoriju naredbi ove sesije                              |
+| directory        | Pretražuje istoriju naredbi izvršenih u trenutnom direktoriju     |
+
+Režimi pretrage mogu biti promenjeni preko ctrl-r
+
+
+```
+search_mode = "fulltext"
+```
+
+#### fuzzy search syntax
+
+Režim pretrage "fuzzy" zasnovan je na
+[fzf search syntax](https://github.com/junegunn/fzf#search-syntax).
+
+| Token     | Tip poklapanja               | Opis                                     |
+|-----------|------------------------------|------------------------------------------|
+| `sbtrkt`  | fuzzy-match                  | Sve što se poklapa sa `sbtrkt`           |
+| `'wild`   | exact-match (pod navodnicima)| Sve što sadrži `wild`                    |
+| `^music`  | prefix-exact-match           | Sve što počinje sa `music`               |
+| `.mp3$`   | suffix-exact-match           | Sve što se završava na `.mp3`            |
+| `!fire`   | inverse-exact-match          | Sve što ne sadrži `fire`                 |
+| `!^music` | inverse-prefix-exact-match   | Sve što ne počinje sa `music`            |
+| `!.mp3$`  | inverse-suffix-exact-match   | Sve što se ne završava na `.mp3`         |
+
+Znak vertikalne crte označava logičko ILI. Na primer, upit ispod vraća
+sve što počinje sa `core` i završava se na `go`, `rb` ili `py`.
+
+```
+^core go$ | rb$ | py$
+```
+
+## Serverska konfiguracija
+
+`// TODO`

--- a/docs-i18n/hr/import.md
+++ b/docs-i18n/hr/import.md
@@ -1,0 +1,27 @@
+# `atuin import`
+
+Atuin može da uveze istoriju iz "stare" datoteke istorije
+
+`atuin import auto` pokušava da odredi tip naredbenog sučelja
+(preko \$SHELL) i pokreće odgovarajući skript za uvoz.
+
+Nažalost, ove datoteke ne sadrže toliko informacija koliko Atuin, tako da neće
+sve funkcije biti dostupne sa uvezenim podacima.
+
+# zsh
+
+```
+atuin import zsh
+```
+
+Ako imate HISTFILE, onda bi ova naredba trebalo da funkcioniše. U suprotnom, pokušajte
+
+```
+HISTFILE=/path/to/history/file atuin import zsh
+```
+
+Ovaj parametar podržava kako pojednostavljen, tako i pun format.
+
+# bash
+
+TODO

--- a/docs-i18n/hr/key-binding.md
+++ b/docs-i18n/hr/key-binding.md
@@ -1,0 +1,39 @@
+# Prečice na tastaturi
+
+Zadano, Atuin će preusmeriti <kbd>Ctrl-r</kbd> i taster 'strelica nagore'.
+Ako to ne želite, postavite parametar ATUIN_NOBIND pre nego što pozovete `atuin init`
+
+Na primer,
+
+```
+export ATUIN_NOBIND="true"
+eval "$(atuin init zsh)"
+```
+
+Na ovaj način možete dozvoliti preusmeravanje tastera u Atuin-u, ako je to neophodno.
+Uradite to pre inicijalizacionog poziva.
+
+# zsh
+
+Atuin instalira ZLE widget "atuin-search"
+
+```
+export ATUIN_NOBIND="true"
+eval "$(atuin init zsh)"
+
+bindkey '^r' atuin-search
+
+# zavisi od režima terminala
+bindkey '^[[A' atuin-search
+bindkey '^[OA' atuin-search
+```
+
+# bash
+
+```
+export ATUIN_NOBIND="true"
+eval "$(atuin init bash)"
+
+# Predefinišite ctrl-r i bilo koje druge kombinacije prečica ovde
+bind -x '"\C-r": __atuin_history'
+```

--- a/docs-i18n/hr/list.md
+++ b/docs-i18n/hr/list.md
@@ -1,0 +1,11 @@
+# Prikaz istorije na ekranu
+
+```
+atuin history list
+```
+
+| Argument       | Opis                                                                                    |
+| -------------- | --------------------------------------------------------------------------------------- |
+| `--cwd/-c`     | Direktorij čija istorija naredbi treba da bude prikazana (zadano svi direktoriji) |
+| `--session/-s` | Prikazuje istoriju naredbi samo trenutne sesije (zadano false)                    |
+| `--human`      | Čitljiv format za vreme i vremenske periode (zadano false)                       |

--- a/docs-i18n/hr/search.md
+++ b/docs-i18n/hr/search.md
@@ -1,0 +1,38 @@
+# `atuin search`
+
+```
+atuin search <query>
+```
+
+Pretraga u Atuin-u takođe podržava wildcards sa znacima `*` ili `%`.
+Zadano, mora biti naveden prefiks (tj. svi upiti se automatski dopunjuju wildcard-ovima)
+
+| Argument           | Opis                                                                                         |
+| ------------------ | -------------------------------------------------------------------------------------------- |
+| `--cwd/-c`         | Direktorij za koji se prikazuje istorija (zadano svi direktoriji)                 |
+| `--exclude-cwd`    | Isključuje naredbe koje su pokrenute u ovom direktoriju (zadano none)               |
+| `--exit/-e`        | Filtriranje po exit code (zadano none)                                                |
+| `--exclude-exit`   | Isključuje naredbe koje su završene sa navedenom vrednošću (zadano none)              |
+| `--before`         | Uključuje samo naredbe koje su pokrenute pre navedenog vremena (zadano none)          |
+| `--after`          | Uključuje samo naredbe koje su pokrenute posle navedenog vremena (zadano none)        |
+| `--interactive/-i` | Otvara interaktivni grafički interfejs za pretragu (zadano false)                     |
+| `--human`          | Koristi čitljivo formatiranje za vreme i vremenske periode (zadano false)             |
+
+## Primeri
+
+```
+# Pokreće interaktivnu pretragu sa tekstualnim korisničkim interfejsom
+atuin search -i
+
+# Pokreće interaktivnu pretragu sa tekstualnim korisničkim interfejsom i već unetim upitom
+atuin search -i atuin
+
+# Pretražuje sve naredbe koje počinju sa cargo i koje su uspešno završene
+atuin search --exit 0 cargo
+
+# Pretražuje sve naredbe koje su završene sa greškom, pokrenute u trenutnom direktoriju i pre prvog aprila 2021
+atuin search --exclude-exit 0 --before 01/04/2021 --cwd .
+
+# Pretražuje sve naredbe koje počinju sa cargo, uspešno završene i pokrenute posle tri sata popodne juče
+atuin search --exit 0 --after "yesterday 3pm" cargo
+```

--- a/docs-i18n/hr/server.md
+++ b/docs-i18n/hr/server.md
@@ -1,0 +1,159 @@
+# `atuin server`
+
+Atuin vam omogućava da pokrenete sopstveni server za sinkronizaciju, ako
+ne želite da koristite zadani :)
+
+Ovde postoji samo jedna podnaredba, `atuin server start`, koja pokreće
+Atuin http server za sinkronizaciju
+
+```
+USAGE:
+    atuin server start [OPTIONS]
+
+FLAGS:
+        --help       Prints help information
+    -V, --version    Prints version information
+
+OPTIONS:
+    -h, --host <host>
+    -p, --port <port>
+```
+
+## config
+
+Serverska konfiguracija se čuva odvojeno od korisničke datoteke konfiguracije, čak i ako
+je u pitanju ista binarna datoteka. Serverska konfiguracija se nalazi u `~/.config/atuin/server.toml`.
+
+Ova datoteka izgleda otprilike ovako:
+
+```toml
+host = "0.0.0.0"
+port = 8888
+open_registration = true
+db_uri="postgres://user:password@hostname/database"
+```
+
+Konfiguracija takođe može biti smeštena u promenljive okruženja.
+
+```sh
+ATUIN_HOST="0.0.0.0"
+ATUIN_PORT=8888
+ATUIN_OPEN_REGISTRATION=true
+ATUIN_DB_URI="postgres://user:password@hostname/database"
+```
+
+### host
+
+Adresa hosta na kojoj će Atuin server osluškivati.
+
+Zadano je `127.0.0.1`.
+
+### port
+
+Port na kojem će Atuin server osluškivati.
+
+Zadano je `8888`.
+
+### open_registration
+
+Ako je `true`, Atuin će dozvoliti registraciju novih korisnika.
+Postavite na `false` ako nakon kreiranja vašeg naloga ne želite da drugi
+koriste vaš server.
+
+Zadano je `false`.
+
+### db_uri
+
+Validan postgres URI gde će biti sačuvan nalog korisnika i istorija.
+
+## Docker
+
+Podržan je Docker image kako bi se olakšalo pokretanje servera u kontejneru.
+
+```sh
+docker run -d -v "$USER/.config/atuin:/config" ghcr.io/ellie/atuin:latest server start
+```
+
+## Docker Compose
+
+Hostovanje sopstvenog Atuin servera pomoću vašeg docker-image-a može biti realizovano kroz
+docker-compose datoteku.
+
+Kreirajte `.env` datoteku pored `docker-compose.yml` sa sadržajem nalik ovom:
+
+```
+ATUIN_DB_USERNAME=atuin
+# Choose your own secure password
+ATUIN_DB_PASSWORD=really-insecure
+```
+
+Kreirajte `docker-compose.yml`:
+
+```yaml
+version: '3.5'
+services:
+  atuin:
+    restart: always
+    image: ghcr.io/ellie/atuin:main
+    command: server start
+    volumes:
+      - "./config:/config"
+    links:
+      - postgresql:db
+    ports:
+      - 8888:8888
+    environment:
+      ATUIN_HOST: "0.0.0.0"
+      ATUIN_OPEN_REGISTRATION: "true"
+      ATUIN_DB_URI: postgres://$ATUIN_DB_USERNAME:$ATUIN_DB_PASSWORD@db/atuin
+  postgresql:
+    image: postgres:14
+    restart: unless-stopped
+    volumes: # Don't remove permanent storage for index database files!
+      - "./database:/var/lib/postgresql/data/"
+    environment:
+      POSTGRES_USER: $ATUIN_DB_USERNAME
+      POSTGRES_PASSWORD: $ATUIN_DB_PASSWORD
+      POSTGRES_DB: atuin
+```
+
+Pokrenite servise pomoću `docker-compose`:
+
+```sh
+docker-compose up -d
+```
+
+### Korišćenje systemd za upravljanje Atuin serverom
+
+`systemd` unit za upravljanje servisima koje kontroliše `docker-compose`:
+
+```
+[Unit]
+Description=Docker Compose Atuin Service
+Requires=docker.service
+After=docker.service
+
+[Service]
+# Where the docker-compose file is located
+WorkingDirectory=/srv/atuin-server 
+ExecStart=/usr/bin/docker-compose up
+ExecStop=/usr/bin/docker-compose down
+TimeoutStartSec=0
+Restart=on-failure
+StartLimitBurst=3
+
+[Install]
+WantedBy=multi-user.target
+```
+
+Omogućite i pokrenite servis naredbom:
+
+```sh
+systemctl enable --now atuin
+```
+
+Proverite da li radi:
+
+```sh
+systemctl status atuin
+```

--- a/docs-i18n/hr/shell-completions.md
+++ b/docs-i18n/hr/shell-completions.md
@@ -1,0 +1,20 @@
+# `atuin gen-completions`
+
+[Dopunjavanje naredbi](https://en.wikipedia.org/wiki/Command-line_completion) za Atuin
+može biti generisano navođenjem direktorija za izlaz i željenog shell-a kroz podnaredbu `gen-completions`.
+
+```
+$ atuin gen-completions --shell bash --out-dir $HOME
+
+Shell completion for BASH is generated in "/home/user"
+```
+
+Moguće vrednosti za argument `--shell` su sledeće:
+
+- `bash`
+- `fish`
+- `zsh`
+- `powershell`
+- `elvish`
+
+Takođe preporučujemo da pročitate [supported shells](./../../README.md#supported-shells).

--- a/docs-i18n/hr/stats.md
+++ b/docs-i18n/hr/stats.md
@@ -1,0 +1,39 @@
+# `atuin stats`
+
+Atuin takođe može da prikaže statistiku zasnovanu na istoriji. Za sada u veoma jednostavnom obliku,
+ali uskoro bi trebalo da bude više mogućnosti.
+
+Statistika se trenutno prikazuje samo na engleskom jeziku
+# TODO
+
+```
+$ atuin stats day last friday
+
++---------------------+------------+
+| Statistic           | Value      |
++---------------------+------------+
+| Most used command   | git status |
++---------------------+------------+
+| Commands ran        |        450 |
++---------------------+------------+
+| Unique commands ran |        213 |
++---------------------+------------+
+
+$ atuin stats day 01/01/21 # takođe prihvata apsolutne datume
+```
+
+Takođe, može biti prikazana statistika celokupne istorije poznate Atuin-u:
+
+```
+$ atuin stats all
+
++---------------------+-------+
+| Statistic           | Value |
++---------------------+-------+
+| Most used command   |    ls |
++---------------------+-------+
+| Commands ran        |  8190 |
++---------------------+-------+
+| Unique commands ran |  2996 |
++---------------------+-------+
+```

--- a/docs-i18n/hr/sync.md
+++ b/docs-i18n/hr/sync.md
@@ -1,0 +1,60 @@
+# `atuin sync`
+
+Atuin može da napravi rezervnu kopiju vaše istorije na serveru kako bi obezbedio korišćenje
+iste istorije na različitim računalima. Celokupna istorija će biti šifrirana dvostranim šifriranjem,
+tako da server _nikada_ neće dobiti vaše podatke!
+
+Možete pokrenuti sopstveni server (pokretanjem `atuin server start`, o tome je napisano u drugim
+datotekama dokumentacije), ali postoji i zadani na https://api.atuin.sh. To je zadana adresa servera
+koja može biti promenjena u [konfiguraciji](config.md). Još jednom, ja _ne mogu_ da pristupim vašim podacima
+i oni mi nisu potrebni.
+
+## Učestalost sinkronizacije
+
+Sinkronizacija će se odvijati automatski, ukoliko suprotno nije navedeno u konfiguraciji.
+Ovaj parametar možete podesiti u [konfiguraciji](config.md)
+
+## Sinkronizacija
+
+Sinkronizaciju takođe možete pokrenuti ručno, koristeći naredbu `atuin sync`
+
+## Registracija
+
+Možete registrovati nalog za sinkronizaciju:
+
+```
+atuin register -u <USERNAME> -e <EMAIL> -p <PASSWORD>
+```
+
+Korisnička imena moraju biti jedinstvena, a elektronska pošta se koristi
+samo za hitna obaveštenja (promene politika, bezbednosni incidenti itd.)
+
+Nakon registracije, već ste prijavljeni na svoj nalog :) Od tog trenutka sinkronizacija
+će se odvijati automatski
+
+## Ključ
+
+Pošto se svi podaci šifriraju, Atuin će prilikom rada generisati vaš ključ. On će biti sačuvan u
+direktoriju sa podacima Atuin-a (`~/.local/share/atuin` na GNU/Linux sistemima)
+
+Takođe možete to uraditi sami:
+
+```
+atuin key
+```
+
+Nikada ne dajte nikome ovaj ključ!
+
+## Prijavljivanje
+
+Ako želite da se prijavite sa drugog računala, biće vam potreban bezbednosni ključ (`atuin key`).
+
+```
+atuin login -u <USERNAME> -p <PASSWORD> -k <KEY>
+```
+
+## Odjavljivanje
+
+```
+atuin logout
+```

--- a/docs-i18n/sr/config.md
+++ b/docs-i18n/sr/config.md
@@ -1,0 +1,146 @@
+# Konfiguracija
+
+Atuin koristi dva konfiguraciona fajla. Oni se nalaze u `~/.config/atuin/`. Podaci
+se skladište u `~/.local/share/atuin` (ukoliko nije drugačije definisano u XDG\_\*).
+
+Putanja do direktorijuma konfiguracije može biti promenjena postavljanjem
+parametra `ATUIN_CONFIG_DIR`. Na primer
+
+```
+export ATUIN_CONFIG_DIR = /home/ellie/.atuin
+```
+
+## Korisnička konfiguracija
+
+```
+~/.config/atuin/config.toml
+```
+
+Ovaj fajl se koristi kada klijent radi na lokalnoj mašini (ne na serveru).
+
+Primer možete pogledati u [config.toml](../../atuin-client/config.toml)
+
+### `dialect`
+
+Ovaj parametar kontroliše kako [stats](stats.md) komanda obrađuje podatke.
+Može imati jednu od dve dozvoljene vrednosti:
+
+```
+dialect = "uk"
+```
+
+ili
+
+```
+dialect = "us"
+```
+
+Podrazumevano je "us".
+
+### `auto_sync`
+
+Da li se automatski sinhronizovati ako je korisnik prijavljen. Podrazumevano je da (true)
+```
+auto_sync = true/false
+```
+
+### `sync_address`
+
+Adresa servera za sinhronizaciju. Podrazumevano je `https://api.atuin.sh`.
+
+```
+sync_address = "https://api.atuin.sh"
+```
+
+### `sync_frequency`
+
+Koliko često se klijent sinhronizuje sa serverom. Može biti navedeno u
+formatu čitljivom za ljude. Na primer, `10s`, `20m`, `1h`, itd.
+Podrazumevano je `1h`
+
+Ako je vrednost postavljena na 0, Atuin će se sinhronizovati nakon svake izvršene komande.
+Imajte na umu da serveri mogu imati ograničenje na broj poslatih zahteva.
+
+```
+sync_frequency = "1h"
+```
+
+### `db_path`
+
+Putanja do SQLite baze podataka. Podrazumevano je
+`~/.local/share/atuin/history.db`.
+
+```
+db_path = "~/.history.db"
+```
+
+### `key_path`
+
+Putanja do ključa za šifrovanje u Atuin-u. Podrazumevano je
+`~/.local/share/atuin/key`.
+
+```
+key = "~/.atuin-key"
+```
+
+### `session_path`
+
+Putanja do serverskog fajla sesije u Atuin-u. Podrazumevano je
+`~/.local/share/atuin/session`. U suštini, ovo je samo API token.
+
+```
+key = "~/.atuin-session"
+```
+
+### `search_mode`
+
+Određuje koji režim pretrage će biti korišćen. Atuin podržava "prefix",
+pretragu po celom tekstu (fulltext) i nepreciznu ("fuzzy") pretragu. Režim "prefix" pretražuje
+po "upit\*", "fulltext" po "\*upit\*", a "fuzzy" koristi
+[sledeći](#fuzzy-search-syntax) sintaksu.
+
+Podrazumevano je "fuzzy"
+
+### `filter_mode`
+
+Filter koji se podrazumevano koristi pri pretrazi
+
+| Vrednost         | Opis                                                               |
+|------------------|--------------------------------------------------------------------|
+| global (default) | Pretražuje istoriju komandi sa svih hostova, sesija i direktorijuma |
+| host             | Pretražuje istoriju komandi sa ovog hosta                           |
+| session          | Pretražuje istoriju komandi ove sesije                              |
+| directory        | Pretražuje istoriju komandi izvršenih u trenutnom direktorijumu     |
+
+Režimi pretrage mogu biti promenjeni preko ctrl-r
+
+
+```
+search_mode = "fulltext"
+```
+
+#### fuzzy search syntax
+
+Režim pretrage "fuzzy" zasnovan je na
+[fzf search syntax](https://github.com/junegunn/fzf#search-syntax).
+
+| Token     | Tip poklapanja               | Opis                                     |
+|-----------|------------------------------|------------------------------------------|
+| `sbtrkt`  | fuzzy-match                  | Sve što se poklapa sa `sbtrkt`           |
+| `'wild`   | exact-match (pod navodnicima)| Sve što sadrži `wild`                    |
+| `^music`  | prefix-exact-match           | Sve što počinje sa `music`               |
+| `.mp3$`   | suffix-exact-match           | Sve što se završava na `.mp3`            |
+| `!fire`   | inverse-exact-match          | Sve što ne sadrži `fire`                 |
+| `!^music` | inverse-prefix-exact-match   | Sve što ne počinje sa `music`            |
+| `!.mp3$`  | inverse-suffix-exact-match   | Sve što se ne završava na `.mp3`         |
+
+Znak vertikalne crte označava logičko ILI. Na primer, upit ispod vraća
+sve što počinje sa `core` i završava se na `go`, `rb` ili `py`.
+
+```
+^core go$ | rb$ | py$
+```
+
+## Serverska konfiguracija
+
+`// TODO`

--- a/docs-i18n/sr/import.md
+++ b/docs-i18n/sr/import.md
@@ -1,0 +1,27 @@
+# `atuin import`
+
+Atuin može da uveze istoriju iz "starog" fajla istorije
+
+`atuin import auto` pokušava da odredi tip komandnog interfejsa
+(preko \$SHELL) i pokreće odgovarajući skript za uvoz.
+
+Nažalost, ovi fajlovi ne sadrže toliko informacija koliko Atuin, tako da neće
+sve funkcije biti dostupne sa uvezenim podacima.
+
+# zsh
+
+```
+atuin import zsh
+```
+
+Ako imate HISTFILE, onda bi ova komanda trebalo da funkcioniše. U suprotnom, pokušajte
+
+```
+HISTFILE=/path/to/history/file atuin import zsh
+```
+
+Ovaj parametar podržava kako pojednostavljen, tako i pun format.
+
+# bash
+
+TODO

--- a/docs-i18n/sr/key-binding.md
+++ b/docs-i18n/sr/key-binding.md
@@ -1,0 +1,39 @@
+# Prečice na tastaturi
+
+Podrazumevano, Atuin će preusmeriti <kbd>Ctrl-r</kbd> i taster 'strelica nagore'.
+Ako to ne želite, postavite parametar ATUIN_NOBIND pre nego što pozovete `atuin init`
+
+Na primer,
+
+```
+export ATUIN_NOBIND="true"
+eval "$(atuin init zsh)"
+```
+
+Na ovaj način možete dozvoliti preusmeravanje tastera u Atuin-u, ako je to neophodno.
+Uradite to pre inicijalizacionog poziva.
+
+# zsh
+
+Atuin instalira ZLE widget "atuin-search"
+
+```
+export ATUIN_NOBIND="true"
+eval "$(atuin init zsh)"
+
+bindkey '^r' atuin-search
+
+# zavisi od režima terminala
+bindkey '^[[A' atuin-search
+bindkey '^[OA' atuin-search
+```
+
+# bash
+
+```
+export ATUIN_NOBIND="true"
+eval "$(atuin init bash)"
+
+# Predefinišite ctrl-r i bilo koje druge kombinacije prečica ovde
+bind -x '"\C-r": __atuin_history'
+```

--- a/docs-i18n/sr/list.md
+++ b/docs-i18n/sr/list.md
@@ -1,0 +1,11 @@
+# Prikaz istorije na ekranu
+
+```
+atuin history list
+```
+
+| Argument       | Opis                                                                                    |
+| -------------- | --------------------------------------------------------------------------------------- |
+| `--cwd/-c`     | Direktorijum čija istorija komandi treba da bude prikazana (podrazumevano svi direktorijumi) |
+| `--session/-s` | Prikazuje istoriju komandi samo trenutne sesije (podrazumevano false)                    |
+| `--human`      | Čitljiv format za vreme i vremenske periode (podrazumevano false)                       |

--- a/docs-i18n/sr/search.md
+++ b/docs-i18n/sr/search.md
@@ -1,0 +1,38 @@
+# `atuin search`
+
+```
+atuin search <query>
+```
+
+Pretraga u Atuin-u takođe podržava wildcards sa znacima `*` ili `%`.
+Podrazumevano, mora biti naveden prefiks (tj. svi upiti se automatski dopunjuju wildcard-ovima)
+
+| Argument           | Opis                                                                                         |
+| ------------------ | -------------------------------------------------------------------------------------------- |
+| `--cwd/-c`         | Direktorijum za koji se prikazuje istorija (podrazumevano svi direktorijumi)                 |
+| `--exclude-cwd`    | Isključuje komande koje su pokrenute u ovom direktorijumu (podrazumevano none)               |
+| `--exit/-e`        | Filtriranje po exit code (podrazumevano none)                                                |
+| `--exclude-exit`   | Isključuje komande koje su završene sa navedenom vrednošću (podrazumevano none)              |
+| `--before`         | Uključuje samo komande koje su pokrenute pre navedenog vremena (podrazumevano none)          |
+| `--after`          | Uključuje samo komande koje su pokrenute posle navedenog vremena (podrazumevano none)        |
+| `--interactive/-i` | Otvara interaktivni grafički interfejs za pretragu (podrazumevano false)                     |
+| `--human`          | Koristi čitljivo formatiranje za vreme i vremenske periode (podrazumevano false)             |
+
+## Primeri
+
+```
+# Pokreće interaktivnu pretragu sa tekstualnim korisničkim interfejsom
+atuin search -i
+
+# Pokreće interaktivnu pretragu sa tekstualnim korisničkim interfejsom i već unetim upitom
+atuin search -i atuin
+
+# Pretražuje sve komande koje počinju sa cargo i koje su uspešno završene
+atuin search --exit 0 cargo
+
+# Pretražuje sve komande koje su završene sa greškom, pokrenute u trenutnom direktorijumu i pre prvog aprila 2021
+atuin search --exclude-exit 0 --before 01/04/2021 --cwd .
+
+# Pretražuje sve komande koje počinju sa cargo, uspešno završene i pokrenute posle tri sata popodne juče
+atuin search --exit 0 --after "yesterday 3pm" cargo
+```

--- a/docs-i18n/sr/server.md
+++ b/docs-i18n/sr/server.md
@@ -1,0 +1,159 @@
+# `atuin server`
+
+Atuin vam omogućava da pokrenete sopstveni server za sinhronizaciju, ako
+ne želite da koristite podrazumevani :)
+
+Ovde postoji samo jedna podkomanda, `atuin server start`, koja pokreće
+Atuin http server za sinhronizaciju
+
+```
+USAGE:
+    atuin server start [OPTIONS]
+
+FLAGS:
+        --help       Prints help information
+    -V, --version    Prints version information
+
+OPTIONS:
+    -h, --host <host>
+    -p, --port <port>
+```
+
+## config
+
+Serverska konfiguracija se čuva odvojeno od korisničkog fajla konfiguracije, čak i ako
+je u pitanju isti binarni fajl. Serverska konfiguracija se nalazi u `~/.config/atuin/server.toml`.
+
+Ovaj fajl izgleda otprilike ovako:
+
+```toml
+host = "0.0.0.0"
+port = 8888
+open_registration = true
+db_uri="postgres://user:password@hostname/database"
+```
+
+Konfiguracija takođe može biti smeštena u promenljive okruženja.
+
+```sh
+ATUIN_HOST="0.0.0.0"
+ATUIN_PORT=8888
+ATUIN_OPEN_REGISTRATION=true
+ATUIN_DB_URI="postgres://user:password@hostname/database"
+```
+
+### host
+
+Adresa hosta na kojoj će Atuin server osluškivati.
+
+Podrazumevano je `127.0.0.1`.
+
+### port
+
+Port na kojem će Atuin server osluškivati.
+
+Podrazumevano je `8888`.
+
+### open_registration
+
+Ako je `true`, Atuin će dozvoliti registraciju novih korisnika.
+Postavite na `false` ako nakon kreiranja vašeg naloga ne želite da drugi
+koriste vaš server.
+
+Podrazumevano je `false`.
+
+### db_uri
+
+Validan postgres URI gde će biti sačuvan nalog korisnika i istorija.
+
+## Docker
+
+Podržan je Docker image kako bi se olakšalo pokretanje servera u kontejneru.
+
+```sh
+docker run -d -v "$USER/.config/atuin:/config" ghcr.io/ellie/atuin:latest server start
+```
+
+## Docker Compose
+
+Hostovanje sopstvenog Atuin servera pomoću vašeg docker-image-a može biti realizovano kroz
+docker-compose fajl.
+
+Kreirajte `.env` fajl pored `docker-compose.yml` sa sadržajem nalik ovom:
+
+```
+ATUIN_DB_USERNAME=atuin
+# Choose your own secure password
+ATUIN_DB_PASSWORD=really-insecure
+```
+
+Kreirajte `docker-compose.yml`:
+
+```yaml
+version: '3.5'
+services:
+  atuin:
+    restart: always
+    image: ghcr.io/ellie/atuin:main
+    command: server start
+    volumes:
+      - "./config:/config"
+    links:
+      - postgresql:db
+    ports:
+      - 8888:8888
+    environment:
+      ATUIN_HOST: "0.0.0.0"
+      ATUIN_OPEN_REGISTRATION: "true"
+      ATUIN_DB_URI: postgres://$ATUIN_DB_USERNAME:$ATUIN_DB_PASSWORD@db/atuin
+  postgresql:
+    image: postgres:14
+    restart: unless-stopped
+    volumes: # Don't remove permanent storage for index database files!
+      - "./database:/var/lib/postgresql/data/"
+    environment:
+      POSTGRES_USER: $ATUIN_DB_USERNAME
+      POSTGRES_PASSWORD: $ATUIN_DB_PASSWORD
+      POSTGRES_DB: atuin
+```
+
+Pokrenite servise pomoću `docker-compose`:
+
+```sh
+docker-compose up -d
+```
+
+### Korišćenje systemd za upravljanje Atuin serverom
+
+`systemd` unit za upravljanje servisima koje kontroliše `docker-compose`:
+
+```
+[Unit]
+Description=Docker Compose Atuin Service
+Requires=docker.service
+After=docker.service
+
+[Service]
+# Where the docker-compose file is located
+WorkingDirectory=/srv/atuin-server 
+ExecStart=/usr/bin/docker-compose up
+ExecStop=/usr/bin/docker-compose down
+TimeoutStartSec=0
+Restart=on-failure
+StartLimitBurst=3
+
+[Install]
+WantedBy=multi-user.target
+```
+
+Omogućite i pokrenite servis komandom:
+
+```sh
+systemctl enable --now atuin
+```
+
+Proverite da li radi:
+
+```sh
+systemctl status atuin
+```

--- a/docs-i18n/sr/shell-completions.md
+++ b/docs-i18n/sr/shell-completions.md
@@ -1,0 +1,20 @@
+# `atuin gen-completions`
+
+[Dopunjavanje komandi](https://en.wikipedia.org/wiki/Command-line_completion) za Atuin
+može biti generisano navođenjem direktorijuma za izlaz i željenog shell-a kroz podkomandu `gen-completions`.
+
+```
+$ atuin gen-completions --shell bash --out-dir $HOME
+
+Shell completion for BASH is generated in "/home/user"
+```
+
+Moguće vrednosti za argument `--shell` su sledeće:
+
+- `bash`
+- `fish`
+- `zsh`
+- `powershell`
+- `elvish`
+
+Takođe preporučujemo da pročitate [supported shells](./../../README.md#supported-shells).

--- a/docs-i18n/sr/stats.md
+++ b/docs-i18n/sr/stats.md
@@ -1,0 +1,39 @@
+# `atuin stats`
+
+Atuin takođe može da prikaže statistiku zasnovanu na istoriji. Za sada u veoma jednostavnom obliku,
+ali uskoro bi trebalo da bude više mogućnosti.
+
+Statistika se trenutno prikazuje samo na engleskom jeziku
+# TODO
+
+```
+$ atuin stats day last friday
+
++---------------------+------------+
+| Statistic           | Value      |
++---------------------+------------+
+| Most used command   | git status |
++---------------------+------------+
+| Commands ran        |        450 |
++---------------------+------------+
+| Unique commands ran |        213 |
++---------------------+------------+
+
+$ atuin stats day 01/01/21 # takođe prihvata apsolutne datume
+```
+
+Takođe, može biti prikazana statistika celokupne istorije poznate Atuin-u:
+
+```
+$ atuin stats all
+
++---------------------+-------+
+| Statistic           | Value |
++---------------------+-------+
+| Most used command   |    ls |
++---------------------+-------+
+| Commands ran        |  8190 |
++---------------------+-------+
+| Unique commands ran |  2996 |
++---------------------+-------+
+```

--- a/docs-i18n/sr/sync.md
+++ b/docs-i18n/sr/sync.md
@@ -1,0 +1,60 @@
+# `atuin sync`
+
+Atuin može da napravi rezervnu kopiju vaše istorije na serveru kako bi obezbedio korišćenje
+iste istorije na različitim računarima. Celokupna istorija će biti šifrovana dvostranim šifrovanjem,
+tako da server _nikada_ neće dobiti vaše podatke!
+
+Možete pokrenuti sopstveni server (pokretanjem `atuin server start`, o tome je napisano u drugim
+fajlovima dokumentacije), ali postoji i podrazumevani na https://api.atuin.sh. To je podrazumevana adresa servera
+koja može biti promenjena u [konfiguraciji](config.md). Još jednom, ja _ne mogu_ da pristupim vašim podacima
+i oni mi nisu potrebni.
+
+## Učestalost sinhronizacije
+
+Sinhronizacija će se odvijati automatski, ukoliko suprotno nije navedeno u konfiguraciji.
+Ovaj parametar možete podesiti u [konfiguraciji](config.md)
+
+## Sinhronizacija
+
+Sinhronizaciju takođe možete pokrenuti ručno, koristeći komandu `atuin sync`
+
+## Registracija
+
+Možete registrovati nalog za sinhronizaciju:
+
+```
+atuin register -u <USERNAME> -e <EMAIL> -p <PASSWORD>
+```
+
+Korisnička imena moraju biti jedinstvena, a elektronska pošta se koristi
+samo za hitna obaveštenja (promene politika, bezbednosni incidenti itd.)
+
+Nakon registracije, već ste prijavljeni na svoj nalog :) Od tog trenutka sinhronizacija
+će se odvijati automatski
+
+## Ključ
+
+Pošto se svi podaci šifruju, Atuin će prilikom rada generisati vaš ključ. On će biti sačuvan u
+direktorijumu sa podacima Atuin-a (`~/.local/share/atuin` na GNU/Linux sistemima)
+
+Takođe možete to uraditi sami:
+
+```
+atuin key
+```
+
+Nikada ne dajte nikome ovaj ključ!
+
+## Prijavljivanje
+
+Ako želite da se prijavite sa drugog računara, biće vam potreban bezbednosni ključ (`atuin key`).
+
+```
+atuin login -u <USERNAME> -p <PASSWORD> -k <KEY>
+```
+
+## Odjavljivanje
+
+```
+atuin logout
+```


### PR DESCRIPTION
This PR adds SR/CRO/BS/CNR localizations for the docs and fixes some Russian typos I found.

The PR is not good -- SR/CR/BS/CNR are _incredibly similar_ and consequently there's a huge amount of duplicated text across this PR.

I am working on a separate package which will allow us to map SR into CRO, BS, CNR. The reason I am leaning in this direction is because the mapping SR -> CRO/BS/CNR is mostly injective, whereas the other direction is not injective. A diagram is provided later helping clear up the morphisms between the languages.

The key relevant details regarding these languages are:

- The grammar is extremely similar. Declinations, conjugations and casing rules apply across all these language. There are many dialects to these languages, many of which follow different grammatical structures, but are comprehensible between speakers. I reference [Matica Srpska](https://sr.wikipedia.org/wiki/%D0%9C%D0%B0%D1%82%D0%B8%D1%86%D0%B0_%D1%81%D1%80%D0%BF%D1%81%D0%BA%D0%B0), [Hrvatska Matica](https://www.matica.hr/odjeli/odjel-za-jezikoslovlje-matice-hrvatske/), [Matica Bosna](https://matica-bosna.org/) and [Matica Crnogorska](https://maticacrnogorska.me/).
- YAT extension. In CR, the word for milk is "mlijeko", whereas the SR word is "mleko". Certain SR speakers (the region where I'm from) perform the YAT extension, regardless.
- Cyrilic <-> Latin. In SR/CNR, both scripts are legal -- "млеко" maps to "mleko". For the most part, mapping between each glyph is bidirectional. Of importance are a set of glyphs "љ, њ, џ" which map to "lj, nj, dž", respectively). Unfortunately, there are difficult words such as "injekcija" which you would expect to map to ”ињекција” but such is not the case, as their root comes from the common roman root of "inject", hence the word remains "инјекција”. Effectively, this means that mapping Cyrillic -> latin is injective, but the mapping latin -> Cyrillic is not.

Consequently, it seems the mathematically optimal way is to implement an algorithm which takes a cyrillic ekavijan text (text in cyrillic, without the yat extension) and then map it to different languages as per the following mermaid graph:

```mermaid
flowchart TD
  subgraph serbian
    cyrillic-ekavian["cyrillic ekavian (published)"]
    cyrillic-ijekavian["cyrillic ijekavian (not published)"]
    latin-ekavian["latin ekavian (published)"]
    latin-ijekavian["latin ijekavian (not published)"]
  end
  croatian["croatian (published)"]
  bosnian["bosnian (published)"]
  latin-montenegrian["latin montenegrian (published)"]
  
  subgraph montenegrian
    cyrillic-montenegrian["cyrillic ijekavian (published)"]
    latin-montenegrian["latin ijekavian (published)"]
  end
  
  cyrillic-ekavian -->|LUT sr-ek to sr-ijek, lossy| cyrillic-ijekavian 
  cyrillic-ekavian -->|fxn cyr to lat, lossy| latin-ekavian
  latin-ekavian -->|LUT sr-ek to sr-ijek, lossy| latin-ijekavian

  latin-ijekavian -->|LUT sr-ijek to cro| croatian
  latin-ijekavian -->|LUT sr-ijek to bos| bosnian

  cyrillic-ijekavian -->|LUT sr-ijek to mo| cyrillic-montenegrian
  cyrillic-montenegrian -->|fxn cyr to lat| latin-montenegrian
```

---

This is a sensitive and politicized issue. For transparency's sake: I am a native Serbian speaker. My goal is to ensure a correct and fair representation of all languages for different speakers. I recognize that I am using Serbian here as the root of the mapping, and do not do so due to favoritism, but rather for the mapping convenience and minimizing the maintenance burden on the maintainers of this repo.