### PR TITLE
fix(search): fix terminal clearing with latest Ratatui

### DIFF
--- a/crates/atuin/src/command/client/search/interactive.rs
+++ b/crates/atuin/src/command/client/search/interactive.rs
@@ -1991,6 +1991,10 @@ pub async fn history(
         }
     } else if inline_height > 0 {
         terminal.clear()?;
+        // ratatui-core v0.1.1 changed the behavior of `Terminal::clear` so it no longer moves the
+        // cursor to the viewport origin; do that manually here.
+        let origin = terminal.get_frame().area().as_position();
+        terminal.set_cursor_position(origin)?;
     }
 
     let accept = accept


### PR DESCRIPTION
Builds that use the latest version of Ratatui (e.g., from `cargo install atuin`, which doesn't respect the lockfile), don't clear the terminal correctly when the inline search UI is closed: the cursor position isn't reset to where it was before the UI was open, and in Bash, the resulting shell prompt is indented.

The culprit is ratatui/ratatui#2320, specifically [this line][0]. This PR restores the old behavior by manually moving the cursor back to the origin on exit. This doesn't appear to cause any issues when using the older version of Ratatui in the lockfile.

[0]: https://github.com/ratatui/ratatui/pull/2320/changes#diff-c8326664fc62937eb6f9d467e1c508574e79ce3993cacc4692445b2a990050bfR128