### PR TITLE
docs: add Debian/Ubuntu installation via deb.griffo.io (unofficial apt repo)

### DIFF
--- a/docs/docs/guide/installation.md
+++ b/docs/docs/guide/installation.md
@@ -59,6 +59,19 @@ If you don't wish to use the installer, the manual installation steps are as fol
     cargo install atuin
     ```
 
+=== "Debian/Ubuntu"
+
+    Atuin is available in the unofficial [deb.griffo.io](https://deb.griffo.io/install-latest-atuin-in-debian.html)
+    APT repository, maintained by [dariogriffo](https://github.com/dariogriffo).
+    Packages are built automatically from the official Atuin releases:
+
+    ```shell
+    sudo install -d -m 0755 /etc/apt/keyrings
+    curl -fsSL https://deb.griffo.io/EA0F721D231FDD3A0A17B9AC7808B4DD62C41256.asc | sudo gpg --dearmor --yes -o /etc/apt/keyrings/deb.griffo.io.gpg
+    echo "deb [signed-by=/etc/apt/keyrings/deb.griffo.io.gpg] https://deb.griffo.io/apt $(lsb_release -sc) main" | sudo tee /etc/apt/sources.list.d/deb.griffo.io.list > /dev/null
+    sudo apt update && sudo apt install atuin
+    ```
+
 === "Homebrew"
 
     ```shell

--- a/docs/docs/guide/installation.md
+++ b/docs/docs/guide/installation.md
@@ -68,7 +68,8 @@ If you don't wish to use the installer, the manual installation steps are as fol
     ```shell
     sudo install -d -m 0755 /etc/apt/keyrings
     curl -fsSL https://deb.griffo.io/EA0F721D231FDD3A0A17B9AC7808B4DD62C41256.asc | sudo gpg --dearmor --yes -o /etc/apt/keyrings/deb.griffo.io.gpg
-    echo "deb [signed-by=/etc/apt/keyrings/deb.griffo.io.gpg] https://deb.griffo.io/apt $(lsb_release -sc) main" | sudo tee /etc/apt/sources.list.d/deb.griffo.io.list > /dev/null
+    . /etc/os-release
+    echo "deb [signed-by=/etc/apt/keyrings/deb.griffo.io.gpg] https://deb.griffo.io/apt ${VERSION_CODENAME:?unsupported distribution} main" | sudo tee /etc/apt/sources.list.d/deb.griffo.io.list > /dev/null
     sudo apt update && sudo apt install atuin
     ```
 


### PR DESCRIPTION
I maintain [deb.griffo.io](https://deb.griffo.io/install-latest-atuin-in-debian.html), an unofficial apt repository for Debian and Ubuntu whose packages are built automatically from the official Atuin releases within hours (packaging is open source at https://github.com/dariogriffo/atuin-debian). This adds a Debian/Ubuntu tab to the manual installation section, clearly labelled as unofficial.

all supported distros available [here](https://deb.griffo.io/apt/dists/)
