### PR TITLE
chore(warnings): fix compile warnings with latest dependencies

### DIFF
--- a/crates/atuin/src/command/client/search/history_list.rs
+++ b/crates/atuin/src/command/client/search/history_list.rs
@@ -337,8 +337,10 @@ impl DrawState<'_> {
         let formatted = h
             .timestamp
             .format(
-                &time::format_description::parse("[year]-[month]-[day] [hour]:[minute]")
-                    .expect("valid format"),
+                &time::format_description::parse_borrowed::<1>(
+                    "[year]-[month]-[day] [hour]:[minute]",
+                )
+                .expect("valid format"),
             )
             .unwrap_or_else(|_| "????-??-?? ??:??".to_string());
         let w = width as usize;


### PR DESCRIPTION
`time::format_description::parse` is deprecated in the latest version of `time` (used when the lockfile is ignored, as with `cargo install atuin`); replace with the recommended alternative. This change is compatible with the older version of `time` in the lockfile.
