### PR TITLE
chore(release): prepare for release 18.17.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,31 @@
 
 All notable changes to this project will be documented in this file.
 
+## 18.17.1
+
+### Bug Fixes
+
+- *(ai)* Default to non-Hub mode for custom AI endpoints ([#3620](https://github.com/atuinsh/atuin/issues/3620))
+- *(import)* Fix order of entries imported from zsh history ([#3597](https://github.com/atuinsh/atuin/issues/3597))
+- *(import)* Fix import order of nushell history entries ([#3598](https://github.com/atuinsh/atuin/issues/3598))
+- Various prefix mode bugs ([#3616](https://github.com/atuinsh/atuin/issues/3616))
+
+
+### Documentation
+
+- Document output capture and mcp ([#3595](https://github.com/atuinsh/atuin/issues/3595))
+
+
+### Features
+
+- *(tui)* Truncate long commands from middle to show start...end ([#3602](https://github.com/atuinsh/atuin/issues/3602))
+
+
+### Miscellaneous Tasks
+
+- *(logging)* Remove the `log` crate in favor of `tracing` ([#3608](https://github.com/atuinsh/atuin/issues/3608))
+- Update to rust 1.97 ([#3617](https://github.com/atuinsh/atuin/issues/3617))
+
 ## 18.17.0
 
 ### Bug Fixes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -214,7 +214,7 @@ checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "atuin"
-version = "18.17.0"
+version = "18.17.1"
 dependencies = [
  "arboard",
  "async-trait",
@@ -274,7 +274,7 @@ dependencies = [
 
 [[package]]
 name = "atuin-ai"
-version = "18.17.0"
+version = "18.17.1"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -329,7 +329,7 @@ dependencies = [
 
 [[package]]
 name = "atuin-client"
-version = "18.17.0"
+version = "18.17.1"
 dependencies = [
  "async-trait",
  "atuin-common",
@@ -386,7 +386,7 @@ dependencies = [
 
 [[package]]
 name = "atuin-common"
-version = "18.17.0"
+version = "18.17.1"
 dependencies = [
  "base64",
  "derive_more",
@@ -409,7 +409,7 @@ dependencies = [
 
 [[package]]
 name = "atuin-daemon"
-version = "18.17.0"
+version = "18.17.1"
 dependencies = [
  "atuin-client",
  "atuin-common",
@@ -443,7 +443,7 @@ dependencies = [
 
 [[package]]
 name = "atuin-dotfiles"
-version = "18.17.0"
+version = "18.17.1"
 dependencies = [
  "atuin-client",
  "atuin-common",
@@ -459,7 +459,7 @@ dependencies = [
 
 [[package]]
 name = "atuin-history"
-version = "18.17.0"
+version = "18.17.1"
 dependencies = [
  "atuin-client",
  "crossterm",
@@ -472,7 +472,7 @@ dependencies = [
 
 [[package]]
 name = "atuin-kv"
-version = "18.17.0"
+version = "18.17.1"
 dependencies = [
  "atuin-client",
  "atuin-common",
@@ -516,7 +516,7 @@ dependencies = [
 
 [[package]]
 name = "atuin-pty-proxy"
-version = "18.17.0"
+version = "18.17.1"
 dependencies = [
  "clap",
  "crossterm",
@@ -528,7 +528,7 @@ dependencies = [
 
 [[package]]
 name = "atuin-scripts"
-version = "18.17.0"
+version = "18.17.1"
 dependencies = [
  "atuin-client",
  "atuin-common",
@@ -551,7 +551,7 @@ dependencies = [
 
 [[package]]
 name = "atuin-server"
-version = "18.17.0"
+version = "18.17.1"
 dependencies = [
  "argon2",
  "atuin-common",
@@ -580,7 +580,7 @@ dependencies = [
 
 [[package]]
 name = "atuin-server-database"
-version = "18.17.0"
+version = "18.17.1"
 dependencies = [
  "async-trait",
  "atuin-common",
@@ -595,7 +595,7 @@ dependencies = [
 
 [[package]]
 name = "atuin-server-postgres"
-version = "18.17.0"
+version = "18.17.1"
 dependencies = [
  "async-trait",
  "atuin-common",
@@ -614,7 +614,7 @@ dependencies = [
 
 [[package]]
 name = "atuin-server-sqlite"
-version = "18.17.0"
+version = "18.17.1"
 dependencies = [
  "async-trait",
  "atuin-common",
@@ -5158,7 +5158,7 @@ dependencies = [
 
 [[package]]
 name = "tests-database"
-version = "18.17.0"
+version = "18.17.1"
 dependencies = [
  "async-trait",
  "atuin-common",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ resolver = "2"
 exclude = ["ui/backend", "crates/atuin-nucleo/matcher/fuzz"]
 
 [workspace.package]
-version = "18.17.0"
+version = "18.17.1"
 authors = ["Ellie Huxtable <ellie@atuin.sh>"]
 rust-version = "1.97.0"
 license = "MIT"
@@ -19,17 +19,17 @@ readme = "README.md"
 
 [workspace.dependencies]
 async-trait = "0.1.58"
-atuin-client = { path = "crates/atuin-client", version = "18.17.0" }
-atuin-common = { path = "crates/atuin-common", version = "18.17.0" }
-atuin-daemon = { path = "crates/atuin-daemon", version = "18.17.0" }
-atuin-dotfiles = { path = "crates/atuin-dotfiles", version = "18.17.0" }
-atuin-history = { path = "crates/atuin-history", version = "18.17.0" }
-atuin-kv = { path = "crates/atuin-kv", version = "18.17.0" }
-atuin-scripts = { path = "crates/atuin-scripts", version = "18.17.0" }
-atuin-server = { path = "crates/atuin-server", version = "18.17.0" }
-atuin-server-database = { path = "crates/atuin-server-database", version = "18.17.0" }
-atuin-server-postgres = { path = "crates/atuin-server-postgres", version = "18.17.0" }
-atuin-server-sqlite = { path = "crates/atuin-server-sqlite", version = "18.17.0" }
+atuin-client = { path = "crates/atuin-client", version = "18.17.1" }
+atuin-common = { path = "crates/atuin-common", version = "18.17.1" }
+atuin-daemon = { path = "crates/atuin-daemon", version = "18.17.1" }
+atuin-dotfiles = { path = "crates/atuin-dotfiles", version = "18.17.1" }
+atuin-history = { path = "crates/atuin-history", version = "18.17.1" }
+atuin-kv = { path = "crates/atuin-kv", version = "18.17.1" }
+atuin-scripts = { path = "crates/atuin-scripts", version = "18.17.1" }
+atuin-server = { path = "crates/atuin-server", version = "18.17.1" }
+atuin-server-database = { path = "crates/atuin-server-database", version = "18.17.1" }
+atuin-server-postgres = { path = "crates/atuin-server-postgres", version = "18.17.1" }
+atuin-server-sqlite = { path = "crates/atuin-server-sqlite", version = "18.17.1" }
 atuin-nucleo = { path = "crates/atuin-nucleo", version = "0.6.0" }
 atuin-nucleo-matcher = { path = "crates/atuin-nucleo/matcher", version = "0.3.1" }
 base64 = "0.22"

--- a/crates/atuin-client/Cargo.toml
+++ b/crates/atuin-client/Cargo.toml
@@ -21,7 +21,7 @@ daemon = []
 check-update = []
 
 [dependencies]
-atuin-common = { path = "../atuin-common", version = "18.17.0" }
+atuin-common = { path = "../atuin-common", version = "18.17.1" }
 derive_more = { workspace = true }
 
 tracing = { workspace = true }
@@ -89,7 +89,7 @@ tempfile = "3"
 # This crate's tests require the `test-utils` feature in atuin-common.
 [dev-dependencies.atuin-common]
 path = "../atuin-common"
-version = "18.17.0"
+version = "18.17.1"
 features = ["test-utils"]
 
 [[bench]]

--- a/crates/atuin-daemon/Cargo.toml
+++ b/crates/atuin-daemon/Cargo.toml
@@ -14,11 +14,11 @@ readme.workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-atuin-client = { path = "../atuin-client", version = "18.17.0" }
-atuin-common = { path = "../atuin-common", version = "18.17.0" }
+atuin-client = { path = "../atuin-client", version = "18.17.1" }
+atuin-common = { path = "../atuin-common", version = "18.17.1" }
 derive_more = { workspace = true }
-atuin-dotfiles = { path = "../atuin-dotfiles", version = "18.17.0" }
-atuin-history = { path = "../atuin-history", version = "18.17.0" }
+atuin-dotfiles = { path = "../atuin-dotfiles", version = "18.17.1" }
+atuin-history = { path = "../atuin-history", version = "18.17.1" }
 
 time = { workspace = true }
 uuid = { workspace = true }

--- a/crates/atuin-dotfiles/Cargo.toml
+++ b/crates/atuin-dotfiles/Cargo.toml
@@ -14,8 +14,8 @@ readme.workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-atuin-common = { path = "../atuin-common", version = "18.17.0" }
-atuin-client = { path = "../atuin-client", version = "18.17.0" }
+atuin-common = { path = "../atuin-common", version = "18.17.1" }
+atuin-client = { path = "../atuin-client", version = "18.17.1" }
 derive_more = { workspace = true }
 
 eyre = { workspace = true }

--- a/crates/atuin-history/Cargo.toml
+++ b/crates/atuin-history/Cargo.toml
@@ -14,7 +14,7 @@ readme.workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-atuin-client = { path = "../atuin-client", version = "18.17.0" }
+atuin-client = { path = "../atuin-client", version = "18.17.1" }
 
 time = { workspace = true }
 serde = { workspace = true }

--- a/crates/atuin-kv/Cargo.toml
+++ b/crates/atuin-kv/Cargo.toml
@@ -14,8 +14,8 @@ readme.workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-atuin-client = { path = "../atuin-client", version = "18.17.0" }
-atuin-common = { path = "../atuin-common", version = "18.17.0" }
+atuin-client = { path = "../atuin-client", version = "18.17.1" }
+atuin-common = { path = "../atuin-common", version = "18.17.1" }
 derive_more = { workspace = true }
 
 tracing = { workspace = true }

--- a/crates/atuin-scripts/Cargo.toml
+++ b/crates/atuin-scripts/Cargo.toml
@@ -14,8 +14,8 @@ readme.workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-atuin-client = { path = "../atuin-client", version = "18.17.0" }
-atuin-common = { path = "../atuin-common", version = "18.17.0" }
+atuin-client = { path = "../atuin-client", version = "18.17.1" }
+atuin-common = { path = "../atuin-common", version = "18.17.1" }
 derive_more = { workspace = true }
 
 tracing = { workspace = true }

--- a/crates/atuin-server-database/Cargo.toml
+++ b/crates/atuin-server-database/Cargo.toml
@@ -10,7 +10,7 @@ homepage = { workspace = true }
 repository = { workspace = true }
 
 [dependencies]
-atuin-common = { path = "../atuin-common", version = "18.17.0" }
+atuin-common = { path = "../atuin-common", version = "18.17.1" }
 derive_more = { workspace = true }
 
 async-trait = { workspace = true }

--- a/crates/atuin-server-postgres/Cargo.toml
+++ b/crates/atuin-server-postgres/Cargo.toml
@@ -10,8 +10,8 @@ homepage = { workspace = true }
 repository = { workspace = true }
 
 [dependencies]
-atuin-common = { path = "../atuin-common", version = "18.17.0" }
-atuin-server-database = { path = "../atuin-server-database", version = "18.17.0" }
+atuin-common = { path = "../atuin-common", version = "18.17.1" }
+atuin-server-database = { path = "../atuin-server-database", version = "18.17.1" }
 derive_more = { workspace = true }
 
 eyre = { workspace = true }

--- a/crates/atuin-server-sqlite/Cargo.toml
+++ b/crates/atuin-server-sqlite/Cargo.toml
@@ -10,8 +10,8 @@ homepage = { workspace = true }
 repository = { workspace = true }
 
 [dependencies]
-atuin-common = { path = "../atuin-common", version = "18.17.0" }
-atuin-server-database = { path = "../atuin-server-database", version = "18.17.0" }
+atuin-common = { path = "../atuin-common", version = "18.17.1" }
+atuin-server-database = { path = "../atuin-server-database", version = "18.17.1" }
 derive_more = { workspace = true }
 
 eyre = { workspace = true }

--- a/crates/atuin/Cargo.toml
+++ b/crates/atuin/Cargo.toml
@@ -44,13 +44,13 @@ clipboard = ["arboard"]
 check-update = ["atuin-client/check-update"]
 
 [dependencies]
-atuin-ai = { path = "../atuin-ai", version = "18.17.0", optional = true, default-features = false }
-atuin-client = { path = "../atuin-client", version = "18.17.0", optional = true, default-features = false }
+atuin-ai = { path = "../atuin-ai", version = "18.17.1", optional = true, default-features = false }
+atuin-client = { path = "../atuin-client", version = "18.17.1", optional = true, default-features = false }
 atuin-common = { workspace = true }
 atuin-dotfiles = { workspace = true }
 atuin-history = { workspace = true }
-atuin-daemon = { path = "../atuin-daemon", version = "18.17.0", optional = true, default-features = false }
-atuin-pty-proxy = { path = "../atuin-pty-proxy", version = "18.17.0", optional = true, default-features = false }
+atuin-daemon = { path = "../atuin-daemon", version = "18.17.1", optional = true, default-features = false }
+atuin-pty-proxy = { path = "../atuin-pty-proxy", version = "18.17.1", optional = true, default-features = false }
 atuin-scripts = { workspace = true }
 atuin-kv = { workspace = true }
 derive_more = { workspace = true }
@@ -110,7 +110,7 @@ daemonize = "0.5.0"
 # compiles cleanly. tree-sitter 0.26's portable/endian.h fails on illumos,
 # Windows cross-compiles, and potentially other exotic targets.
 [target.'cfg(any(target_os = "linux", target_os = "macos"))'.dependencies]
-atuin-ai = { path = "../atuin-ai", version = "18.17.0", optional = true, default-features = false, features = ["tree-sitter"] }
+atuin-ai = { path = "../atuin-ai", version = "18.17.1", optional = true, default-features = false, features = ["tree-sitter"] }
 
 [target.'cfg(windows)'.dependencies]
 windows-sys = { version = "0.61.2", features = ["Win32_System_Console"] }


### PR DESCRIPTION

### Bug Fixes

- *(ai)* Default to non-Hub mode for custom AI endpoints ([#3620](https://github.com/atuinsh/atuin/issues/3620))
- *(import)* Fix order of entries imported from zsh history ([#3597](https://github.com/atuinsh/atuin/issues/3597))
- *(import)* Fix import order of nushell history entries ([#3598](https://github.com/atuinsh/atuin/issues/3598))
- Various prefix mode bugs ([#3616](https://github.com/atuinsh/atuin/issues/3616))


### Documentation

- Document output capture and mcp ([#3595](https://github.com/atuinsh/atuin/issues/3595))


### Features

- *(tui)* Truncate long commands from middle to show start...end ([#3602](https://github.com/atuinsh/atuin/issues/3602))


### Miscellaneous Tasks

- *(logging)* Remove the `log` crate in favor of `tracing` ([#3608](https://github.com/atuinsh/atuin/issues/3608))
- Update to rust 1.97 ([#3617](https://github.com/atuinsh/atuin/issues/3617))

