### PR TITLE
fix: strip NUL bytes from history commands (closes #3589)

### DIFF
--- a/crates/atuin-client/src/history.rs
+++ b/crates/atuin-client/src/history.rs
@@ -163,6 +163,21 @@ impl History {
             .map_or_else(|| hostname.to_owned(), |(_, user)| user.to_owned())
     }
 
+    /// Strip NUL bytes from a command string.
+    ///
+    /// NUL bytes can enter the history when an external tool writes a raw NUL
+    /// byte into the command. They break downstream consumers that expect
+    /// valid UTF-8 text. Rather than reject the whole entry, we silently
+    /// strip the offending bytes. See atuinsh/atuin#3589.
+    fn sanitize_command(command: String) -> String {
+        if !command.contains('\0') {
+            // fast path: most commands are clean
+            command
+        } else {
+            command.replace('\0', "")
+        }
+    }
+
     #[allow(clippy::too_many_arguments)]
     fn new(
         timestamp: OffsetDateTime,
@@ -191,7 +206,7 @@ impl History {
         Self {
             id: uuid_v7().as_simple().to_string().into(),
             timestamp,
-            command,
+            command: Self::sanitize_command(command),
             cwd,
             exit,
             duration,
@@ -652,6 +667,31 @@ mod tests {
             .expect("failed to deserialize history");
 
         assert_eq!(history, deserialized);
+    }
+
+    #[test]
+    fn test_sanitize_strips_nul_bytes() {
+        // Simulate the "start=\0" mis-escape reported in #3589
+        let entry: History = History::capture()
+            .timestamp(time::OffsetDateTime::now_utc())
+            .command("start=\0 foo\0bar")
+            .cwd("/")
+            .build()
+            .into();
+
+        assert_eq!(entry.command, "start= foobar");
+    }
+
+    #[test]
+    fn test_sanitize_preserves_clean_command() {
+        let entry: History = History::capture()
+            .timestamp(time::OffsetDateTime::now_utc())
+            .command("git status")
+            .cwd("/")
+            .build()
+            .into();
+
+        assert_eq!(entry.command, "git status");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

External tools — in particular AI agents that mis-escape values — can write raw NUL bytes (`\0`) into the shell history. For example, writing `start=\0` instead of `start=0` lands a literal NUL byte in the command string.

NUL bytes break everything downstream that expects valid UTF-8 text: `atuin search` output needs to be piped through `tr -d \x27\\000\x27` or it corrupts the consuming process, messagepack serialisation chokes, and even simple terminal output is garbled.

## Fix

Rather than reject the whole entry (which loses an otherwise useful command), this PR strips NUL bytes at the single point where **all** new history entries are constructed — `History::new`. This covers every entry path (import, capture, daemon capture) with one change.

The new `sanitize_command` helper has a fast-path: it checks `command.contains(\x27\\0\x27)` first and returns the string unchanged when clean, so there is zero allocation overhead for the overwhelmingly common case of a normal command.

## Testing

Added two unit tests in `history::tests`:

- `test_sanitize_strips_nul_bytes` — verifies `start=\0 foo\0bar` becomes `start= foobar`
- `test_sanitize_preserves_clean_command` — verifies a normal command is untouched

All 12 existing `history::` tests continue to pass:

```
running 12 tests
test history::store::tests::test_serialize_deserialize_delete ... ok
test history::store::tests::test_serialize_deserialize_create ... ok
test history::tests::disable_secrets ... ok
test history::tests::known_agents_include_pi ... ok
test history::tests::test_sanitize_preserves_clean_command ... ok
test history::tests::test_sanitize_strips_nul_bytes ... ok
test history::tests::test_serialize_deserialize ... ok
test history::tests::test_serialize_deserialize_deleted ... ok
test history::tests::test_serialize_deserialize_version ... ok
test history::tests::test_serialize_deserialize_with_author_and_intent ... ok
test history::store::tests::test_history_skips_corrupt_records ... ok
test history::tests::privacy_test ... ok
test result: ok. 12 passed; 0 failed; 0 ignored; 0 measured; 82 filtered out
```

Closes #3589.