### PR TITLE
perf: increase sync page size from 100 to 1000 records

### DIFF
--- a/crates/atuin-client/benches/record/sqlite_store.rs
+++ b/crates/atuin-client/benches/record/sqlite_store.rs
@@ -89,8 +89,9 @@ impl BenchSqliteStore {
 /// Benchmark to exercise the latency of pushing a batch of varying records.
 /// The parameters are:
 ///  - 1 proves out the case of adding one shell entry via `push_record` (history/store.rs).
-///  - 100 is the page size used by `sync_remote` (record/sync.rs).
-#[divan::bench(args = [1, 10, 100], sample_count = 500, min_time = 1)]
+///  - 100 is the old page size used by `sync_remote` (record/sync.rs).
+///  - 1000 is the new page size used by `sync_remote`.
+#[divan::bench(args = [1, 10, 100, 1000], sample_count = 500, min_time = 1)]
 fn push_batch(bencher: divan::Bencher, n: usize) {
     let rt = tokio::runtime::Runtime::new().unwrap();
 

--- a/crates/atuin-client/src/record/sync.rs
+++ b/crates/atuin-client/src/record/sync.rs
@@ -365,7 +365,7 @@ pub async fn sync(
     check_encryption_key(&client, &remote_index, encryption_key).await?;
 
     let operations = operations(diff, store).await?;
-    let (uploaded, downloaded) = sync_remote(&client, operations, store, 100).await?;
+    let (uploaded, downloaded) = sync_remote(&client, operations, store, 1000).await?;
 
     Ok((uploaded, downloaded))
 }


### PR DESCRIPTION
## Summary

- Add divan benchmark harness with `push_batch` benchmark covering batch sizes 1, 10, 100, and 1000
- Increase record sync page size from 100 to 1000 (`record/sync.rs`), reducing HTTP round-trips per sync by 10×
- Server default `page_size` is already 1100 (`atuin-server/src/settings.rs:79`), so 1000 is well within the accepted limit

## Test plan

- [ ] `cargo check -p atuin-client` compiles clean
- [ ] `cargo test -p atuin-client` passes (sync tests don't exercise live sync)
- [ ] `cargo bench -p atuin-client --bench benchmarks -- push_batch` runs all 4 batch sizes
- [ ] Verify server accepts 1000-record batches in a real sync