### PR TITLE
fix: Default to non-Hub mode for custom AI endpoints

### DIFF
--- a/crates/atuin-ai/src/commands/inline.rs
+++ b/crates/atuin-ai/src/commands/inline.rs
@@ -49,12 +49,15 @@ pub(crate) async fn run(
             .as_deref()
             .unwrap_or("https://hub.atuin.sh"),
     );
+    let endpoint_is_hub = settings.is_hub_ai_endpoint(endpoint);
     let api_token = api_token.as_deref().or(settings.ai.api_token.as_deref());
 
-    let token = if let Some(token) = &api_token {
-        token.to_string()
-    } else {
-        ensure_hub_session(settings).await?
+    let (token, token_from_hub_session) = match api_token {
+        Some(token) => (token.to_string(), false),
+        None if endpoint_is_hub => (ensure_hub_session(settings).await?, true),
+        // An OSS server may not require auth; hit it without a token rather
+        // than forcing a login flow that doesn't apply.
+        None => (String::new(), false),
     };
 
     let history_db_path = PathBuf::from(settings.db_path.as_str());
@@ -79,6 +82,8 @@ pub(crate) async fn run(
     let ctx = AppContext {
         endpoint: endpoint.to_string(),
         token,
+        endpoint_is_hub,
+        token_from_hub_session,
         send_cwd,
         last_command,
         history_db: std::sync::Arc::new(history_db),
@@ -164,18 +169,25 @@ async fn run_inline_tui(
         .context("failed to open AI session database")?;
 
     // Cached usage renders immediately; a background fetch (spawned below,
-    // once the event channel exists) replaces it unless it's fresh.
-    let usage_key = crate::usage::cache_key(&ctx.token);
-    let (cached_usage, usage_is_fresh) = match service.get_cached_usage(&usage_key).await {
-        Ok(Some(cached_snapshot)) => {
-            let age = time::OffsetDateTime::now_utc().unix_timestamp() - cached_snapshot.written_at;
-            let fresh = age < crate::usage::REFRESH_AFTER.as_secs() as i64;
-            (Some(cached_snapshot.snapshot), fresh)
-        }
-        Ok(None) => (None, false),
-        Err(e) => {
-            debug!("failed to read usage cache: {e}");
-            (None, false)
+    // once the event channel exists) replaces it unless it's fresh. OSS
+    // endpoints have no usage API, so both are skipped ("fresh" suppresses
+    // the fetch).
+    let (cached_usage, usage_is_fresh) = if !ctx.endpoint_is_hub {
+        (None, true)
+    } else {
+        let usage_key = crate::usage::cache_key(&ctx.token);
+        match service.get_cached_usage(&usage_key).await {
+            Ok(Some(cached_snapshot)) => {
+                let age =
+                    time::OffsetDateTime::now_utc().unix_timestamp() - cached_snapshot.written_at;
+                let fresh = age < crate::usage::REFRESH_AFTER.as_secs() as i64;
+                (Some(cached_snapshot.snapshot), fresh)
+            }
+            Ok(None) => (None, false),
+            Err(e) => {
+                debug!("failed to read usage cache: {e}");
+                (None, false)
+            }
         }
     };
 

--- a/crates/atuin-ai/src/context.rs
+++ b/crates/atuin-ai/src/context.rs
@@ -10,7 +10,17 @@ use atuin_client::settings::AiCapabilities;
 #[derive(Clone, Debug)]
 pub(crate) struct AppContext {
     pub endpoint: String,
+    /// Bearer token for `endpoint`. Empty means unauthenticated — no
+    /// Authorization header is sent (an OSS server may not require auth).
     pub token: String,
+    /// Whether `endpoint` is an Atuin Hub instance. Hub endpoints report
+    /// credit usage; OSS endpoints (e.g. atuin-ai-server) don't have the
+    /// usage API, so usage fetching and caching are skipped.
+    pub endpoint_is_hub: bool,
+    /// Whether `token` came from the stored Hub session rather than
+    /// `ai.api_token` or the CLI flag. Only a session-sourced token may be
+    /// cleared (logging the user out) when the server rejects it.
+    pub token_from_hub_session: bool,
     pub send_cwd: bool,
     pub last_command: Option<History>,
     pub history_db: Arc<atuin_client::database::Sqlite>,

--- a/crates/atuin-ai/src/driver.rs
+++ b/crates/atuin-ai/src/driver.rs
@@ -1047,6 +1047,7 @@ async fn run_stream_bridge(
     let stream = create_chat_stream(
         app_ctx.endpoint.clone(),
         app_ctx.token.clone(),
+        app_ctx.token_from_hub_session,
         request,
         client_ctx,
         app_ctx.send_cwd,

--- a/crates/atuin-ai/src/models.rs
+++ b/crates/atuin-ai/src/models.rs
@@ -30,14 +30,14 @@ pub(crate) async fn fetch_models(endpoint: &str, token: &str) -> Result<ModelLis
     atuin_common::tls::ensure_crypto_provider();
     let url = crate::stream::hub_url(endpoint, "/api/cli/models")?;
 
-    let response = reqwest::Client::new()
+    let mut request = reqwest::Client::new()
         .get(url)
         .header(USER_AGENT, crate::stream::APP_USER_AGENT)
-        .bearer_auth(token)
-        .timeout(Duration::from_secs(10))
-        .send()
-        .await
-        .context("failed to fetch model list")?;
+        .timeout(Duration::from_secs(10));
+    if !token.is_empty() {
+        request = request.bearer_auth(token);
+    }
+    let response = request.send().await.context("failed to fetch model list")?;
 
     let status = response.status();
     if !status.is_success() {

--- a/crates/atuin-ai/src/stream.rs
+++ b/crates/atuin-ai/src/stream.rs
@@ -119,6 +119,7 @@ impl ChatRequest {
 pub(crate) fn create_chat_stream(
     hub_address: String,
     token: String,
+    token_from_hub_session: bool,
     request: ChatRequest,
     client_ctx: ClientContext,
     send_cwd: bool,
@@ -173,15 +174,15 @@ pub(crate) fn create_chat_stream(
         }
 
         let client = reqwest::Client::new();
-        let response = match client
+        let mut request_builder = client
             .post(endpoint.clone())
             .header("Accept", "text/event-stream")
             .header(USER_AGENT, APP_USER_AGENT)
-            .bearer_auth(&token)
-            .json(&request_body)
-            .send()
-            .await
-        {
+            .json(&request_body);
+        if !token.is_empty() {
+            request_builder = request_builder.bearer_auth(&token);
+        }
+        let response = match request_builder.send().await {
             Ok(resp) => resp,
             Err(e) => {
                 yield Err(eyre::eyre!("Failed to send SSE request: {}", e));
@@ -191,9 +192,17 @@ pub(crate) fn create_chat_stream(
 
         let status = response.status();
         if status == reqwest::StatusCode::UNAUTHORIZED {
-            tracing::error!("SSE request failed with status: {status}, clearing session");
-            let _ = atuin_client::hub::delete_session().await;
-            yield Err(eyre::eyre!("Hub session expired. Re-run to authenticate again."));
+            if token_from_hub_session {
+                tracing::error!("SSE request failed with status: {status}, clearing session");
+                let _ = atuin_client::hub::delete_session().await;
+                yield Err(eyre::eyre!("Hub session expired. Re-run to authenticate again."));
+            } else if token.is_empty() {
+                tracing::error!("SSE request failed with status: {status}");
+                yield Err(eyre::eyre!("The endpoint requires authentication. Set ai.api_token in your config."));
+            } else {
+                tracing::error!("SSE request failed with status: {status}");
+                yield Err(eyre::eyre!("The endpoint rejected the API token. Check ai.api_token in your config."));
+            }
             return;
         }
         if !status.is_success() {

--- a/crates/atuin-client/src/settings.rs
+++ b/crates/atuin-client/src/settings.rs
@@ -645,6 +645,25 @@ pub struct Logs {
     pub ai: LogConfig,
 }
 
+/// Endpoint protocol for Atuin AI.
+///
+/// When set to "auto" (default), the protocol is inferred from `ai.endpoint`:
+/// an unset or official Atuin address is treated as Hub, anything else as an
+/// OSS server. Set explicitly to "hub" to keep Hub behavior with a custom
+/// endpoint (useful for local development against a Hub instance).
+#[derive(Clone, Copy, Debug, Deserialize, PartialEq, Eq, Serialize, Default)]
+#[serde(rename_all = "lowercase")]
+pub enum AiEndpointProtocol {
+    /// Atuin Hub: browser-based login flow, stored Hub session, usage reporting.
+    Hub,
+    /// A standalone AI server (e.g. atuin-ai-server): requests go straight to
+    /// the endpoint, authenticated with `ai.api_token` if set.
+    Oss,
+    /// Infer from ai.endpoint (default behavior)
+    #[default]
+    Auto,
+}
+
 #[derive(Default, Clone, Debug, Deserialize, Serialize)]
 pub struct Ai {
     /// Whether or not the AI features are enabled.
@@ -653,6 +672,10 @@ pub struct Ai {
     /// The address of the Atuin AI endpoint. Used for AI features like command generation.
     /// Only necessary for custom AI endpoints.
     pub endpoint: Option<String>,
+
+    /// How to talk to `endpoint`. See [`AiEndpointProtocol`].
+    #[serde(default)]
+    pub endpoint_protocol: AiEndpointProtocol,
 
     /// The API token for the Atuin AI endpoint. Used for AI features like command generation.
     /// Only necessary for custom AI endpoints.
@@ -1296,6 +1319,21 @@ impl Settings {
         }
     }
 
+    /// Returns whether the resolved AI endpoint should be treated as an Atuin
+    /// Hub instance (browser login flow, Hub session management, usage
+    /// reporting) rather than a standalone OSS server.
+    ///
+    /// `endpoint` is the resolved AI endpoint — the `--api-endpoint` flag or
+    /// `ai.endpoint` setting, after defaults are applied — which is why it's a
+    /// parameter rather than read from `self.ai.endpoint`.
+    pub fn is_hub_ai_endpoint(&self, endpoint: &str) -> bool {
+        match self.ai.endpoint_protocol {
+            AiEndpointProtocol::Hub => true,
+            AiEndpointProtocol::Oss => false,
+            AiEndpointProtocol::Auto => Self::is_official_address(endpoint),
+        }
+    }
+
     /// Returns the base URL for the Hub endpoint.
     ///
     /// For Atuin's official hosted service, this always returns `https://hub.atuin.sh`
@@ -1885,6 +1923,24 @@ mod tests {
         assert!(Timezone::from_str("10:30").is_err());
 
         Ok(())
+    }
+
+    #[test]
+    fn ai_endpoint_protocol_resolution() {
+        let mut settings = super::Settings::default();
+
+        // Auto: official addresses are Hub, anything else is OSS
+        assert!(settings.is_hub_ai_endpoint("https://hub.atuin.sh"));
+        assert!(settings.is_hub_ai_endpoint("https://api.atuin.sh"));
+        assert!(!settings.is_hub_ai_endpoint("https://ai.example.com"));
+        assert!(!settings.is_hub_ai_endpoint("http://localhost:4000"));
+
+        // Explicit settings override the address check
+        settings.ai.endpoint_protocol = super::AiEndpointProtocol::Hub;
+        assert!(settings.is_hub_ai_endpoint("http://localhost:4000"));
+
+        settings.ai.endpoint_protocol = super::AiEndpointProtocol::Oss;
+        assert!(!settings.is_hub_ai_endpoint("https://hub.atuin.sh"));
     }
 
     #[test]

--- a/docs/docs/ai/settings.md
+++ b/docs/docs/ai/settings.md
@@ -38,6 +38,18 @@ Default: `null`
 
 The API token for the Atuin AI endpoint. Used for AI features like command generation. Most users will not need this setting; it is only necessary for custom AI endpoints.
 
+### endpoint_protocol
+
+Default: `"auto"`
+
+How the client talks to the configured `endpoint`. One of:
+
+- `"auto"` — infer from `endpoint`: official Atuin addresses use the Hub protocol, anything else is treated as an OSS server.
+- `"hub"` — treat the endpoint as an Atuin Hub instance: log in via the browser-based Hub flow and report credit usage. Mostly useful for developing against a local Hub instance.
+- `"oss"` — treat the endpoint as a standalone AI server, such as [atuin-ai-server](https://github.com/atuinsh/atuin-ai-server). No login flow; requests are authenticated with `api_token` if set.
+
+With the default of `"auto"`, pointing `endpoint` at your own server just works: set `api_token` if your server requires one.
+
 ## Capabilities
 
 Settings that control what capabilities are sent to the LLM, which the LLM uses to understand what features the client has available. These are specified under `[ai.capabilities]`.


### PR DESCRIPTION
Prior to this PR, the Atuin client treated all custom AI endpoints as Hub endpoints, enforcing the login/logout flow.

This PR introduces a new setting, `ai.endpoint_protocol`, which defaults to `"auto"`. In Auto mode, we use the Hub protocol for `.atuin.sh` addresses, and the OSS protocol otherwise. Users of the [open source server](https://github.com/atuinsh/atuin-ai-server) can simply set `ai.endpoint` and everything will work normally; Atuin developers can set the new setting to `"hub"` to develop locally against Atuin Hub.