### PR TITLE
fix(search): show ultracompact prompt for empty results

### DIFF
--- a/crates/atuin/src/command/client/search/history_list.rs
+++ b/crates/atuin/src/command/client/search/history_list.rs
@@ -31,6 +31,12 @@ impl HistoryHighlighter<'_> {
     }
 }
 
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum EmptyHistoryRow {
+    Hidden,
+    Prompt,
+}
+
 pub struct HistoryList<'a> {
     history: &'a [History],
     block: Option<Block<'a>>,
@@ -42,7 +48,7 @@ pub struct HistoryList<'a> {
     theme: &'a Theme,
     history_highlighter: HistoryHighlighter<'a>,
     show_numeric_shortcuts: bool,
-    ultracompact: bool,
+    empty_history_row: EmptyHistoryRow,
     /// Columns to display (in order, after the indicator)
     columns: &'a [UiColumn],
 }
@@ -93,7 +99,7 @@ impl StatefulWidget for HistoryList<'_> {
             // Ultracompact mode renders the prompt as part of the selected
             // history row. Preserve that prompt when the current filter has no
             // matches so the UI does not appear blank.
-            if self.ultracompact {
+            if self.empty_history_row == EmptyHistoryRow::Prompt {
                 DrawState {
                     buf,
                     list_area,
@@ -170,7 +176,7 @@ impl<'a> HistoryList<'a> {
             theme,
             history_highlighter,
             show_numeric_shortcuts,
-            ultracompact: false,
+            empty_history_row: EmptyHistoryRow::Hidden,
             columns,
         }
     }
@@ -181,7 +187,11 @@ impl<'a> HistoryList<'a> {
     }
 
     pub fn ultracompact(mut self, ultracompact: bool) -> Self {
-        self.ultracompact = ultracompact;
+        self.empty_history_row = if ultracompact {
+            EmptyHistoryRow::Prompt
+        } else {
+            EmptyHistoryRow::Hidden
+        };
         self
     }
 

--- a/crates/atuin/src/command/client/search/history_list.rs
+++ b/crates/atuin/src/command/client/search/history_list.rs
@@ -42,6 +42,7 @@ pub struct HistoryList<'a> {
     theme: &'a Theme,
     history_highlighter: HistoryHighlighter<'a>,
     show_numeric_shortcuts: bool,
+    ultracompact: bool,
     /// Columns to display (in order, after the indicator)
     columns: &'a [UiColumn],
 }
@@ -81,9 +82,39 @@ impl StatefulWidget for HistoryList<'_> {
             inner_area
         });
 
-        if list_area.width < 1 || list_area.height < 1 || self.history.is_empty() {
+        if list_area.width < 1 || list_area.height < 1 {
             return;
         }
+
+        if self.history.is_empty() {
+            state.offset = 0;
+            state.max_entries = 0;
+
+            // Ultracompact mode renders the prompt as part of the selected
+            // history row. Preserve that prompt when the current filter has no
+            // matches so the UI does not appear blank.
+            if self.ultracompact {
+                DrawState {
+                    buf,
+                    list_area,
+                    x: 0,
+                    y: 0,
+                    state,
+                    inverted: self.inverted,
+                    alternate_highlight: self.alternate_highlight,
+                    now: &self.now,
+                    indicator: self.indicator,
+                    theme: self.theme,
+                    history_highlighter: self.history_highlighter,
+                    show_numeric_shortcuts: self.show_numeric_shortcuts,
+                    columns: self.columns,
+                }
+                .render_empty_row();
+            }
+
+            return;
+        }
+
         let list_height = list_area.height as usize;
 
         let (start, end) = self.get_items_bounds(state.selected, state.offset, list_height);
@@ -139,12 +170,18 @@ impl<'a> HistoryList<'a> {
             theme,
             history_highlighter,
             show_numeric_shortcuts,
+            ultracompact: false,
             columns,
         }
     }
 
     pub fn block(mut self, block: Block<'a>) -> Self {
         self.block = Some(block);
+        self
+    }
+
+    pub fn ultracompact(mut self, ultracompact: bool) -> Self {
+        self.ultracompact = ultracompact;
         self
     }
 
@@ -184,6 +221,14 @@ struct DrawState<'a> {
 static SLICES: &str = " > 1 2 3 4 5 6 7 8 9   ";
 
 impl DrawState<'_> {
+    fn render_empty_row(&mut self) {
+        self.index();
+        self.draw(
+            self.history_highlighter.search_input,
+            Style::from_crossterm(self.theme.as_style(Meaning::Base)),
+        );
+    }
+
     /// Render a complete row for a history item based on configured columns.
     fn render_row(&mut self, h: &History) {
         // Always render the indicator first (width 3)

--- a/crates/atuin/src/command/client/search/interactive.rs
+++ b/crates/atuin/src/command/client/search/interactive.rs
@@ -1173,7 +1173,8 @@ impl State {
             history_highlighter,
             show_numeric_shortcuts,
             columns,
-        );
+        )
+        .ultracompact(matches!(style.compactness, Compactness::Ultracompact));
 
         match style.compactness {
             Compactness::Full => {


### PR DESCRIPTION
Ultracompact search renders the input prompt as part of the selected history row. When a filter has no matches, HistoryList returned before drawing anything, leaving the UI completely blank. This is confusing when cycling between ctrl-r modes (I thought it hung).

Render an empty prompt row in that case so users can still see the active filter and query.

(I am confident that the diagnosis is correct--we should not just return on empty here--less confident that there is no existing helper for "we are in ultracompact mode" that I missed.)

## Checks
- [X] I am happy for maintainers to push small adjustments to this PR, to speed up the review cycle
- [X] I have checked that there are no existing pull requests for the same thing

Screenshot of "after" [screenshot of "before" would just be blank space]
<img width="649" height="187" alt="image" src="https://github.com/user-attachments/assets/718bb734-21c3-4017-a088-4c933a19a894" />
