### PR TITLE
fix(import): fix order of entries imported from zsh history

### DIFF
--- a/crates/atuin-client/src/import/bash.rs
+++ b/crates/atuin-client/src/import/bash.rs
@@ -53,7 +53,7 @@ impl Importer for Bash {
                 _ => None,
             })
             // if no known timestamps, use now as base
-            .unwrap_or((lines.len(), OffsetDateTime::now_utc()));
+            .unwrap_or_else(|| (lines.len(), OffsetDateTime::now_utc()));
 
         // if no timestamp is recorded, then use this increment to set an arbitrary timestamp
         // to preserve ordering
@@ -64,8 +64,9 @@ impl Importer for Bash {
 
         // make sure there is a minimum amount of time before the first known timestamp
         // to fit all commands, given the default increment
-        let mut next_timestamp =
-            first_timestamp - timestamp_increment * commands_before_first_timestamp as i32;
+        let mut next_timestamp = first_timestamp
+            - timestamp_increment
+                * u32::try_from(commands_before_first_timestamp).unwrap_or(u32::MAX);
 
         for line in lines.into_iter() {
             match line {

--- a/crates/atuin-client/src/import/zsh.rs
+++ b/crates/atuin-client/src/import/zsh.rs
@@ -112,9 +112,10 @@ impl Importer for Zsh {
                 line.push_str(s);
                 line.push('\n');
             } else {
+                line.push_str(&s);
                 entries.push(Entry::parse(&line));
+                line.clear();
             }
-            line.clear();
         }
 
         // Similar approach to preserving order as the Bash importer.

--- a/crates/atuin-client/src/import/zsh.rs
+++ b/crates/atuin-client/src/import/zsh.rs
@@ -50,6 +50,41 @@ fn default_histpath() -> Result<PathBuf> {
     }
 }
 
+/// Represents a line of zsh history.
+struct Entry {
+    pub command: String,
+    pub timestamp: Option<OffsetDateTime>,
+    /// Nanoseconds
+    pub duration: Option<i64>,
+}
+
+impl Entry {
+    pub fn parse(line: &str) -> Self {
+        if let Some(rest) = line.strip_prefix(": ") {
+            let (time, rest) = rest.split_once(':').unwrap();
+            let (duration, command) = rest.split_once(';').unwrap();
+            let time = time
+                .parse::<i64>()
+                .ok()
+                .and_then(|t| OffsetDateTime::from_unix_timestamp(t).ok());
+
+            // use nanos, because why the hell not? we won't display them.
+            let duration = duration.parse::<i64>().map_or(-1, |t| t * 1_000_000_000);
+            Self {
+                command: command.trim_end().to_owned(),
+                timestamp: time,
+                duration: Some(duration),
+            }
+        } else {
+            Self {
+                command: line.trim_end().to_owned(),
+                timestamp: None,
+                duration: None,
+            }
+        }
+    }
+}
+
 #[async_trait]
 impl Importer for Zsh {
     const NAME: &'static str = "zsh";
@@ -76,26 +111,9 @@ impl Importer for Zsh {
             if let Some(s) = s.strip_suffix('\\') {
                 line.push_str(s);
                 line.push('\n');
-                continue;
-            }
-
-            line.push_str(&s);
-            let entry = if let Some(rest) = line.strip_prefix(": ") {
-                let (time, rest) = rest.split_once(':').unwrap();
-                let (duration, command) = rest.split_once(';').unwrap();
-                let time = time
-                    .parse::<i64>()
-                    .ok()
-                    .and_then(|t| OffsetDateTime::from_unix_timestamp(t).ok());
-
-                // use nanos, because why the hell not? we won't display them.
-                let duration = duration.parse::<i64>().map_or(-1, |t| t * 1_000_000_000);
-                let command = command.trim_end().to_owned();
-                (command, time, Some(duration))
             } else {
-                (std::mem::take(&mut line), None, None)
-            };
-            entries.push(entry);
+                entries.push(Entry::parse(&line));
+            }
             line.clear();
         }
 
@@ -103,23 +121,25 @@ impl Importer for Zsh {
         let (commands_until_timestamp, first_timestamp) = entries
             .iter()
             .enumerate()
-            .find_map(|(i, (_, time, _))| time.map(|t| (i + 1, t)))
+            .find_map(|(i, entry)| entry.timestamp.map(|t| (i + 1, t)))
             .unwrap_or_else(|| (entries.len(), OffsetDateTime::now_utc()));
 
         let timestamp_increment = Duration::milliseconds(1);
         let mut timestamp = first_timestamp
             - u32::try_from(commands_until_timestamp).unwrap_or(u32::MAX) * timestamp_increment;
 
-        for (command, time, duration) in entries {
-            if let Some(time) = time {
+        for entry in entries {
+            if let Some(time) = entry.timestamp {
                 timestamp = time;
             } else {
                 timestamp += timestamp_increment;
             }
 
-            let builder = History::import().timestamp(timestamp).command(command);
+            let builder = History::import()
+                .timestamp(timestamp)
+                .command(entry.command);
 
-            let imported = if let Some(duration) = duration {
+            let imported = if let Some(duration) = entry.duration {
                 builder.duration(duration).build()
             } else {
                 builder.build()
@@ -160,39 +180,39 @@ mod test {
 
     #[test]
     fn test_parse_extended_simple() {
-        let parsed = parse_extended("1613322469:0;cargo install atuin", 0);
+        let parsed = Entry::parse(": 1613322469:0;cargo install atuin");
 
         assert_eq!(parsed.command, "cargo install atuin");
-        assert_eq!(parsed.duration, 0);
+        assert_eq!(parsed.duration, Some(0));
         assert_eq!(
-            parsed.timestamp,
+            parsed.timestamp.unwrap(),
             OffsetDateTime::from_unix_timestamp(1_613_322_469).unwrap()
         );
 
-        let parsed = parse_extended("1613322469:10;cargo install atuin;cargo update", 0);
+        let parsed = Entry::parse(": 1613322469:10;cargo install atuin;cargo update");
 
         assert_eq!(parsed.command, "cargo install atuin;cargo update");
-        assert_eq!(parsed.duration, 10_000_000_000);
+        assert_eq!(parsed.duration, Some(10_000_000_000));
         assert_eq!(
-            parsed.timestamp,
+            parsed.timestamp.unwrap(),
             OffsetDateTime::from_unix_timestamp(1_613_322_469).unwrap()
         );
 
-        let parsed = parse_extended("1613322469:10;cargo :b̷i̶t̴r̵o̴t̴ ̵i̷s̴ ̷r̶e̵a̸l̷", 0);
+        let parsed = Entry::parse(": 1613322469:10;cargo :b̷i̶t̴r̵o̴t̴ ̵i̷s̴ ̷r̶e̵a̸l̷");
 
         assert_eq!(parsed.command, "cargo :b̷i̶t̴r̵o̴t̴ ̵i̷s̴ ̷r̶e̵a̸l̷");
-        assert_eq!(parsed.duration, 10_000_000_000);
+        assert_eq!(parsed.duration, Some(10_000_000_000));
         assert_eq!(
-            parsed.timestamp,
+            parsed.timestamp.unwrap(),
             OffsetDateTime::from_unix_timestamp(1_613_322_469).unwrap()
         );
 
-        let parsed = parse_extended("1613322469:10;cargo install \\n atuin\n", 0);
+        let parsed = Entry::parse(": 1613322469:10;cargo install \\n atuin\n");
 
         assert_eq!(parsed.command, "cargo install \\n atuin");
-        assert_eq!(parsed.duration, 10_000_000_000);
+        assert_eq!(parsed.duration, Some(10_000_000_000));
         assert_eq!(
-            parsed.timestamp,
+            parsed.timestamp.unwrap(),
             OffsetDateTime::from_unix_timestamp(1_613_322_469).unwrap()
         );
     }

--- a/crates/atuin-client/src/import/zsh.rs
+++ b/crates/atuin-client/src/import/zsh.rs
@@ -7,7 +7,7 @@ use std::path::PathBuf;
 use async_trait::async_trait;
 use directories::UserDirs;
 use eyre::{Result, eyre};
-use time::OffsetDateTime;
+use time::{Duration, OffsetDateTime};
 
 use super::{Importer, Loader, get_histfile_path, unix_byte_lines};
 use crate::history::History;
@@ -16,6 +16,12 @@ use crate::import::read_to_end;
 #[derive(Debug)]
 pub struct Zsh {
     bytes: Vec<u8>,
+}
+
+impl Zsh {
+    fn num_entries(&self) -> usize {
+        super::count_lines(&self.bytes)
+    }
 }
 
 fn default_histpath() -> Result<PathBuf> {
@@ -54,14 +60,13 @@ impl Importer for Zsh {
     }
 
     async fn entries(&mut self) -> Result<usize> {
-        Ok(super::count_lines(&self.bytes))
+        Ok(self.num_entries())
     }
 
     async fn load(self, h: &mut impl Loader) -> Result<()> {
-        let now = OffsetDateTime::now_utc();
         let mut line = String::new();
+        let mut entries = Vec::with_capacity(self.num_entries());
 
-        let mut counter = 0;
         for b in unix_byte_lines(&self.bytes) {
             let s = match unmetafy(b) {
                 Some(s) => s,
@@ -71,51 +76,58 @@ impl Importer for Zsh {
             if let Some(s) = s.strip_suffix('\\') {
                 line.push_str(s);
                 line.push('\n');
-            } else {
-                line.push_str(&s);
-                let command = std::mem::take(&mut line);
-
-                if let Some(command) = command.strip_prefix(": ") {
-                    counter += 1;
-                    h.push(parse_extended(command, counter)).await?;
-                } else {
-                    let offset = time::Duration::seconds(counter);
-                    counter += 1;
-
-                    let imported = History::import()
-                        // preserve ordering
-                        .timestamp(now - offset)
-                        .command(command.trim_end().to_string());
-
-                    h.push(imported.build().into()).await?;
-                }
+                continue;
             }
+
+            line.push_str(&s);
+            let entry = if let Some(rest) = line.strip_prefix(": ") {
+                let (time, rest) = rest.split_once(':').unwrap();
+                let (duration, command) = rest.split_once(';').unwrap();
+                let time = time
+                    .parse::<i64>()
+                    .ok()
+                    .and_then(|t| OffsetDateTime::from_unix_timestamp(t).ok());
+
+                // use nanos, because why the hell not? we won't display them.
+                let duration = duration.parse::<i64>().map_or(-1, |t| t * 1_000_000_000);
+                let command = command.trim_end().to_owned();
+                (command, time, Some(duration))
+            } else {
+                (std::mem::take(&mut line), None, None)
+            };
+            entries.push(entry);
+            line.clear();
         }
 
+        // Similar approach to preserving order as the Bash importer.
+        let (commands_until_timestamp, first_timestamp) = entries
+            .iter()
+            .enumerate()
+            .find_map(|(i, (_, time, _))| time.map(|t| (i + 1, t)))
+            .unwrap_or_else(|| (entries.len(), OffsetDateTime::now_utc()));
+
+        let timestamp_increment = Duration::milliseconds(1);
+        let mut timestamp = first_timestamp
+            - u32::try_from(commands_until_timestamp).unwrap_or(u32::MAX) * timestamp_increment;
+
+        for (command, time, duration) in entries {
+            if let Some(time) = time {
+                timestamp = time;
+            } else {
+                timestamp += timestamp_increment;
+            }
+
+            let builder = History::import().timestamp(timestamp).command(command);
+
+            let imported = if let Some(duration) = duration {
+                builder.duration(duration).build()
+            } else {
+                builder.build()
+            };
+            h.push(imported.into()).await?;
+        }
         Ok(())
     }
-}
-
-fn parse_extended(line: &str, counter: i64) -> History {
-    let (time, duration) = line.split_once(':').unwrap();
-    let (duration, command) = duration.split_once(';').unwrap();
-
-    let time = time
-        .parse::<i64>()
-        .ok()
-        .and_then(|t| OffsetDateTime::from_unix_timestamp(t).ok())
-        .unwrap_or_else(OffsetDateTime::now_utc)
-        + time::Duration::milliseconds(counter);
-
-    // use nanos, because why the hell not? we won't display them.
-    let duration = duration.parse::<i64>().map_or(-1, |t| t * 1_000_000_000);
-
-    let imported = History::import()
-        .timestamp(time)
-        .command(command.trim_end().to_string())
-        .duration(duration);
-
-    imported.build().into()
 }
 
 fn unmetafy(line: &[u8]) -> Option<Cow<'_, str>> {


### PR DESCRIPTION
Currently, `atuin import zsh` imports items in reverse order when zsh's extended history format is not used. The entries are also spaced one second apart, so they may become interleaved if the user has recently added other commands to their Atuin history.

This PR uses a similar approach to the Bash importer. Entries for which no timestamp exists are spaced one millisecond apart.