### PR TITLE
chore(rustdoc): fix Rustdoc warnings

### DIFF
--- a/crates/atuin-ai/src/tui/view/mod.rs
+++ b/crates/atuin-ai/src/tui/view/mod.rs
@@ -829,7 +829,7 @@ fn visible_group_calls(group: &turn::ToolGroup) -> &[turn::ToolCallDetails] {
     &group.calls[start..]
 }
 
-/// Render a single row in a grouped list: [tree marker][status][content].
+/// Render a single row in a grouped list: `[tree marker][status][content]`.
 fn group_row_view(is_first: bool, status: &turn::ToolResultStatus, content: Elements) -> Elements {
     element! {
         HStack {

--- a/crates/atuin-client/src/import/fish.rs
+++ b/crates/atuin-client/src/import/fish.rs
@@ -17,7 +17,7 @@ pub struct Fish {
     bytes: Vec<u8>,
 }
 
-/// see https://fishshell.com/docs/current/interactive.html#searchable-command-history
+/// see <https://fishshell.com/docs/current/interactive.html#searchable-command-history>
 fn default_histpath() -> Result<PathBuf> {
     let base = BaseDirs::new().ok_or_else(|| eyre!("could not determine data directory"))?;
     let data = std::env::var("XDG_DATA_HOME").map_or_else(

--- a/crates/atuin-client/src/settings.rs
+++ b/crates/atuin-client/src/settings.rs
@@ -171,7 +171,7 @@ impl fmt::Display for Timezone {
         self.0.fmt(f)
     }
 }
-/// format: <+|-><hour>[:<minute>[:<second>]]
+/// format: `<+|-><hour>[:<minute>[:<second>]]`
 static OFFSET_FMT: &[FormatItem<'_>] = format_description!(
     "[offset_hour sign:mandatory padding:none][optional [:[offset_minute padding:none][optional [:[offset_second padding:none]]]]]"
 );
@@ -1379,7 +1379,7 @@ impl Settings {
 
     /// Returns the appropriate auth token for sync operations.
     ///
-    /// Delegates to [`resolve_sync_auth`] and converts the result to an
+    /// Delegates to [`Self::resolve_sync_auth`] and converts the result to an
     /// `AuthToken`. Callers that need to distinguish between auth states
     /// (e.g. to show different UI) should call `resolve_sync_auth` directly.
     #[cfg(feature = "sync")]

--- a/crates/atuin-common/src/api.rs
+++ b/crates/atuin-common/src/api.rs
@@ -128,13 +128,13 @@ pub struct MeResponse {
 
 // Hub CLI authentication types
 
-/// Response from POST /auth/cli/code - generates a code for CLI auth
+/// Response from `POST /auth/cli/code` - generates a code for CLI auth
 #[derive(Debug, Serialize, Deserialize)]
 pub struct CliCodeResponse {
     pub code: String,
 }
 
-/// Response from GET /auth/cli/verify?code=<code> - polls for authorization
+/// Response from `GET /auth/cli/verify?code=<code>` - polls for authorization
 #[derive(Debug, Serialize, Deserialize)]
 pub struct CliVerifyResponse {
     /// Session token, present only when authorization is complete

--- a/crates/atuin-daemon/src/search/index.rs
+++ b/crates/atuin-daemon/src/search/index.rs
@@ -253,8 +253,9 @@ type FrecencyMap = Arc<HashMap<Arc<str>, u32>>;
 /// although this should never happen due to precomputing the frecency map.
 pub struct SearchIndex {
     /// Map from command text to command data.
-    /// Using DashMap for concurrent read/write access, wrapped in Arc for sharing with scorer.
-    /// Keys are Arc<str> to enable zero-copy sharing with frecency_map.
+    ///
+    /// Using `DashMap` for concurrent read/write access, wrapped in `Arc` for sharing with scorer.
+    /// Keys are `Arc<str>` to enable zero-copy sharing with frecency_map.
     commands: Arc<DashMap<Arc<str>, CommandData>>,
     /// Nucleo fuzzy matcher - items are command strings.
     nucleo: RwLock<Nucleo<String>>,

--- a/crates/atuin-pty-proxy/src/osc133.rs
+++ b/crates/atuin-pty-proxy/src/osc133.rs
@@ -2,15 +2,15 @@
 //!
 //! OSC 133 marks four regions of a shell interaction:
 //!
-//! | Marker | Meaning                              |
-//! |--------|--------------------------------------|
-//! | A      | Prompt is about to be printed        |
-//! | B      | Prompt ended — command input begins   |
-//! | C      | Command submitted — output begins     |
-//! | D[;n]  | Command finished with exit code *n*   |
+//! | Marker  | Meaning                               |
+//! |---------|---------------------------------------|
+//! | `A`     | Prompt is about to be printed         |
+//! | `B`     | Prompt ended — command input begins   |
+//! | `C`     | Command submitted — output begins     |
+//! | `D[;n]` | Command finished with exit code *n*   |
 //!
-//! The wire format is `ESC ] 133 ; <cmd> [; <params>] ST` where ST is BEL
-//! (0x07), ESC \ (0x1B 0x5C), or C1 ST (0x9C).
+//! The wire format is `ESC ] 133 ; <cmd> [; <params>] ST` where `ST` is `BEL`
+//! (0x07), `ESC \` (0x1B 0x5C), or `C1 ST` (0x9C).
 //!
 //! # Design goals
 //!
@@ -18,8 +18,8 @@
 //!   the caller remains responsible for forwarding bytes to their destination.
 //! * **Bounded** — OSC parameter buffering is capped so malformed output cannot
 //!   grow memory without limit.
-//! * **Non-blocking** — [`Parser::push`] processes whatever bytes are available
-//!   and returns immediately.
+//! * **Non-blocking** — [`Parser::push_located`] processes whatever bytes are
+//!   available and returns immediately.
 //! * **Extensible** — marker parameters are preserved so Atuin-specific metadata
 //!   can ride alongside standard OSC 133 markers.
 
@@ -145,7 +145,7 @@ enum State {
 
 /// A streaming, zero-allocation parser for OSC 133 escape sequences.
 ///
-/// Feed arbitrary byte slices into [`Parser::push`].  The parser detects
+/// Feed arbitrary byte slices into [`Parser::push_located`].  The parser detects
 /// OSC 133 markers and reports [`Event`]s through a caller-supplied callback
 /// without modifying the data.  It can sit transparently between a PTY reader
 /// and stdout.

--- a/crates/atuin-server/src/metrics.rs
+++ b/crates/atuin-server/src/metrics.rs
@@ -23,8 +23,9 @@ pub fn setup_metrics_recorder() -> PrometheusHandle {
 }
 
 /// Middleware to record some common HTTP metrics
-/// Generic over B to allow for arbitrary body types (eg Vec<u8>, Streams, a deserialized thing, etc)
-/// Someday tower-http might provide a metrics middleware: https://github.com/tower-rs/tower-http/issues/57
+///
+/// Generic over B to allow for arbitrary body types (eg `Vec<u8>`, `Stream`s, a deserialized thing, etc).
+/// Someday tower-http might provide a metrics middleware: <https://github.com/tower-rs/tower-http/issues/57>
 pub async fn track_metrics(req: Request, next: Next) -> impl IntoResponse {
     let start = Instant::now();
 

--- a/crates/atuin/src/command/client/search/keybindings/conditions.rs
+++ b/crates/atuin/src/command/client/search/keybindings/conditions.rs
@@ -263,7 +263,7 @@ impl<'a> ExprParser<'a> {
         }
     }
 
-    /// atom = [a-z][a-z0-9-]*
+    /// atom = `[a-z][a-z0-9-]*`
     fn parse_atom(&mut self) -> Result<ConditionExpr, String> {
         self.skip_whitespace();
         let start = self.pos;


### PR DESCRIPTION
Fix warnings generated by `cargo doc --document-private-items`, mostly about invalid Markdown syntax and broken links to items. This is not a user facing change but makes the generated internal API documentation more useful.