### PR TITLE
fix(ai): dispatch skills registered in the slash command registry

### DIFF
--- a/crates/atuin-ai/src/driver.rs
+++ b/crates/atuin-ai/src/driver.rs
@@ -374,7 +374,7 @@ fn resolve_skill_name(input: &str, handle: &Handle<ViewState>) -> Option<(String
     let is_skill = handle
         .fetch({
             let cmd_name = cmd_name.clone();
-            move |vs| vs.skill_names.contains(&cmd_name) && !vs.slash_registry.contains(&cmd_name)
+            move |vs| is_skill_command(&cmd_name, &vs.skill_names, &vs.slash_registry)
         })
         .blocking_recv()
         .unwrap_or(false);
@@ -390,6 +390,16 @@ fn resolve_skill_name(input: &str, handle: &Handle<ViewState>) -> Option<(String
         .map(|s| s.to_string());
 
     Some((cmd_name, args))
+}
+
+/// Skills are registered in `slash_registry` too (for autocomplete and
+/// `/help`), so precedence is decided by the builtin flag, not membership.
+fn is_skill_command(
+    cmd_name: &str,
+    skill_names: &std::collections::HashSet<String>,
+    slash_registry: &crate::tui::slash::SlashCommandRegistry,
+) -> bool {
+    skill_names.contains(cmd_name) && !slash_registry.contains_builtin(cmd_name)
 }
 
 fn resolve_slash_command(command: &str, handle: &Handle<ViewState>, io: &IoContext) -> String {
@@ -1117,5 +1127,41 @@ async fn run_stream_bridge(
                 break;
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::is_skill_command;
+    use crate::tui::slash::{SlashCommand, SlashCommandRegistry};
+
+    /// Regression test: skills are registered into the slash registry so they
+    /// appear in autocomplete, which must not stop them dispatching as skills.
+    #[test]
+    fn skill_dispatches_even_when_registered_for_autocomplete() {
+        let mut registry = SlashCommandRegistry::default();
+        let mut skill_names = std::collections::HashSet::new();
+        registry.register(SlashCommand::new("release", "Cut a release"));
+        skill_names.insert("release".to_string());
+
+        assert!(is_skill_command("release", &skill_names, &registry));
+    }
+
+    #[test]
+    fn builtin_takes_precedence_over_skill_with_same_name() {
+        let mut registry = SlashCommandRegistry::default();
+        let mut skill_names = std::collections::HashSet::new();
+        registry.register(SlashCommand::new("reload", "A skill shadowing /reload"));
+        skill_names.insert("reload".to_string());
+
+        assert!(!is_skill_command("reload", &skill_names, &registry));
+    }
+
+    #[test]
+    fn unregistered_name_is_not_a_skill() {
+        let registry = SlashCommandRegistry::default();
+        let skill_names = std::collections::HashSet::new();
+
+        assert!(!is_skill_command("release", &skill_names, &registry));
     }
 }

--- a/crates/atuin-ai/src/tui/slash.rs
+++ b/crates/atuin-ai/src/tui/slash.rs
@@ -2,6 +2,9 @@
 pub(crate) struct SlashCommand {
     pub name: String,
     pub description: String,
+    /// Built-in commands take dispatch precedence over skills with the same
+    /// name; skill-backed commands are registered with `new`.
+    pub is_builtin: bool,
 }
 
 impl SlashCommand {
@@ -9,6 +12,14 @@ impl SlashCommand {
         Self {
             name: name.to_string(),
             description: description.to_string(),
+            is_builtin: false,
+        }
+    }
+
+    pub fn builtin(name: &str, description: &str) -> Self {
+        Self {
+            is_builtin: true,
+            ..Self::new(name, description)
         }
     }
 }
@@ -40,8 +51,8 @@ impl SlashCommandRegistry {
         &self.commands
     }
 
-    pub fn contains(&self, name: &str) -> bool {
-        self.commands.iter().any(|c| c.name == name)
+    pub fn contains_builtin(&self, name: &str) -> bool {
+        self.commands.iter().any(|c| c.is_builtin && c.name == name)
     }
 
     pub fn search_fuzzy(&self, query: &str) -> Vec<SlashCommandSearchResult> {
@@ -72,16 +83,16 @@ impl SlashCommandRegistry {
 impl Default for SlashCommandRegistry {
     fn default() -> Self {
         let mut registry = Self::new();
-        registry.register(SlashCommand::new("help", "Show help information"));
-        registry.register(SlashCommand::new(
+        registry.register(SlashCommand::builtin("help", "Show help information"));
+        registry.register(SlashCommand::builtin(
             "model",
             "Select the AI model to use for this and future sessions",
         ));
-        registry.register(SlashCommand::new(
+        registry.register(SlashCommand::builtin(
             "new",
             "Start a new conversation, archiving the current one",
         ));
-        registry.register(SlashCommand::new(
+        registry.register(SlashCommand::builtin(
             "reload",
             "Reload context files (TERMINAL.md) on the next request",
         ));


### PR DESCRIPTION
Since #3525, resolve_skill_name required a skill's name to be absent from the slash command registry (so built-ins take precedence), but every skill is registered there for autocomplete; every skill invocation fell through to "Unknown command".

This PR decides precedence with an `is_builtin` flag on `SlashCommand` instead of registry membership, and extracts the predicate into a testable function with regression coverage.