### PR TITLE
fix(nu): suppress error when ATUIN_HISTORY_ID is missing in pre_prompt hook

### DIFF
--- a/crates/atuin/src/shell/atuin.nu
+++ b/crates/atuin/src/shell/atuin.nu
@@ -69,7 +69,7 @@ let _atuin_pre_prompt = {||
         }
 
     }
-    hide-env ATUIN_HISTORY_ID
+    hide-env -i ATUIN_HISTORY_ID
 }
 
 def _atuin_search_cmd [...flags: string] {


### PR DESCRIPTION
## What

Fixes a crash in the nushell integration when `ATUIN_HISTORY_ID` is not set in the environment.

The `_atuin_pre_prompt` hook calls `hide-env ATUIN_HISTORY_ID` at the end of every prompt. If the env var doesn't exist (e.g. when using nushell overlays/subshells that don't capture it, like `nu -e "overlay use ..."`), this throws an unhandled `env_variable_not_found` error.

## How

The fix mirrors what the script already does at line 15 — use the `-i` (ignore-if-missing) flag:

```nu
// Before
hide-env ATUIN_HISTORY_ID

// After
hide-env -i ATUIN_HISTORY_ID
```

This is the exact same pattern already used in the initialization section (line 15: `hide-env -i ATUIN_HISTORY_ID`), so it's consistent with the existing code. The reporter of #3520 also suggested this approach. (◕‿◕)

One file, one line changed. No behavior change for the normal case (var exists → it gets hidden). Only difference: missing var no longer crashes.

Closes #3520.