### PR TITLE
perf: remove unnecessary clones in a hot path

### DIFF
--- a/crates/atuin-client/Cargo.toml
+++ b/crates/atuin-client/Cargo.toml
@@ -2,6 +2,7 @@
 name = "atuin-client"
 edition = "2024"
 description = "client library for atuin"
+autobenches = false
 
 rust-version = { workspace = true }
 version = { workspace = true }
@@ -86,5 +87,5 @@ divan = "0.1.14"
 tempfile = "3"
 
 [[bench]]
-name = "record_store"
+name = "benchmarks"
 harness = false

--- a/crates/atuin-client/benches/_util/context.rs
+++ b/crates/atuin-client/benches/_util/context.rs
@@ -1,0 +1,38 @@
+use rand::SeedableRng;
+use rand::rngs::StdRng;
+use time::OffsetDateTime;
+use time::macros::datetime;
+
+/// Utility used to create a benchmarking context.
+///
+/// Generally useful for establishing stable and robust benchmarks. It's an anti-pattern to use a
+/// bare `rand` accessor as that causes benchmarks to be non-deterministic.
+pub struct BenchCtx {
+    rng: StdRng,
+}
+
+impl BenchCtx {
+    // Changing any of these values will result in irreproducible benchmarks.
+    const SEED_RNG: u64 = 42;
+    const SEED_NOW: OffsetDateTime = datetime!(2026-01-01 12:59:59 -5);
+
+    pub fn new() -> Self {
+        Self {
+            rng: StdRng::seed_from_u64(Self::SEED_RNG),
+        }
+    }
+
+    /// Access a random number generator which is stable across the given benchmark.
+    pub fn rng(&mut self) -> &mut StdRng {
+        &mut self.rng
+    }
+
+    /// Get the timestamp recognized as the current timestamp in the stable benchmarking
+    /// environment.
+    ///
+    /// Using the standard library will provide timestamps which are not stable and will result in
+    /// irreproducible benchmarks.
+    pub fn now(&self) -> OffsetDateTime {
+        Self::SEED_NOW
+    }
+}

--- a/crates/atuin-client/benches/_util/mod.rs
+++ b/crates/atuin-client/benches/_util/mod.rs
@@ -1,0 +1,1 @@
+pub mod context;

--- a/crates/atuin-client/benches/benchmarks.rs
+++ b/crates/atuin-client/benches/benchmarks.rs
@@ -1,3 +1,6 @@
+mod _util;
+mod history;
+mod ordering;
 mod record;
 
 fn main() {

--- a/crates/atuin-client/benches/history.rs
+++ b/crates/atuin-client/benches/history.rs
@@ -1,0 +1,35 @@
+use atuin_client::history::History;
+use rand::Rng;
+use rand::seq::SliceRandom;
+
+use crate::_util::context::BenchCtx;
+
+pub struct BenchHistory;
+
+impl BenchHistory {
+    /// List of commands which will be used to create some sort of history.
+    const SEED_COMMANDS: [&str; 6] = [
+        "cargo build --release",
+        "git commit -m 'fix bug'",
+        "curl -s https://example.com/api",
+        "grep -rn pattern src/",
+        "docker compose up -d",
+        "ls -la /tmp",
+    ];
+
+    pub fn one(ctx: &mut BenchCtx) -> History {
+        let now = ctx.now().unix_timestamp();
+        let cmd = *Self::SEED_COMMANDS.choose(ctx.rng()).unwrap();
+        History::import()
+            .command(cmd)
+            .timestamp(
+                time::OffsetDateTime::from_unix_timestamp(ctx.rng().gen_range(0..now)).unwrap(),
+            )
+            .build()
+            .into()
+    }
+
+    pub fn count(ctx: &mut BenchCtx, n: usize) -> Vec<History> {
+        (0..n).map(|_| Self::one(ctx)).collect()
+    }
+}

--- a/crates/atuin-client/benches/ordering.rs
+++ b/crates/atuin-client/benches/ordering.rs
@@ -1,0 +1,18 @@
+use crate::_util::context::BenchCtx;
+use crate::history::BenchHistory;
+use atuin_client::ordering::reorder_fuzzy;
+use atuin_client::settings::SearchMode;
+
+/// reorder_fuzzy is invoked on every keystroke during interactive fuzzy search, so keeping the
+/// performance in check is important.
+///
+/// The interactive search hardcodes a limit of 200 deduplicated entries (`engines/db.rs`).
+#[divan::bench(args = [10, 200, 1_000], min_time = 1)]
+fn reorder_fuzzy_bench(bencher: divan::Bencher, n: usize) {
+    bencher
+        .with_inputs(|| {
+            let mut ctx = BenchCtx::new();
+            BenchHistory::count(&mut ctx, n)
+        })
+        .bench_values(|histories| reorder_fuzzy(SearchMode::Fuzzy, "curl", histories));
+}

--- a/crates/atuin-client/benches/record/sqlite_store.rs
+++ b/crates/atuin-client/benches/record/sqlite_store.rs
@@ -2,12 +2,15 @@ use atuin_client::record::sqlite_store::SqliteStore;
 use atuin_client::record::store::Store;
 use atuin_common::record::{EncryptedData, Host, HostId, Record};
 use atuin_common::utils::uuid_v7;
-use rand::{Rng, distributions::Alphanumeric};
+use rand::Rng;
+use rand::distributions::Alphanumeric;
 use tempfile::TempDir;
 
-struct BenchRecordBuilder;
+use crate::_util::context::BenchCtx;
 
-impl BenchRecordBuilder {
+struct BenchRecord;
+
+impl BenchRecord {
     /// Controls how large the record payload is. Roughly, this is between 200 and 400 bytes for
     /// a typical history record.
     ///
@@ -27,16 +30,18 @@ impl BenchRecordBuilder {
     /// Rough size of the PASETO PIE-wrapped key.
     const KEY_SIZE: usize = 150;
 
-    fn chain(n: usize) -> Vec<Record<EncryptedData>> {
+    fn chain(ctx: &mut BenchCtx, n: usize) -> Vec<Record<EncryptedData>> {
         let host = Host::new(HostId(uuid_v7()));
         let version: String = "v1".into();
         let tag = uuid_v7().simple().to_string();
-        let data: String = rand::thread_rng()
+        let data: String = ctx
+            .rng()
             .sample_iter(&Alphanumeric)
             .take(Self::PAYLOAD_SIZE)
             .map(char::from)
             .collect();
-        let key: String = rand::thread_rng()
+        let key: String = ctx
+            .rng()
             .sample_iter(&Alphanumeric)
             .take(Self::KEY_SIZE)
             .map(char::from)
@@ -85,14 +90,15 @@ impl BenchSqliteStore {
 /// The parameters are:
 ///  - 1 proves out the case of adding one shell entry via `push_record` (history/store.rs).
 ///  - 100 is the page size used by `sync_remote` (record/sync.rs).
-#[divan::bench(args = [1, 10, 100], sample_count = 500, min_time = 5)]
+#[divan::bench(args = [1, 10, 100], sample_count = 500, min_time = 1)]
 fn push_batch(bencher: divan::Bencher, n: usize) {
     let rt = tokio::runtime::Runtime::new().unwrap();
 
     bencher
         .with_inputs(|| {
+            let mut ctx = BenchCtx::new();
             let db = rt.block_on(BenchSqliteStore::new());
-            let records = BenchRecordBuilder::chain(n);
+            let records = BenchRecord::chain(&mut ctx, n);
             (db, records)
         })
         .bench_values(|(db, records)| {

--- a/crates/atuin-client/src/ordering.rs
+++ b/crates/atuin-client/src/ordering.rs
@@ -12,9 +12,9 @@ pub fn reorder_fuzzy(mode: SearchMode, query: &str, res: Vec<History>) -> Vec<Hi
 fn reorder<F, A>(query: &str, f: F, res: Vec<A>) -> Vec<A>
 where
     F: Fn(&A) -> &String,
-    A: Clone,
 {
-    let mut r = res.clone();
+    let mut r = res;
+    let len = r.len();
     let qvec = &query.chars().collect();
     r.sort_by_cached_key(|h| {
         // TODO for fzf search we should sum up scores for each matched term
@@ -24,7 +24,7 @@ where
             // we don't want to return a None, as the comparison behaviour would put the worst matches
             // at the front. therefore, we'll return a set of indices that are one larger than the longest
             // possible legitimate match. This is meaningless except as a comparison.
-            None => (0, res.len()),
+            None => (0, len),
         };
         1 + to - from
     });


### PR DESCRIPTION
This PR adds two commits:

- The first commit adds another benchmark to `crates/atuin-client`.
- The second commit adds a tiny performance optimization to `reorder_fuzzy` which avoids an unnecessary clone.

Hand-rolled PR (I hated claude's output).

## Benchmarking

I did a couple more changes to benchmarking.

- In https://github.com/atuinsh/atuin/pull/3577, I naively used `rand`, but I realized this is pretty bad for benchmark reproducibility, so I created a new `BenchCtx` utility which is a more stable random number generator (and a dumping ground for similar things where we want stability, another example in this PR being the "now" timestamp).
- I reduced the minimum time per iteration of a benchmark to be `1s` from `5s`.


## Optimization

Pretty bog-standard removal of a potentially large clone.
  
### Results

Tested on an M4 mac.

#### Before

```
benchmarks                 fastest       │ slowest       │ median        │ mean          │ samples │ iters
├─ ordering                              │               │               │               │         │
│  ╰─ reorder_fuzzy_bench                │               │               │               │         │
│     ├─ 10                2.124 µs      │ 31.91 µs      │ 2.499 µs      │ 2.593 µs      │ 47246   │ 47246
│     ├─ 200               43.62 µs      │ 81.62 µs      │ 49.2 µs       │ 49.58 µs      │ 2488    │ 2488
│     ╰─ 1000              230.2 µs      │ 305.4 µs      │ 252.4 µs      │ 256.5 µs      │ 495     │ 495
╰─ record                                │               │               │               │         │
   ╰─ sqlite_store                       │               │               │               │         │
      ╰─ push_batch                      │               │               │               │         │
         ├─ 1              99.45 µs      │ 1.326 ms      │ 187.6 µs      │ 189.9 µs      │ 945     │ 945
         ├─ 10             155.5 µs      │ 5.674 ms      │ 173.4 µs      │ 191.3 µs      │ 957     │ 957
         ╰─ 100            582.2 µs      │ 6.717 ms      │ 659.4 µs      │ 697.9 µs      │ 568     │ 568
```

#### After

```
benchmarks                 fastest       │ slowest       │ median        │ mean          │ samples │ iters
├─ ordering                              │               │               │               │         │
│  ╰─ reorder_fuzzy_bench                │               │               │               │         │
│     ├─ 10                1.249 µs      │ 30.54 µs      │ 1.582 µs      │ 1.602 µs      │ 49473   │ 49473
│     ├─ 200               25.62 µs      │ 59.7 µs       │ 29.16 µs      │ 29.55 µs      │ 2616    │ 2616
│     ╰─ 1000              135.4 µs      │ 190.3 µs      │ 152.9 µs      │ 155.6 µs      │ 519     │ 519
╰─ record                                │               │               │               │         │
   ╰─ sqlite_store                       │               │               │               │         │
      ╰─ push_batch                      │               │               │               │         │
         ├─ 1              97.95 µs      │ 1.344 ms      │ 178.8 µs      │ 179.3 µs      │ 970     │ 970
         ├─ 10             155.9 µs      │ 4.397 ms      │ 171.3 µs      │ 181.5 µs      │ 994     │ 994
         ╰─ 100            578.9 µs      │ 8.866 ms      │ 653.4 µs      │ 711.1 µs      │ 565     │ 565
```

#### Comparison

```
  ┌────────────────────┬─────────────────┬────────────────┬────────────────────┐
  │     Benchmark      │ Before (median) │ After (median) │      Speedup       │
  ├────────────────────┼─────────────────┼────────────────┼────────────────────┤
  │ reorder_fuzzy 10   │ 2.499 µs        │ 1.582 µs       │ 1.58× (37% faster) │
  ├────────────────────┼─────────────────┼────────────────┼────────────────────┤
  │ reorder_fuzzy 200  │ 49.20 µs        │ 29.16 µs       │ 1.69× (41% faster) │
  ├────────────────────┼─────────────────┼────────────────┼────────────────────┤
  │ reorder_fuzzy 1000 │ 252.4 µs        │ 152.9 µs       │ 1.65× (39% faster) │
  └────────────────────┼─────────────────┼────────────────┼────────────────────┘
```

## Checks

- [x] I am happy for maintainers to push small adjustments to this PR, to speed up the review cycle
- [x] I have checked that there are no existing pull requests for the same thing