### PR TITLE
feat(tui): truncate long commands from middle to show start...end

### DIFF
--- a/crates/atuin/src/command/client/search/history_list.rs
+++ b/crates/atuin/src/command/client/search/history_list.rs
@@ -222,7 +222,7 @@ impl DrawState<'_> {
                 UiColumnType::Host => self.host(h, width),
                 UiColumnType::User => self.user(h, width),
                 UiColumnType::Exit => self.exit_code(h, width),
-                UiColumnType::Command => self.command(h),
+                UiColumnType::Command => self.command(h, width),
             }
         }
     }
@@ -283,7 +283,7 @@ impl DrawState<'_> {
         self.draw(&display, Style::from_crossterm(style));
     }
 
-    fn command(&mut self, h: &History) {
+    fn command(&mut self, h: &History, _width: u16) {
         let mut style = self.theme.as_style(Meaning::Base);
         let mut row_highlighted = false;
         if !self.alternate_highlight && (self.y as usize + self.state.offset == self.state.selected)
@@ -294,39 +294,44 @@ impl DrawState<'_> {
             style.attributes.set(style::Attribute::Bold);
         }
 
-        let highlight_indices = self.history_highlighter.get_highlight_indices(
-            h.command
-                .escape_control()
-                .split_ascii_whitespace()
-                .join(" ")
-                .as_str(),
-        );
+        // Build the normalized command string (whitespace-collapsed, control chars escaped)
+        let normalized: String = h
+            .command
+            .escape_control()
+            .split_ascii_whitespace()
+            .join(" ");
 
-        let mut pos = 0;
-        for section in h.command.escape_control().split_ascii_whitespace() {
-            if pos != 0 {
-                self.draw(" ", Style::from_crossterm(style));
+        let highlight_indices = self.history_highlighter.get_highlight_indices(&normalized);
+
+        // Calculate the available width for the command text.
+        // `self.x` is already past the indicator and any preceding columns,
+        // so the remaining width is how far we can draw.
+        let avail = (self.list_area.width.saturating_sub(self.x)) as usize;
+
+        // Truncate long commands from the middle to show both start and end,
+        // so users can identify commands even in narrow terminals (issue #3596).
+        let (display, display_to_original) = truncate_middle(&normalized, avail);
+        let normalized_byte_len = normalized.len();
+
+        // Render each character of the display string, applying highlights
+        // where the original position matches a highlight index.
+        for (ch, &original_byte_pos) in display.chars().zip(display_to_original.iter()) {
+            if self.x > self.list_area.width {
+                return;
             }
-            for ch in section.chars() {
-                if self.x > self.list_area.width {
-                    // Avoid attempting to draw a command section beyond the width
-                    // of the list
-                    return;
+
+            let mut char_style = style;
+            if original_byte_pos < normalized_byte_len
+                && highlight_indices.contains(&original_byte_pos)
+            {
+                if row_highlighted {
+                    char_style = self.theme.as_style(Meaning::AlertWarn);
                 }
-                let mut style = style;
-                if highlight_indices.contains(&pos) {
-                    if row_highlighted {
-                        // if the row is highlighted bold is not enough as the whole row is bold
-                        // change the color too
-                        style = self.theme.as_style(Meaning::AlertWarn);
-                    }
-                    style.attributes.set(style::Attribute::Bold);
-                }
-                let s = ch.to_string();
-                self.draw(&s, Style::from_crossterm(style));
-                pos += s.len();
+                char_style.attributes.set(style::Attribute::Bold);
             }
-            pos += 1;
+
+            let s = ch.to_string();
+            self.draw(&s, Style::from_crossterm(char_style));
         }
     }
 
@@ -427,5 +432,130 @@ impl DrawState<'_> {
 
         let w = (self.list_area.width - self.x) as usize;
         self.x += self.buf.set_stringn(cx, cy, s, w, style).0 - cx;
+    }
+}
+
+/// Truncate a string from the middle to fit within `avail` characters,
+/// showing the start and end separated by "...".
+///
+/// Returns the truncated display string and a mapping from each display
+/// character's byte position to the corresponding byte position in the
+/// original string. Characters in the "..." sentinel map to
+/// `original.len()` (an out-of-range value that will never match any
+/// real highlight index).
+///
+/// If the string fits within `avail`, or `avail < 7` (too small to
+/// truncate meaningfully), the original string is returned as-is with
+/// a 1:1 mapping.
+fn truncate_middle(original: &str, avail: usize) -> (String, Vec<usize>) {
+    let char_byte_offsets: Vec<usize> = original.char_indices().map(|(bp, _)| bp).collect();
+    let char_count = char_byte_offsets.len();
+
+    if char_count <= avail || avail < 7 {
+        return (original.to_string(), char_byte_offsets);
+    }
+
+    let remaining = avail - 3;
+    let prefix_len = remaining.div_ceil(2);
+    let suffix_len = remaining / 2;
+
+    let prefix: String = original.chars().take(prefix_len).collect();
+    let suffix: String = original.chars().skip(char_count - suffix_len).collect();
+    let display = format!("{prefix}...{suffix}");
+
+    let original_byte_len = original.len();
+    let mut mapping = Vec::with_capacity(avail);
+    mapping.extend_from_slice(&char_byte_offsets[..prefix_len]);
+    mapping.extend(std::iter::repeat_n(original_byte_len, 3));
+    for i in 0..suffix_len {
+        mapping.push(char_byte_offsets[char_count - suffix_len + i]);
+    }
+
+    (display, mapping)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::truncate_middle;
+
+    #[test]
+    fn test_no_truncation_when_fits() {
+        let (display, mapping) = truncate_middle("hello", 10);
+        assert_eq!(display, "hello");
+        assert_eq!(mapping.len(), 5);
+        // Mapping should be 1:1 with byte offsets
+        assert_eq!(mapping, vec![0, 1, 2, 3, 4]);
+    }
+
+    #[test]
+    fn test_no_truncation_exact_fit() {
+        let (display, _) = truncate_middle("hello", 5);
+        assert_eq!(display, "hello");
+    }
+
+    #[test]
+    fn test_no_truncation_when_too_small() {
+        // avail < 7 — too small to truncate, return as-is
+        let (display, _) = truncate_middle("hello world this is long", 6);
+        assert_eq!(display, "hello world this is long");
+    }
+
+    #[test]
+    fn test_truncation_shows_start_and_end() {
+        let (display, _) = truncate_middle("abcdefghijklmnopqrstuvwxyz", 11);
+        // avail=11, remaining=8, prefix=4, suffix=4
+        // "abcd...wxyz"
+        assert_eq!(display, "abcd...wxyz");
+        assert_eq!(display.len(), 11);
+    }
+
+    #[test]
+    fn test_truncation_preserves_byte_mapping() {
+        let original = "abcdefghij";
+        let (display, mapping) = truncate_middle(original, 7);
+        // avail=7, remaining=4, prefix=2, suffix=2
+        // "ab...ij"
+        assert_eq!(display, "ab...ij");
+
+        // Prefix chars map to original positions 0, 1
+        assert_eq!(mapping[0], 0); // 'a'
+        assert_eq!(mapping[1], 1); // 'b'
+        // "..." maps to original.len() (out of range)
+        assert_eq!(mapping[2], original.len());
+        assert_eq!(mapping[3], original.len());
+        assert_eq!(mapping[4], original.len());
+        // Suffix chars map to original positions 8, 9
+        assert_eq!(mapping[5], 8); // 'i'
+        assert_eq!(mapping[6], 9); // 'j'
+    }
+
+    #[test]
+    fn test_truncation_with_unicode() {
+        let original = "héllo wörld thïs ïs ä löng cömmänd";
+        let (display, mapping) = truncate_middle(original, 15);
+        // Should still be 15 chars
+        assert_eq!(display.chars().count(), 15);
+        // Should contain "..."
+        assert!(display.contains("..."));
+        // Mapping length matches display char count
+        assert_eq!(mapping.len(), 15);
+    }
+
+    #[test]
+    fn test_truncation_minimum_width() {
+        // avail=7 is the minimum for truncation
+        let original = "abcdefghij";
+        let (display, _) = truncate_middle(original, 7);
+        assert_eq!(display, "ab...ij");
+    }
+
+    #[test]
+    fn test_truncation_odd_remaining() {
+        // avail=10, remaining=7, prefix=4 (ceil), suffix=3
+        let original = "abcdefghijklmno"; // 15 chars
+        let (display, _) = truncate_middle(original, 10);
+        // "abcd...mno"
+        assert_eq!(display, "abcd...mno");
+        assert_eq!(display.len(), 10);
     }
 }


### PR DESCRIPTION
## Summary

Resolves #3596

When a command is too long to fit in the available terminal width, truncate it from the middle showing both the beginning and end of the command separated by `...` instead of cutting off at the end.

This makes it easier to identify long commands at a glance in narrow terminals, similar to how `hstr` handles command display.

## Changes

- **`history_list.rs`**: Modified `command()` render method to use middle-truncation when the command doesn't fit the available width
- **`truncate_middle()`**: Extracted the truncation logic as a pure, testable function that:
  - Returns the display string and a byte-position mapping (for search highlight alignment)
  - Handles Unicode correctly (char-based, not byte-based)
  - Returns the original string as-is when it fits or when the width is too small (< 7 chars)
- **8 unit tests** covering: no truncation when fits, exact fit, too-small width, start/end display, byte mapping preservation, Unicode, minimum width, odd remaining

## Behavior

| Before | After |
|--------|-------|
| `docker run --rm -it -v /home/user/long/path:/data ubuntu:22.04 bash -c` (cut off) | `docker run --rm -it -v /home/u...:22.04 bash -c` |

The prefix gets slightly more space than the suffix (ceiling division) since the beginning of a command is usually more identifying.

## Testing

- `cargo test --bin atuin` — 222 passed (214 existing + 8 new)
- `cargo clippy -- -D warnings` — clean
- `cargo fmt --check` — clean