### PR TITLE
fix(search): correct fuzzy result ranking (#3603)

### DIFF
--- a/crates/atuin-client/src/database.rs
+++ b/crates/atuin-client/src/database.rs
@@ -1796,11 +1796,14 @@ mod test {
     }
 
     // Reproduces the trailing-space ranking bug (atuinsh/atuin#3603).
+    #[rstest]
     #[tokio::test(flavor = "multi_thread")]
-    async fn test_search_fuzzy_trailing_space() {
-        let mut db = Sqlite::new("sqlite::memory:", test_local_timeout())
-            .await
-            .unwrap();
+    async fn test_search_fuzzy_trailing_space(
+        #[future(awt)]
+        #[from(empty_db)]
+        db: Sqlite,
+    ) {
+        let mut db = db;
 
         let now = OffsetDateTime::now_utc();
         let irssi = "screen irssi";

--- a/crates/atuin-client/src/database.rs
+++ b/crates/atuin-client/src/database.rs
@@ -806,9 +806,16 @@ impl Database for Sqlite {
             .fetch_all(&self.pool)
             .await?;
 
-        // Rank against the same characters SQL matched: the tokenizer drops spaces, so
-        // strip them here too rather than scoring them as part of the fuzzy subsequence.
-        let reorder_query: String = orig_query.split_whitespace().collect();
+        // Rank against the same characters SQL matched: drop spaces and operators.
+        let reorder_query: String = QueryTokenizer::new(orig_query)
+            .filter_map(|token| match token {
+                QueryToken::Match(term, _)
+                | QueryToken::MatchStart(term, _)
+                | QueryToken::MatchEnd(term, _)
+                | QueryToken::MatchFull(term, _) => Some(term),
+                QueryToken::Or | QueryToken::Regex(_) => None,
+            })
+            .collect();
         Ok(ordering::reorder_fuzzy(search_mode, &reorder_query, res))
     }
 
@@ -1915,6 +1922,63 @@ mod test {
             FilterMode::Global,
             "foo bar",
             vec!["foo bar", "foo qux bar"],
+        )
+        .await;
+    }
+
+    // Isolates the operator fix: the "$" survives whitespace stripping, so both rows score None
+    // and fall back to recency; only dropping operators ranks them by span and the tight match wins.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_search_fuzzy_operator_true_span() {
+        let mut db = Sqlite::new("sqlite::memory:", test_local_timeout())
+            .await
+            .unwrap();
+
+        let now = OffsetDateTime::now_utc();
+        let tight = "foo screen";
+        let loose = "foo x screen";
+
+        new_history_item_at(&mut db, tight, Some(now - time::Duration::days(5)))
+            .await
+            .unwrap();
+        new_history_item_at(&mut db, loose, Some(now - time::Duration::hours(1)))
+            .await
+            .unwrap();
+
+        let results = assert_search_eq(
+            &db,
+            DbSearchMode::Fuzzy,
+            FilterMode::Global,
+            "foo screen$",
+            2,
+        )
+        .await
+        .unwrap();
+        assert_eq!(
+            results[0].command,
+            tight,
+            "\"foo screen$\" should rank the tight match first, got: {:?}",
+            results.iter().map(|h| &h.command).collect::<Vec<_>>()
+        );
+    }
+
+    // Dropping operators from the ranking query must not disturb SQL matching: the end-anchor
+    // still selects only commands ending in the term.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_search_fuzzy_operator_query_returns_expected() {
+        let mut db = Sqlite::new("sqlite::memory:", test_local_timeout())
+            .await
+            .unwrap();
+
+        new_history_item(&mut db, "use screen").await.unwrap();
+        new_history_item(&mut db, "screenshot tool").await.unwrap();
+
+        assert_search_commands(
+            &db,
+            DbSearchMode::Fuzzy,
+            FilterMode::Global,
+            "screen$",
+            vec!["use screen"],
         )
         .await;
     }

--- a/crates/atuin-client/src/database.rs
+++ b/crates/atuin-client/src/database.rs
@@ -1998,6 +1998,46 @@ mod test {
         .await;
     }
 
+    // A negated term's characters are absent from every row by construction, so ranking against
+    // them scores every row None and falls back to recency, burying the tight match.
+    #[rstest]
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_search_fuzzy_inverse_true_span(
+        #[future(awt)]
+        #[from(empty_db)]
+        db: Sqlite,
+    ) {
+        let mut db = db;
+
+        let now = OffsetDateTime::now_utc();
+        let tight = "foo screen";
+        let loose = "foo x screen";
+
+        new_history_item_at(&mut db, tight, Some(now - time::Duration::days(5)))
+            .await
+            .unwrap();
+        new_history_item_at(&mut db, loose, Some(now - time::Duration::hours(1)))
+            .await
+            .unwrap();
+
+        // "!zzz" excludes neither row, so both are ranked and the tight match must win.
+        let results = assert_search_eq(
+            &db,
+            DbSearchMode::Fuzzy,
+            FilterMode::Global,
+            "foo screen !zzz",
+            2,
+        )
+        .await
+        .unwrap();
+        assert_eq!(
+            results[0].command,
+            tight,
+            "\"foo screen !zzz\" should rank the tight match first, got: {:?}",
+            results.iter().map(|h| &h.command).collect::<Vec<_>>()
+        );
+    }
+
     #[rstest]
     #[tokio::test(flavor = "multi_thread")]
     async fn test_paged_basic(

--- a/crates/atuin-client/src/database.rs
+++ b/crates/atuin-client/src/database.rs
@@ -1796,15 +1796,16 @@ mod test {
         .await;
     }
 
-    // Reproduces the trailing-space ranking bug (atuinsh/atuin#3603).
+    // Reproduces the trailing-space ranking bug (atuinsh/atuin#3603): "screen" ranked the results
+    // containing `screen` first, but "screen " prioritized an unrelated `ls` command.
     #[rstest]
+    #[case::no_trailing_space("screen")]
+    #[case::trailing_space("screen ")]
     #[tokio::test(flavor = "multi_thread")]
-    async fn test_search_fuzzy_trailing_space(
-        #[future(awt)]
-        #[from(empty_db)]
-        db: Sqlite,
-    ) {
-        let mut db = db;
+    async fn test_search_fuzzy_trailing_space(#[case] query: &str) {
+        let mut db = Sqlite::new("sqlite::memory:", test_local_timeout())
+            .await
+            .unwrap();
 
         let now = OffsetDateTime::now_utc();
         let irssi = "screen irssi";
@@ -1829,165 +1830,61 @@ mod test {
             .await
             .unwrap();
 
-        // Baseline: "screen" ranks the screen rows first, most-recent on top.
-        let results = assert_search_eq(&db, DbSearchMode::Fuzzy, FilterMode::Global, "screen", 4)
+        let results = assert_search_eq(&db, DbSearchMode::Fuzzy, FilterMode::Global, query, 4)
             .await
             .unwrap();
         assert_eq!(
             results[0].command,
             screen_r,
-            "\"screen\" should rank the screen command first, got: {:?}",
-            results.iter().map(|h| &h.command).collect::<Vec<_>>()
-        );
-
-        // "screen " should still rank the row that literally contains "screen " first,
-        // not an unrelated `ls` row.
-        let results = assert_search_eq(&db, DbSearchMode::Fuzzy, FilterMode::Global, "screen ", 4)
-            .await
-            .unwrap();
-        assert_eq!(
-            results[0].command,
-            screen_r,
-            "\"screen \" should rank the literal \"screen \" match first, got: {:?}",
+            "\"{query}\" should rank the screen command first, got: {:?}",
             results.iter().map(|h| &h.command).collect::<Vec<_>>()
         );
     }
 
-    // Isolates the whitespace fix: for "screen " both rows score None and fall back to recency,
-    // so only stripping the trailing space ranks them by span and the tight match wins.
+    // Make sure fuzzy search prioritizes results that contain the query as a contiguous substring,
+    // but ignoring query operators, inverse terms, and whitespace. Each test case has a "close"
+    // result that should rank higher by fuzzy score but is less recent, and a "far" result that is
+    // more recent.
     #[rstest]
+    #[case::plain_single_term("screen", "screen", "search green")]
+    #[case::plain_two_terms("foo bar", "foo bar", "foo qux bar")]
+    #[case::trailing_space("screen ", "screen", "search green")]
+    #[case::extra_middle_space("foo   bar", "foo bar", "foo qux bar")]
+    #[case::end_anchor("foo screen$", "foo screen", "foo x screen")]
+    #[case::negated_term("foo screen !zzz", "foo screen", "foo x screen")]
     #[tokio::test(flavor = "multi_thread")]
-    async fn test_search_fuzzy_trailing_space_true_span(
-        #[future(awt)]
-        #[from(empty_db)]
-        db: Sqlite,
+    async fn test_search_fuzzy_prioritizes_contiguous_match(
+        #[case] query: &str,
+        #[case] close: &str,
+        #[case] far: &str,
     ) {
-        let mut db = db;
+        let mut db = Sqlite::new("sqlite::memory:", test_local_timeout())
+            .await
+            .unwrap();
 
         let now = OffsetDateTime::now_utc();
-        let exact = "screen";
-        let loose = "search green";
-
-        new_history_item_at(&mut db, exact, Some(now - time::Duration::days(5)))
+        new_history_item_at(&mut db, close, Some(now - time::Duration::days(5)))
             .await
             .unwrap();
-        new_history_item_at(&mut db, loose, Some(now - time::Duration::hours(1)))
+        new_history_item_at(&mut db, far, Some(now - time::Duration::hours(1)))
             .await
             .unwrap();
 
-        let results = assert_search_eq(&db, DbSearchMode::Fuzzy, FilterMode::Global, "screen ", 2)
-            .await
-            .unwrap();
-        assert_eq!(
-            results[0].command,
-            exact,
-            "\"screen \" should rank the tight match first, got: {:?}",
-            results.iter().map(|h| &h.command).collect::<Vec<_>>()
-        );
-    }
-
-    // Queries the normalization does not alter must rank identically: a space-free and a two-word
-    // query both rank by span, unchanged by stripping spaces from the ranking query.
-    #[rstest]
-    #[tokio::test(flavor = "multi_thread")]
-    async fn test_search_fuzzy_plain_query_unchanged(
-        #[future(awt)]
-        #[from(empty_db)]
-        db: Sqlite,
-    ) {
-        let mut db = db;
-
-        let now = OffsetDateTime::now_utc();
-        new_history_item_at(&mut db, "screen", Some(now - time::Duration::days(5)))
-            .await
-            .unwrap();
-        new_history_item_at(
-            &mut db,
-            "search green",
-            Some(now - time::Duration::hours(1)),
-        )
-        .await
-        .unwrap();
-        new_history_item_at(&mut db, "foo bar", Some(now - time::Duration::days(5)))
-            .await
-            .unwrap();
-        new_history_item_at(&mut db, "foo qux bar", Some(now - time::Duration::hours(1)))
-            .await
-            .unwrap();
-
-        // Single token: tight "screen" beats loose "search green".
         assert_search_commands(
             &db,
             DbSearchMode::Fuzzy,
             FilterMode::Global,
-            "screen",
-            vec!["screen", "search green"],
-        )
-        .await;
-
-        // Two tokens: tight "foo bar" beats loose "foo qux bar".
-        assert_search_commands(
-            &db,
-            DbSearchMode::Fuzzy,
-            FilterMode::Global,
-            "foo bar",
-            vec!["foo bar", "foo qux bar"],
+            query,
+            vec![close, far],
         )
         .await;
     }
 
-    // Isolates the operator fix: the "$" survives whitespace stripping, so both rows score None
-    // and fall back to recency; only dropping operators ranks them by span and the tight match wins.
-    #[rstest]
+    // SQL operators are stripped when performing fuzzy reordering, but this must not affect the
+    // initial SQL matching.
     #[tokio::test(flavor = "multi_thread")]
-    async fn test_search_fuzzy_operator_true_span(
-        #[future(awt)]
-        #[from(empty_db)]
-        db: Sqlite,
-    ) {
-        let mut db = db;
-
-        let now = OffsetDateTime::now_utc();
-        let tight = "foo screen";
-        let loose = "foo x screen";
-
-        new_history_item_at(&mut db, tight, Some(now - time::Duration::days(5)))
-            .await
-            .unwrap();
-        new_history_item_at(&mut db, loose, Some(now - time::Duration::hours(1)))
-            .await
-            .unwrap();
-
-        let results = assert_search_eq(
-            &db,
-            DbSearchMode::Fuzzy,
-            FilterMode::Global,
-            "foo screen$",
-            2,
-        )
-        .await
-        .unwrap();
-        assert_eq!(
-            results[0].command,
-            tight,
-            "\"foo screen$\" should rank the tight match first, got: {:?}",
-            results.iter().map(|h| &h.command).collect::<Vec<_>>()
-        );
-    }
-
-    // Dropping operators from the ranking query must not disturb SQL matching: the end-anchor
-    // still selects only commands ending in the term.
-    #[rstest]
-    #[tokio::test(flavor = "multi_thread")]
-    async fn test_search_fuzzy_operator_query_returns_expected(
-        #[future(awt)]
-        #[from(empty_db)]
-        db: Sqlite,
-    ) {
-        let mut db = db;
-
-        new_history_item(&mut db, "use screen").await.unwrap();
-        new_history_item(&mut db, "screenshot tool").await.unwrap();
+    async fn test_search_fuzzy_operator() {
+        let db = db_with(&["use screen", "screenshot tool"]).await;
 
         assert_search_commands(
             &db,
@@ -1997,46 +1894,6 @@ mod test {
             vec!["use screen"],
         )
         .await;
-    }
-
-    // A negated term's characters are absent from every row by construction, so ranking against
-    // them scores every row None and falls back to recency, burying the tight match.
-    #[rstest]
-    #[tokio::test(flavor = "multi_thread")]
-    async fn test_search_fuzzy_inverse_true_span(
-        #[future(awt)]
-        #[from(empty_db)]
-        db: Sqlite,
-    ) {
-        let mut db = db;
-
-        let now = OffsetDateTime::now_utc();
-        let tight = "foo screen";
-        let loose = "foo x screen";
-
-        new_history_item_at(&mut db, tight, Some(now - time::Duration::days(5)))
-            .await
-            .unwrap();
-        new_history_item_at(&mut db, loose, Some(now - time::Duration::hours(1)))
-            .await
-            .unwrap();
-
-        // "!zzz" excludes neither row, so both are ranked and the tight match must win.
-        let results = assert_search_eq(
-            &db,
-            DbSearchMode::Fuzzy,
-            FilterMode::Global,
-            "foo screen !zzz",
-            2,
-        )
-        .await
-        .unwrap();
-        assert_eq!(
-            results[0].command,
-            tight,
-            "\"foo screen !zzz\" should rank the tight match first, got: {:?}",
-            results.iter().map(|h| &h.command).collect::<Vec<_>>()
-        );
     }
 
     #[rstest]

--- a/crates/atuin-client/src/database.rs
+++ b/crates/atuin-client/src/database.rs
@@ -806,7 +806,10 @@ impl Database for Sqlite {
             .fetch_all(&self.pool)
             .await?;
 
-        Ok(ordering::reorder_fuzzy(search_mode, orig_query, res))
+        // Rank against the same characters SQL matched: the tokenizer drops spaces, so
+        // strip them here too rather than scoring them as part of the fuzzy subsequence.
+        let reorder_query: String = orig_query.split_whitespace().collect();
+        Ok(ordering::reorder_fuzzy(search_mode, &reorder_query, res))
     }
 
     async fn query_history(&self, query: &str) -> Result<Vec<History>> {
@@ -1837,6 +1840,83 @@ mod test {
             "\"screen \" should rank the literal \"screen \" match first, got: {:?}",
             results.iter().map(|h| &h.command).collect::<Vec<_>>()
         );
+    }
+
+    // Isolates the whitespace fix: for "screen " both rows score None and fall back to recency,
+    // so only stripping the trailing space ranks them by span and the tight match wins.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_search_fuzzy_trailing_space_true_span() {
+        let mut db = Sqlite::new("sqlite::memory:", test_local_timeout())
+            .await
+            .unwrap();
+
+        let now = OffsetDateTime::now_utc();
+        let exact = "screen";
+        let loose = "search green";
+
+        new_history_item_at(&mut db, exact, Some(now - time::Duration::days(5)))
+            .await
+            .unwrap();
+        new_history_item_at(&mut db, loose, Some(now - time::Duration::hours(1)))
+            .await
+            .unwrap();
+
+        let results = assert_search_eq(&db, DbSearchMode::Fuzzy, FilterMode::Global, "screen ", 2)
+            .await
+            .unwrap();
+        assert_eq!(
+            results[0].command,
+            exact,
+            "\"screen \" should rank the tight match first, got: {:?}",
+            results.iter().map(|h| &h.command).collect::<Vec<_>>()
+        );
+    }
+
+    // Queries the normalization does not alter must rank identically: a space-free and a two-word
+    // query both rank by span, unchanged by stripping spaces from the ranking query.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_search_fuzzy_plain_query_unchanged() {
+        let mut db = Sqlite::new("sqlite::memory:", test_local_timeout())
+            .await
+            .unwrap();
+
+        let now = OffsetDateTime::now_utc();
+        new_history_item_at(&mut db, "screen", Some(now - time::Duration::days(5)))
+            .await
+            .unwrap();
+        new_history_item_at(
+            &mut db,
+            "search green",
+            Some(now - time::Duration::hours(1)),
+        )
+        .await
+        .unwrap();
+        new_history_item_at(&mut db, "foo bar", Some(now - time::Duration::days(5)))
+            .await
+            .unwrap();
+        new_history_item_at(&mut db, "foo qux bar", Some(now - time::Duration::hours(1)))
+            .await
+            .unwrap();
+
+        // Single token: tight "screen" beats loose "search green".
+        assert_search_commands(
+            &db,
+            DbSearchMode::Fuzzy,
+            FilterMode::Global,
+            "screen",
+            vec!["screen", "search green"],
+        )
+        .await;
+
+        // Two tokens: tight "foo bar" beats loose "foo qux bar".
+        assert_search_commands(
+            &db,
+            DbSearchMode::Fuzzy,
+            FilterMode::Global,
+            "foo bar",
+            vec!["foo bar", "foo qux bar"],
+        )
+        .await;
     }
 
     #[rstest]

--- a/crates/atuin-client/src/database.rs
+++ b/crates/atuin-client/src/database.rs
@@ -1785,6 +1785,60 @@ mod test {
         .await;
     }
 
+    // Reproduces the trailing-space ranking bug (atuinsh/atuin#3603).
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_search_fuzzy_trailing_space() {
+        let mut db = Sqlite::new("sqlite::memory:", test_local_timeout())
+            .await
+            .unwrap();
+
+        let now = OffsetDateTime::now_utc();
+        let irssi = "screen irssi";
+        let ls_l = "ls -l secrets/rendered";
+        let ls_ld = "ls -ld secrets/rendered";
+        let screen_r = "screen -r";
+
+        new_history_item_at(&mut db, irssi, Some(now - time::Duration::days(5)))
+            .await
+            .unwrap();
+        new_history_item_at(&mut db, ls_l, Some(now - time::Duration::days(4)))
+            .await
+            .unwrap();
+        new_history_item_at(
+            &mut db,
+            ls_ld,
+            Some(now - time::Duration::days(4) + time::Duration::seconds(1)),
+        )
+        .await
+        .unwrap();
+        new_history_item_at(&mut db, screen_r, Some(now - time::Duration::hours(1)))
+            .await
+            .unwrap();
+
+        // Baseline: "screen" ranks the screen rows first, most-recent on top.
+        let results = assert_search_eq(&db, DbSearchMode::Fuzzy, FilterMode::Global, "screen", 4)
+            .await
+            .unwrap();
+        assert_eq!(
+            results[0].command,
+            screen_r,
+            "\"screen\" should rank the screen command first, got: {:?}",
+            results.iter().map(|h| &h.command).collect::<Vec<_>>()
+        );
+
+        // "screen " should still rank the row that literally contains "screen " first,
+        // not an unrelated `ls` row.
+        let results = assert_search_eq(&db, DbSearchMode::Fuzzy, FilterMode::Global, "screen ", 4)
+            .await
+            .unwrap();
+        assert_eq!(
+            results[0].command,
+            screen_r,
+            "\"screen \" should rank the literal \"screen \" match first, got: {:?}",
+            results.iter().map(|h| &h.command).collect::<Vec<_>>()
+        );
+    }
+
     #[rstest]
     #[tokio::test(flavor = "multi_thread")]
     async fn test_paged_basic(

--- a/crates/atuin-client/src/database.rs
+++ b/crates/atuin-client/src/database.rs
@@ -1854,11 +1854,14 @@ mod test {
 
     // Isolates the whitespace fix: for "screen " both rows score None and fall back to recency,
     // so only stripping the trailing space ranks them by span and the tight match wins.
+    #[rstest]
     #[tokio::test(flavor = "multi_thread")]
-    async fn test_search_fuzzy_trailing_space_true_span() {
-        let mut db = Sqlite::new("sqlite::memory:", test_local_timeout())
-            .await
-            .unwrap();
+    async fn test_search_fuzzy_trailing_space_true_span(
+        #[future(awt)]
+        #[from(empty_db)]
+        db: Sqlite,
+    ) {
+        let mut db = db;
 
         let now = OffsetDateTime::now_utc();
         let exact = "screen";
@@ -1884,11 +1887,14 @@ mod test {
 
     // Queries the normalization does not alter must rank identically: a space-free and a two-word
     // query both rank by span, unchanged by stripping spaces from the ranking query.
+    #[rstest]
     #[tokio::test(flavor = "multi_thread")]
-    async fn test_search_fuzzy_plain_query_unchanged() {
-        let mut db = Sqlite::new("sqlite::memory:", test_local_timeout())
-            .await
-            .unwrap();
+    async fn test_search_fuzzy_plain_query_unchanged(
+        #[future(awt)]
+        #[from(empty_db)]
+        db: Sqlite,
+    ) {
+        let mut db = db;
 
         let now = OffsetDateTime::now_utc();
         new_history_item_at(&mut db, "screen", Some(now - time::Duration::days(5)))

--- a/crates/atuin-client/src/database.rs
+++ b/crates/atuin-client/src/database.rs
@@ -806,8 +806,9 @@ impl Database for Sqlite {
             .fetch_all(&self.pool)
             .await?;
 
-        // Rank against the same characters SQL matched: drop spaces and operators.
+        // Rank against the same characters SQL matched: drop spaces, operators and negated terms.
         let reorder_query: String = QueryTokenizer::new(orig_query)
+            .filter(|token| !token.is_inverse())
             .filter_map(|token| match token {
                 QueryToken::Match(term, _)
                 | QueryToken::MatchStart(term, _)

--- a/crates/atuin-client/src/database.rs
+++ b/crates/atuin-client/src/database.rs
@@ -1937,11 +1937,14 @@ mod test {
 
     // Isolates the operator fix: the "$" survives whitespace stripping, so both rows score None
     // and fall back to recency; only dropping operators ranks them by span and the tight match wins.
+    #[rstest]
     #[tokio::test(flavor = "multi_thread")]
-    async fn test_search_fuzzy_operator_true_span() {
-        let mut db = Sqlite::new("sqlite::memory:", test_local_timeout())
-            .await
-            .unwrap();
+    async fn test_search_fuzzy_operator_true_span(
+        #[future(awt)]
+        #[from(empty_db)]
+        db: Sqlite,
+    ) {
+        let mut db = db;
 
         let now = OffsetDateTime::now_utc();
         let tight = "foo screen";
@@ -1973,11 +1976,14 @@ mod test {
 
     // Dropping operators from the ranking query must not disturb SQL matching: the end-anchor
     // still selects only commands ending in the term.
+    #[rstest]
     #[tokio::test(flavor = "multi_thread")]
-    async fn test_search_fuzzy_operator_query_returns_expected() {
-        let mut db = Sqlite::new("sqlite::memory:", test_local_timeout())
-            .await
-            .unwrap();
+    async fn test_search_fuzzy_operator_query_returns_expected(
+        #[future(awt)]
+        #[from(empty_db)]
+        db: Sqlite,
+    ) {
+        let mut db = db;
 
         new_history_item(&mut db, "use screen").await.unwrap();
         new_history_item(&mut db, "screenshot tool").await.unwrap();

--- a/crates/atuin-client/src/ordering.rs
+++ b/crates/atuin-client/src/ordering.rs
@@ -14,19 +14,48 @@ where
     F: Fn(&A) -> &String,
 {
     let mut r = res;
-    let len = r.len();
     let qvec = &query.chars().collect();
     r.sort_by_cached_key(|h| {
         // TODO for fzf search we should sum up scores for each matched term
-        let (from, to) = match minspan::span(qvec, &(f(h).chars().collect())) {
-            Some(x) => x,
-            // this is a little unfortunate: when we are asked to match a query that is found nowhere,
-            // we don't want to return a None, as the comparison behaviour would put the worst matches
-            // at the front. therefore, we'll return a set of indices that are one larger than the longest
-            // possible legitimate match. This is meaningless except as a comparison.
-            None => (0, len),
-        };
-        1 + to - from
+        // A non-matching row sorts last rather than by a sentinel that can undercut a real match.
+        minspan::span(qvec, &(f(h).chars().collect()))
+            .map_or(usize::MAX, |(from, to)| 1 + to - from)
     });
     r
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::history::History;
+    use time::OffsetDateTime;
+
+    fn hist(command: &str) -> History {
+        History::capture()
+            .timestamp(OffsetDateTime::now_utc())
+            .command(command)
+            .cwd("/")
+            .build()
+            .into()
+    }
+
+    fn commands(res: Vec<History>) -> Vec<String> {
+        res.into_iter().map(|h| h.command).collect()
+    }
+
+    // A non-matching row must sort last, not ahead of a genuine match.
+    #[test]
+    fn reorder_nonmatch_sorts_last() {
+        let res = vec![hist("screen"), hist("hello")];
+        let out = reorder_fuzzy(DbSearchMode::Fuzzy, "screen", res);
+        assert_eq!(commands(out), vec!["screen", "hello"]);
+    }
+
+    // The unchanged match path: a tight match outranks a loose one.
+    #[test]
+    fn reorder_matches_by_span() {
+        let res = vec![hist("central urllib"), hist("curl")];
+        let out = reorder_fuzzy(DbSearchMode::Fuzzy, "curl", res);
+        assert_eq!(commands(out), vec!["curl", "central urllib"]);
+    }
 }

--- a/crates/atuin-client/src/ordering.rs
+++ b/crates/atuin-client/src/ordering.rs
@@ -28,6 +28,7 @@ where
 mod tests {
     use super::*;
     use crate::history::History;
+    use rstest::rstest;
     use time::OffsetDateTime;
 
     fn hist(command: &str) -> History {
@@ -43,19 +44,14 @@ mod tests {
         res.into_iter().map(|h| h.command).collect()
     }
 
+    #[rstest]
     // A non-matching row must sort last, not ahead of a genuine match.
-    #[test]
-    fn reorder_nonmatch_sorts_last() {
-        let res = vec![hist("screen"), hist("hello")];
-        let out = reorder_fuzzy(DbSearchMode::Fuzzy, "screen", res);
-        assert_eq!(commands(out), vec!["screen", "hello"]);
-    }
-
+    #[case::nonmatch_sorts_last("screen", vec!["screen", "hello"], vec!["screen", "hello"])]
     // The unchanged match path: a tight match outranks a loose one.
-    #[test]
-    fn reorder_matches_by_span() {
-        let res = vec![hist("central urllib"), hist("curl")];
-        let out = reorder_fuzzy(DbSearchMode::Fuzzy, "curl", res);
-        assert_eq!(commands(out), vec!["curl", "central urllib"]);
+    #[case::matches_by_span("curl", vec!["central urllib", "curl"], vec!["curl", "central urllib"])]
+    fn reorder_ranks(#[case] query: &str, #[case] input: Vec<&str>, #[case] expected: Vec<&str>) {
+        let res = input.into_iter().map(hist).collect();
+        let out = reorder_fuzzy(DbSearchMode::Fuzzy, query, res);
+        assert_eq!(commands(out), expected);
     }
 }


### PR DESCRIPTION
- Fixes #3603

Fuzzy search ranked results wrongly whenever the query handed to the span scorer didn't match the characters SQL actually matched on. Most visibly: adding a trailing space to a query pushed an unrelated row to the top.

- **Non-matches outranked real matches.** `reorder_fuzzy` scored an unmatched row with the sentinel `(0, results.len())`. With few results that number is tiny and could beat a genuine match's span. Unmatched rows now map to `usize::MAX`, so they always sort last.
- **The ranking query carried characters SQL never matched.** SQL matches on tokens with whitespace and operators (`^ $ ' ! |`, `r/.../`) stripped, but the raw query went to the span scorer. Any space or operator failed the subsequence check, so every row scored as a non-match and fell back to recency. The ranking query is now rebuilt from the tokenizer's plain terms, so it always equals what SQL matched.

Each fix ships a regression test isolating it from the others, plus a characterisation test that plain and multi-word queries rank unchanged.