### PR TITLE
feat(daemon)!: ATU-538 — daemon-only client (daemonless code removed)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -426,6 +426,7 @@ dependencies = [
  "prost-types",
  "protox",
  "rand 0.8.5",
+ "sqlx",
  "tempfile",
  "time",
  "tokio",

--- a/crates/atuin-ai/Cargo.toml
+++ b/crates/atuin-ai/Cargo.toml
@@ -14,7 +14,6 @@ repository = { workspace = true }
 
 [features]
 default = []
-daemon = []
 tree-sitter = ["dep:tree-sitter-lib", "dep:tree-sitter-bash", "dep:tree-sitter-fish"]
 
 [dependencies]

--- a/crates/atuin-ai/src/commands/inline.rs
+++ b/crates/atuin-ai/src/commands/inline.rs
@@ -1,5 +1,3 @@
-#[cfg(not(feature = "daemon"))]
-use std::path::PathBuf;
 use std::sync::mpsc;
 
 use crate::context::{AppContext, ClientContext};
@@ -10,8 +8,6 @@ use crate::session::{LocalSessionService, SessionManager, SessionService};
 use crate::tui::events::AiTuiEvent;
 use crate::tui::state::ConversationEvent;
 use crate::tui::view::ai_view;
-#[cfg(not(feature = "daemon"))]
-use atuin_client::database::Sqlite;
 use eye_declare::{Application, CtrlCBehavior};
 use eyre::{Context as _, Result, bail};
 use tracing::{debug, info};
@@ -64,20 +60,10 @@ pub(crate) async fn run(
 
     // History access goes through the daemon (sole storage owner). The caller
     // (the atuin dispatcher) has already ensured the daemon is running.
-    #[cfg(feature = "daemon")]
     let history_db: std::sync::Arc<dyn atuin_client::database::Database> = std::sync::Arc::new(
         atuin_daemon::proxy::DaemonDatabase::from_settings(settings)
             .await
             .context("failed to connect to the daemon for AI")?,
-    );
-    #[cfg(not(feature = "daemon"))]
-    let history_db: std::sync::Arc<dyn atuin_client::database::Database> = std::sync::Arc::new(
-        Sqlite::new(
-            PathBuf::from(settings.db_path.as_str()),
-            settings.local_timeout,
-        )
-        .await
-        .context("failed to open history database for AI")?,
     );
 
     // Support both legacy [ai] send_cwd and new [ai.opening] send_cwd

--- a/crates/atuin-ai/src/commands/inline.rs
+++ b/crates/atuin-ai/src/commands/inline.rs
@@ -1,3 +1,4 @@
+#[cfg(not(feature = "daemon"))]
 use std::path::PathBuf;
 use std::sync::mpsc;
 
@@ -9,7 +10,8 @@ use crate::session::{LocalSessionService, SessionManager, SessionService};
 use crate::tui::events::AiTuiEvent;
 use crate::tui::state::ConversationEvent;
 use crate::tui::view::ai_view;
-use atuin_client::database::{Database, Sqlite};
+#[cfg(not(feature = "daemon"))]
+use atuin_client::database::Sqlite;
 use eye_declare::{Application, CtrlCBehavior};
 use eyre::{Context as _, Result, bail};
 use tracing::{debug, info};
@@ -60,10 +62,23 @@ pub(crate) async fn run(
         None => (String::new(), false),
     };
 
-    let history_db_path = PathBuf::from(settings.db_path.as_str());
-    let history_db = Sqlite::new(history_db_path, settings.local_timeout)
+    // History access goes through the daemon (sole storage owner). The caller
+    // (the atuin dispatcher) has already ensured the daemon is running.
+    #[cfg(feature = "daemon")]
+    let history_db: std::sync::Arc<dyn atuin_client::database::Database> = std::sync::Arc::new(
+        atuin_daemon::proxy::DaemonDatabase::from_settings(settings)
+            .await
+            .context("failed to connect to the daemon for AI")?,
+    );
+    #[cfg(not(feature = "daemon"))]
+    let history_db: std::sync::Arc<dyn atuin_client::database::Database> = std::sync::Arc::new(
+        Sqlite::new(
+            PathBuf::from(settings.db_path.as_str()),
+            settings.local_timeout,
+        )
         .await
-        .context("failed to open history database for AI")?;
+        .context("failed to open history database for AI")?,
+    );
 
     // Support both legacy [ai] send_cwd and new [ai.opening] send_cwd
     let send_cwd =
@@ -86,7 +101,7 @@ pub(crate) async fn run(
         token_from_hub_session,
         send_cwd,
         last_command,
-        history_db: std::sync::Arc::new(history_db),
+        history_db,
         git_root,
         capabilities: settings.ai.capabilities.clone(),
         daemon_enabled: settings.daemon.enabled,

--- a/crates/atuin-ai/src/context.rs
+++ b/crates/atuin-ai/src/context.rs
@@ -1,13 +1,14 @@
 use std::path::PathBuf;
 use std::sync::Arc;
 
+use atuin_client::database::Database;
 use atuin_client::distro::detect_linux_distribution;
 use atuin_client::history::History;
 use atuin_client::settings::AiCapabilities;
 
 /// Session-scoped context for the AI chat session.
 /// Holds the API configuration and client settings needed by the event loop and stream task.
-#[derive(Clone, Debug)]
+#[derive(Clone)]
 pub(crate) struct AppContext {
     pub endpoint: String,
     /// Bearer token for `endpoint`. Empty means unauthenticated — no
@@ -23,12 +24,29 @@ pub(crate) struct AppContext {
     pub token_from_hub_session: bool,
     pub send_cwd: bool,
     pub last_command: Option<History>,
-    pub history_db: Arc<atuin_client::database::Sqlite>,
+    pub history_db: Arc<dyn Database>,
     /// Git root of the current working directory, if inside a git repo.
     /// Resolves through worktrees to the main repo root.
     pub git_root: Option<PathBuf>,
     pub capabilities: AiCapabilities,
     pub daemon_enabled: bool,
+}
+
+impl std::fmt::Debug for AppContext {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("AppContext")
+            .field("endpoint", &self.endpoint)
+            .field("token", &self.token)
+            .field("endpoint_is_hub", &self.endpoint_is_hub)
+            .field("token_from_hub_session", &self.token_from_hub_session)
+            .field("send_cwd", &self.send_cwd)
+            .field("last_command", &self.last_command)
+            .field("history_db", &"<Database>")
+            .field("git_root", &self.git_root)
+            .field("capabilities", &self.capabilities)
+            .field("daemon_enabled", &self.daemon_enabled)
+            .finish()
+    }
 }
 
 pub(crate) fn history_output_capability_available(daemon_enabled: bool) -> bool {

--- a/crates/atuin-ai/src/context.rs
+++ b/crates/atuin-ai/src/context.rs
@@ -50,7 +50,7 @@ impl std::fmt::Debug for AppContext {
 }
 
 pub(crate) fn history_output_capability_available(daemon_enabled: bool) -> bool {
-    cfg!(feature = "daemon") && daemon_enabled
+    daemon_enabled
 }
 
 impl AppContext {

--- a/crates/atuin-ai/src/driver.rs
+++ b/crates/atuin-ai/src/driver.rs
@@ -779,7 +779,7 @@ fn execute_effect(effect: &Effect, ctx: DriverContext) {
                     // History search needs async DB access
                     let tool = tool.clone();
                     tokio::spawn(async move {
-                        let outcome = tool.execute(&db).await;
+                        let outcome = tool.execute(db.as_ref()).await;
                         let _ = tx.send(DriverEvent::Fsm(Event::ToolExecutionDone {
                             tool_id,
                             outcome,

--- a/crates/atuin-ai/src/mcp.rs
+++ b/crates/atuin-ai/src/mcp.rs
@@ -8,7 +8,7 @@
 //! daemon; output retrieval talks to the daemon and returns a tool error when
 //! it is not running.
 
-use atuin_client::database::Sqlite;
+use atuin_client::database::Database;
 use atuin_client::history::{AUTHOR_FILTER_ALL_AGENT, AUTHOR_FILTER_ALL_USER, KNOWN_AGENTS};
 use eyre::Result;
 use rmcp::model::{
@@ -22,7 +22,7 @@ use serde_json::{Value, json};
 use crate::tools::{AtuinHistoryToolCall, AtuinOutputToolCall, ToolOutcome};
 
 struct AtuinMcp {
-    db: Sqlite,
+    db: Box<dyn Database>,
 }
 
 impl ServerHandler for AtuinMcp {
@@ -49,7 +49,7 @@ impl ServerHandler for AtuinMcp {
             "atuin_history" => {
                 AtuinHistoryToolCall::try_from(&arguments)
                     .map_err(|e| ErrorData::invalid_params(e.to_string(), None))?
-                    .execute(&self.db)
+                    .execute(self.db.as_ref())
                     .await
             }
             "atuin_output" => {
@@ -82,11 +82,9 @@ impl ServerHandler for AtuinMcp {
 ///
 /// stdout carries only JSON-RPC messages; anything else (logs, errors) must
 /// go to stderr or it will corrupt the protocol stream.
-pub async fn run(db: &Sqlite) -> Result<()> {
+pub async fn run(db: &dyn Database) -> Result<()> {
     let server = AtuinMcp {
-        db: Sqlite {
-            pool: db.pool.clone(),
-        },
+        db: db.clone_boxed(),
     }
     .serve(rmcp::transport::stdio())
     .await?;

--- a/crates/atuin-ai/src/tools/mod.rs
+++ b/crates/atuin-ai/src/tools/mod.rs
@@ -1165,8 +1165,8 @@ impl PermissibleToolCall for AtuinHistoryToolCall {
 }
 
 impl AtuinHistoryToolCall {
-    pub(crate) async fn execute(&self, db: &atuin_client::database::Sqlite) -> ToolOutcome {
-        use atuin_client::database::{self, Database as _, OptFilters};
+    pub(crate) async fn execute(&self, db: &dyn atuin_client::database::Database) -> ToolOutcome {
+        use atuin_client::database::{self, OptFilters};
         use atuin_client::settings::SearchMode;
 
         // query_context rather than current_context: when running outside an

--- a/crates/atuin-client/Cargo.toml
+++ b/crates/atuin-client/Cargo.toml
@@ -14,10 +14,9 @@ repository = { workspace = true }
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [features]
-default = ["sync", "hub", "daemon"]
+default = ["sync", "hub"]
 sync = ["urlencoding", "reqwest", "sha2", "hex"]
 hub = ["reqwest"]
-daemon = []
 check-update = []
 
 [dependencies]

--- a/crates/atuin-client/benches/record/sqlite_store.rs
+++ b/crates/atuin-client/benches/record/sqlite_store.rs
@@ -102,7 +102,7 @@ fn push_batch(bencher: divan::Bencher, n: usize) {
             (db, records)
         })
         .bench_values(|(db, records)| {
-            rt.block_on(db.sqlite_store.push_batch(records.iter()))
+            rt.block_on(db.sqlite_store.push_batch(&mut records.iter()))
                 .unwrap();
         });
 }

--- a/crates/atuin-client/src/database.rs
+++ b/crates/atuin-client/src/database.rs
@@ -199,6 +199,90 @@ pub trait Database: Send + Sync + 'static {
     fn clone_boxed(&self) -> Box<dyn Database + 'static>;
 }
 
+/// Blanket forwarding impl so a `Box<dyn Database>` is itself a `Database`.
+///
+/// This lets callers hold a boxed trait object (e.g. a gRPC-backed proxy that
+/// talks to the daemon) and pass it to any handler written against
+/// `impl Database` / `&impl Database` without changing those handlers.
+#[async_trait]
+impl Database for Box<dyn Database> {
+    async fn save(&self, h: &History) -> Result<()> {
+        (**self).save(h).await
+    }
+    async fn save_bulk(&self, h: &[History]) -> Result<()> {
+        (**self).save_bulk(h).await
+    }
+    async fn load(&self, id: &str) -> Result<Option<History>> {
+        (**self).load(id).await
+    }
+    async fn list(
+        &self,
+        filters: &[FilterMode],
+        context: &Context,
+        max: Option<usize>,
+        unique: bool,
+        include_deleted: bool,
+    ) -> Result<Vec<History>> {
+        (**self)
+            .list(filters, context, max, unique, include_deleted)
+            .await
+    }
+    async fn range(&self, from: OffsetDateTime, to: OffsetDateTime) -> Result<Vec<History>> {
+        (**self).range(from, to).await
+    }
+    async fn update(&self, h: &History) -> Result<()> {
+        (**self).update(h).await
+    }
+    async fn history_count(&self, include_deleted: bool) -> Result<i64> {
+        (**self).history_count(include_deleted).await
+    }
+    async fn last(&self) -> Result<Option<History>> {
+        (**self).last().await
+    }
+    async fn before(&self, timestamp: OffsetDateTime, count: i64) -> Result<Vec<History>> {
+        (**self).before(timestamp, count).await
+    }
+    async fn delete(&self, h: History) -> Result<()> {
+        (**self).delete(h).await
+    }
+    async fn delete_rows(&self, ids: &[HistoryId]) -> Result<()> {
+        (**self).delete_rows(ids).await
+    }
+    async fn deleted(&self) -> Result<Vec<History>> {
+        (**self).deleted().await
+    }
+    async fn search(
+        &self,
+        search_mode: SearchMode,
+        filter: FilterMode,
+        context: &Context,
+        query: &str,
+        filter_options: OptFilters,
+    ) -> Result<Vec<History>> {
+        (**self)
+            .search(search_mode, filter, context, query, filter_options)
+            .await
+    }
+    async fn query_history(&self, query: &str) -> Result<Vec<History>> {
+        (**self).query_history(query).await
+    }
+    async fn all_with_count(&self) -> Result<Vec<(History, i32)>> {
+        (**self).all_with_count().await
+    }
+    fn all_paged(&self, page_size: usize, include_deleted: bool, unique: bool) -> Paged {
+        (**self).all_paged(page_size, include_deleted, unique)
+    }
+    async fn stats(&self, h: &History) -> Result<HistoryStats> {
+        (**self).stats(h).await
+    }
+    async fn get_dups(&self, before: i64, dupkeep: u32) -> Result<Vec<History>> {
+        (**self).get_dups(before, dupkeep).await
+    }
+    fn clone_boxed(&self) -> Box<dyn Database + 'static> {
+        (**self).clone_boxed()
+    }
+}
+
 // Intended for use on a developer machine and not a sync server.
 // TODO: implement IntoIterator
 #[derive(Debug, Clone)]

--- a/crates/atuin-client/src/history/store.rs
+++ b/crates/atuin-client/src/history/store.rs
@@ -4,9 +4,14 @@ use eyre::{Result, bail, eyre};
 use indicatif::{ProgressBar, ProgressState, ProgressStyle};
 use rmp::decode::Bytes;
 
+use std::sync::Arc;
+
 use crate::{
     database::{Database, current_context},
-    record::{encryption::PASETO_V4, sqlite_store::SqliteStore, store::Store},
+    record::{
+        encryption::PASETO_V4,
+        store::{ArcStore, Store},
+    },
 };
 use atuin_common::record::{DecryptedData, Host, HostId, Record, RecordId, RecordIdx};
 
@@ -14,7 +19,7 @@ use super::{HISTORY_TAG, HISTORY_VERSION, HISTORY_VERSION_V0, History, HistoryId
 
 #[derive(Debug, Clone)]
 pub struct HistoryStore {
-    pub store: SqliteStore,
+    pub store: ArcStore,
     pub host_id: HostId,
     pub encryption_key: [u8; 32],
 }
@@ -109,9 +114,9 @@ impl HistoryRecord {
 }
 
 impl HistoryStore {
-    pub fn new(store: SqliteStore, host_id: HostId, encryption_key: [u8; 32]) -> Self {
+    pub fn new(store: impl Store + 'static, host_id: HostId, encryption_key: [u8; 32]) -> Self {
         HistoryStore {
-            store,
+            store: Arc::new(store),
             host_id,
             encryption_key,
         }

--- a/crates/atuin-client/src/history/store.rs
+++ b/crates/atuin-client/src/history/store.rs
@@ -169,7 +169,7 @@ impl HistoryStore {
             ret.push(record);
         }
 
-        self.store.push_batch(ret.iter()).await?;
+        self.store.push_batch(&mut ret.iter()).await?;
 
         Ok(())
     }

--- a/crates/atuin-client/src/record/sqlite_store.rs
+++ b/crates/atuin-client/src/record/sqlite_store.rs
@@ -134,7 +134,7 @@ impl SqliteStore {
 impl Store for SqliteStore {
     async fn push_batch(
         &self,
-        records: impl Iterator<Item = &Record<EncryptedData>> + Send + Sync,
+        records: &mut (dyn Iterator<Item = &Record<EncryptedData>> + Send),
     ) -> Result<()> {
         let mut tx = self.pool.begin().await?;
 
@@ -573,7 +573,7 @@ mod tests {
             records.push(tail.clone());
         }
 
-        db.push_batch(records.iter()).await.unwrap();
+        db.push_batch(&mut records.iter()).await.unwrap();
 
         assert_eq!(
             db.len(tail.host.id, tail.tag.as_str()).await.unwrap(),

--- a/crates/atuin-client/src/record/store.rs
+++ b/crates/atuin-client/src/record/store.rs
@@ -11,13 +11,16 @@ use atuin_common::record::{EncryptedData, HostId, Record, RecordId, RecordIdx, R
 pub trait Store {
     // Push a record
     async fn push(&self, record: &Record<EncryptedData>) -> Result<()> {
-        self.push_batch(std::iter::once(record)).await
+        self.push_batch(&mut std::iter::once(record)).await
     }
 
-    // Push a batch of records, all in one transaction
+    // Push a batch of records, all in one transaction.
+    //
+    // Takes a `&mut dyn Iterator` rather than `impl Iterator` so that `Store`
+    // stays object-safe (`Box<dyn Store>` is used for the daemon proxy).
     async fn push_batch(
         &self,
-        records: impl Iterator<Item = &Record<EncryptedData>> + Send + Sync,
+        records: &mut (dyn Iterator<Item = &Record<EncryptedData>> + Send),
     ) -> Result<()>;
 
     async fn get(&self, id: RecordId) -> Result<Record<EncryptedData>>;
@@ -57,4 +60,75 @@ pub trait Store {
 
     /// Get all records for a given tag
     async fn all_tagged(&self, tag: &str) -> Result<Vec<Record<EncryptedData>>>;
+}
+
+/// A boxed record store. This is the type the typed stores hold so they can be
+/// backed either by the local `SqliteStore` or by the daemon proxy.
+pub type BoxStore = Box<dyn Store + Send + Sync>;
+
+/// Blanket forwarding impl so a `BoxStore` is itself a `Store`.
+#[async_trait]
+impl Store for BoxStore {
+    async fn push_batch(
+        &self,
+        records: &mut (dyn Iterator<Item = &Record<EncryptedData>> + Send),
+    ) -> Result<()> {
+        (**self).push_batch(records).await
+    }
+    async fn get(&self, id: RecordId) -> Result<Record<EncryptedData>> {
+        (**self).get(id).await
+    }
+    async fn delete(&self, id: RecordId) -> Result<()> {
+        (**self).delete(id).await
+    }
+    async fn delete_all(&self) -> Result<()> {
+        (**self).delete_all().await
+    }
+    async fn len_all(&self) -> Result<u64> {
+        (**self).len_all().await
+    }
+    async fn len(&self, host: HostId, tag: &str) -> Result<u64> {
+        (**self).len(host, tag).await
+    }
+    async fn len_tag(&self, tag: &str) -> Result<u64> {
+        (**self).len_tag(tag).await
+    }
+    async fn last(&self, host: HostId, tag: &str) -> Result<Option<Record<EncryptedData>>> {
+        (**self).last(host, tag).await
+    }
+    async fn first(&self, host: HostId, tag: &str) -> Result<Option<Record<EncryptedData>>> {
+        (**self).first(host, tag).await
+    }
+    async fn re_encrypt(&self, old_key: &[u8; 32], new_key: &[u8; 32]) -> Result<()> {
+        (**self).re_encrypt(old_key, new_key).await
+    }
+    async fn verify(&self, key: &[u8; 32]) -> Result<()> {
+        (**self).verify(key).await
+    }
+    async fn purge(&self, key: &[u8; 32]) -> Result<()> {
+        (**self).purge(key).await
+    }
+    async fn next(
+        &self,
+        host: HostId,
+        tag: &str,
+        idx: RecordIdx,
+        limit: u64,
+    ) -> Result<Vec<Record<EncryptedData>>> {
+        (**self).next(host, tag, idx, limit).await
+    }
+    async fn idx(
+        &self,
+        host: HostId,
+        tag: &str,
+        idx: RecordIdx,
+    ) -> Result<Option<Record<EncryptedData>>> {
+        (**self).idx(host, tag, idx).await
+    }
+    async fn status(&self) -> Result<RecordStatus> {
+        (**self).status().await
+    }
+    async fn all_tagged(&self, tag: &str) -> Result<Vec<Record<EncryptedData>>> {
+        (**self).all_tagged(tag).await
+    }
 }

--- a/crates/atuin-client/src/record/store.rs
+++ b/crates/atuin-client/src/record/store.rs
@@ -1,3 +1,6 @@
+use std::fmt::Debug;
+use std::sync::Arc;
+
 use async_trait::async_trait;
 use eyre::Result;
 
@@ -7,8 +10,11 @@ use atuin_common::record::{EncryptedData, HostId, Record, RecordId, RecordIdx, R
 /// In more detail - we tend to need to process this into _another_ format to actually query it.
 /// As is, the record store is intended as the source of truth for arbitrary data, which could
 /// be shell history, kvs, etc.
+///
+/// `Debug + Send + Sync` are required so a `Store` can be held behind a shared
+/// trait object (`ArcStore`) inside the typed stores, which derive `Debug`/`Clone`.
 #[async_trait]
-pub trait Store {
+pub trait Store: Debug + Send + Sync {
     // Push a record
     async fn push(&self, record: &Record<EncryptedData>) -> Result<()> {
         self.push_batch(&mut std::iter::once(record)).await
@@ -62,9 +68,80 @@ pub trait Store {
     async fn all_tagged(&self, tag: &str) -> Result<Vec<Record<EncryptedData>>>;
 }
 
-/// A boxed record store. This is the type the typed stores hold so they can be
-/// backed either by the local `SqliteStore` or by the daemon proxy.
-pub type BoxStore = Box<dyn Store + Send + Sync>;
+/// A shared record store. This is the type the typed stores hold so they can be
+/// backed either by the local `SqliteStore` or by the daemon proxy. `Arc` (not
+/// `Box`) so the typed stores stay cheaply `Clone`.
+pub type ArcStore = Arc<dyn Store>;
+
+/// A boxed record store.
+pub type BoxStore = Box<dyn Store>;
+
+/// Blanket forwarding impl so an `ArcStore` is itself a `Store`.
+#[async_trait]
+impl Store for ArcStore {
+    async fn push_batch(
+        &self,
+        records: &mut (dyn Iterator<Item = &Record<EncryptedData>> + Send),
+    ) -> Result<()> {
+        (**self).push_batch(records).await
+    }
+    async fn get(&self, id: RecordId) -> Result<Record<EncryptedData>> {
+        (**self).get(id).await
+    }
+    async fn delete(&self, id: RecordId) -> Result<()> {
+        (**self).delete(id).await
+    }
+    async fn delete_all(&self) -> Result<()> {
+        (**self).delete_all().await
+    }
+    async fn len_all(&self) -> Result<u64> {
+        (**self).len_all().await
+    }
+    async fn len(&self, host: HostId, tag: &str) -> Result<u64> {
+        (**self).len(host, tag).await
+    }
+    async fn len_tag(&self, tag: &str) -> Result<u64> {
+        (**self).len_tag(tag).await
+    }
+    async fn last(&self, host: HostId, tag: &str) -> Result<Option<Record<EncryptedData>>> {
+        (**self).last(host, tag).await
+    }
+    async fn first(&self, host: HostId, tag: &str) -> Result<Option<Record<EncryptedData>>> {
+        (**self).first(host, tag).await
+    }
+    async fn re_encrypt(&self, old_key: &[u8; 32], new_key: &[u8; 32]) -> Result<()> {
+        (**self).re_encrypt(old_key, new_key).await
+    }
+    async fn verify(&self, key: &[u8; 32]) -> Result<()> {
+        (**self).verify(key).await
+    }
+    async fn purge(&self, key: &[u8; 32]) -> Result<()> {
+        (**self).purge(key).await
+    }
+    async fn next(
+        &self,
+        host: HostId,
+        tag: &str,
+        idx: RecordIdx,
+        limit: u64,
+    ) -> Result<Vec<Record<EncryptedData>>> {
+        (**self).next(host, tag, idx, limit).await
+    }
+    async fn idx(
+        &self,
+        host: HostId,
+        tag: &str,
+        idx: RecordIdx,
+    ) -> Result<Option<Record<EncryptedData>>> {
+        (**self).idx(host, tag, idx).await
+    }
+    async fn status(&self) -> Result<RecordStatus> {
+        (**self).status().await
+    }
+    async fn all_tagged(&self, tag: &str) -> Result<Vec<Record<EncryptedData>>> {
+        (**self).all_tagged(tag).await
+    }
+}
 
 /// Blanket forwarding impl so a `BoxStore` is itself a `Store`.
 #[async_trait]

--- a/crates/atuin-client/src/record/sync.rs
+++ b/crates/atuin-client/src/record/sync.rs
@@ -263,7 +263,7 @@ async fn sync_download(
         }
 
         store
-            .push_batch(page.iter())
+            .push_batch(&mut page.iter())
             .await
             .map_err(|e| SyncError::LocalStoreError { msg: e.to_string() })?;
 

--- a/crates/atuin-daemon/Cargo.toml
+++ b/crates/atuin-daemon/Cargo.toml
@@ -22,6 +22,7 @@ atuin-history = { path = "../atuin-history", version = "18.17.1" }
 
 time = { workspace = true }
 uuid = { workspace = true }
+sqlx = { workspace = true, features = ["sqlite"] }
 tokio = { workspace = true }
 tower = { workspace = true }
 eyre = { workspace = true }

--- a/crates/atuin-daemon/build.rs
+++ b/crates/atuin-daemon/build.rs
@@ -8,6 +8,7 @@ fn main() -> std::io::Result<()> {
         "proto/search.proto",
         "proto/control.proto",
         "proto/semantic.proto",
+        "proto/database.proto",
     ];
     let proto_include_dirs = ["proto"];
 

--- a/crates/atuin-daemon/build.rs
+++ b/crates/atuin-daemon/build.rs
@@ -9,6 +9,7 @@ fn main() -> std::io::Result<()> {
         "proto/control.proto",
         "proto/semantic.proto",
         "proto/database.proto",
+        "proto/store.proto",
     ];
     let proto_include_dirs = ["proto"];
 

--- a/crates/atuin-daemon/proto/database.proto
+++ b/crates/atuin-daemon/proto/database.proto
@@ -1,0 +1,110 @@
+syntax = "proto3";
+package database;
+
+// A full history row, mirroring atuin_client::history::History.
+message HistoryRecord {
+  string id = 1;
+  uint64 timestamp = 2; // nanosecond unix epoch
+  int64 duration = 3;
+  int64 exit = 4;
+  string command = 5;
+  string cwd = 6;
+  string session = 7;
+  string hostname = 8;
+  string author = 9;
+  optional string intent = 10;
+  optional uint64 deleted_at = 11; // nanosecond unix epoch when soft-deleted
+}
+
+// Mirrors atuin_client::database::Context.
+message Context {
+  string session = 1;
+  string cwd = 2;
+  string hostname = 3;
+  string host_id = 4;
+  optional string git_root = 5;
+}
+
+// Mirrors atuin_client::database::OptFilters.
+message OptFiltersMsg {
+  optional int64 exit = 1;
+  optional int64 exclude_exit = 2;
+  bool only_failed = 3;
+  optional string cwd = 4;
+  optional string exclude_cwd = 5;
+  optional string before = 6;
+  optional string after = 7;
+  optional int64 limit = 8;
+  optional int64 offset = 9;
+  bool reverse = 10;
+  bool include_duplicates = 11;
+  repeated string authors = 12;
+}
+
+// Mirrors atuin_client::settings::SearchMode discriminants.
+enum SearchMode {
+  SEARCH_MODE_PREFIX = 0;
+  SEARCH_MODE_FULL_TEXT = 1;
+  SEARCH_MODE_FUZZY = 2;
+  SEARCH_MODE_SKIM = 3;
+  SEARCH_MODE_DAEMON_FUZZY = 4;
+}
+
+// Mirrors atuin_client::settings::FilterMode discriminants.
+enum FilterMode {
+  FILTER_MODE_GLOBAL = 0;
+  FILTER_MODE_HOST = 1;
+  FILTER_MODE_SESSION = 2;
+  FILTER_MODE_DIRECTORY = 3;
+  FILTER_MODE_WORKSPACE = 4;
+  FILTER_MODE_SESSION_PRELOAD = 5;
+}
+
+message Empty {}
+message Records { repeated HistoryRecord records = 1; }
+message OptionalRecord { optional HistoryRecord record = 1; }
+
+message SaveRequest { HistoryRecord record = 1; }
+message SaveBulkRequest { repeated HistoryRecord records = 1; }
+message LoadRequest { string id = 1; }
+message ListRequest {
+  repeated FilterMode filters = 1;
+  Context context = 2;
+  optional uint64 max = 3;
+  bool unique = 4;
+  bool include_deleted = 5;
+}
+message RangeRequest { uint64 from = 1; uint64 to = 2; }
+message HistoryCountRequest { bool include_deleted = 1; }
+message HistoryCountReply { int64 count = 1; }
+message BeforeRequest { uint64 timestamp = 1; int64 count = 2; }
+message DeleteRowsRequest { repeated string ids = 1; }
+message SearchRequest {
+  SearchMode search_mode = 1;
+  FilterMode filter = 2;
+  Context context = 3;
+  string query = 4;
+  OptFiltersMsg filter_options = 5;
+}
+message QueryHistoryRequest { string query = 1; }
+message GetDupsRequest { int64 before = 1; uint32 dupkeep = 2; }
+
+// atuin_client::database::Database, served by the daemon over gRPC so the
+// client never has to open the local SQLite database itself.
+service StorageDatabase {
+  rpc Save(SaveRequest) returns (Empty);
+  rpc SaveBulk(SaveBulkRequest) returns (Empty);
+  rpc Load(LoadRequest) returns (OptionalRecord);
+  rpc List(ListRequest) returns (Records);
+  rpc Range(RangeRequest) returns (Records);
+  rpc Update(SaveRequest) returns (Empty);
+  rpc HistoryCount(HistoryCountRequest) returns (HistoryCountReply);
+  rpc Last(Empty) returns (OptionalRecord);
+  rpc Before(BeforeRequest) returns (Records);
+  rpc Delete(SaveRequest) returns (Empty);
+  rpc DeleteRows(DeleteRowsRequest) returns (Empty);
+  rpc Deleted(Empty) returns (Records);
+  rpc Search(SearchRequest) returns (Records);
+  rpc QueryHistory(QueryHistoryRequest) returns (Records);
+  rpc GetDups(GetDupsRequest) returns (Records);
+}

--- a/crates/atuin-daemon/proto/database.proto
+++ b/crates/atuin-daemon/proto/database.proto
@@ -64,6 +64,23 @@ message Empty {}
 message Records { repeated HistoryRecord records = 1; }
 message OptionalRecord { optional HistoryRecord record = 1; }
 
+message I64Pair { int64 a = 1; int64 b = 2; }
+message StrI64Pair { string a = 1; int64 b = 2; }
+
+// Mirrors atuin_client::history::HistoryStats.
+message HistoryStatsReply {
+  optional HistoryRecord next = 1;
+  optional HistoryRecord previous = 2;
+  uint64 total = 3;
+  uint64 average_duration = 4;
+  repeated I64Pair exits = 5;
+  repeated StrI64Pair day_of_week = 6;
+  repeated StrI64Pair duration_over_time = 7;
+}
+
+message RecordWithCount { HistoryRecord record = 1; int32 count = 2; }
+message RecordsWithCount { repeated RecordWithCount items = 1; }
+
 message SaveRequest { HistoryRecord record = 1; }
 message SaveBulkRequest { repeated HistoryRecord records = 1; }
 message LoadRequest { string id = 1; }
@@ -107,4 +124,6 @@ service StorageDatabase {
   rpc Search(SearchRequest) returns (Records);
   rpc QueryHistory(QueryHistoryRequest) returns (Records);
   rpc GetDups(GetDupsRequest) returns (Records);
+  rpc Stats(SaveRequest) returns (HistoryStatsReply);
+  rpc AllWithCount(Empty) returns (RecordsWithCount);
 }

--- a/crates/atuin-daemon/proto/store.proto
+++ b/crates/atuin-daemon/proto/store.proto
@@ -1,0 +1,68 @@
+syntax = "proto3";
+package store;
+
+// Mirrors atuin_common::record::Host.
+message Host {
+  string id = 1;   // HostId uuid (hyphenated)
+  string name = 2;
+}
+
+// Mirrors atuin_common::record::EncryptedData.
+message EncryptedData {
+  string data = 1;
+  string content_encryption_key = 2;
+}
+
+// Mirrors atuin_common::record::Record<EncryptedData>.
+message EncryptedRecord {
+  string id = 1;   // RecordId uuid (hyphenated)
+  uint64 idx = 2;
+  Host host = 3;
+  uint64 timestamp = 4;
+  string version = 5;
+  string tag = 6;
+  EncryptedData data = 7;
+}
+
+message Empty {}
+message Records { repeated EncryptedRecord records = 1; }
+message OptionalRecord { optional EncryptedRecord record = 1; }
+message Count { uint64 count = 1; }
+
+message PushBatchRequest { repeated EncryptedRecord records = 1; }
+message RecordIdRequest { string id = 1; }
+message HostTagRequest { string host = 1; string tag = 2; }
+message TagRequest { string tag = 1; }
+message KeyRequest { bytes key = 1; }
+message ReEncryptRequest { bytes old_key = 1; bytes new_key = 2; }
+message NextRequest { string host = 1; string tag = 2; uint64 idx = 3; uint64 limit = 4; }
+message IdxRequest { string host = 1; string tag = 2; uint64 idx = 3; }
+
+// Mirrors atuin_common::record::RecordStatus (host -> tag -> max idx).
+message HostTags {
+  string host = 1;
+  map<string, uint64> tags = 2;
+}
+message RecordStatusReply { repeated HostTags hosts = 1; }
+
+// atuin_client::record::store::Store, served by the daemon over gRPC so the
+// client never opens the local record store itself. Records stay encrypted on
+// the wire; the daemon is a blob store and crypto remains client-side.
+service StorageStore {
+  rpc PushBatch(PushBatchRequest) returns (Empty);
+  rpc Get(RecordIdRequest) returns (EncryptedRecord);
+  rpc Delete(RecordIdRequest) returns (Empty);
+  rpc DeleteAll(Empty) returns (Empty);
+  rpc LenAll(Empty) returns (Count);
+  rpc Len(HostTagRequest) returns (Count);
+  rpc LenTag(TagRequest) returns (Count);
+  rpc Last(HostTagRequest) returns (OptionalRecord);
+  rpc First(HostTagRequest) returns (OptionalRecord);
+  rpc ReEncrypt(ReEncryptRequest) returns (Empty);
+  rpc Verify(KeyRequest) returns (Empty);
+  rpc Purge(KeyRequest) returns (Empty);
+  rpc Next(NextRequest) returns (Records);
+  rpc Idx(IdxRequest) returns (OptionalRecord);
+  rpc Status(Empty) returns (RecordStatusReply);
+  rpc AllTagged(TagRequest) returns (Records);
+}

--- a/crates/atuin-daemon/src/components/database.rs
+++ b/crates/atuin-daemon/src/components/database.rs
@@ -14,11 +14,11 @@ use time::OffsetDateTime;
 use tonic::{Request, Response, Status};
 
 use crate::database::{
-    Context, Empty, FilterMode, HistoryCountReply, HistoryCountRequest, HistoryRecord, ListRequest,
-    LoadRequest, OptionalRecord, QueryHistoryRequest, RangeRequest, Records, SaveBulkRequest,
-    SaveRequest, SearchMode, SearchRequest,
+    BeforeRequest, Context, DeleteRowsRequest, Empty, FilterMode, GetDupsRequest,
+    HistoryCountReply, HistoryCountRequest, HistoryRecord, HistoryStatsReply, ListRequest,
+    LoadRequest, OptionalRecord, QueryHistoryRequest, RangeRequest, Records, RecordsWithCount,
+    SaveBulkRequest, SaveRequest, SearchMode, SearchRequest,
     storage_database_server::{StorageDatabase, StorageDatabaseServer},
-    BeforeRequest, DeleteRowsRequest, GetDupsRequest,
 };
 
 use atuin_client::database::Sqlite as HistoryDatabase;
@@ -223,5 +223,22 @@ impl StorageDatabase for StorageDatabaseService {
             .await
             .map_err(internal)?;
         Ok(Response::new(Records::from_history(history)))
+    }
+
+    async fn stats(
+        &self,
+        request: Request<SaveRequest>,
+    ) -> Result<Response<HistoryStatsReply>, Status> {
+        let record = require_record(request.into_inner().record)?;
+        let stats = self.db.stats(&record.into()).await.map_err(internal)?;
+        Ok(Response::new(stats.into()))
+    }
+
+    async fn all_with_count(
+        &self,
+        _request: Request<Empty>,
+    ) -> Result<Response<RecordsWithCount>, Status> {
+        let items = self.db.all_with_count().await.map_err(internal)?;
+        Ok(Response::new(RecordsWithCount::from_history_with_count(items)))
     }
 }

--- a/crates/atuin-daemon/src/components/database.rs
+++ b/crates/atuin-daemon/src/components/database.rs
@@ -1,0 +1,227 @@
+//! StorageDatabase gRPC service.
+//!
+//! A thin adapter that exposes the daemon's owned history `Sqlite` database
+//! over gRPC by delegating each call to the `atuin_client::database::Database`
+//! trait. This lets the CLI act as a pure client and never open the local
+//! SQLite database itself.
+
+use atuin_client::{
+    database::{Database, OptFilters},
+    history::HistoryId,
+    settings::{FilterMode as DbFilterMode, SearchMode as DbSearchMode},
+};
+use time::OffsetDateTime;
+use tonic::{Request, Response, Status};
+
+use crate::database::{
+    Context, Empty, FilterMode, HistoryCountReply, HistoryCountRequest, HistoryRecord, ListRequest,
+    LoadRequest, OptionalRecord, QueryHistoryRequest, RangeRequest, Records, SaveBulkRequest,
+    SaveRequest, SearchMode, SearchRequest,
+    storage_database_server::{StorageDatabase, StorageDatabaseServer},
+    BeforeRequest, DeleteRowsRequest, GetDupsRequest,
+};
+
+use atuin_client::database::Sqlite as HistoryDatabase;
+
+/// The StorageDatabase gRPC service, backed by the daemon's `Sqlite`.
+pub struct StorageDatabaseService {
+    db: HistoryDatabase,
+}
+
+impl StorageDatabaseService {
+    pub fn new(db: HistoryDatabase) -> Self {
+        Self { db }
+    }
+
+    pub fn into_server(self) -> StorageDatabaseServer<Self> {
+        StorageDatabaseServer::new(self)
+    }
+}
+
+fn internal<E: std::fmt::Display>(e: E) -> Status {
+    Status::internal(e.to_string())
+}
+
+fn nanos_to_ts(nanos: u64) -> Result<OffsetDateTime, Status> {
+    OffsetDateTime::from_unix_timestamp_nanos(nanos as i128)
+        .map_err(|_| Status::invalid_argument("invalid timestamp"))
+}
+
+fn require_record(record: Option<HistoryRecord>) -> Result<HistoryRecord, Status> {
+    record.ok_or_else(|| Status::invalid_argument("missing history record"))
+}
+
+fn ctx(context: Option<Context>) -> atuin_client::database::Context {
+    context.map(Into::into).unwrap_or_else(|| atuin_client::database::Context {
+        session: String::new(),
+        cwd: String::new(),
+        hostname: String::new(),
+        host_id: String::new(),
+        git_root: None,
+    })
+}
+
+#[tonic::async_trait]
+impl StorageDatabase for StorageDatabaseService {
+    async fn save(&self, request: Request<SaveRequest>) -> Result<Response<Empty>, Status> {
+        let record = require_record(request.into_inner().record)?;
+        self.db.save(&record.into()).await.map_err(internal)?;
+        Ok(Response::new(Empty {}))
+    }
+
+    async fn save_bulk(
+        &self,
+        request: Request<SaveBulkRequest>,
+    ) -> Result<Response<Empty>, Status> {
+        let history: Vec<_> = request
+            .into_inner()
+            .records
+            .into_iter()
+            .map(Into::into)
+            .collect();
+        self.db.save_bulk(&history).await.map_err(internal)?;
+        Ok(Response::new(Empty {}))
+    }
+
+    async fn load(&self, request: Request<LoadRequest>) -> Result<Response<OptionalRecord>, Status> {
+        let id = request.into_inner().id;
+        let record = self.db.load(&id).await.map_err(internal)?;
+        Ok(Response::new(OptionalRecord {
+            record: record.map(Into::into),
+        }))
+    }
+
+    async fn list(&self, request: Request<ListRequest>) -> Result<Response<Records>, Status> {
+        let req = request.into_inner();
+        let filters: Vec<DbFilterMode> = req
+            .filters
+            .into_iter()
+            .filter_map(|f| FilterMode::try_from(f).ok())
+            .map(DbFilterMode::from)
+            .collect();
+        let context = ctx(req.context);
+        let history = self
+            .db
+            .list(
+                &filters,
+                &context,
+                req.max.map(|m| m as usize),
+                req.unique,
+                req.include_deleted,
+            )
+            .await
+            .map_err(internal)?;
+        Ok(Response::new(Records::from_history(history)))
+    }
+
+    async fn range(&self, request: Request<RangeRequest>) -> Result<Response<Records>, Status> {
+        let req = request.into_inner();
+        let history = self
+            .db
+            .range(nanos_to_ts(req.from)?, nanos_to_ts(req.to)?)
+            .await
+            .map_err(internal)?;
+        Ok(Response::new(Records::from_history(history)))
+    }
+
+    async fn update(&self, request: Request<SaveRequest>) -> Result<Response<Empty>, Status> {
+        let record = require_record(request.into_inner().record)?;
+        self.db.update(&record.into()).await.map_err(internal)?;
+        Ok(Response::new(Empty {}))
+    }
+
+    async fn history_count(
+        &self,
+        request: Request<HistoryCountRequest>,
+    ) -> Result<Response<HistoryCountReply>, Status> {
+        let count = self
+            .db
+            .history_count(request.into_inner().include_deleted)
+            .await
+            .map_err(internal)?;
+        Ok(Response::new(HistoryCountReply { count }))
+    }
+
+    async fn last(&self, _request: Request<Empty>) -> Result<Response<OptionalRecord>, Status> {
+        let record = self.db.last().await.map_err(internal)?;
+        Ok(Response::new(OptionalRecord {
+            record: record.map(Into::into),
+        }))
+    }
+
+    async fn before(&self, request: Request<BeforeRequest>) -> Result<Response<Records>, Status> {
+        let req = request.into_inner();
+        let history = self
+            .db
+            .before(nanos_to_ts(req.timestamp)?, req.count)
+            .await
+            .map_err(internal)?;
+        Ok(Response::new(Records::from_history(history)))
+    }
+
+    async fn delete(&self, request: Request<SaveRequest>) -> Result<Response<Empty>, Status> {
+        let record = require_record(request.into_inner().record)?;
+        self.db.delete(record.into()).await.map_err(internal)?;
+        Ok(Response::new(Empty {}))
+    }
+
+    async fn delete_rows(
+        &self,
+        request: Request<DeleteRowsRequest>,
+    ) -> Result<Response<Empty>, Status> {
+        let ids: Vec<HistoryId> = request
+            .into_inner()
+            .ids
+            .into_iter()
+            .map(HistoryId)
+            .collect();
+        self.db.delete_rows(&ids).await.map_err(internal)?;
+        Ok(Response::new(Empty {}))
+    }
+
+    async fn deleted(&self, _request: Request<Empty>) -> Result<Response<Records>, Status> {
+        let history = self.db.deleted().await.map_err(internal)?;
+        Ok(Response::new(Records::from_history(history)))
+    }
+
+    async fn search(&self, request: Request<SearchRequest>) -> Result<Response<Records>, Status> {
+        let req = request.into_inner();
+        let search_mode: DbSearchMode = SearchMode::try_from(req.search_mode)
+            .map(DbSearchMode::from)
+            .unwrap_or(DbSearchMode::Fuzzy);
+        let filter: DbFilterMode = FilterMode::try_from(req.filter)
+            .map(DbFilterMode::from)
+            .unwrap_or(DbFilterMode::Global);
+        let context = ctx(req.context);
+        let filter_options: OptFilters = req.filter_options.map(Into::into).unwrap_or_default();
+
+        let history = self
+            .db
+            .search(search_mode, filter, &context, &req.query, filter_options)
+            .await
+            .map_err(internal)?;
+        Ok(Response::new(Records::from_history(history)))
+    }
+
+    async fn query_history(
+        &self,
+        request: Request<QueryHistoryRequest>,
+    ) -> Result<Response<Records>, Status> {
+        let history = self
+            .db
+            .query_history(&request.into_inner().query)
+            .await
+            .map_err(internal)?;
+        Ok(Response::new(Records::from_history(history)))
+    }
+
+    async fn get_dups(&self, request: Request<GetDupsRequest>) -> Result<Response<Records>, Status> {
+        let req = request.into_inner();
+        let history = self
+            .db
+            .get_dups(req.before, req.dupkeep)
+            .await
+            .map_err(internal)?;
+        Ok(Response::new(Records::from_history(history)))
+    }
+}

--- a/crates/atuin-daemon/src/components/mod.rs
+++ b/crates/atuin-daemon/src/components/mod.rs
@@ -14,6 +14,7 @@
 //! - [`semantic::SemanticComponent`]: In-memory semantic command captures
 //! - [`sync::SyncComponent`]: Cloud sync
 
+pub mod database;
 pub mod history;
 pub mod search;
 pub mod semantic;

--- a/crates/atuin-daemon/src/components/mod.rs
+++ b/crates/atuin-daemon/src/components/mod.rs
@@ -18,6 +18,7 @@ pub mod database;
 pub mod history;
 pub mod search;
 pub mod semantic;
+pub mod store;
 pub mod sync;
 
 pub use history::HistoryComponent;

--- a/crates/atuin-daemon/src/components/store.rs
+++ b/crates/atuin-daemon/src/components/store.rs
@@ -1,0 +1,214 @@
+//! StorageStore gRPC service.
+//!
+//! A thin adapter exposing the daemon's owned record `SqliteStore` over gRPC by
+//! delegating to the `atuin_client::record::store::Store` trait. Records stay
+//! encrypted; the daemon is a blob store and crypto stays client-side.
+
+use atuin_client::record::{sqlite_store::SqliteStore, store::Store};
+use atuin_common::record::{HostId, RecordId};
+use tonic::{Request, Response, Status};
+use uuid::Uuid;
+
+use crate::store::{
+    Count, Empty, HostTagRequest, IdxRequest, KeyRequest, NextRequest, OptionalRecord,
+    PushBatchRequest, ReEncryptRequest, RecordIdRequest, Records, RecordStatusReply, TagRequest,
+    storage_store_server::{StorageStore, StorageStoreServer},
+};
+
+pub struct StorageStoreService {
+    store: SqliteStore,
+}
+
+impl StorageStoreService {
+    pub fn new(store: SqliteStore) -> Self {
+        Self { store }
+    }
+
+    pub fn into_server(self) -> StorageStoreServer<Self> {
+        StorageStoreServer::new(self)
+    }
+}
+
+fn internal<E: std::fmt::Display>(e: E) -> Status {
+    Status::internal(e.to_string())
+}
+
+fn host_id(s: &str) -> HostId {
+    HostId(Uuid::parse_str(s).unwrap_or(Uuid::nil()))
+}
+
+fn record_id(s: &str) -> RecordId {
+    RecordId(Uuid::parse_str(s).unwrap_or(Uuid::nil()))
+}
+
+fn key32(bytes: &[u8]) -> Result<[u8; 32], Status> {
+    bytes
+        .try_into()
+        .map_err(|_| Status::invalid_argument("key must be 32 bytes"))
+}
+
+#[tonic::async_trait]
+impl StorageStore for StorageStoreService {
+    async fn push_batch(
+        &self,
+        request: Request<PushBatchRequest>,
+    ) -> Result<Response<Empty>, Status> {
+        let records: Vec<_> = request
+            .into_inner()
+            .records
+            .into_iter()
+            .map(Into::into)
+            .collect();
+        self.store
+            .push_batch(&mut records.iter())
+            .await
+            .map_err(internal)?;
+        Ok(Response::new(Empty {}))
+    }
+
+    async fn get(
+        &self,
+        request: Request<RecordIdRequest>,
+    ) -> Result<Response<crate::store::EncryptedRecord>, Status> {
+        let record = self
+            .store
+            .get(record_id(&request.into_inner().id))
+            .await
+            .map_err(internal)?;
+        Ok(Response::new(record.into()))
+    }
+
+    async fn delete(&self, request: Request<RecordIdRequest>) -> Result<Response<Empty>, Status> {
+        self.store
+            .delete(record_id(&request.into_inner().id))
+            .await
+            .map_err(internal)?;
+        Ok(Response::new(Empty {}))
+    }
+
+    async fn delete_all(&self, _request: Request<Empty>) -> Result<Response<Empty>, Status> {
+        self.store.delete_all().await.map_err(internal)?;
+        Ok(Response::new(Empty {}))
+    }
+
+    async fn len_all(&self, _request: Request<Empty>) -> Result<Response<Count>, Status> {
+        let count = self.store.len_all().await.map_err(internal)?;
+        Ok(Response::new(Count { count }))
+    }
+
+    async fn len(&self, request: Request<HostTagRequest>) -> Result<Response<Count>, Status> {
+        let req = request.into_inner();
+        let count = self
+            .store
+            .len(host_id(&req.host), &req.tag)
+            .await
+            .map_err(internal)?;
+        Ok(Response::new(Count { count }))
+    }
+
+    async fn len_tag(&self, request: Request<TagRequest>) -> Result<Response<Count>, Status> {
+        let count = self
+            .store
+            .len_tag(&request.into_inner().tag)
+            .await
+            .map_err(internal)?;
+        Ok(Response::new(Count { count }))
+    }
+
+    async fn last(
+        &self,
+        request: Request<HostTagRequest>,
+    ) -> Result<Response<OptionalRecord>, Status> {
+        let req = request.into_inner();
+        let record = self
+            .store
+            .last(host_id(&req.host), &req.tag)
+            .await
+            .map_err(internal)?;
+        Ok(Response::new(OptionalRecord {
+            record: record.map(Into::into),
+        }))
+    }
+
+    async fn first(
+        &self,
+        request: Request<HostTagRequest>,
+    ) -> Result<Response<OptionalRecord>, Status> {
+        let req = request.into_inner();
+        let record = self
+            .store
+            .first(host_id(&req.host), &req.tag)
+            .await
+            .map_err(internal)?;
+        Ok(Response::new(OptionalRecord {
+            record: record.map(Into::into),
+        }))
+    }
+
+    async fn re_encrypt(
+        &self,
+        request: Request<ReEncryptRequest>,
+    ) -> Result<Response<Empty>, Status> {
+        let req = request.into_inner();
+        self.store
+            .re_encrypt(&key32(&req.old_key)?, &key32(&req.new_key)?)
+            .await
+            .map_err(internal)?;
+        Ok(Response::new(Empty {}))
+    }
+
+    async fn verify(&self, request: Request<KeyRequest>) -> Result<Response<Empty>, Status> {
+        self.store
+            .verify(&key32(&request.into_inner().key)?)
+            .await
+            .map_err(internal)?;
+        Ok(Response::new(Empty {}))
+    }
+
+    async fn purge(&self, request: Request<KeyRequest>) -> Result<Response<Empty>, Status> {
+        self.store
+            .purge(&key32(&request.into_inner().key)?)
+            .await
+            .map_err(internal)?;
+        Ok(Response::new(Empty {}))
+    }
+
+    async fn next(&self, request: Request<NextRequest>) -> Result<Response<Records>, Status> {
+        let req = request.into_inner();
+        let records = self
+            .store
+            .next(host_id(&req.host), &req.tag, req.idx, req.limit)
+            .await
+            .map_err(internal)?;
+        Ok(Response::new(Records::from_records(records)))
+    }
+
+    async fn idx(&self, request: Request<IdxRequest>) -> Result<Response<OptionalRecord>, Status> {
+        let req = request.into_inner();
+        let record = self
+            .store
+            .idx(host_id(&req.host), &req.tag, req.idx)
+            .await
+            .map_err(internal)?;
+        Ok(Response::new(OptionalRecord {
+            record: record.map(Into::into),
+        }))
+    }
+
+    async fn status(
+        &self,
+        _request: Request<Empty>,
+    ) -> Result<Response<RecordStatusReply>, Status> {
+        let status = self.store.status().await.map_err(internal)?;
+        Ok(Response::new(status.into()))
+    }
+
+    async fn all_tagged(&self, request: Request<TagRequest>) -> Result<Response<Records>, Status> {
+        let records = self
+            .store
+            .all_tagged(&request.into_inner().tag)
+            .await
+            .map_err(internal)?;
+        Ok(Response::new(Records::from_records(records)))
+    }
+}

--- a/crates/atuin-daemon/src/database/mod.rs
+++ b/crates/atuin-daemon/src/database/mod.rs
@@ -11,7 +11,7 @@ use std::path::PathBuf;
 
 use atuin_client::{
     database::{Context as DbContext, OptFilters},
-    history::{History, HistoryId},
+    history::{History, HistoryId, HistoryStats},
     settings::{FilterMode as DbFilterMode, SearchMode as DbSearchMode},
 };
 use time::OffsetDateTime;
@@ -184,6 +184,71 @@ impl Records {
     pub fn from_history(history: Vec<History>) -> Self {
         Self {
             records: history.into_iter().map(HistoryRecord::from).collect(),
+        }
+    }
+}
+
+impl From<HistoryStats> for HistoryStatsReply {
+    fn from(s: HistoryStats) -> Self {
+        Self {
+            next: s.next.map(HistoryRecord::from),
+            previous: s.previous.map(HistoryRecord::from),
+            total: s.total,
+            average_duration: s.average_duration,
+            exits: s
+                .exits
+                .into_iter()
+                .map(|(a, b)| I64Pair { a, b })
+                .collect(),
+            day_of_week: s
+                .day_of_week
+                .into_iter()
+                .map(|(a, b)| StrI64Pair { a, b })
+                .collect(),
+            duration_over_time: s
+                .duration_over_time
+                .into_iter()
+                .map(|(a, b)| StrI64Pair { a, b })
+                .collect(),
+        }
+    }
+}
+
+impl From<HistoryStatsReply> for HistoryStats {
+    fn from(s: HistoryStatsReply) -> Self {
+        Self {
+            next: s.next.map(History::from),
+            previous: s.previous.map(History::from),
+            total: s.total,
+            average_duration: s.average_duration,
+            exits: s.exits.into_iter().map(|p| (p.a, p.b)).collect(),
+            day_of_week: s.day_of_week.into_iter().map(|p| (p.a, p.b)).collect(),
+            duration_over_time: s
+                .duration_over_time
+                .into_iter()
+                .map(|p| (p.a, p.b))
+                .collect(),
+        }
+    }
+}
+
+impl RecordsWithCount {
+    pub fn into_history_with_count(self) -> Vec<(History, i32)> {
+        self.items
+            .into_iter()
+            .filter_map(|i| i.record.map(|r| (History::from(r), i.count)))
+            .collect()
+    }
+
+    pub fn from_history_with_count(items: Vec<(History, i32)>) -> Self {
+        Self {
+            items: items
+                .into_iter()
+                .map(|(h, count)| RecordWithCount {
+                    record: Some(HistoryRecord::from(h)),
+                    count,
+                })
+                .collect(),
         }
     }
 }

--- a/crates/atuin-daemon/src/database/mod.rs
+++ b/crates/atuin-daemon/src/database/mod.rs
@@ -1,0 +1,189 @@
+//! Database module for the daemon gRPC storage service.
+//!
+//! This exposes the `atuin_client::database::Database` surface over gRPC so
+//! the CLI never has to open the local SQLite database itself — the daemon is
+//! the sole owner of on-disk history storage.
+//!
+//! This module contains the proto-generated types plus conversions to and from
+//! the corresponding `atuin_client` types.
+
+use std::path::PathBuf;
+
+use atuin_client::{
+    database::{Context as DbContext, OptFilters},
+    history::{History, HistoryId},
+    settings::{FilterMode as DbFilterMode, SearchMode as DbSearchMode},
+};
+use time::OffsetDateTime;
+
+// Include the generated proto code
+tonic::include_proto!("database");
+
+fn ts_to_nanos(ts: OffsetDateTime) -> u64 {
+    ts.unix_timestamp_nanos().max(0) as u64
+}
+
+fn nanos_to_ts(nanos: u64) -> OffsetDateTime {
+    OffsetDateTime::from_unix_timestamp_nanos(nanos as i128)
+        .unwrap_or(OffsetDateTime::UNIX_EPOCH)
+}
+
+impl From<History> for HistoryRecord {
+    fn from(h: History) -> Self {
+        Self {
+            id: h.id.0,
+            timestamp: ts_to_nanos(h.timestamp),
+            duration: h.duration,
+            exit: h.exit,
+            command: h.command,
+            cwd: h.cwd,
+            session: h.session,
+            hostname: h.hostname,
+            author: h.author,
+            intent: h.intent,
+            deleted_at: h.deleted_at.map(ts_to_nanos),
+        }
+    }
+}
+
+impl From<HistoryRecord> for History {
+    fn from(r: HistoryRecord) -> Self {
+        Self {
+            id: HistoryId(r.id),
+            timestamp: nanos_to_ts(r.timestamp),
+            duration: r.duration,
+            exit: r.exit,
+            command: r.command,
+            cwd: r.cwd,
+            session: r.session,
+            hostname: r.hostname,
+            author: r.author,
+            intent: r.intent,
+            deleted_at: r.deleted_at.map(nanos_to_ts),
+        }
+    }
+}
+
+impl From<DbContext> for Context {
+    fn from(c: DbContext) -> Self {
+        Self {
+            session: c.session,
+            cwd: c.cwd,
+            hostname: c.hostname,
+            host_id: c.host_id,
+            git_root: c.git_root.map(|p| p.to_string_lossy().into_owned()),
+        }
+    }
+}
+
+impl From<Context> for DbContext {
+    fn from(c: Context) -> Self {
+        Self {
+            session: c.session,
+            cwd: c.cwd,
+            hostname: c.hostname,
+            host_id: c.host_id,
+            git_root: c.git_root.map(PathBuf::from),
+        }
+    }
+}
+
+impl From<OptFilters> for OptFiltersMsg {
+    fn from(o: OptFilters) -> Self {
+        Self {
+            exit: o.exit,
+            exclude_exit: o.exclude_exit,
+            only_failed: o.only_failed,
+            cwd: o.cwd,
+            exclude_cwd: o.exclude_cwd,
+            before: o.before,
+            after: o.after,
+            limit: o.limit,
+            offset: o.offset,
+            reverse: o.reverse,
+            include_duplicates: o.include_duplicates,
+            authors: o.authors,
+        }
+    }
+}
+
+impl From<OptFiltersMsg> for OptFilters {
+    fn from(o: OptFiltersMsg) -> Self {
+        Self {
+            exit: o.exit,
+            exclude_exit: o.exclude_exit,
+            only_failed: o.only_failed,
+            cwd: o.cwd,
+            exclude_cwd: o.exclude_cwd,
+            before: o.before,
+            after: o.after,
+            limit: o.limit,
+            offset: o.offset,
+            reverse: o.reverse,
+            include_duplicates: o.include_duplicates,
+            authors: o.authors,
+        }
+    }
+}
+
+impl From<DbSearchMode> for SearchMode {
+    fn from(m: DbSearchMode) -> Self {
+        match m {
+            DbSearchMode::Prefix => SearchMode::Prefix,
+            DbSearchMode::FullText => SearchMode::FullText,
+            DbSearchMode::Fuzzy => SearchMode::Fuzzy,
+            DbSearchMode::Skim => SearchMode::Skim,
+            DbSearchMode::DaemonFuzzy => SearchMode::DaemonFuzzy,
+        }
+    }
+}
+
+impl From<SearchMode> for DbSearchMode {
+    fn from(m: SearchMode) -> Self {
+        match m {
+            SearchMode::Prefix => DbSearchMode::Prefix,
+            SearchMode::FullText => DbSearchMode::FullText,
+            SearchMode::Fuzzy => DbSearchMode::Fuzzy,
+            SearchMode::Skim => DbSearchMode::Skim,
+            SearchMode::DaemonFuzzy => DbSearchMode::DaemonFuzzy,
+        }
+    }
+}
+
+impl From<DbFilterMode> for FilterMode {
+    fn from(m: DbFilterMode) -> Self {
+        match m {
+            DbFilterMode::Global => FilterMode::Global,
+            DbFilterMode::Host => FilterMode::Host,
+            DbFilterMode::Session => FilterMode::Session,
+            DbFilterMode::Directory => FilterMode::Directory,
+            DbFilterMode::Workspace => FilterMode::Workspace,
+            DbFilterMode::SessionPreload => FilterMode::SessionPreload,
+        }
+    }
+}
+
+impl From<FilterMode> for DbFilterMode {
+    fn from(m: FilterMode) -> Self {
+        match m {
+            FilterMode::Global => DbFilterMode::Global,
+            FilterMode::Host => DbFilterMode::Host,
+            FilterMode::Session => DbFilterMode::Session,
+            FilterMode::Directory => DbFilterMode::Directory,
+            FilterMode::Workspace => DbFilterMode::Workspace,
+            FilterMode::SessionPreload => DbFilterMode::SessionPreload,
+        }
+    }
+}
+
+impl Records {
+    pub fn into_history(self) -> Vec<History> {
+        self.records.into_iter().map(History::from).collect()
+    }
+
+    pub fn from_history(history: Vec<History>) -> Self {
+        Self {
+            records: history.into_iter().map(HistoryRecord::from).collect(),
+        }
+    }
+}

--- a/crates/atuin-daemon/src/lib.rs
+++ b/crates/atuin-daemon/src/lib.rs
@@ -9,6 +9,8 @@ pub mod control;
 pub mod daemon;
 pub mod database;
 pub mod proxy;
+pub mod store;
+pub mod store_proxy;
 pub mod events;
 pub mod history;
 pub mod search;
@@ -50,6 +52,9 @@ pub async fn boot(
     // the CLI can act as a pure client. It clones the pool (cheap, shared).
     let database_service =
         components::database::StorageDatabaseService::new(history_db.clone()).into_server();
+
+    // The record-store service exposes the owned record store over gRPC.
+    let store_service = components::store::StorageStoreService::new(store.clone()).into_server();
 
     // Build the daemon
     let mut daemon = Daemon::builder(settings.clone())
@@ -107,6 +112,7 @@ pub async fn boot(
         semantic_service,
         control_service.into_server(),
         database_service,
+        store_service,
         handle,
     )
     .await?;

--- a/crates/atuin-daemon/src/lib.rs
+++ b/crates/atuin-daemon/src/lib.rs
@@ -7,6 +7,8 @@ pub mod client;
 pub mod components;
 pub mod control;
 pub mod daemon;
+pub mod database;
+pub mod proxy;
 pub mod events;
 pub mod history;
 pub mod search;
@@ -43,6 +45,11 @@ pub async fn boot(
     let history_service = history_component.grpc_service();
     let search_service = search_component.grpc_service();
     let semantic_service = semantic_component.grpc_service();
+
+    // The storage-database service exposes the owned history DB over gRPC so
+    // the CLI can act as a pure client. It clones the pool (cheap, shared).
+    let database_service =
+        components::database::StorageDatabaseService::new(history_db.clone()).into_server();
 
     // Build the daemon
     let mut daemon = Daemon::builder(settings.clone())
@@ -99,6 +106,7 @@ pub async fn boot(
         search_service,
         semantic_service,
         control_service.into_server(),
+        database_service,
         handle,
     )
     .await?;

--- a/crates/atuin-daemon/src/proxy.rs
+++ b/crates/atuin-daemon/src/proxy.rs
@@ -1,0 +1,322 @@
+//! `DaemonDatabase`: a client-side `atuin_client::database::Database`
+//! implementation that forwards every call to the daemon over gRPC.
+//!
+//! This is the core of the "daemon owns all storage" architecture: the CLI
+//! constructs a `DaemonDatabase` instead of a `Sqlite`, so it never opens the
+//! local history database itself — the daemon (the sole owner) services the
+//! request against its own `Sqlite`.
+
+use atuin_client::{
+    database::{Context, Database, OptFilters, Paged},
+    history::{History, HistoryId, HistoryStats},
+    settings::{FilterMode as DbFilterMode, SearchMode as DbSearchMode, Settings},
+};
+use sqlx::Result;
+use time::OffsetDateTime;
+use tonic::transport::{Channel, Endpoint, Uri};
+use tower::service_fn;
+
+use hyper_util::rt::TokioIo;
+
+#[cfg(not(unix))]
+use tokio::net::TcpStream;
+#[cfg(unix)]
+use tokio::net::UnixStream;
+
+use crate::database::{
+    BeforeRequest, DeleteRowsRequest, FilterMode, GetDupsRequest, HistoryCountRequest, ListRequest,
+    LoadRequest, QueryHistoryRequest, RangeRequest, SaveBulkRequest, SaveRequest, SearchMode,
+    SearchRequest, storage_database_client::StorageDatabaseClient,
+};
+
+/// Map any error coming off the wire into a `sqlx::Error`, which is the error
+/// type the `Database` trait speaks. This keeps the proxy a drop-in for
+/// `Sqlite` from the callers' point of view.
+fn wire_err<E: std::error::Error + Send + Sync + 'static>(e: E) -> sqlx::Error {
+    sqlx::Error::Configuration(Box::new(e))
+}
+
+fn unsupported(what: &str) -> sqlx::Error {
+    sqlx::Error::Protocol(format!(
+        "{what} is not yet supported via the daemon database proxy"
+    ))
+}
+
+fn ts_to_nanos(ts: OffsetDateTime) -> u64 {
+    ts.unix_timestamp_nanos().max(0) as u64
+}
+
+/// A `Database` backed by a remote atuin daemon.
+#[derive(Clone)]
+pub struct DaemonDatabase {
+    client: StorageDatabaseClient<Channel>,
+}
+
+impl DaemonDatabase {
+    #[cfg(unix)]
+    pub async fn from_settings(settings: &Settings) -> eyre::Result<Self> {
+        Self::connect_unix(settings.daemon.socket_path.clone()).await
+    }
+
+    #[cfg(not(unix))]
+    pub async fn from_settings(settings: &Settings) -> eyre::Result<Self> {
+        Self::connect_tcp(settings.daemon.tcp_port).await
+    }
+
+    #[cfg(unix)]
+    async fn connect_unix(path: String) -> eyre::Result<Self> {
+        use eyre::WrapErr;
+
+        let log_path = path.clone();
+        let channel = Endpoint::try_from("http://atuin_local_daemon:0")?
+            .connect_with_connector(service_fn(move |_: Uri| {
+                let path = path.clone();
+                async move {
+                    Ok::<_, std::io::Error>(TokioIo::new(UnixStream::connect(path.clone()).await?))
+                }
+            }))
+            .await
+            .wrap_err_with(|| {
+                format!("failed to connect to local atuin daemon at {log_path}. Is it running?")
+            })?;
+
+        Ok(Self {
+            client: StorageDatabaseClient::new(channel),
+        })
+    }
+
+    #[cfg(not(unix))]
+    async fn connect_tcp(port: u64) -> eyre::Result<Self> {
+        use eyre::WrapErr;
+
+        let channel = Endpoint::try_from("http://atuin_local_daemon:0")?
+            .connect_with_connector(service_fn(move |_: Uri| {
+                let url = format!("127.0.0.1:{port}");
+                async move {
+                    Ok::<_, std::io::Error>(TokioIo::new(TcpStream::connect(url.clone()).await?))
+                }
+            }))
+            .await
+            .wrap_err_with(|| {
+                format!(
+                    "failed to connect to local atuin daemon at 127.0.0.1:{port}. Is it running?"
+                )
+            })?;
+
+        Ok(Self {
+            client: StorageDatabaseClient::new(channel),
+        })
+    }
+}
+
+#[tonic::async_trait]
+impl Database for DaemonDatabase {
+    async fn save(&self, h: &History) -> Result<()> {
+        let mut client = self.client.clone();
+        client
+            .save(SaveRequest {
+                record: Some(h.clone().into()),
+            })
+            .await
+            .map_err(wire_err)?;
+        Ok(())
+    }
+
+    async fn save_bulk(&self, h: &[History]) -> Result<()> {
+        let mut client = self.client.clone();
+        client
+            .save_bulk(SaveBulkRequest {
+                records: h.iter().cloned().map(Into::into).collect(),
+            })
+            .await
+            .map_err(wire_err)?;
+        Ok(())
+    }
+
+    async fn load(&self, id: &str) -> Result<Option<History>> {
+        let mut client = self.client.clone();
+        let reply = client
+            .load(LoadRequest { id: id.to_string() })
+            .await
+            .map_err(wire_err)?
+            .into_inner();
+        Ok(reply.record.map(Into::into))
+    }
+
+    async fn list(
+        &self,
+        filters: &[DbFilterMode],
+        context: &Context,
+        max: Option<usize>,
+        unique: bool,
+        include_deleted: bool,
+    ) -> Result<Vec<History>> {
+        let mut client = self.client.clone();
+        let reply = client
+            .list(ListRequest {
+                filters: filters.iter().map(|f| FilterMode::from(*f) as i32).collect(),
+                context: Some(context.clone().into()),
+                max: max.map(|m| m as u64),
+                unique,
+                include_deleted,
+            })
+            .await
+            .map_err(wire_err)?
+            .into_inner();
+        Ok(reply.into_history())
+    }
+
+    async fn range(&self, from: OffsetDateTime, to: OffsetDateTime) -> Result<Vec<History>> {
+        let mut client = self.client.clone();
+        let reply = client
+            .range(RangeRequest {
+                from: ts_to_nanos(from),
+                to: ts_to_nanos(to),
+            })
+            .await
+            .map_err(wire_err)?
+            .into_inner();
+        Ok(reply.into_history())
+    }
+
+    async fn update(&self, h: &History) -> Result<()> {
+        let mut client = self.client.clone();
+        client
+            .update(SaveRequest {
+                record: Some(h.clone().into()),
+            })
+            .await
+            .map_err(wire_err)?;
+        Ok(())
+    }
+
+    async fn history_count(&self, include_deleted: bool) -> Result<i64> {
+        let mut client = self.client.clone();
+        let reply = client
+            .history_count(HistoryCountRequest { include_deleted })
+            .await
+            .map_err(wire_err)?
+            .into_inner();
+        Ok(reply.count)
+    }
+
+    async fn last(&self) -> Result<Option<History>> {
+        let mut client = self.client.clone();
+        let reply = client
+            .last(crate::database::Empty {})
+            .await
+            .map_err(wire_err)?
+            .into_inner();
+        Ok(reply.record.map(Into::into))
+    }
+
+    async fn before(&self, timestamp: OffsetDateTime, count: i64) -> Result<Vec<History>> {
+        let mut client = self.client.clone();
+        let reply = client
+            .before(BeforeRequest {
+                timestamp: ts_to_nanos(timestamp),
+                count,
+            })
+            .await
+            .map_err(wire_err)?
+            .into_inner();
+        Ok(reply.into_history())
+    }
+
+    async fn delete(&self, h: History) -> Result<()> {
+        let mut client = self.client.clone();
+        client
+            .delete(SaveRequest {
+                record: Some(h.into()),
+            })
+            .await
+            .map_err(wire_err)?;
+        Ok(())
+    }
+
+    async fn delete_rows(&self, ids: &[HistoryId]) -> Result<()> {
+        let mut client = self.client.clone();
+        client
+            .delete_rows(DeleteRowsRequest {
+                ids: ids.iter().map(|id| id.0.clone()).collect(),
+            })
+            .await
+            .map_err(wire_err)?;
+        Ok(())
+    }
+
+    async fn deleted(&self) -> Result<Vec<History>> {
+        let mut client = self.client.clone();
+        let reply = client
+            .deleted(crate::database::Empty {})
+            .await
+            .map_err(wire_err)?
+            .into_inner();
+        Ok(reply.into_history())
+    }
+
+    async fn search(
+        &self,
+        search_mode: DbSearchMode,
+        filter: DbFilterMode,
+        context: &Context,
+        query: &str,
+        filter_options: OptFilters,
+    ) -> Result<Vec<History>> {
+        let mut client = self.client.clone();
+        let reply = client
+            .search(SearchRequest {
+                search_mode: SearchMode::from(search_mode) as i32,
+                filter: FilterMode::from(filter) as i32,
+                context: Some(context.clone().into()),
+                query: query.to_string(),
+                filter_options: Some(filter_options.into()),
+            })
+            .await
+            .map_err(wire_err)?
+            .into_inner();
+        Ok(reply.into_history())
+    }
+
+    async fn query_history(&self, query: &str) -> Result<Vec<History>> {
+        let mut client = self.client.clone();
+        let reply = client
+            .query_history(QueryHistoryRequest {
+                query: query.to_string(),
+            })
+            .await
+            .map_err(wire_err)?
+            .into_inner();
+        Ok(reply.into_history())
+    }
+
+    async fn all_with_count(&self) -> Result<Vec<(History, i32)>> {
+        // Only the skim search engine uses this; wire it up in the full cutover.
+        Err(unsupported("all_with_count"))
+    }
+
+    fn all_paged(&self, page_size: usize, include_deleted: bool, unique: bool) -> Paged {
+        // Paged only needs a boxed Database; it drives itself via query_history,
+        // which the proxy forwards. So this works transparently.
+        Paged::new(self.clone_boxed(), page_size, include_deleted, unique)
+    }
+
+    async fn stats(&self, _h: &History) -> Result<HistoryStats> {
+        // Only the interactive inspector uses this; wire it up in the full cutover.
+        Err(unsupported("stats"))
+    }
+
+    async fn get_dups(&self, before: i64, dupkeep: u32) -> Result<Vec<History>> {
+        let mut client = self.client.clone();
+        let reply = client
+            .get_dups(GetDupsRequest { before, dupkeep })
+            .await
+            .map_err(wire_err)?
+            .into_inner();
+        Ok(reply.into_history())
+    }
+
+    fn clone_boxed(&self) -> Box<dyn Database + 'static> {
+        Box::new(self.clone())
+    }
+}

--- a/crates/atuin-daemon/src/proxy.rs
+++ b/crates/atuin-daemon/src/proxy.rs
@@ -36,12 +36,6 @@ fn wire_err<E: std::error::Error + Send + Sync + 'static>(e: E) -> sqlx::Error {
     sqlx::Error::Configuration(Box::new(e))
 }
 
-fn unsupported(what: &str) -> sqlx::Error {
-    sqlx::Error::Protocol(format!(
-        "{what} is not yet supported via the daemon database proxy"
-    ))
-}
-
 fn ts_to_nanos(ts: OffsetDateTime) -> u64 {
     ts.unix_timestamp_nanos().max(0) as u64
 }
@@ -291,8 +285,13 @@ impl Database for DaemonDatabase {
     }
 
     async fn all_with_count(&self) -> Result<Vec<(History, i32)>> {
-        // Only the skim search engine uses this; wire it up in the full cutover.
-        Err(unsupported("all_with_count"))
+        let mut client = self.client.clone();
+        let reply = client
+            .all_with_count(crate::database::Empty {})
+            .await
+            .map_err(wire_err)?
+            .into_inner();
+        Ok(reply.into_history_with_count())
     }
 
     fn all_paged(&self, page_size: usize, include_deleted: bool, unique: bool) -> Paged {
@@ -301,9 +300,16 @@ impl Database for DaemonDatabase {
         Paged::new(self.clone_boxed(), page_size, include_deleted, unique)
     }
 
-    async fn stats(&self, _h: &History) -> Result<HistoryStats> {
-        // Only the interactive inspector uses this; wire it up in the full cutover.
-        Err(unsupported("stats"))
+    async fn stats(&self, h: &History) -> Result<HistoryStats> {
+        let mut client = self.client.clone();
+        let reply = client
+            .stats(SaveRequest {
+                record: Some(h.clone().into()),
+            })
+            .await
+            .map_err(wire_err)?
+            .into_inner();
+        Ok(reply.into())
     }
 
     async fn get_dups(&self, before: i64, dupkeep: u32) -> Result<Vec<History>> {

--- a/crates/atuin-daemon/src/server.rs
+++ b/crates/atuin-daemon/src/server.rs
@@ -1,10 +1,12 @@
 use eyre::Result;
 
+use crate::components::database::StorageDatabaseService;
 use crate::components::history::HistoryGrpcService;
 use crate::components::search::SearchGrpcService;
 use crate::components::semantic::SemanticGrpcService;
 use crate::control::{ControlService, control_server::ControlServer};
 use crate::daemon::DaemonHandle;
+use crate::database::storage_database_server::StorageDatabaseServer;
 use crate::history::history_server::HistoryServer;
 use crate::search::search_server::SearchServer;
 use crate::semantic::semantic_server::SemanticServer;
@@ -22,6 +24,7 @@ pub async fn run_grpc_server(
     search_service: SearchServer<SearchGrpcService>,
     semantic_service: SemanticServer<SemanticGrpcService>,
     control_service: ControlServer<ControlService>,
+    database_service: StorageDatabaseServer<StorageDatabaseService>,
     handle: DaemonHandle,
 ) -> Result<()> {
     use tokio::net::UnixListener;
@@ -106,6 +109,7 @@ pub async fn run_grpc_server(
             .add_service(search_service)
             .add_service(semantic_service)
             .add_service(control_service)
+            .add_service(database_service)
             .serve_with_incoming_shutdown(uds_stream, shutdown_signal)
             .await
         {
@@ -124,6 +128,7 @@ pub async fn run_grpc_server(
     search_service: SearchServer<SearchGrpcService>,
     semantic_service: SemanticServer<SemanticGrpcService>,
     control_service: ControlServer<ControlService>,
+    database_service: StorageDatabaseServer<StorageDatabaseService>,
     handle: DaemonHandle,
 ) -> Result<()> {
     use tokio::net::TcpListener;
@@ -159,6 +164,7 @@ pub async fn run_grpc_server(
             .add_service(search_service)
             .add_service(semantic_service)
             .add_service(control_service)
+            .add_service(database_service)
             .serve_with_incoming_shutdown(tcp_stream, shutdown_signal)
             .await
         {

--- a/crates/atuin-daemon/src/server.rs
+++ b/crates/atuin-daemon/src/server.rs
@@ -19,6 +19,7 @@ use atuin_client::settings::Settings;
 ///
 /// This starts the gRPC server in the background and returns immediately.
 /// The server will shut down when a ShutdownRequested event is received.
+#[allow(clippy::too_many_arguments)]
 #[cfg(unix)]
 pub async fn run_grpc_server(
     settings: Settings,
@@ -125,6 +126,7 @@ pub async fn run_grpc_server(
 }
 
 /// Run the gRPC server with the given services (Windows/TCP version).
+#[allow(clippy::too_many_arguments)]
 #[cfg(not(unix))]
 pub async fn run_grpc_server(
     settings: Settings,

--- a/crates/atuin-daemon/src/server.rs
+++ b/crates/atuin-daemon/src/server.rs
@@ -1,12 +1,14 @@
 use eyre::Result;
 
 use crate::components::database::StorageDatabaseService;
+use crate::components::store::StorageStoreService;
 use crate::components::history::HistoryGrpcService;
 use crate::components::search::SearchGrpcService;
 use crate::components::semantic::SemanticGrpcService;
 use crate::control::{ControlService, control_server::ControlServer};
 use crate::daemon::DaemonHandle;
 use crate::database::storage_database_server::StorageDatabaseServer;
+use crate::store::storage_store_server::StorageStoreServer;
 use crate::history::history_server::HistoryServer;
 use crate::search::search_server::SearchServer;
 use crate::semantic::semantic_server::SemanticServer;
@@ -25,6 +27,7 @@ pub async fn run_grpc_server(
     semantic_service: SemanticServer<SemanticGrpcService>,
     control_service: ControlServer<ControlService>,
     database_service: StorageDatabaseServer<StorageDatabaseService>,
+    store_service: StorageStoreServer<StorageStoreService>,
     handle: DaemonHandle,
 ) -> Result<()> {
     use tokio::net::UnixListener;
@@ -110,6 +113,7 @@ pub async fn run_grpc_server(
             .add_service(semantic_service)
             .add_service(control_service)
             .add_service(database_service)
+            .add_service(store_service)
             .serve_with_incoming_shutdown(uds_stream, shutdown_signal)
             .await
         {
@@ -129,6 +133,7 @@ pub async fn run_grpc_server(
     semantic_service: SemanticServer<SemanticGrpcService>,
     control_service: ControlServer<ControlService>,
     database_service: StorageDatabaseServer<StorageDatabaseService>,
+    store_service: StorageStoreServer<StorageStoreService>,
     handle: DaemonHandle,
 ) -> Result<()> {
     use tokio::net::TcpListener;
@@ -165,6 +170,7 @@ pub async fn run_grpc_server(
             .add_service(semantic_service)
             .add_service(control_service)
             .add_service(database_service)
+            .add_service(store_service)
             .serve_with_incoming_shutdown(tcp_stream, shutdown_signal)
             .await
         {

--- a/crates/atuin-daemon/src/store/mod.rs
+++ b/crates/atuin-daemon/src/store/mod.rs
@@ -1,0 +1,127 @@
+//! Store module for the daemon gRPC record-store service.
+//!
+//! Exposes the `atuin_client::record::store::Store` surface over gRPC so the
+//! CLI never opens the local record store itself. Records stay encrypted on the
+//! wire (the daemon is a blob store; crypto stays client-side).
+
+use atuin_common::record::{
+    EncryptedData as CommonEncryptedData, Host as CommonHost, HostId, Record, RecordId,
+    RecordStatus,
+};
+use uuid::Uuid;
+
+// Include the generated proto code
+tonic::include_proto!("store");
+
+fn parse_uuid(s: &str) -> Uuid {
+    Uuid::parse_str(s).unwrap_or(Uuid::nil())
+}
+
+impl From<CommonHost> for Host {
+    fn from(h: CommonHost) -> Self {
+        Self {
+            id: h.id.0.as_hyphenated().to_string(),
+            name: h.name,
+        }
+    }
+}
+
+impl From<Host> for CommonHost {
+    fn from(h: Host) -> Self {
+        Self {
+            id: HostId(parse_uuid(&h.id)),
+            name: h.name,
+        }
+    }
+}
+
+impl From<CommonEncryptedData> for EncryptedData {
+    fn from(d: CommonEncryptedData) -> Self {
+        Self {
+            data: d.data,
+            content_encryption_key: d.content_encryption_key,
+        }
+    }
+}
+
+impl From<EncryptedData> for CommonEncryptedData {
+    fn from(d: EncryptedData) -> Self {
+        Self {
+            data: d.data,
+            content_encryption_key: d.content_encryption_key,
+        }
+    }
+}
+
+impl From<Record<CommonEncryptedData>> for EncryptedRecord {
+    fn from(r: Record<CommonEncryptedData>) -> Self {
+        Self {
+            id: r.id.0.as_hyphenated().to_string(),
+            idx: r.idx,
+            host: Some(r.host.into()),
+            timestamp: r.timestamp,
+            version: r.version,
+            tag: r.tag,
+            data: Some(r.data.into()),
+        }
+    }
+}
+
+impl From<EncryptedRecord> for Record<CommonEncryptedData> {
+    fn from(r: EncryptedRecord) -> Self {
+        Self {
+            id: RecordId(parse_uuid(&r.id)),
+            idx: r.idx,
+            host: r.host.map(Into::into).unwrap_or_else(|| CommonHost {
+                id: HostId(Uuid::nil()),
+                name: String::new(),
+            }),
+            timestamp: r.timestamp,
+            version: r.version,
+            tag: r.tag,
+            data: r.data.map(Into::into).unwrap_or(CommonEncryptedData {
+                data: String::new(),
+                content_encryption_key: String::new(),
+            }),
+        }
+    }
+}
+
+impl Records {
+    pub fn into_records(self) -> Vec<Record<CommonEncryptedData>> {
+        self.records.into_iter().map(Into::into).collect()
+    }
+    pub fn from_records(records: Vec<Record<CommonEncryptedData>>) -> Self {
+        Self {
+            records: records.into_iter().map(Into::into).collect(),
+        }
+    }
+}
+
+impl From<RecordStatus> for RecordStatusReply {
+    fn from(s: RecordStatus) -> Self {
+        Self {
+            hosts: s
+                .hosts
+                .into_iter()
+                .map(|(host, tags)| HostTags {
+                    host: host.0.as_hyphenated().to_string(),
+                    tags: tags.into_iter().collect(),
+                })
+                .collect(),
+        }
+    }
+}
+
+impl From<RecordStatusReply> for RecordStatus {
+    fn from(s: RecordStatusReply) -> Self {
+        let mut status = RecordStatus::new();
+        for host in s.hosts {
+            let host_id = HostId(parse_uuid(&host.host));
+            for (tag, idx) in host.tags {
+                status.set_raw(host_id, tag, idx);
+            }
+        }
+        status
+    }
+}

--- a/crates/atuin-daemon/src/store_proxy.rs
+++ b/crates/atuin-daemon/src/store_proxy.rs
@@ -1,0 +1,261 @@
+//! `DaemonStore`: a client-side `atuin_client::record::store::Store` that
+//! forwards every call to the daemon over gRPC. Records stay encrypted on the
+//! wire; the daemon is a blob store and crypto stays client-side.
+
+use atuin_client::record::store::Store;
+use atuin_common::record::{EncryptedData, HostId, Record, RecordId, RecordStatus};
+use atuin_client::settings::Settings;
+use eyre::Result;
+use tonic::transport::{Channel, Endpoint, Uri};
+use tower::service_fn;
+
+use hyper_util::rt::TokioIo;
+
+#[cfg(not(unix))]
+use tokio::net::TcpStream;
+#[cfg(unix)]
+use tokio::net::UnixStream;
+
+use crate::store::{
+    HostTagRequest, IdxRequest, KeyRequest, NextRequest, PushBatchRequest, ReEncryptRequest,
+    RecordIdRequest, TagRequest, storage_store_client::StorageStoreClient,
+};
+
+fn hid(host: HostId) -> String {
+    host.0.as_hyphenated().to_string()
+}
+
+/// A `Store` backed by a remote atuin daemon.
+#[derive(Clone, Debug)]
+pub struct DaemonStore {
+    client: StorageStoreClient<Channel>,
+}
+
+impl DaemonStore {
+    #[cfg(unix)]
+    pub async fn from_settings(settings: &Settings) -> Result<Self> {
+        Self::connect_unix(settings.daemon.socket_path.clone()).await
+    }
+
+    #[cfg(not(unix))]
+    pub async fn from_settings(settings: &Settings) -> Result<Self> {
+        Self::connect_tcp(settings.daemon.tcp_port).await
+    }
+
+    #[cfg(unix)]
+    async fn connect_unix(path: String) -> Result<Self> {
+        use eyre::WrapErr;
+        let log_path = path.clone();
+        let channel = Endpoint::try_from("http://atuin_local_daemon:0")?
+            .connect_with_connector(service_fn(move |_: Uri| {
+                let path = path.clone();
+                async move {
+                    Ok::<_, std::io::Error>(TokioIo::new(UnixStream::connect(path.clone()).await?))
+                }
+            }))
+            .await
+            .wrap_err_with(|| {
+                format!("failed to connect to local atuin daemon at {log_path}. Is it running?")
+            })?;
+        Ok(Self {
+            client: StorageStoreClient::new(channel),
+        })
+    }
+
+    #[cfg(not(unix))]
+    async fn connect_tcp(port: u64) -> Result<Self> {
+        use eyre::WrapErr;
+        let channel = Endpoint::try_from("http://atuin_local_daemon:0")?
+            .connect_with_connector(service_fn(move |_: Uri| {
+                let url = format!("127.0.0.1:{port}");
+                async move {
+                    Ok::<_, std::io::Error>(TokioIo::new(TcpStream::connect(url.clone()).await?))
+                }
+            }))
+            .await
+            .wrap_err_with(|| {
+                format!("failed to connect to local atuin daemon at 127.0.0.1:{port}. Is it running?")
+            })?;
+        Ok(Self {
+            client: StorageStoreClient::new(channel),
+        })
+    }
+}
+
+#[tonic::async_trait]
+impl Store for DaemonStore {
+    async fn push_batch(
+        &self,
+        records: &mut (dyn Iterator<Item = &Record<EncryptedData>> + Send),
+    ) -> Result<()> {
+        let records = records.map(|r| r.clone().into()).collect();
+        let mut client = self.client.clone();
+        client.push_batch(PushBatchRequest { records }).await?;
+        Ok(())
+    }
+
+    async fn get(&self, id: RecordId) -> Result<Record<EncryptedData>> {
+        let mut client = self.client.clone();
+        let reply = client
+            .get(RecordIdRequest {
+                id: id.0.as_hyphenated().to_string(),
+            })
+            .await?
+            .into_inner();
+        Ok(reply.into())
+    }
+
+    async fn delete(&self, id: RecordId) -> Result<()> {
+        let mut client = self.client.clone();
+        client
+            .delete(RecordIdRequest {
+                id: id.0.as_hyphenated().to_string(),
+            })
+            .await?;
+        Ok(())
+    }
+
+    async fn delete_all(&self) -> Result<()> {
+        let mut client = self.client.clone();
+        client.delete_all(crate::store::Empty {}).await?;
+        Ok(())
+    }
+
+    async fn len_all(&self) -> Result<u64> {
+        let mut client = self.client.clone();
+        Ok(client.len_all(crate::store::Empty {}).await?.into_inner().count)
+    }
+
+    async fn len(&self, host: HostId, tag: &str) -> Result<u64> {
+        let mut client = self.client.clone();
+        Ok(client
+            .len(HostTagRequest {
+                host: hid(host),
+                tag: tag.to_string(),
+            })
+            .await?
+            .into_inner()
+            .count)
+    }
+
+    async fn len_tag(&self, tag: &str) -> Result<u64> {
+        let mut client = self.client.clone();
+        Ok(client
+            .len_tag(TagRequest {
+                tag: tag.to_string(),
+            })
+            .await?
+            .into_inner()
+            .count)
+    }
+
+    async fn last(&self, host: HostId, tag: &str) -> Result<Option<Record<EncryptedData>>> {
+        let mut client = self.client.clone();
+        let reply = client
+            .last(HostTagRequest {
+                host: hid(host),
+                tag: tag.to_string(),
+            })
+            .await?
+            .into_inner();
+        Ok(reply.record.map(Into::into))
+    }
+
+    async fn first(&self, host: HostId, tag: &str) -> Result<Option<Record<EncryptedData>>> {
+        let mut client = self.client.clone();
+        let reply = client
+            .first(HostTagRequest {
+                host: hid(host),
+                tag: tag.to_string(),
+            })
+            .await?
+            .into_inner();
+        Ok(reply.record.map(Into::into))
+    }
+
+    async fn re_encrypt(&self, old_key: &[u8; 32], new_key: &[u8; 32]) -> Result<()> {
+        let mut client = self.client.clone();
+        client
+            .re_encrypt(ReEncryptRequest {
+                old_key: old_key.to_vec(),
+                new_key: new_key.to_vec(),
+            })
+            .await?;
+        Ok(())
+    }
+
+    async fn verify(&self, key: &[u8; 32]) -> Result<()> {
+        let mut client = self.client.clone();
+        client
+            .verify(KeyRequest {
+                key: key.to_vec(),
+            })
+            .await?;
+        Ok(())
+    }
+
+    async fn purge(&self, key: &[u8; 32]) -> Result<()> {
+        let mut client = self.client.clone();
+        client
+            .purge(KeyRequest {
+                key: key.to_vec(),
+            })
+            .await?;
+        Ok(())
+    }
+
+    async fn next(
+        &self,
+        host: HostId,
+        tag: &str,
+        idx: atuin_common::record::RecordIdx,
+        limit: u64,
+    ) -> Result<Vec<Record<EncryptedData>>> {
+        let mut client = self.client.clone();
+        let reply = client
+            .next(NextRequest {
+                host: hid(host),
+                tag: tag.to_string(),
+                idx,
+                limit,
+            })
+            .await?
+            .into_inner();
+        Ok(reply.into_records())
+    }
+
+    async fn idx(
+        &self,
+        host: HostId,
+        tag: &str,
+        idx: atuin_common::record::RecordIdx,
+    ) -> Result<Option<Record<EncryptedData>>> {
+        let mut client = self.client.clone();
+        let reply = client
+            .idx(IdxRequest {
+                host: hid(host),
+                tag: tag.to_string(),
+                idx,
+            })
+            .await?
+            .into_inner();
+        Ok(reply.record.map(Into::into))
+    }
+
+    async fn status(&self) -> Result<RecordStatus> {
+        let mut client = self.client.clone();
+        let reply = client.status(crate::store::Empty {}).await?.into_inner();
+        Ok(reply.into())
+    }
+
+    async fn all_tagged(&self, tag: &str) -> Result<Vec<Record<EncryptedData>>> {
+        let mut client = self.client.clone();
+        let reply = client
+            .all_tagged(TagRequest {
+                tag: tag.to_string(),
+            })
+            .await?
+            .into_inner();
+        Ok(reply.into_records())
+    }
+}

--- a/crates/atuin-dotfiles/src/store.rs
+++ b/crates/atuin-dotfiles/src/store.rs
@@ -1,6 +1,6 @@
 use std::collections::BTreeMap;
+use std::sync::Arc;
 
-use atuin_client::record::sqlite_store::SqliteStore;
 // Sync aliases
 // This will be noticeable similar to the kv store, though I expect the two shall diverge
 // While we will support a range of shell config, I'd rather have a larger number of small records
@@ -10,7 +10,7 @@ use atuin_common::utils::unquote;
 use eyre::{Result, bail, ensure, eyre};
 
 use atuin_client::record::encryption::PASETO_V4;
-use atuin_client::record::store::Store;
+use atuin_client::record::store::{ArcStore, Store};
 
 use crate::shell::Alias;
 
@@ -125,16 +125,16 @@ impl AliasRecord {
 
 #[derive(Debug, Clone)]
 pub struct AliasStore {
-    pub store: SqliteStore,
+    pub store: ArcStore,
     pub host_id: HostId,
     pub encryption_key: [u8; 32],
 }
 
 impl AliasStore {
     // will want to init the actual kv store when that is done
-    pub fn new(store: SqliteStore, host_id: HostId, encryption_key: [u8; 32]) -> AliasStore {
+    pub fn new(store: impl Store + 'static, host_id: HostId, encryption_key: [u8; 32]) -> AliasStore {
         AliasStore {
-            store,
+            store: Arc::new(store),
             host_id,
             encryption_key,
         }

--- a/crates/atuin-dotfiles/src/store/var.rs
+++ b/crates/atuin-dotfiles/src/store/var.rs
@@ -3,13 +3,13 @@
 /// This is easier for now
 /// Once I have two implementations, building a common base is much easier.
 use std::collections::BTreeMap;
+use std::sync::Arc;
 
-use atuin_client::record::sqlite_store::SqliteStore;
 use atuin_common::record::{DecryptedData, Host, HostId};
 use eyre::{Result, bail, ensure, eyre};
 
 use atuin_client::record::encryption::PASETO_V4;
-use atuin_client::record::store::Store;
+use atuin_client::record::store::{ArcStore, Store};
 
 use crate::shell::Var;
 
@@ -100,16 +100,16 @@ impl VarRecord {
 
 #[derive(Debug, Clone)]
 pub struct VarStore {
-    pub store: SqliteStore,
+    pub store: ArcStore,
     pub host_id: HostId,
     pub encryption_key: [u8; 32],
 }
 
 impl VarStore {
     // will want to init the actual kv store when that is done
-    pub fn new(store: SqliteStore, host_id: HostId, encryption_key: [u8; 32]) -> VarStore {
+    pub fn new(store: impl Store + 'static, host_id: HostId, encryption_key: [u8; 32]) -> VarStore {
         VarStore {
-            store,
+            store: Arc::new(store),
             host_id,
             encryption_key,
         }

--- a/crates/atuin-kv/src/store.rs
+++ b/crates/atuin-kv/src/store.rs
@@ -2,8 +2,12 @@ use std::collections::HashSet;
 
 use eyre::{Result, eyre};
 
-use atuin_client::record::sqlite_store::SqliteStore;
-use atuin_client::record::{encryption::PASETO_V4, store::Store};
+use std::sync::Arc;
+
+use atuin_client::record::{
+    encryption::PASETO_V4,
+    store::{ArcStore, Store},
+};
 use atuin_common::record::{Host, HostId, Record, RecordId, RecordIdx};
 use entry::KvEntry;
 use record::{KV_TAG, KV_VERSION, KvRecord};
@@ -15,7 +19,7 @@ pub mod record;
 
 #[derive(Debug, Clone)]
 pub struct KvStore {
-    pub record_store: SqliteStore,
+    pub record_store: ArcStore,
     pub kv_db: Database,
     pub host_id: HostId,
     pub encryption_key: [u8; 32],
@@ -23,13 +27,13 @@ pub struct KvStore {
 
 impl KvStore {
     pub fn new(
-        record_store: SqliteStore,
+        record_store: impl Store + 'static,
         kv_db: Database,
         host_id: HostId,
         encryption_key: [u8; 32],
     ) -> Self {
         KvStore {
-            record_store,
+            record_store: Arc::new(record_store),
             kv_db,
             host_id,
             encryption_key,

--- a/crates/atuin-kv/src/store.rs
+++ b/crates/atuin-kv/src/store.rs
@@ -190,6 +190,7 @@ impl KvStore {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use atuin_client::record::sqlite_store::SqliteStore;
 
     async fn setup() -> Result<KvStore> {
         let record_store = SqliteStore::new("sqlite::memory:", 1.0).await.unwrap();

--- a/crates/atuin-scripts/src/store.rs
+++ b/crates/atuin-scripts/src/store.rs
@@ -1,7 +1,11 @@
 use eyre::{Result, eyre};
 
-use atuin_client::record::sqlite_store::SqliteStore;
-use atuin_client::record::{encryption::PASETO_V4, store::Store};
+use std::sync::Arc;
+
+use atuin_client::record::{
+    encryption::PASETO_V4,
+    store::{ArcStore, Store},
+};
 use atuin_common::record::{Host, HostId, Record, RecordId, RecordIdx};
 use record::ScriptRecord;
 use script::{SCRIPT_TAG, SCRIPT_VERSION, Script};
@@ -13,15 +17,15 @@ pub mod script;
 
 #[derive(Debug, Clone)]
 pub struct ScriptStore {
-    pub store: SqliteStore,
+    pub store: ArcStore,
     pub host_id: HostId,
     pub encryption_key: [u8; 32],
 }
 
 impl ScriptStore {
-    pub fn new(store: SqliteStore, host_id: HostId, encryption_key: [u8; 32]) -> Self {
+    pub fn new(store: impl Store + 'static, host_id: HostId, encryption_key: [u8; 32]) -> Self {
         ScriptStore {
-            store,
+            store: Arc::new(store),
             host_id,
             encryption_key,
         }

--- a/crates/atuin/Cargo.toml
+++ b/crates/atuin/Cargo.toml
@@ -33,10 +33,9 @@ buildflags = ["--release"]
 atuin = { path = "/usr/bin/atuin" }
 
 [features]
-default = ["client", "sync", "clipboard", "check-update", "daemon", "ai", "pty-proxy"]
+default = ["client", "sync", "clipboard", "check-update", "ai", "pty-proxy"]
 client = ["atuin-client"]
 sync = ["atuin-client/sync"]
-daemon = ["atuin-client/daemon", "atuin-daemon", "atuin-ai?/daemon"]
 ai = ["atuin-ai"]
 pty-proxy = ["dep:atuin-pty-proxy"]
 hex = ["pty-proxy"]
@@ -49,7 +48,7 @@ atuin-client = { path = "../atuin-client", version = "18.17.1", optional = true,
 atuin-common = { workspace = true }
 atuin-dotfiles = { workspace = true }
 atuin-history = { workspace = true }
-atuin-daemon = { path = "../atuin-daemon", version = "18.17.1", optional = true, default-features = false }
+atuin-daemon = { path = "../atuin-daemon", version = "18.17.1", default-features = false }
 atuin-pty-proxy = { path = "../atuin-pty-proxy", version = "18.17.1", optional = true, default-features = false }
 atuin-scripts = { workspace = true }
 atuin-kv = { workspace = true }

--- a/crates/atuin/src/command/client.rs
+++ b/crates/atuin/src/command/client.rs
@@ -5,7 +5,7 @@ use clap::Subcommand;
 use eyre::{Result, WrapErr};
 
 use atuin_client::{
-    database::Sqlite, record::sqlite_store::SqliteStore, settings::Settings, theme,
+    database::Database, record::sqlite_store::SqliteStore, settings::Settings, theme,
 };
 use tracing_appender::rolling::{RollingFileAppender, Rotation};
 use tracing_subscriber::{
@@ -353,10 +353,8 @@ impl Cmd {
             _ => {}
         }
 
-        let db_path = PathBuf::from(settings.db_path.as_str());
         let record_store_path = PathBuf::from(settings.record_store_path.as_str());
 
-        let db = Sqlite::new(db_path, settings.local_timeout).await?;
         let sqlite_store = SqliteStore::new(record_store_path, settings.local_timeout).await?;
 
         let theme_name = settings.theme.name.clone();
@@ -364,23 +362,41 @@ impl Cmd {
 
         match self {
             Self::Setup => setup::run(&settings).await,
-            Self::Import(import) => import.run(&db).await,
-            Self::Stats(stats) => stats.run(&db, &settings, theme).await,
-            Self::Search(search) => search.run(db, &mut settings, sqlite_store, theme).await,
+            Self::Import(import) => {
+                let db = history_database(&settings).await?;
+                import.run(&db).await
+            }
+            Self::Stats(stats) => {
+                let db = history_database(&settings).await?;
+                stats.run(&db, &settings, theme).await
+            }
+            Self::Search(search) => {
+                let db = history_database(&settings).await?;
+                search.run(db, &mut settings, sqlite_store, theme).await
+            }
 
             #[cfg(feature = "sync")]
-            Self::Sync(sync) => sync.run(settings, &db, sqlite_store).await,
+            Self::Sync(sync) => {
+                let db = history_database(&settings).await?;
+                sync.run(settings, &db, sqlite_store).await
+            }
 
             #[cfg(feature = "sync")]
             Self::Account(account) => account.run(settings, sqlite_store).await,
 
             Self::Kv(kv) => kv.run(&settings, &sqlite_store).await,
 
-            Self::Store(store) => store.run(&settings, &db, sqlite_store).await,
+            Self::Store(store) => {
+                let db = history_database(&settings).await?;
+                store.run(&settings, &*db, sqlite_store).await
+            }
 
             Self::Dotfiles(dotfiles) => dotfiles.run(&settings, sqlite_store).await,
 
-            Self::Scripts(scripts) => scripts.run(&settings, sqlite_store, &db).await,
+            Self::Scripts(scripts) => {
+                let db = history_database(&settings).await?;
+                scripts.run(&settings, sqlite_store, &db).await
+            }
 
             Self::Info => {
                 info::run(&settings);
@@ -392,10 +408,13 @@ impl Cmd {
                 Ok(())
             }
 
-            Self::Wrapped { year } => wrapped::run(year, &db, &settings, sqlite_store, theme).await,
+            Self::Wrapped { year } => {
+                let db = history_database(&settings).await?;
+                wrapped::run(year, &db, &settings, sqlite_store, theme).await
+            }
 
             #[cfg(feature = "daemon")]
-            Self::Daemon(cmd) => cmd.run(settings, sqlite_store, db).await,
+            Self::Daemon(cmd) => cmd.run(settings).await,
 
             Self::History(_) | Self::Hook(_) | Self::Init(_) | Self::Doctor | Self::Config(_) => {
                 unreachable!()
@@ -405,7 +424,32 @@ impl Cmd {
             Self::Ai(cli) => atuin_ai::commands::run(cli, &settings).await,
 
             #[cfg(feature = "ai")]
-            Self::Mcp => atuin_ai::mcp::run(&db).await,
+            Self::Mcp => {
+                let db = history_database(&settings).await?;
+                atuin_ai::mcp::run(&*db).await
+            }
         }
     }
+}
+
+/// Obtain a handle to the history database.
+///
+/// With the `daemon` feature (the shipped default) the daemon is the sole
+/// owner of on-disk storage: ensure it is running and return a gRPC-backed
+/// proxy that implements `Database`. Without the feature (a minimal build with
+/// no daemon) open the local `SQLite` database directly.
+#[cfg(feature = "daemon")]
+async fn history_database(settings: &Settings) -> Result<Box<dyn Database>> {
+    daemon::ensure_daemon_running(settings).await?;
+    Ok(Box::new(
+        atuin_daemon::proxy::DaemonDatabase::from_settings(settings).await?,
+    ))
+}
+
+#[cfg(not(feature = "daemon"))]
+async fn history_database(settings: &Settings) -> Result<Box<dyn Database>> {
+    let db_path = PathBuf::from(settings.db_path.as_str());
+    Ok(Box::new(
+        atuin_client::database::Sqlite::new(db_path, settings.local_timeout).await?,
+    ))
 }

--- a/crates/atuin/src/command/client.rs
+++ b/crates/atuin/src/command/client.rs
@@ -4,9 +4,9 @@ use std::path::{Path, PathBuf};
 use clap::Subcommand;
 use eyre::{Result, WrapErr};
 
-use atuin_client::{
-    database::Database, record::sqlite_store::SqliteStore, settings::Settings, theme,
-};
+use atuin_client::{database::Database, settings::Settings, theme};
+#[cfg(not(feature = "daemon"))]
+use atuin_client::record::sqlite_store::SqliteStore;
 use tracing_appender::rolling::{RollingFileAppender, Rotation};
 use tracing_subscriber::{
     Layer, filter::EnvFilter, filter::LevelFilter, fmt, fmt::format::FmtSpan, prelude::*,
@@ -353,10 +353,6 @@ impl Cmd {
             _ => {}
         }
 
-        let record_store_path = PathBuf::from(settings.record_store_path.as_str());
-
-        let sqlite_store = SqliteStore::new(record_store_path, settings.local_timeout).await?;
-
         let theme_name = settings.theme.name.clone();
         let theme = theme_manager.load_theme(theme_name.as_str(), settings.theme.max_depth);
 
@@ -372,30 +368,43 @@ impl Cmd {
             }
             Self::Search(search) => {
                 let db = history_database(&settings).await?;
-                search.run(db, &mut settings, sqlite_store, theme).await
+                let store = record_store(&settings).await?;
+                search.run(db, &mut settings, store, theme).await
             }
 
             #[cfg(feature = "sync")]
             Self::Sync(sync) => {
                 let db = history_database(&settings).await?;
-                sync.run(settings, &db, sqlite_store).await
+                let store = record_store(&settings).await?;
+                sync.run(settings, &db, store).await
             }
 
             #[cfg(feature = "sync")]
-            Self::Account(account) => account.run(settings, sqlite_store).await,
-
-            Self::Kv(kv) => kv.run(&settings, &sqlite_store).await,
-
-            Self::Store(store) => {
-                let db = history_database(&settings).await?;
-                store.run(&settings, &*db, sqlite_store).await
+            Self::Account(account) => {
+                let store = record_store(&settings).await?;
+                account.run(settings, store).await
             }
 
-            Self::Dotfiles(dotfiles) => dotfiles.run(&settings, sqlite_store).await,
+            Self::Kv(kv) => {
+                let store = record_store(&settings).await?;
+                kv.run(&settings, &store).await
+            }
+
+            Self::Store(store_cmd) => {
+                let db = history_database(&settings).await?;
+                let store = record_store(&settings).await?;
+                store_cmd.run(&settings, &*db, store).await
+            }
+
+            Self::Dotfiles(dotfiles) => {
+                let store = record_store(&settings).await?;
+                dotfiles.run(&settings, store).await
+            }
 
             Self::Scripts(scripts) => {
                 let db = history_database(&settings).await?;
-                scripts.run(&settings, sqlite_store, &db).await
+                let store = record_store(&settings).await?;
+                scripts.run(&settings, store, &db).await
             }
 
             Self::Info => {
@@ -410,7 +419,8 @@ impl Cmd {
 
             Self::Wrapped { year } => {
                 let db = history_database(&settings).await?;
-                wrapped::run(year, &db, &settings, sqlite_store, theme).await
+                let store = record_store(&settings).await?;
+                wrapped::run(year, &db, &settings, store, theme).await
             }
 
             #[cfg(feature = "daemon")]
@@ -456,5 +466,24 @@ async fn history_database(settings: &Settings) -> Result<Box<dyn Database>> {
     let db_path = PathBuf::from(settings.db_path.as_str());
     Ok(Box::new(
         atuin_client::database::Sqlite::new(db_path, settings.local_timeout).await?,
+    ))
+}
+
+/// Obtain a handle to the record store, mirroring [`history_database`]: with the
+/// `daemon` feature it is a gRPC-backed `DaemonStore` (the daemon is the sole
+/// owner of the record store); without it, the local `SqliteStore`.
+#[cfg(feature = "daemon")]
+async fn record_store(settings: &Settings) -> Result<atuin_client::record::store::ArcStore> {
+    daemon::ensure_daemon_running(settings).await?;
+    Ok(std::sync::Arc::new(
+        atuin_daemon::store_proxy::DaemonStore::from_settings(settings).await?,
+    ))
+}
+
+#[cfg(not(feature = "daemon"))]
+async fn record_store(settings: &Settings) -> Result<atuin_client::record::store::ArcStore> {
+    let record_store_path = PathBuf::from(settings.record_store_path.as_str());
+    Ok(std::sync::Arc::new(
+        SqliteStore::new(record_store_path, settings.local_timeout).await?,
     ))
 }

--- a/crates/atuin/src/command/client.rs
+++ b/crates/atuin/src/command/client.rs
@@ -5,8 +5,6 @@ use clap::Subcommand;
 use eyre::{Result, WrapErr};
 
 use atuin_client::{database::Database, settings::Settings, theme};
-#[cfg(not(feature = "daemon"))]
-use atuin_client::record::sqlite_store::SqliteStore;
 use tracing_appender::rolling::{RollingFileAppender, Rotation};
 use tracing_subscriber::{
     Layer, filter::EnvFilter, filter::LevelFilter, fmt, fmt::format::FmtSpan, prelude::*,
@@ -46,7 +44,6 @@ mod sync;
 #[cfg(feature = "sync")]
 mod account;
 
-#[cfg(feature = "daemon")]
 mod daemon;
 
 mod config;
@@ -130,7 +127,6 @@ pub enum Cmd {
     Wrapped { year: Option<i32> },
 
     /// *Experimental* Manage the background daemon
-    #[cfg(feature = "daemon")]
     #[command()]
     Daemon(daemon::Cmd),
 
@@ -156,7 +152,7 @@ impl Cmd {
     pub fn run(self) -> Result<()> {
         // Daemonize before creating the async runtime – fork() inside a live
         // tokio runtime corrupts its internal state.
-        #[cfg(all(unix, feature = "daemon"))]
+        #[cfg(unix)]
         if let Self::Daemon(ref cmd) = self
             && cmd.should_daemonize()
         {
@@ -205,18 +201,10 @@ impl Cmd {
         let use_search_logging = is_interactive_search && settings.logs.search_enabled();
 
         // Use file-based logging for daemon
-        #[cfg(feature = "daemon")]
         let use_daemon_logging = matches!(&self, Self::Daemon(_)) && settings.logs.daemon_enabled();
 
-        #[cfg(not(feature = "daemon"))]
-        let use_daemon_logging = false;
-
         // Check if daemon should also log to console
-        #[cfg(feature = "daemon")]
         let daemon_show_logs = matches!(&self, Self::Daemon(cmd) if cmd.show_logs());
-
-        #[cfg(not(feature = "daemon"))]
-        let daemon_show_logs = false;
 
         // Set up span timing JSON logs if ATUIN_SPAN is set
         let span_path = std::env::var("ATUIN_SPAN").ok().map(|p| {
@@ -423,7 +411,6 @@ impl Cmd {
                 wrapped::run(year, &db, &settings, store, theme).await
             }
 
-            #[cfg(feature = "daemon")]
             Self::Daemon(cmd) => cmd.run(settings).await,
 
             Self::History(_) | Self::Hook(_) | Self::Init(_) | Self::Doctor | Self::Config(_) => {
@@ -433,7 +420,6 @@ impl Cmd {
             #[cfg(feature = "ai")]
             Self::Ai(cli) => {
                 // The AI TUI reaches history through the daemon; ensure it is up.
-                #[cfg(feature = "daemon")]
                 daemon::ensure_daemon_running(&settings).await?;
                 atuin_ai::commands::run(cli, &settings).await
             }
@@ -453,7 +439,6 @@ impl Cmd {
 /// owner of on-disk storage: ensure it is running and return a gRPC-backed
 /// proxy that implements `Database`. Without the feature (a minimal build with
 /// no daemon) open the local `SQLite` database directly.
-#[cfg(feature = "daemon")]
 async fn history_database(settings: &Settings) -> Result<Box<dyn Database>> {
     daemon::ensure_daemon_running(settings).await?;
     Ok(Box::new(
@@ -461,29 +446,11 @@ async fn history_database(settings: &Settings) -> Result<Box<dyn Database>> {
     ))
 }
 
-#[cfg(not(feature = "daemon"))]
-async fn history_database(settings: &Settings) -> Result<Box<dyn Database>> {
-    let db_path = PathBuf::from(settings.db_path.as_str());
-    Ok(Box::new(
-        atuin_client::database::Sqlite::new(db_path, settings.local_timeout).await?,
-    ))
-}
-
-/// Obtain a handle to the record store, mirroring [`history_database`]: with the
-/// `daemon` feature it is a gRPC-backed `DaemonStore` (the daemon is the sole
-/// owner of the record store); without it, the local `SqliteStore`.
-#[cfg(feature = "daemon")]
+/// Obtain a handle to the record store, mirroring [`history_database`]: a
+/// gRPC-backed `DaemonStore` (the daemon is the sole owner of the record store).
 async fn record_store(settings: &Settings) -> Result<atuin_client::record::store::ArcStore> {
     daemon::ensure_daemon_running(settings).await?;
     Ok(std::sync::Arc::new(
         atuin_daemon::store_proxy::DaemonStore::from_settings(settings).await?,
-    ))
-}
-
-#[cfg(not(feature = "daemon"))]
-async fn record_store(settings: &Settings) -> Result<atuin_client::record::store::ArcStore> {
-    let record_store_path = PathBuf::from(settings.record_store_path.as_str());
-    Ok(std::sync::Arc::new(
-        SqliteStore::new(record_store_path, settings.local_timeout).await?,
     ))
 }

--- a/crates/atuin/src/command/client.rs
+++ b/crates/atuin/src/command/client.rs
@@ -421,7 +421,12 @@ impl Cmd {
             }
 
             #[cfg(feature = "ai")]
-            Self::Ai(cli) => atuin_ai::commands::run(cli, &settings).await,
+            Self::Ai(cli) => {
+                // The AI TUI reaches history through the daemon; ensure it is up.
+                #[cfg(feature = "daemon")]
+                daemon::ensure_daemon_running(&settings).await?;
+                atuin_ai::commands::run(cli, &settings).await
+            }
 
             #[cfg(feature = "ai")]
             Self::Mcp => {

--- a/crates/atuin/src/command/client/account.rs
+++ b/crates/atuin/src/command/client/account.rs
@@ -1,7 +1,7 @@
 use clap::{Args, Subcommand};
 use eyre::Result;
 
-use atuin_client::record::sqlite_store::SqliteStore;
+use atuin_client::record::store::ArcStore;
 use atuin_client::settings::Settings;
 
 pub mod change_password;
@@ -39,7 +39,7 @@ pub enum Commands {
 }
 
 impl Cmd {
-    pub async fn run(self, settings: Settings, store: SqliteStore) -> Result<()> {
+    pub async fn run(self, settings: Settings, store: ArcStore) -> Result<()> {
         match self.command {
             Commands::Login(l) => l.run(&settings, &store).await,
             Commands::Register(r) => r.run(&settings, &store).await,

--- a/crates/atuin/src/command/client/account/login.rs
+++ b/crates/atuin/src/command/client/account/login.rs
@@ -7,7 +7,7 @@ use tokio::{fs::File, io::AsyncWriteExt};
 use atuin_client::{
     auth::{self, AuthResponse},
     encryption::{Key, decode_key, encode_key, load_key},
-    record::sqlite_store::SqliteStore,
+    record::store::ArcStore,
     record::store::Store,
     record::sync::{self, SyncError},
     settings::{Settings, SyncAuth},
@@ -41,7 +41,7 @@ fn get_input() -> Result<String> {
 }
 
 impl Cmd {
-    pub async fn run(&self, settings: &Settings, store: &SqliteStore) -> Result<()> {
+    pub async fn run(&self, settings: &Settings, store: &ArcStore) -> Result<()> {
         match settings.resolve_sync_auth().await {
             SyncAuth::Hub { .. } => {
                 println!("You are authenticated with Atuin Hub.");
@@ -72,7 +72,7 @@ impl Cmd {
     }
 
     /// Hub login: use the browser flow unless the username was provided for headless use.
-    async fn run_hub_login(&self, settings: &Settings, store: &SqliteStore) -> Result<()> {
+    async fn run_hub_login(&self, settings: &Settings, store: &ArcStore) -> Result<()> {
         let endpoint = settings.active_hub_endpoint().unwrap_or_default();
 
         if let Some(username) = &self.username {
@@ -134,7 +134,7 @@ impl Cmd {
 
     /// Legacy login: always prompt for username/password interactively
     /// (or accept them via flags).
-    async fn run_legacy_login(&self, settings: &Settings, store: &SqliteStore) -> Result<()> {
+    async fn run_legacy_login(&self, settings: &Settings, store: &ArcStore) -> Result<()> {
         let username = or_user_input(self.username.clone(), "username");
         let password = self.password.clone().unwrap_or_else(read_user_password);
 
@@ -178,7 +178,7 @@ impl Cmd {
         Ok(())
     }
 
-    async fn prompt_and_store_key(&self, settings: &Settings, store: &SqliteStore) -> Result<()> {
+    async fn prompt_and_store_key(&self, settings: &Settings, store: &ArcStore) -> Result<()> {
         let key_path = settings.key_path.as_str();
         let key_path = PathBuf::from(key_path);
 

--- a/crates/atuin/src/command/client/account/register.rs
+++ b/crates/atuin/src/command/client/account/register.rs
@@ -4,7 +4,7 @@ use eyre::{Result, bail};
 use super::login::or_user_input;
 use atuin_client::{
     auth::{self, AuthResponse},
-    record::sqlite_store::SqliteStore,
+    record::store::ArcStore,
     settings::{Settings, SyncAuth},
 };
 
@@ -22,7 +22,7 @@ pub struct Cmd {
 
 impl Cmd {
     #[allow(clippy::too_many_lines)]
-    pub async fn run(&self, settings: &Settings, store: &SqliteStore) -> Result<()> {
+    pub async fn run(&self, settings: &Settings, store: &ArcStore) -> Result<()> {
         match settings.resolve_sync_auth().await {
             SyncAuth::Hub { .. } => {
                 println!("You are already authenticated with Atuin Hub.");

--- a/crates/atuin/src/command/client/daemon.rs
+++ b/crates/atuin/src/command/client/daemon.rs
@@ -80,23 +80,36 @@ impl Cmd {
         }
     }
 
-    pub async fn run(
-        self,
-        settings: Settings,
-        store: SqliteStore,
-        history_db: Sqlite,
-    ) -> Result<()> {
+    pub async fn run(self, settings: Settings) -> Result<()> {
         match self.subcmd {
             None => {
                 eprintln!("Warning: `atuin daemon` is deprecated, use `atuin daemon start`");
+                let (store, history_db) = open_local_storage(&settings).await?;
                 run(settings, store, history_db, false).await
             }
-            Some(SubCmd::Start { force, .. }) => run(settings, store, history_db, force).await,
+            Some(SubCmd::Start { force, .. }) => {
+                let (store, history_db) = open_local_storage(&settings).await?;
+                run(settings, store, history_db, force).await
+            }
             Some(SubCmd::Status) => status_cmd(&settings).await,
             Some(SubCmd::Stop) => stop_cmd(&settings).await,
             Some(SubCmd::Restart) => restart_cmd(&settings).await,
         }
     }
+}
+
+/// Open the local history DB and record store that the daemon owns.
+///
+/// The daemon is the sole process that touches these files directly; every
+/// other command reaches them through the daemon over gRPC.
+async fn open_local_storage(settings: &Settings) -> Result<(SqliteStore, Sqlite)> {
+    let db_path = PathBuf::from(settings.db_path.as_str());
+    let record_store_path = PathBuf::from(settings.record_store_path.as_str());
+
+    let history_db = Sqlite::new(db_path, settings.local_timeout).await?;
+    let store = SqliteStore::new(record_store_path, settings.local_timeout).await?;
+
+    Ok((store, history_db))
 }
 
 const DAEMON_VERSION: &str = env!("CARGO_PKG_VERSION");
@@ -412,6 +425,16 @@ struct TryWithRestartOptions {
     pub retry_on_version_mismatch: bool,
 }
 
+/// Whether the client may spawn/restart the daemon itself.
+///
+/// The client is daemon-only: the daemon is the sole owner of storage, so we
+/// always manage its lifecycle — the historical `daemon.autostart` opt-in no
+/// longer gates this. The one exception is systemd socket-activation, where the
+/// daemon's lifecycle is owned by systemd and we must not spawn it ourselves.
+fn autostart_enabled(settings: &Settings) -> bool {
+    !settings.daemon.systemd_socket
+}
+
 /// Try to send a request to the daemon, restarting it and retrying if necessary.
 ///
 /// `context` will be passed to the closure. Compared to capturing the needed context in the
@@ -434,9 +457,9 @@ where
                 return Ok(resp);
             }
 
-            if !settings.daemon.autostart {
+            if !autostart_enabled(settings) {
                 return Err(eyre!(
-                    "{}. Enable `daemon.autostart = true` or restart the daemon manually",
+                    "{}. Restart the daemon manually (its lifecycle is managed by systemd)",
                     daemon_mismatch_message(resp.version(), resp.protocol())
                 ));
             }
@@ -448,7 +471,7 @@ where
                 return Ok(resp);
             }
         }
-        Err(err) if !settings.daemon.autostart => return Err(err),
+        Err(err) if !autostart_enabled(settings) => return Err(err),
         Err(err) if !should_retry_after_error(&err) => return Err(err),
         Err(_) => {}
     }

--- a/crates/atuin/src/command/client/doctor.rs
+++ b/crates/atuin/src/command/client/doctor.rs
@@ -371,7 +371,7 @@ impl AtuinInfo {
             sync,
             sqlite_version,
             setting_paths: SettingPaths::new(settings),
-            daemon_enabled: cfg!(feature = "daemon") && settings.daemon.enabled,
+            daemon_enabled: settings.daemon.enabled,
         }
     }
 }

--- a/crates/atuin/src/command/client/dotfiles.rs
+++ b/crates/atuin/src/command/client/dotfiles.rs
@@ -1,7 +1,7 @@
 use clap::Subcommand;
 use eyre::Result;
 
-use atuin_client::{record::sqlite_store::SqliteStore, settings::Settings};
+use atuin_client::{record::store::ArcStore, settings::Settings};
 
 mod alias;
 mod var;
@@ -19,7 +19,7 @@ pub enum Cmd {
 }
 
 impl Cmd {
-    pub async fn run(self, settings: &Settings, store: SqliteStore) -> Result<()> {
+    pub async fn run(self, settings: &Settings, store: ArcStore) -> Result<()> {
         match self {
             Self::Alias(cmd) => cmd.run(settings, store).await,
             Self::Var(cmd) => cmd.run(settings, store).await,

--- a/crates/atuin/src/command/client/dotfiles/alias.rs
+++ b/crates/atuin/src/command/client/dotfiles/alias.rs
@@ -1,7 +1,7 @@
 use clap::{Subcommand, ValueEnum};
 use eyre::{Context, Result, eyre};
 
-use atuin_client::{encryption, record::sqlite_store::SqliteStore, settings::Settings};
+use atuin_client::{encryption, record::store::ArcStore, settings::Settings};
 
 use atuin_dotfiles::{shell::Alias, store::AliasStore};
 
@@ -147,7 +147,7 @@ impl Cmd {
     }
     */
 
-    pub async fn run(&self, settings: &Settings, store: SqliteStore) -> Result<()> {
+    pub async fn run(&self, settings: &Settings, store: ArcStore) -> Result<()> {
         if !settings.dotfiles.enabled {
             eprintln!(
                 "Dotfiles are not enabled. Add\n\n[dotfiles]\nenabled = true\n\nto your configuration file to enable them.\n"

--- a/crates/atuin/src/command/client/dotfiles/var.rs
+++ b/crates/atuin/src/command/client/dotfiles/var.rs
@@ -1,7 +1,7 @@
 use clap::{Subcommand, ValueEnum};
 use eyre::{Context, Result};
 
-use atuin_client::{encryption, record::sqlite_store::SqliteStore, settings::Settings};
+use atuin_client::{encryption, record::store::ArcStore, settings::Settings};
 
 use atuin_dotfiles::{shell::Var, store::var::VarStore};
 
@@ -147,7 +147,7 @@ impl Cmd {
         Ok(())
     }
 
-    pub async fn run(&self, settings: &Settings, store: SqliteStore) -> Result<()> {
+    pub async fn run(&self, settings: &Settings, store: ArcStore) -> Result<()> {
         if !settings.dotfiles.enabled {
             eprintln!(
                 "Dotfiles are not enabled. Add\n\n[dotfiles]\nenabled = true\n\nto your configuration file to enable them.\n"

--- a/crates/atuin/src/command/client/history.rs
+++ b/crates/atuin/src/command/client/history.rs
@@ -21,7 +21,7 @@ use serde::Serialize;
 use atuin_daemon::history::{HistoryEventKind, TailHistoryReply};
 
 use atuin_client::{
-    database::{Database, Sqlite, current_context},
+    database::{Database, current_context},
     encryption,
     history::{History, store::HistoryStore},
     record::sqlite_store::SqliteStore,
@@ -31,11 +31,18 @@ use atuin_client::{
     },
 };
 
-#[cfg(feature = "sync")]
+// `Sqlite` is opened directly only by the no-daemon build and by tests; the
+// daemon build reaches storage through the gRPC proxy.
+#[cfg(any(test, not(feature = "daemon")))]
+use atuin_client::database::Sqlite;
+
+#[cfg(all(feature = "sync", not(feature = "daemon")))]
 use atuin_client::{record, sync};
 
 use time::{OffsetDateTime, macros::format_description};
-use tracing::{debug, warn};
+use tracing::debug;
+#[cfg(not(feature = "daemon"))]
+use tracing::warn;
 
 #[cfg(feature = "daemon")]
 use super::daemon;
@@ -410,6 +417,7 @@ fn normalize_command_for_storage<'a>(command: &'a str, settings: &Settings) -> &
     }
 }
 
+#[cfg(not(feature = "daemon"))]
 async fn handle_start(
     db: &impl Database,
     settings: &Settings,
@@ -482,6 +490,7 @@ async fn handle_daemon_start(
     Ok(Some(resp))
 }
 
+#[cfg(not(feature = "daemon"))]
 #[allow(unused_variables)]
 async fn handle_end(
     db: &impl Database,
@@ -573,14 +582,17 @@ pub(super) async fn start_history_entry(
     author: Option<&str>,
     intent: Option<&str>,
 ) -> Result<Option<String>> {
+    // The daemon is the sole owner of storage; route the write through it.
     #[cfg(feature = "daemon")]
-    if settings.daemon.enabled {
-        return handle_daemon_start(settings, command, author, intent).await;
+    {
+        handle_daemon_start(settings, command, author, intent).await
     }
-
-    let db_path = PathBuf::from(settings.db_path.as_str());
-    let db = Sqlite::new(db_path, settings.local_timeout).await?;
-    handle_start(&db, settings, command, author, intent).await
+    #[cfg(not(feature = "daemon"))]
+    {
+        let db_path = PathBuf::from(settings.db_path.as_str());
+        let db = Sqlite::new(db_path, settings.local_timeout).await?;
+        handle_start(&db, settings, command, author, intent).await
+    }
 }
 
 pub(super) async fn end_history_entry(
@@ -589,24 +601,27 @@ pub(super) async fn end_history_entry(
     exit: i64,
     duration: Option<u64>,
 ) -> Result<()> {
+    // The daemon is the sole owner of storage; route the write through it.
     #[cfg(feature = "daemon")]
-    if settings.daemon.enabled {
-        return handle_daemon_end(settings, id, exit, duration).await;
+    {
+        handle_daemon_end(settings, id, exit, duration).await
     }
+    #[cfg(not(feature = "daemon"))]
+    {
+        let db_path = PathBuf::from(settings.db_path.as_str());
+        let record_store_path = PathBuf::from(settings.record_store_path.as_str());
 
-    let db_path = PathBuf::from(settings.db_path.as_str());
-    let record_store_path = PathBuf::from(settings.record_store_path.as_str());
+        let db = Sqlite::new(db_path, settings.local_timeout).await?;
+        let store = SqliteStore::new(record_store_path, settings.local_timeout).await?;
 
-    let db = Sqlite::new(db_path, settings.local_timeout).await?;
-    let store = SqliteStore::new(record_store_path, settings.local_timeout).await?;
+        let encryption_key: [u8; 32] = encryption::load_key(settings)
+            .context("could not load encryption key")?
+            .into();
+        let host_id = Settings::host_id().await?;
+        let history_store = HistoryStore::new(store.clone(), host_id, encryption_key);
 
-    let encryption_key: [u8; 32] = encryption::load_key(settings)
-        .context("could not load encryption key")?
-        .into();
-    let host_id = Settings::host_id().await?;
-    let history_store = HistoryStore::new(store.clone(), host_id, encryption_key);
-
-    handle_end(&db, store, history_store, settings, id, exit, duration).await
+        handle_end(&db, store, history_store, settings, id, exit, duration).await
+    }
 }
 
 #[cfg(feature = "daemon")]
@@ -1136,10 +1151,20 @@ impl Cmd {
             cmd => {
                 let context = current_context().await?;
 
-                let db_path = PathBuf::from(settings.db_path.as_str());
                 let record_store_path = PathBuf::from(settings.record_store_path.as_str());
 
-                let db = Sqlite::new(db_path, settings.local_timeout).await?;
+                // History reads/writes go through the daemon (sole storage owner).
+                #[cfg(feature = "daemon")]
+                let db: Box<dyn Database> = {
+                    super::daemon::ensure_daemon_running(settings).await?;
+                    Box::new(atuin_daemon::proxy::DaemonDatabase::from_settings(settings).await?)
+                };
+                #[cfg(not(feature = "daemon"))]
+                let db = {
+                    let db_path = PathBuf::from(settings.db_path.as_str());
+                    Sqlite::new(db_path, settings.local_timeout).await?
+                };
+
                 let store = SqliteStore::new(record_store_path, settings.local_timeout).await?;
 
                 let encryption_key: [u8; 32] = encryption::load_key(settings)
@@ -1251,6 +1276,7 @@ mod tests {
         );
     }
 
+    #[cfg(not(feature = "daemon"))]
     #[tokio::test]
     async fn handle_start_saves_trimmed_command() {
         let db = Sqlite::new("sqlite::memory:", 2.0).await.unwrap();
@@ -1269,6 +1295,7 @@ mod tests {
         assert_eq!(history.command, "ls");
     }
 
+    #[cfg(not(feature = "daemon"))]
     #[tokio::test]
     async fn handle_start_can_keep_trailing_whitespace() {
         let db = Sqlite::new("sqlite::memory:", 2.0).await.unwrap();

--- a/crates/atuin/src/command/client/history.rs
+++ b/crates/atuin/src/command/client/history.rs
@@ -1,9 +1,10 @@
 use std::{
     fmt::{self, Display},
     io::{self, IsTerminal, Write},
-    path::PathBuf,
     time::Duration,
 };
+#[cfg(any(test, not(feature = "daemon")))]
+use std::path::PathBuf;
 
 use atuin_common::utils::{self, Escapable as _};
 use clap::Subcommand;
@@ -24,17 +25,21 @@ use atuin_client::{
     database::{Database, current_context},
     encryption,
     history::{History, store::HistoryStore},
-    record::sqlite_store::SqliteStore,
+    record::store::Store,
     settings::{
         FilterMode::{Directory, Global, Session},
         Settings, Timezone,
     },
 };
 
-// `Sqlite` is opened directly only by the no-daemon build and by tests; the
-// daemon build reaches storage through the gRPC proxy.
+// `Sqlite`/`SqliteStore` are opened directly only by the no-daemon build and by
+// tests; the daemon build reaches storage through the gRPC proxy.
 #[cfg(any(test, not(feature = "daemon")))]
 use atuin_client::database::Sqlite;
+#[cfg(any(test, not(feature = "daemon")))]
+use atuin_client::record::sqlite_store::SqliteStore;
+#[cfg(feature = "daemon")]
+use atuin_client::record::store::ArcStore;
 
 #[cfg(all(feature = "sync", not(feature = "daemon")))]
 use atuin_client::{record, sync};
@@ -996,7 +1001,7 @@ impl Cmd {
     async fn handle_prune(
         db: &impl Database,
         settings: &Settings,
-        store: SqliteStore,
+        store: impl Store + Clone + 'static,
         context: atuin_client::database::Context,
         dry_run: bool,
     ) -> Result<()> {
@@ -1053,7 +1058,7 @@ impl Cmd {
     async fn handle_dedup(
         db: &impl Database,
         settings: &Settings,
-        store: SqliteStore,
+        store: impl Store + Clone + 'static,
         before: i64,
         dupkeep: u32,
         dry_run: bool,
@@ -1151,21 +1156,27 @@ impl Cmd {
             cmd => {
                 let context = current_context().await?;
 
-                let record_store_path = PathBuf::from(settings.record_store_path.as_str());
-
-                // History reads/writes go through the daemon (sole storage owner).
+                // History DB and record store both go through the daemon (sole
+                // storage owner).
                 #[cfg(feature = "daemon")]
-                let db: Box<dyn Database> = {
+                let (db, store): (Box<dyn Database>, ArcStore) = {
                     super::daemon::ensure_daemon_running(settings).await?;
-                    Box::new(atuin_daemon::proxy::DaemonDatabase::from_settings(settings).await?)
+                    (
+                        Box::new(atuin_daemon::proxy::DaemonDatabase::from_settings(settings).await?),
+                        std::sync::Arc::new(
+                            atuin_daemon::store_proxy::DaemonStore::from_settings(settings).await?,
+                        ),
+                    )
                 };
                 #[cfg(not(feature = "daemon"))]
-                let db = {
+                let (db, store) = {
                     let db_path = PathBuf::from(settings.db_path.as_str());
-                    Sqlite::new(db_path, settings.local_timeout).await?
+                    let record_store_path = PathBuf::from(settings.record_store_path.as_str());
+                    (
+                        Sqlite::new(db_path, settings.local_timeout).await?,
+                        SqliteStore::new(record_store_path, settings.local_timeout).await?,
+                    )
                 };
-
-                let store = SqliteStore::new(record_store_path, settings.local_timeout).await?;
 
                 let encryption_key: [u8; 32] = encryption::load_key(settings)
                     .context("could not load encryption key")?

--- a/crates/atuin/src/command/client/history.rs
+++ b/crates/atuin/src/command/client/history.rs
@@ -3,7 +3,7 @@ use std::{
     io::{self, IsTerminal, Write},
     time::Duration,
 };
-#[cfg(any(test, not(feature = "daemon")))]
+#[cfg(test)]
 use std::path::PathBuf;
 
 use atuin_common::utils::{self, Escapable as _};
@@ -11,14 +11,10 @@ use clap::Subcommand;
 use eyre::{Context, Result, bail};
 use runtime_format::{FormatKey, FormatKeyError, ParseSegment, ParsedFmt};
 
-#[cfg(feature = "daemon")]
 use super::daemon as daemon_cmd;
-#[cfg(feature = "daemon")]
 use colored::Colorize;
-#[cfg(feature = "daemon")]
 use serde::Serialize;
 
-#[cfg(feature = "daemon")]
 use atuin_daemon::history::{HistoryEventKind, TailHistoryReply};
 
 use atuin_client::{
@@ -34,22 +30,15 @@ use atuin_client::{
 
 // `Sqlite`/`SqliteStore` are opened directly only by the no-daemon build and by
 // tests; the daemon build reaches storage through the gRPC proxy.
-#[cfg(any(test, not(feature = "daemon")))]
+#[cfg(test)]
 use atuin_client::database::Sqlite;
-#[cfg(any(test, not(feature = "daemon")))]
+#[cfg(test)]
 use atuin_client::record::sqlite_store::SqliteStore;
-#[cfg(feature = "daemon")]
 use atuin_client::record::store::ArcStore;
-
-#[cfg(all(feature = "sync", not(feature = "daemon")))]
-use atuin_client::{record, sync};
 
 use time::{OffsetDateTime, macros::format_description};
 use tracing::debug;
-#[cfg(not(feature = "daemon"))]
-use tracing::warn;
 
-#[cfg(feature = "daemon")]
 use super::daemon;
 use super::search::format_duration_into;
 
@@ -422,43 +411,6 @@ fn normalize_command_for_storage<'a>(command: &'a str, settings: &Settings) -> &
     }
 }
 
-#[cfg(not(feature = "daemon"))]
-async fn handle_start(
-    db: &impl Database,
-    settings: &Settings,
-    command: &str,
-    author: Option<&str>,
-    intent: Option<&str>,
-) -> Result<Option<String>> {
-    // It's better for atuin to silently fail here and attempt to
-    // store whatever is ran, than to throw an error to the terminal
-    let cwd = utils::get_current_dir();
-    let command = normalize_command_for_storage(command, settings);
-
-    let mut h: History = History::capture()
-        .timestamp(OffsetDateTime::now_utc())
-        .command(command)
-        .cwd(cwd)
-        .build()
-        .into();
-    apply_start_metadata(&mut h, author, intent);
-
-    if !h.should_save(settings) {
-        return Ok(None);
-    }
-
-    let id = h.id.0.clone();
-
-    // Silently ignore database errors to avoid breaking the shell
-    // This is important when disk is full or database is locked
-    if let Err(e) = db.save(&h).await {
-        debug!("failed to save history: {e}");
-    }
-
-    Ok(Some(id))
-}
-
-#[cfg(feature = "daemon")]
 async fn handle_daemon_start(
     settings: &Settings,
     command: &str,
@@ -495,76 +447,6 @@ async fn handle_daemon_start(
     Ok(Some(resp))
 }
 
-#[cfg(not(feature = "daemon"))]
-#[allow(unused_variables)]
-async fn handle_end(
-    db: &impl Database,
-    store: SqliteStore,
-    history_store: HistoryStore,
-    settings: &Settings,
-    id: &str,
-    exit: i64,
-    duration: Option<u64>,
-) -> Result<()> {
-    if id.trim() == "" {
-        return Ok(());
-    }
-
-    let Some(mut h) = db.load(id).await? else {
-        warn!("history entry is missing");
-        return Ok(());
-    };
-
-    if h.duration > 0 {
-        debug!("cannot end history - already has duration");
-
-        // returning OK as this can occur if someone Ctrl-c a prompt
-        return Ok(());
-    }
-
-    if !settings.store_failed && exit > 0 {
-        debug!("history has non-zero exit code, and store_failed is false");
-
-        // the history has already been inserted half complete. remove it
-        db.delete(h).await?;
-
-        return Ok(());
-    }
-
-    h.exit = exit;
-    h.duration = match duration {
-        Some(value) => i64::try_from(value).context("command took over 292 years")?,
-        None => i64::try_from((OffsetDateTime::now_utc() - h.timestamp).whole_nanoseconds())
-            .context("command took over 292 years")?,
-    };
-
-    db.update(&h).await?;
-    history_store.push(h).await?;
-
-    if settings.should_sync().await? {
-        #[cfg(feature = "sync")]
-        {
-            if settings.sync.records {
-                let (_, downloaded) =
-                    record::sync::sync(settings, &store, &history_store.encryption_key).await?;
-                Settings::save_sync_time().await?;
-
-                crate::sync::build(settings, &store, db, Some(&downloaded)).await?;
-            } else {
-                debug!("running periodic background sync");
-                sync::sync(settings, false, db).await?;
-            }
-        }
-        #[cfg(not(feature = "sync"))]
-        debug!("not compiled with sync support");
-    } else {
-        debug!("sync disabled! not syncing");
-    }
-
-    Ok(())
-}
-
-#[cfg(feature = "daemon")]
 async fn handle_daemon_end(
     settings: &Settings,
     id: &str,
@@ -588,16 +470,7 @@ pub(super) async fn start_history_entry(
     intent: Option<&str>,
 ) -> Result<Option<String>> {
     // The daemon is the sole owner of storage; route the write through it.
-    #[cfg(feature = "daemon")]
-    {
-        handle_daemon_start(settings, command, author, intent).await
-    }
-    #[cfg(not(feature = "daemon"))]
-    {
-        let db_path = PathBuf::from(settings.db_path.as_str());
-        let db = Sqlite::new(db_path, settings.local_timeout).await?;
-        handle_start(&db, settings, command, author, intent).await
-    }
+    handle_daemon_start(settings, command, author, intent).await
 }
 
 pub(super) async fn end_history_entry(
@@ -607,50 +480,27 @@ pub(super) async fn end_history_entry(
     duration: Option<u64>,
 ) -> Result<()> {
     // The daemon is the sole owner of storage; route the write through it.
-    #[cfg(feature = "daemon")]
-    {
-        handle_daemon_end(settings, id, exit, duration).await
-    }
-    #[cfg(not(feature = "daemon"))]
-    {
-        let db_path = PathBuf::from(settings.db_path.as_str());
-        let record_store_path = PathBuf::from(settings.record_store_path.as_str());
-
-        let db = Sqlite::new(db_path, settings.local_timeout).await?;
-        let store = SqliteStore::new(record_store_path, settings.local_timeout).await?;
-
-        let encryption_key: [u8; 32] = encryption::load_key(settings)
-            .context("could not load encryption key")?
-            .into();
-        let host_id = Settings::host_id().await?;
-        let history_store = HistoryStore::new(store.clone(), host_id, encryption_key);
-
-        handle_end(&db, store, history_store, settings, id, exit, duration).await
-    }
+    handle_daemon_end(settings, id, exit, duration).await
 }
 
-#[cfg(feature = "daemon")]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 enum TailKind {
     Started,
     Ended,
 }
 
-#[cfg(feature = "daemon")]
 #[derive(Clone, Debug, Eq, PartialEq)]
 struct TailEvent {
     kind: TailKind,
     history: History,
 }
 
-#[cfg(feature = "daemon")]
 #[derive(Serialize)]
 struct TailJsonEvent<'a> {
     event: &'static str,
     history: TailJsonHistory<'a>,
 }
 
-#[cfg(feature = "daemon")]
 #[derive(Serialize)]
 struct TailJsonHistory<'a> {
     id: &'a str,
@@ -677,7 +527,6 @@ struct TailJsonHistory<'a> {
     finished_at: Option<String>,
 }
 
-#[cfg(feature = "daemon")]
 impl TailEvent {
     fn from_proto(reply: TailHistoryReply) -> Result<Self> {
         let history = reply
@@ -863,7 +712,6 @@ impl TailEvent {
     }
 }
 
-#[cfg(feature = "daemon")]
 impl TailKind {
     const fn as_str(self) -> &'static str {
         match self {
@@ -881,12 +729,10 @@ impl TailKind {
     }
 }
 
-#[cfg(feature = "daemon")]
 fn format_history_time(timestamp: OffsetDateTime, tz: Timezone) -> Result<String> {
     Ok(timestamp.to_offset(tz.0).format(TIME_FMT)?)
 }
 
-#[cfg(feature = "daemon")]
 fn format_duration_ns(duration_ns: i64) -> String {
     struct F(Duration);
     impl Display for F {
@@ -898,7 +744,6 @@ fn format_duration_ns(duration_ns: i64) -> String {
     F(Duration::from_nanos(duration_ns.max(0).cast_unsigned())).to_string()
 }
 
-#[cfg(feature = "daemon")]
 fn push_pretty_field(out: &mut String, label: &str, value: &str) {
     out.push_str("  ");
     let label = format!("{label}:");
@@ -920,7 +765,6 @@ fn push_pretty_field(out: &mut String, label: &str, value: &str) {
     }
 }
 
-#[cfg(feature = "daemon")]
 fn normalize_optional_field(value: &str) -> Option<String> {
     let trimmed = value.trim();
     if trimmed.is_empty() {
@@ -931,7 +775,6 @@ fn normalize_optional_field(value: &str) -> Option<String> {
 }
 
 impl Cmd {
-    #[cfg(feature = "daemon")]
     async fn handle_tail(settings: &Settings) -> Result<()> {
         let tty = std::io::stdout().is_terminal();
         let mut client = daemon::tail_client(settings).await?;
@@ -1049,7 +892,6 @@ impl Cmd {
                 }
             }
 
-            #[cfg(feature = "daemon")]
             daemon_cmd::emit_event(settings, atuin_daemon::DaemonEvent::HistoryPruned).await;
         }
         Ok(())
@@ -1097,7 +939,6 @@ impl Cmd {
             let host_id = Settings::host_id().await?;
             let history_store = HistoryStore::new(store.clone(), host_id, encryption_key);
 
-            #[cfg(feature = "daemon")]
             let ids = matches.iter().map(|h| h.id.clone()).collect::<Vec<_>>();
 
             for entry in matches {
@@ -1110,7 +951,6 @@ impl Cmd {
                 }
             }
 
-            #[cfg(feature = "daemon")]
             daemon_cmd::emit_event(settings, atuin_daemon::DaemonEvent::HistoryDeleted { ids })
                 .await;
         }
@@ -1144,21 +984,12 @@ impl Cmd {
             Self::End { id, exit, duration } => {
                 end_history_entry(settings, &id, exit, duration).await
             }
-            Self::Tail => {
-                #[cfg(feature = "daemon")]
-                {
-                    return Self::handle_tail(settings).await;
-                }
-
-                #[cfg(not(feature = "daemon"))]
-                bail!("`atuin history tail` requires Atuin to be built with the `daemon` feature");
-            }
+            Self::Tail => Self::handle_tail(settings).await,
             cmd => {
                 let context = current_context().await?;
 
                 // History DB and record store both go through the daemon (sole
                 // storage owner).
-                #[cfg(feature = "daemon")]
                 let (db, store): (Box<dyn Database>, ArcStore) = {
                     super::daemon::ensure_daemon_running(settings).await?;
                     (
@@ -1166,15 +997,6 @@ impl Cmd {
                         std::sync::Arc::new(
                             atuin_daemon::store_proxy::DaemonStore::from_settings(settings).await?,
                         ),
-                    )
-                };
-                #[cfg(not(feature = "daemon"))]
-                let (db, store) = {
-                    let db_path = PathBuf::from(settings.db_path.as_str());
-                    let record_store_path = PathBuf::from(settings.record_store_path.as_str());
-                    (
-                        Sqlite::new(db_path, settings.local_timeout).await?,
-                        SqliteStore::new(record_store_path, settings.local_timeout).await?,
                     )
                 };
 
@@ -1260,7 +1082,6 @@ impl Cmd {
 
 #[cfg(test)]
 mod tests {
-    #[cfg(feature = "daemon")]
     use time::macros::datetime;
 
     use super::*;
@@ -1287,46 +1108,6 @@ mod tests {
         );
     }
 
-    #[cfg(not(feature = "daemon"))]
-    #[tokio::test]
-    async fn handle_start_saves_trimmed_command() {
-        let db = Sqlite::new("sqlite::memory:", 2.0).await.unwrap();
-        let settings = Settings::utc();
-
-        handle_start(&db, &settings, "ls   \t", None, None)
-            .await
-            .unwrap();
-
-        let history = db
-            .before(OffsetDateTime::now_utc() + time::Duration::SECOND, 1)
-            .await
-            .unwrap()
-            .pop()
-            .unwrap();
-        assert_eq!(history.command, "ls");
-    }
-
-    #[cfg(not(feature = "daemon"))]
-    #[tokio::test]
-    async fn handle_start_can_keep_trailing_whitespace() {
-        let db = Sqlite::new("sqlite::memory:", 2.0).await.unwrap();
-        let settings = Settings {
-            strip_trailing_whitespace: false,
-            ..Settings::utc()
-        };
-
-        handle_start(&db, &settings, "ls   \t", None, None)
-            .await
-            .unwrap();
-
-        let history = db
-            .before(OffsetDateTime::now_utc() + time::Duration::SECOND, 1)
-            .await
-            .unwrap()
-            .pop()
-            .unwrap();
-        assert_eq!(history.command, "ls   \t");
-    }
 
     #[test]
     fn test_format_string_no_panic() {
@@ -1344,7 +1125,6 @@ mod tests {
         assert!(std::panic::catch_unwind(|| parse_fmt("{time} - {command}")).is_ok());
     }
 
-    #[cfg(feature = "daemon")]
     fn sample_tail_event(kind: TailKind) -> TailEvent {
         TailEvent {
             kind,
@@ -1364,7 +1144,6 @@ mod tests {
         }
     }
 
-    #[cfg(feature = "daemon")]
     #[test]
     fn test_tail_json_output_contains_history_fields() {
         let json = sample_tail_event(TailKind::Ended)
@@ -1379,7 +1158,6 @@ mod tests {
         assert!(value.get("record").is_none());
     }
 
-    #[cfg(feature = "daemon")]
     #[test]
     fn test_tail_pretty_output_shows_pending_fields_for_started_events() {
         let rendered = sample_tail_event(TailKind::Started)

--- a/crates/atuin/src/command/client/init.rs
+++ b/crates/atuin/src/command/client/init.rs
@@ -1,12 +1,7 @@
-#[cfg(not(feature = "daemon"))]
-use std::path::PathBuf;
-
 use atuin_client::{
     encryption,
     settings::{Settings, Tmux},
 };
-#[cfg(not(feature = "daemon"))]
-use atuin_client::record::sqlite_store::SqliteStore;
 use atuin_dotfiles::store::{AliasStore, var::VarStore};
 use clap::{Parser, ValueEnum};
 use eyre::{Result, WrapErr};
@@ -129,17 +124,11 @@ $env.config = (
 
     async fn dotfiles_init(&self, settings: &Settings) -> Result<()> {
         // The record store is owned by the daemon; reach it through the proxy.
-        #[cfg(feature = "daemon")]
         let record_store: atuin_client::record::store::ArcStore = {
             super::daemon::ensure_daemon_running(settings).await?;
             std::sync::Arc::new(
                 atuin_daemon::store_proxy::DaemonStore::from_settings(settings).await?,
             )
-        };
-        #[cfg(not(feature = "daemon"))]
-        let record_store = {
-            let record_store_path = PathBuf::from(settings.record_store_path.as_str());
-            SqliteStore::new(record_store_path, settings.local_timeout).await?
         };
 
         let encryption_key: [u8; 32] = encryption::load_key(settings)

--- a/crates/atuin/src/command/client/init.rs
+++ b/crates/atuin/src/command/client/init.rs
@@ -1,10 +1,12 @@
+#[cfg(not(feature = "daemon"))]
 use std::path::PathBuf;
 
 use atuin_client::{
     encryption,
-    record::sqlite_store::SqliteStore,
     settings::{Settings, Tmux},
 };
+#[cfg(not(feature = "daemon"))]
+use atuin_client::record::sqlite_store::SqliteStore;
 use atuin_dotfiles::store::{AliasStore, var::VarStore};
 use clap::{Parser, ValueEnum};
 use eyre::{Result, WrapErr};
@@ -126,16 +128,27 @@ $env.config = (
     }
 
     async fn dotfiles_init(&self, settings: &Settings) -> Result<()> {
-        let record_store_path = PathBuf::from(settings.record_store_path.as_str());
-        let sqlite_store = SqliteStore::new(record_store_path, settings.local_timeout).await?;
+        // The record store is owned by the daemon; reach it through the proxy.
+        #[cfg(feature = "daemon")]
+        let record_store: atuin_client::record::store::ArcStore = {
+            super::daemon::ensure_daemon_running(settings).await?;
+            std::sync::Arc::new(
+                atuin_daemon::store_proxy::DaemonStore::from_settings(settings).await?,
+            )
+        };
+        #[cfg(not(feature = "daemon"))]
+        let record_store = {
+            let record_store_path = PathBuf::from(settings.record_store_path.as_str());
+            SqliteStore::new(record_store_path, settings.local_timeout).await?
+        };
 
         let encryption_key: [u8; 32] = encryption::load_key(settings)
             .context("could not load encryption key")?
             .into();
         let host_id = Settings::host_id().await?;
 
-        let alias_store = AliasStore::new(sqlite_store.clone(), host_id, encryption_key);
-        let var_store = VarStore::new(sqlite_store.clone(), host_id, encryption_key);
+        let alias_store = AliasStore::new(record_store.clone(), host_id, encryption_key);
+        let var_store = VarStore::new(record_store.clone(), host_id, encryption_key);
 
         let disable_ai = self.disable_ai || matches!(settings.ai.enabled, Some(false));
 

--- a/crates/atuin/src/command/client/kv.rs
+++ b/crates/atuin/src/command/client/kv.rs
@@ -3,7 +3,7 @@ use std::io::{self, IsTerminal, Read};
 use clap::Subcommand;
 use eyre::{Context, Result, eyre};
 
-use atuin_client::{encryption, record::sqlite_store::SqliteStore, settings::Settings};
+use atuin_client::{encryption, record::store::ArcStore, settings::Settings};
 use atuin_kv::store::KvStore;
 
 #[derive(Subcommand, Debug)]
@@ -62,7 +62,7 @@ pub enum Cmd {
 }
 
 impl Cmd {
-    pub async fn run(&self, settings: &Settings, store: &SqliteStore) -> Result<()> {
+    pub async fn run(&self, settings: &Settings, store: &ArcStore) -> Result<()> {
         let encryption_key: [u8; 32] = encryption::load_key(settings)
             .context("could not load encryption key")?
             .into();

--- a/crates/atuin/src/command/client/scripts.rs
+++ b/crates/atuin/src/command/client/scripts.rs
@@ -14,7 +14,7 @@ use eyre::OptionExt;
 use eyre::{Result, bail};
 use tempfile::NamedTempFile;
 
-use atuin_client::{database::Database, record::sqlite_store::SqliteStore, settings::Settings};
+use atuin_client::{database::Database, record::store::ArcStore, settings::Settings};
 use tracing::debug;
 
 #[derive(Parser, Debug)]
@@ -563,7 +563,7 @@ impl Cmd {
     pub async fn run(
         self,
         settings: &Settings,
-        store: SqliteStore,
+        store: ArcStore,
         history_db: &impl Database,
     ) -> Result<()> {
         let host_id = Settings::host_id().await?;

--- a/crates/atuin/src/command/client/search.rs
+++ b/crates/atuin/src/command/client/search.rs
@@ -10,7 +10,7 @@ use atuin_client::{
     database::{OptFilters, current_context},
     encryption,
     history::{History, store::HistoryStore},
-    record::sqlite_store::SqliteStore,
+    record::store::ArcStore,
     settings::{FilterMode, KeymapMode, SearchMode, Settings, Timezone},
     theme::Theme,
 };
@@ -159,7 +159,7 @@ impl Cmd {
         self,
         db: impl Database,
         settings: &mut Settings,
-        store: SqliteStore,
+        store: ArcStore,
         theme: &Theme,
     ) -> Result<()> {
         let query = self.query.unwrap_or_else(|| {

--- a/crates/atuin/src/command/client/search.rs
+++ b/crates/atuin/src/command/client/search.rs
@@ -257,8 +257,26 @@ impl Cmd {
                 authors: self.author.clone().unwrap_or_default(),
             };
 
-            let mut entries =
-                run_non_interactive(settings, opt_filter.clone(), &query, &db).await?;
+            // When the daemon owns storage, route the read through it: spawn
+            // the daemon on demand and query it via the DaemonDatabase proxy
+            // instead of opening SQLite ourselves.
+            let mut entries;
+            #[cfg(feature = "daemon")]
+            {
+                if settings.daemon.enabled {
+                    super::daemon::ensure_daemon_running(settings).await?;
+                    let ddb = atuin_daemon::proxy::DaemonDatabase::from_settings(settings).await?;
+                    entries =
+                        run_non_interactive(settings, opt_filter.clone(), &query, &ddb).await?;
+                } else {
+                    entries =
+                        run_non_interactive(settings, opt_filter.clone(), &query, &db).await?;
+                }
+            }
+            #[cfg(not(feature = "daemon"))]
+            {
+                entries = run_non_interactive(settings, opt_filter.clone(), &query, &db).await?;
+            }
 
             if entries.is_empty() {
                 std::process::exit(1)

--- a/crates/atuin/src/command/client/search.rs
+++ b/crates/atuin/src/command/client/search.rs
@@ -257,26 +257,11 @@ impl Cmd {
                 authors: self.author.clone().unwrap_or_default(),
             };
 
-            // When the daemon owns storage, route the read through it: spawn
-            // the daemon on demand and query it via the DaemonDatabase proxy
-            // instead of opening SQLite ourselves.
-            let mut entries;
-            #[cfg(feature = "daemon")]
-            {
-                if settings.daemon.enabled {
-                    super::daemon::ensure_daemon_running(settings).await?;
-                    let ddb = atuin_daemon::proxy::DaemonDatabase::from_settings(settings).await?;
-                    entries =
-                        run_non_interactive(settings, opt_filter.clone(), &query, &ddb).await?;
-                } else {
-                    entries =
-                        run_non_interactive(settings, opt_filter.clone(), &query, &db).await?;
-                }
-            }
-            #[cfg(not(feature = "daemon"))]
-            {
-                entries = run_non_interactive(settings, opt_filter.clone(), &query, &db).await?;
-            }
+            // `db` is provided by the dispatcher; with the daemon feature it is a
+            // gRPC-backed proxy so this read is served by the daemon, not by
+            // opening SQLite here.
+            let mut entries =
+                run_non_interactive(settings, opt_filter.clone(), &query, &db).await?;
 
             if entries.is_empty() {
                 std::process::exit(1)

--- a/crates/atuin/src/command/client/search/engines.rs
+++ b/crates/atuin/src/command/client/search/engines.rs
@@ -8,22 +8,14 @@ use eyre::Result;
 
 use super::cursor::Cursor;
 
-#[cfg(feature = "daemon")]
 pub mod daemon;
 pub mod db;
 pub mod skim;
 
-#[allow(unused)] // settings is only used if daemon feature is enabled
 pub fn engine(search_mode: SearchMode, settings: &Settings) -> Box<dyn SearchEngine> {
     match search_mode {
         SearchMode::Skim => Box::new(skim::Search::new()) as Box<_>,
-        #[cfg(feature = "daemon")]
         SearchMode::DaemonFuzzy => Box::new(daemon::Search::new(settings)) as Box<_>,
-        #[cfg(not(feature = "daemon"))]
-        SearchMode::DaemonFuzzy => {
-            // Fall back to fuzzy mode if daemon feature is not enabled
-            Box::new(db::Search(SearchMode::Fuzzy)) as Box<_>
-        }
         mode => Box::new(db::Search(mode)) as Box<_>,
     }
 }

--- a/crates/atuin/src/command/client/store.rs
+++ b/crates/atuin/src/command/client/store.rs
@@ -3,7 +3,7 @@ use eyre::Result;
 
 use atuin_client::{
     database::Database,
-    record::{sqlite_store::SqliteStore, store::Store},
+    record::store::{ArcStore, Store},
     settings::Settings,
 };
 use itertools::Itertools;
@@ -52,7 +52,7 @@ impl Cmd {
         &self,
         settings: &Settings,
         database: &dyn Database,
-        store: SqliteStore,
+        store: ArcStore,
     ) -> Result<()> {
         match self {
             Self::Status => self.status(store).await,
@@ -69,7 +69,7 @@ impl Cmd {
         }
     }
 
-    pub async fn status(&self, store: SqliteStore) -> Result<()> {
+    pub async fn status(&self, store: ArcStore) -> Result<()> {
         let host_id = Settings::host_id().await?;
         let offset = UtcOffset::current_local_offset().unwrap_or(UtcOffset::UTC);
 

--- a/crates/atuin/src/command/client/store/pull.rs
+++ b/crates/atuin/src/command/client/store/pull.rs
@@ -6,7 +6,7 @@ use atuin_client::{
     encryption::load_key,
     record::store::Store,
     record::sync::Operation,
-    record::{sqlite_store::SqliteStore, sync},
+    record::{store::ArcStore, sync},
     settings::Settings,
 };
 
@@ -31,7 +31,7 @@ impl Pull {
     pub async fn run(
         &self,
         settings: &Settings,
-        store: SqliteStore,
+        store: ArcStore,
         db: &dyn Database,
     ) -> Result<()> {
         if self.force {

--- a/crates/atuin/src/command/client/store/purge.rs
+++ b/crates/atuin/src/command/client/store/purge.rs
@@ -3,7 +3,7 @@ use eyre::Result;
 
 use atuin_client::{
     encryption::load_key,
-    record::{sqlite_store::SqliteStore, store::Store},
+    record::store::{ArcStore, Store},
     settings::Settings,
 };
 
@@ -11,7 +11,7 @@ use atuin_client::{
 pub struct Purge {}
 
 impl Purge {
-    pub async fn run(&self, settings: &Settings, store: SqliteStore) -> Result<()> {
+    pub async fn run(&self, settings: &Settings, store: ArcStore) -> Result<()> {
         println!("Purging local records that cannot be decrypted");
 
         let key = load_key(settings)?;

--- a/crates/atuin/src/command/client/store/push.rs
+++ b/crates/atuin/src/command/client/store/push.rs
@@ -7,7 +7,7 @@ use atuin_client::{
     api_client::Client,
     encryption::load_key,
     record::sync::Operation,
-    record::{sqlite_store::SqliteStore, sync},
+    record::{store::ArcStore, sync},
     settings::Settings,
 };
 
@@ -34,7 +34,7 @@ pub struct Push {
 }
 
 impl Push {
-    pub async fn run(&self, settings: &Settings, store: SqliteStore) -> Result<()> {
+    pub async fn run(&self, settings: &Settings, store: ArcStore) -> Result<()> {
         let host_id = Settings::host_id().await?;
 
         if self.force {

--- a/crates/atuin/src/command/client/store/rebuild.rs
+++ b/crates/atuin/src/command/client/store/rebuild.rs
@@ -3,7 +3,6 @@ use atuin_scripts::store::ScriptStore;
 use clap::Args;
 use eyre::{Result, bail};
 
-#[cfg(feature = "daemon")]
 use crate::command::client::daemon as daemon_cmd;
 
 use atuin_client::{
@@ -60,7 +59,6 @@ impl Rebuild {
 
         history_store.build(database).await?;
 
-        #[cfg(feature = "daemon")]
         daemon_cmd::emit_event(settings, atuin_daemon::DaemonEvent::HistoryRebuilt).await;
 
         Ok(())

--- a/crates/atuin/src/command/client/store/rebuild.rs
+++ b/crates/atuin/src/command/client/store/rebuild.rs
@@ -8,7 +8,7 @@ use crate::command::client::daemon as daemon_cmd;
 
 use atuin_client::{
     database::Database, encryption, history::store::HistoryStore,
-    record::sqlite_store::SqliteStore, settings::Settings,
+    record::store::ArcStore, settings::Settings,
 };
 
 #[derive(Args, Debug)]
@@ -20,7 +20,7 @@ impl Rebuild {
     pub async fn run(
         &self,
         settings: &Settings,
-        store: SqliteStore,
+        store: ArcStore,
         database: &dyn Database,
     ) -> Result<()> {
         // keep it as a string and not an enum atm
@@ -50,7 +50,7 @@ impl Rebuild {
     async fn rebuild_history(
         &self,
         settings: &Settings,
-        store: SqliteStore,
+        store: ArcStore,
         database: &dyn Database,
     ) -> Result<()> {
         let encryption_key: [u8; 32] = encryption::load_key(settings)?.into();
@@ -66,7 +66,7 @@ impl Rebuild {
         Ok(())
     }
 
-    async fn rebuild_dotfiles(&self, settings: &Settings, store: SqliteStore) -> Result<()> {
+    async fn rebuild_dotfiles(&self, settings: &Settings, store: ArcStore) -> Result<()> {
         let encryption_key: [u8; 32] = encryption::load_key(settings)?.into();
 
         let host_id = Settings::host_id().await?;
@@ -80,7 +80,7 @@ impl Rebuild {
         Ok(())
     }
 
-    async fn rebuild_scripts(&self, settings: &Settings, store: SqliteStore) -> Result<()> {
+    async fn rebuild_scripts(&self, settings: &Settings, store: ArcStore) -> Result<()> {
         let encryption_key: [u8; 32] = encryption::load_key(settings)?.into();
         let host_id = Settings::host_id().await?;
         let script_store = ScriptStore::new(store, host_id, encryption_key);

--- a/crates/atuin/src/command/client/store/rekey.rs
+++ b/crates/atuin/src/command/client/store/rekey.rs
@@ -4,7 +4,7 @@ use tokio::{fs::File, io::AsyncWriteExt};
 
 use atuin_client::{
     encryption::{Key, decode_key, encode_key, generate_encoded_key, load_key},
-    record::sqlite_store::SqliteStore,
+    record::store::ArcStore,
     record::store::Store,
     settings::Settings,
 };
@@ -16,7 +16,7 @@ pub struct Rekey {
 }
 
 impl Rekey {
-    pub async fn run(&self, settings: &Settings, store: SqliteStore) -> Result<()> {
+    pub async fn run(&self, settings: &Settings, store: ArcStore) -> Result<()> {
         let key = if let Some(key) = self.key.clone() {
             println!("Re-encrypting store with specified key");
 

--- a/crates/atuin/src/command/client/store/verify.rs
+++ b/crates/atuin/src/command/client/store/verify.rs
@@ -3,7 +3,7 @@ use eyre::Result;
 
 use atuin_client::{
     encryption::load_key,
-    record::{sqlite_store::SqliteStore, store::Store},
+    record::store::{ArcStore, Store},
     settings::Settings,
 };
 
@@ -11,7 +11,7 @@ use atuin_client::{
 pub struct Verify {}
 
 impl Verify {
-    pub async fn run(&self, settings: &Settings, store: SqliteStore) -> Result<()> {
+    pub async fn run(&self, settings: &Settings, store: ArcStore) -> Result<()> {
         println!("Verifying local store can be decrypted with the current key");
 
         let key = load_key(settings)?;

--- a/crates/atuin/src/command/client/sync.rs
+++ b/crates/atuin/src/command/client/sync.rs
@@ -5,7 +5,10 @@ use atuin_client::{
     database::Database,
     encryption,
     history::store::HistoryStore,
-    record::{sqlite_store::SqliteStore, store::Store, sync},
+    record::{
+        store::{ArcStore, Store},
+        sync,
+    },
     settings::Settings,
 };
 
@@ -48,7 +51,7 @@ impl Cmd {
         self,
         settings: Settings,
         db: &impl Database,
-        store: SqliteStore,
+        store: ArcStore,
     ) -> Result<()> {
         match self {
             Self::Sync { force } => run(&settings, force, db, store).await,
@@ -78,7 +81,7 @@ async fn run(
     settings: &Settings,
     force: bool,
     db: &impl Database,
-    store: SqliteStore,
+    store: ArcStore,
 ) -> Result<()> {
     if settings.sync.records {
         let encryption_key: [u8; 32] = encryption::load_key(settings)

--- a/crates/atuin/src/command/client/wrapped.rs
+++ b/crates/atuin/src/command/client/wrapped.rs
@@ -4,7 +4,7 @@ use std::collections::{HashMap, HashSet};
 use time::{Date, Duration, Month, OffsetDateTime, Time};
 
 use atuin_client::{
-    database::Database, encryption, record::sqlite_store::SqliteStore, settings::Settings,
+    database::Database, encryption, record::store::ArcStore, settings::Settings,
     theme::Theme,
 };
 use atuin_dotfiles::store::AliasStore;
@@ -290,7 +290,7 @@ pub async fn run(
     year: Option<i32>,
     db: &impl Database,
     settings: &Settings,
-    store: SqliteStore,
+    store: ArcStore,
     theme: &Theme,
 ) -> Result<()> {
     let now = OffsetDateTime::now_utc().to_offset(settings.timezone.0);

--- a/crates/atuin/src/command/mod.rs
+++ b/crates/atuin/src/command/mod.rs
@@ -74,11 +74,7 @@ impl AtuinCmd {
 
 #[cfg(all(feature = "pty-proxy", unix))]
 fn run_pty_proxy(proxy: atuin_pty_proxy::PtyProxy) {
-    #[cfg(feature = "daemon")]
     proxy.run(semantic_command_capture_sink());
-
-    #[cfg(not(feature = "daemon"))]
-    proxy.run(None);
 }
 
 #[cfg(all(feature = "pty-proxy", not(unix)))]
@@ -87,7 +83,7 @@ fn run_pty_proxy(_proxy: atuin_pty_proxy::PtyProxy) {
     std::process::exit(1);
 }
 
-#[cfg(all(feature = "daemon", feature = "pty-proxy", unix))]
+#[cfg(all(feature = "pty-proxy", unix))]
 fn semantic_command_capture_sink() -> Option<atuin_pty_proxy::CommandCaptureSink> {
     use std::sync::mpsc;
     use std::time::Duration;
@@ -128,7 +124,7 @@ fn semantic_command_capture_sink() -> Option<atuin_pty_proxy::CommandCaptureSink
     }))
 }
 
-#[cfg(all(feature = "daemon", feature = "pty-proxy", unix))]
+#[cfg(all(feature = "pty-proxy", unix))]
 #[inline]
 fn is_truthy_env(name: &str) -> bool {
     std::env::var(name)
@@ -137,7 +133,7 @@ fn is_truthy_env(name: &str) -> bool {
         .is_some_and(|value| !value.trim().is_empty() && value.trim() != "false")
 }
 
-#[cfg(all(feature = "daemon", feature = "pty-proxy", unix))]
+#[cfg(all(feature = "pty-proxy", unix))]
 async fn send_semantic_command_captures(
     settings: &atuin_client::settings::Settings,
     batch: Vec<atuin_pty_proxy::CommandCapture>,

--- a/crates/atuin/src/sync.rs
+++ b/crates/atuin/src/sync.rs
@@ -3,7 +3,7 @@ use atuin_scripts::store::ScriptStore;
 use eyre::{Context, Result};
 
 use atuin_client::{
-    database::Database, history::store::HistoryStore, record::sqlite_store::SqliteStore,
+    database::Database, history::store::HistoryStore, record::store::Store,
     settings::Settings,
 };
 use atuin_common::record::RecordId;
@@ -17,7 +17,7 @@ use atuin_kv::store::KvStore;
 /// records.
 pub async fn build(
     settings: &Settings,
-    store: &SqliteStore,
+    store: &(impl Store + Clone + 'static),
     db: &dyn Database,
     downloaded: Option<&[RecordId]>,
 ) -> Result<()> {

--- a/docs/dev/atu-538-ephemeral-daemon-investigation.md
+++ b/docs/dev/atu-538-ephemeral-daemon-investigation.md
@@ -1,265 +1,256 @@
-# ATU-538 — Ephemeral Daemon Investigation & Cutover Plan
+# ATU-538 — Removing the Daemonless Code Paths (Daemon-Only Client)
 
-> **Status:** Investigation complete — recommendation and phased implementation plan below.
+> **Status:** Investigation complete — full census, feasibility verdict, architecture, and phased plan below.
 > **Issue:** ATU-538 "Investigate whether making daemonless mode just spawn an ephemeral daemon is possible."
 > **Project:** Completely Cutover to Daemon.
+> **Goal (as clarified by maintainer):** **Completely remove** the client's direct-to-SQLite and direct-to-record-store code paths. No config toggle, no fallback. The daemon becomes the sole owner of all local storage; the CLI becomes a thin RPC client that spawns the daemon on demand.
 >
-> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement the plan in Part 3 task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking. **Do not begin implementation before the design decisions in Part 2 are ratified by a maintainer** — this is an investigation deliverable, and the plan is contingent on those decisions.
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement the plan in Part 4 task-by-task. Steps use checkbox (`- [ ]`) syntax. **This is a multi-release re-architecture, not a single PR** — do not attempt it in one shot, and get the Part 3 design decisions ratified before starting.
 
-**Goal of the investigation:** Determine whether the daemonless code path can be eliminated by having the client transparently spawn/talk to a daemon, so we stop maintaining two storage code paths.
-
-**One-line verdict:** **Yes, it is feasible — and most of the mechanism already exists.** The autostart feature already does `fork`/`spawn`-into-daemon and waits for readiness. The real work is not "make spawning possible" (it is), but "collapse the branch so the daemon path is the *only* write path," plus deciding the fallback story for environments where a daemon genuinely cannot run. A *truly* ephemeral (spawn → serve one request → die) daemon is **not** recommended; a **spawn-on-demand, persistent** daemon is.
+**One-line verdict:** **Feasible, and the right end-state — but it is a re-architecture, not a refactor.** "Just spawn a daemon" is already solved (autostart does `fork`+exec today). The real cost is that *removing direct storage access entirely* forces the daemon to serve the **complete** data API that ~25 subcommands currently satisfy by opening SQLite themselves — including full search-row hydration, stats, import bulk-insert, sync, key rotation, and the dotfiles/kv/scripts record stores. The tractable way to do this without rewriting every command is to **proxy the existing `Database`/`Store` traits over gRPC** so command handlers stay unchanged and only the ~6 construction sites and the trait backends move.
 
 ---
 
-## Part 1 — What exists today (grounded architecture map)
+## Part 1 — The mechanism already exists; the hard part is the surface
 
-### 1.1 There are two independent axes, not one switch
+### 1.1 Spawning a daemon on demand is a solved problem
 
-The word "daemonless" hides two separate decisions:
+The autostart infrastructure in `crates/atuin/src/command/client/daemon.rs` already implements the issue's "`fork+execve` into the daemon" idea:
 
-| Axis | Gate | Where |
-|---|---|---|
-| **Write path** (record `start`/`end`) | runtime `settings.daemon.enabled` | `crates/atuin/src/command/client/history.rs:577`, `:593` |
-| **Read path** (interactive TUI search only) | `settings.search_mode == SearchMode::DaemonFuzzy` | `crates/atuin/src/command/client/search/engines.rs:17-29` |
+- `spawn_daemon_process()` (`daemon.rs:253-269`) re-execs `atuin daemon start` (+ `--daemonize` on unix; detached `spawn` on Windows).
+- `ensure_daemon_running()` (`daemon.rs:355-389`) takes a cross-process startup lock, probes, cleans a stale socket, spawns, and `wait_until_ready()`.
+- `try_with_restart()` (`daemon.rs:419-459`) already retries write RPCs across a restart.
+- systemd socket-activation is honored and excluded from autostart (`ensure_autostart_supported`, `daemon.rs:335-346`).
 
-Both are additionally behind the compile-time `#[cfg(feature = "daemon")]` gate. **Non-interactive `atuin search <query>` never uses the daemon at all** — it always queries local SQLite (`crates/atuin/src/command/client/search.rs:310-342`).
+So "is it possible to spawn an ephemeral daemon and talk to it?" — **yes, that code ships today.** A *truly* ephemeral (spawn → serve one request → die) daemon is the wrong shape (per-command spawn thrash defeats the in-memory index and background sync); the correct shape is **spawn-on-demand, resident** — exactly what autostart already does. What ATU-538 actually requires beyond this is deleting the *other* half: the direct storage code the client still runs when it isn't talking to a daemon.
 
-This decoupling matters: "cutover to daemon" is really "collapse the *write* axis," because the read axis already has a sane story (see §1.4).
+### 1.2 What "the other half" actually is (the census result)
 
-### 1.2 The write path — the actual dual-maintenance burden
+Two exhaustive censuses (Appendix A/B) found that **essentially the entire data surface of atuin** is reached by opening local storage directly in the client. The chokepoints:
 
-`crates/atuin/src/command/client/history.rs`:
+- `crates/atuin/src/command/client.rs:359-360` opens **both** the history `Sqlite` and the record `SqliteStore` for nearly every non-history subcommand.
+- `crates/atuin/src/command/client/history.rs:582 / 600 / 1142` open the history DB for the history subcommands.
+- `crates/atuin/src/command/client/history.rs:601 / 607 / 1143 / 1150` open the record store / `HistoryStore`.
+- `crates/atuin-ai/src/commands/inline.rs:64` and `crates/atuin-ai/src/mcp.rs:87` open the history DB for `atuin ai` / `atuin mcp`.
 
-```rust
-// start_history_entry — history.rs:570-584
-#[cfg(feature = "daemon")]
-if settings.daemon.enabled {
-    return handle_daemon_start(settings, command, author, intent).await; // gRPC to daemon
-}
-let db = Sqlite::new(db_path, settings.local_timeout).await?;             // daemonless: open DB directly
-handle_start(&db, settings, command, author, intent).await
+Commands that would stop working the instant the client can no longer open storage:
 
-// end_history_entry — history.rs:586-610
-#[cfg(feature = "daemon")]
-if settings.daemon.enabled {
-    return handle_daemon_end(settings, id, exit, duration).await;        // gRPC to daemon
-}
-// daemonless: open Sqlite + SqliteStore + HistoryStore, then...
-handle_end(&db, store, history_store, settings, id, exit, duration).await
+`history start/end/list/last/init-store/prune/dedup`, `search` (non-interactive **and** the full interactive TUI: search, count, load, stats, get_dups, query_history, all_with_count), `stats`, `wrapped`, `import` (bulk insert), `sync`, `sync status`, `store status/rebuild/rekey/purge/verify/push/pull`, `scripts new --last`, `ai`, `mcp`, `login`/`register` (key re-encryption), `kv *`, `dotfiles alias/var *`, `scripts *`, `init <shell>` (dotfiles read), and `daemon start` (opens then legitimately hands off to the daemon crate).
+
+That is the true scope of "remove the direct paths": **every one of those operations must become a daemon RPC, or be deleted.**
+
+### 1.3 The one place direct access must remain
+
+The **daemon crate itself** (`crates/atuin-daemon/`) keeps direct `Sqlite`/`SqliteStore` access — it is the single owner. `atuin daemon start` (`client.rs:359`, `daemon.rs:659/669`) opening the DB and handing it to `atuin_daemon::boot` is not a "daemonless path"; it is the boot path. The maintenance-burden duplication we are deleting is the *client-side second implementation* of the same operations, and the `if settings.daemon.enabled { rpc } else { direct }` branching that keeps both alive.
+
+---
+
+## Part 2 — Architecture: proxy the storage traits, don't rewrite every command
+
+### 2.1 The naive approach explodes; the trait-proxy approach doesn't
+
+The history DB is reached through the `Database` trait (`crates/atuin-client/src/database.rs:151-200`): ~18 methods — `save`, `save_bulk`, `load`, `list`, `range`, `update`, `history_count`, `last`, `before`, `delete`, `delete_rows`, `deleted`, `search`, `query_history`, `all_with_count`, `all_paged`, `stats`, `get_dups`. Record stores go through the `Store` trait (`record/store.rs`) and the typed `HistoryStore`/`AliasStore`/`VarStore`/`KvStore`/`ScriptStore` wrappers.
+
+Two ways to make the daemon serve these:
+
+- **(A) Curated RPCs** — design a bespoke gRPC method per command's need (`Stats`, `ListHistory`, `Dedup`, …). *Rejected:* it forces rewriting every command handler to call the new RPCs, re-deriving query/filter logic on the wire, and it multiplies the branch points we are trying to delete.
+- **(B) Trait proxy (RECOMMENDED)** — add gRPC methods that mirror the `Database`/`Store` trait surface, then implement **`DaemonDatabase: Database`** and **`DaemonStore: Store`** in the client that forward each call over gRPC to the daemon, which services it with the *one* `Sqlite`/`SqliteStore` impl. Command handlers keep taking `&dyn Database` / `impl Store` and **do not change**. Only the ~6 construction sites swap the concrete type, and the query logic stays single-sourced inside the daemon.
+
+Approach (B) is what makes "delete the direct paths" a bounded, mostly-mechanical project instead of a rewrite of 25 commands.
+
+### 2.2 The resulting shape
+
+```
+                 today                              target
+   CLI cmd ──► Sqlite (local file)      CLI cmd ──► &dyn Database
+   CLI cmd ──► SqliteStore (local)                     │
+       (also, when daemon.enabled,                     ▼
+        a *second* path over gRPC)          DaemonDatabase / DaemonStore  (client-side proxy)
+                                                        │ gRPC (unix socket / TCP)
+                                                        ▼
+                                            atuin-daemon ──► Sqlite / SqliteStore   (sole owner)
 ```
 
-The daemonless `handle_end` (`history.rs:485-551`) does: `db.update()` → `history_store.push()` → **inline sync** (`history.rs:530-548`). The daemon replicates the exact same `db.save` / `history_store.push` server-side (`crates/atuin-daemon/src/components/history.rs:184-248`) and moves sync to a **background timer** (`crates/atuin-daemon/src/components/sync.rs`). So the two paths differ in *when sync happens* — a semantic difference the cutover must preserve or consciously change.
+Benefits beyond deleting the duplication:
+- **Single-writer SQLite for free.** Only the daemon opens the DB, eliminating multi-process lock contention (a recurring source of `database is locked`).
+- **One place for query/sync/crypto logic.** No more "inline sync in `history end`" vs "background sync in the daemon" divergence.
 
-### 1.3 The daemon can already be spawned on demand — this is the crux
+### 2.3 Prerequisite: handlers must be generic over the trait, not the concrete `Sqlite`
 
-The autostart infrastructure in `crates/atuin/src/command/client/daemon.rs` **already implements the issue's proposed `fork+execve` idea**:
+Several handlers today take a concrete `Sqlite`/`SqliteStore` rather than `&dyn Database`/`impl Store`, and `HistoryStore::new` holds a concrete `SqliteStore`. Making them generic (or trait-object) is a mechanical but wide-reaching prerequisite (Task 1). Where a handler needs the *whole* history set (the **skim** engine calls `all_with_count`, `engines/skim.rs:60`, loading all rows), the proxy must stream — see risks.
 
-- `spawn_daemon_process()` (`daemon.rs:253-269`): re-execs the current binary as `atuin daemon start` (+ `--daemonize` on unix), stdio nulled.
-- `ensure_daemon_running()` (`daemon.rs:355-389`): takes a cross-process startup lock, probes, removes a stale socket, spawns, then `wait_until_ready()`.
-- `try_with_restart()` (`daemon.rs:419-459`): on a retriable error and if `settings.daemon.autostart`, restarts and retries. Already wraps `start_history`/`end_history`/`cancel_history`.
-- Cold-start is serialized against thundering-herd shell hooks by a pidfile + `.startup.lock` (`daemon.rs:359-361`, `wait_for_pidfile_available` at `:379`).
+### 2.4 Records/sync/dotfiles are higher-level and can use direct RPCs
 
-**Conclusion:** the question "is it *possible* to spawn a daemon and talk to it ephemerally?" is already answered by shipping code. Autostart is that mechanism, minus the "it stays resident afterward" part.
-
-### 1.4 The read path already depends on local SQLite regardless
-
-Even in `DaemonFuzzy` search mode, the daemon only returns **ranked UUIDs** from its in-memory index; the client still hydrates full rows from local SQLite (`crates/atuin/src/command/client/search/engines/daemon.rs:104-112`, `full_query` at `:118-228`), and falls back to `db.search` for regex. So the client *always* links and opens SQLite for reads. This means removing the daemonless *read* path is neither necessary nor clearly beneficial — keeping local reads is fine. **The cutover should focus on writes.**
-
-### 1.5 Lifecycle & platform facts that constrain the design
-
-- **No idle/ephemeral shutdown exists.** The daemon runs until `ShutdownRequested`/SIGTERM (`crates/atuin-daemon/src/daemon.rs:297-322`). There is no "serve one request then exit."
-- **Windows is a first-class target** (`dist-workspace.toml`, CI matrix `windows-latest`). It has **no `fork`/daemonize** — autostart just `cmd.spawn()`s a detached `atuin daemon start` and the daemon listens on **TCP loopback** `127.0.0.1:8889` (`crates/atuin-daemon/src/server.rs:120-170`, `client.rs` `#[cfg(not(unix))]` blocks). So "fork+execve" is unix-specific framing; the portable primitive is "spawn a detached child process."
-- **macOS** has no systemd; it relies on autostart or a manual launch (no launchd plist in-repo).
-- **systemd socket activation** exists on Linux (`server.rs:32-67`) and is *incompatible* with autostart (`ensure_autostart_supported` bails, `daemon.rs:335-346`). Any always-on-daemon design must keep deferring to systemd when `daemon.systemd_socket = true`.
+Unlike the wide history *read* surface, record-store *writes* and sync are few and high-level (`push`, `delete_entries`, `re_encrypt`, `purge`, `verify`, `status`, `sync`, `rebuild`, plus dotfiles/kv/scripts `set/get/list/delete`). These are better exposed as explicit daemon RPCs than as a raw `Store`-trait proxy, because they carry policy (encryption keys, sync cadence, projection rebuilds) that must live daemon-side anyway. The daemon already owns the encryption key and a background sync loop (`components/sync.rs`), so moving `login`'s `re_encrypt` and `sync`'s network calls behind the daemon also **centralizes key handling** instead of loading the key in every client process.
 
 ---
 
-## Part 2 — Design analysis & recommendation
+## Part 3 — Decisions to ratify before coding
 
-### 2.1 Option A — Truly ephemeral daemon (spawn → serve → die). NOT recommended.
-
-Spawn a fresh daemon per shell command (or per burst), serve the request, exit when idle.
-
-- **Cost:** every `history start`/`end` hook (i.e. every shell command) pays process-spawn + gRPC-connect + component-boot latency. Even with a short idle window, interactive shells fire these constantly; you'd thrash spawn/teardown.
-- **Loses the daemon's whole point:** the in-memory fuzzy index and the background sync loop only pay off if the process persists across commands. An ephemeral daemon rebuilds/dumps that state every time.
-- **Verdict:** technically possible, practically worse than both current modes. Reject.
-
-### 2.2 Option B — Spawn-on-demand, *persistent* daemon (RECOMMENDED)
-
-Keep exactly one resident daemon, spawned lazily on first need, reused thereafter — i.e. make autostart's behavior the default and remove the daemonless write branch.
-
-- The daemon becomes the single write path. The daemonless `handle_start`/`handle_end` inline-DB logic is deleted (or demoted to a narrow fallback — see §2.4).
-- Sync semantics converge on the daemon's background loop (a deliberate, documented change from inline-on-every-`end`).
-- Reuses all the hardening already built: startup lock, stale-socket cleanup, version negotiation, retry-on-restart.
-- "Ephemeral" in the issue's spirit is satisfied by *spawn-on-demand*: users who never opened a daemon still get one transparently, without adopting systemd.
-
-**This is the recommendation.** The rest of the plan implements Option B.
-
-### 2.3 The load-bearing open questions (need maintainer ratification before coding)
-
-1. **Fallback policy.** `atuin history start/end` runs on *every shell command*. If the daemon cannot be spawned (locked-down container, no fork, exhausted PIDs, read-only runtime dir), do we:
-   - **(2a)** fall back to the current direct-DB write (keep `handle_start`/`handle_end` alive as a fallback only), or
-   - **(2b)** fail the hook (history silently not recorded)?
-
-   Recommendation: **(2a) keep the direct-DB path as an explicit, last-resort fallback**, not as a co-equal mode. This retains reliability while removing it from the *happy path*. It does **not** fully eliminate the code — but it removes the *config-driven* dual maintenance and lets the fallback be tested as one narrow branch. If the goal is truly deleting the code, that is **(2b)**, which is riskier and should be a follow-up once telemetry shows autostart is reliable in the wild.
-2. **Default flip.** Do we flip `daemon.enabled`/`daemon.autostart` defaults to `true`, or keep them opt-in for a release and only change the *plumbing*? Flipping defaults changes behavior for every existing user (first command in a shell now spawns a daemon). Recommendation: land the plumbing first (Phase 1-3) behind existing config, then flip defaults in a separate, well-announced release (Phase 4).
-3. **Sync latency change.** Moving from inline-per-`end` sync to the background loop means the last command before a shell exits may not sync immediately. Acceptable? (The daemon already behaves this way for autostart users; this just makes it universal.) Recommendation: accept and document.
-4. **Non-interactive `atuin search` in scripts/CI.** Should a one-off `atuin search` in a script spawn a daemon? Today it never does (pure local read). Recommendation: **leave non-interactive search local** — it is a read, §1.4 shows reads always use local SQLite anyway, and spawning a daemon for a one-shot scripted query is pure overhead.
-
-### 2.4 What "unification" concretely reduces to
-
-After Option B, the only genuinely dual-maintained logic left is the §2.3-item-1 fallback. Everything else collapses:
-
-- `history.rs:577`/`:593` branch → single `ensure_daemon_running` + daemon RPC (with optional fallback).
-- Autostart stops being an opt-in feature and becomes the mechanism the write path always uses.
-- The daemon `search` engine and local `db` engine remain as-is (read axis unchanged, §1.4).
+1. **No fallback — accepted consequence.** With the direct paths deleted, if the daemon cannot be spawned (no `fork`, locked-down sandbox, read-only `XDG_RUNTIME_DIR`, exhausted PIDs), **atuin cannot record or search history at all** — it fails rather than degrades. This is the explicit goal; documenting it here so it is a chosen tradeoff, not a surprise. Mitigation is limited to clear error messaging and making spawn as robust as possible.
+2. **Every command spawns/needs a daemon**, including one-shots in scripts/CI (`atuin stats`, `atuin search <q>`, `atuin import`, `atuin mcp`, `atuin ai`). First invocation pays cold-start (already serialized by the startup lock). Acceptable? (Recommendation: yes, but keep cold-start fast and consider a `--no-daemon`-style *escape hatch for import only*, see risks.)
+3. **Import bulk path.** `atuin import` does `save_bulk` of potentially millions of rows (`import.rs:155/168`). Proxying that row-by-row over gRPC is a non-starter; it needs a **client-streaming `SaveBulk` RPC**, or import runs *inside* the daemon. Ratify which.
+4. **Sync/network ownership moves to the daemon** (diff/operations/sync_remote, `store push`/`pull`, `history end` auto-sync). Confirm the daemon becomes the sole sync driver and the CLI `sync`/`store push/pull` commands become thin RPC triggers.
+5. **Scope of stores.** Confirm the dotfiles (`alias`/`var`), `kv`, and `scripts` record stores are in scope for removal too (they are separate `Store`-backed DBs). They are the long tail of the census and the largest incremental surface.
+6. **Non-daemon build (`--no-default-features`, `daemon` feature off).** Today the daemonless path *is* the code that compiles with the `daemon` feature off. If we delete it, either (a) the `daemon` feature becomes non-optional, or (b) a minimal embedded path remains for that build. Ratify — this decides whether `#[cfg(feature = "daemon")]` gates disappear entirely.
 
 ---
 
-## Part 3 — Phased implementation plan (contingent on §2.3 ratification)
+## Part 4 — Phased implementation plan (contingent on Part 3)
 
-> This plan implements **Option B with a §2.3-item-1(2a) fallback**: the daemon becomes the default write path, spawned on demand; the direct-DB write survives only as an explicit last-resort fallback. Each task ends with an independently testable deliverable. TDD throughout: write the failing test, watch it fail, implement, watch it pass, commit.
+> Multi-release. Each phase is independently shippable and leaves the tree working. TDD throughout: write the failing test, watch it fail, implement, watch it pass, commit. Every phase keeps Windows CI (`windows-latest`, TCP transport) green and preserves the non-fatal-on-error behavior of the shell hooks.
 
 ### Global Constraints
 
-- **Rust edition/toolchain:** as pinned by `rust-toolchain.toml` (currently 1.97). Do not bump.
-- **Must compile with `--no-default-features` and with the `daemon` feature off.** All new daemon-path code stays behind `#[cfg(feature = "daemon")]`; the fallback path must remain the code that compiles when `daemon` is disabled.
-- **Windows must keep building and passing CI** (`windows-latest`). Never assume `fork`/unix sockets; use the existing `#[cfg(unix)]` / `#[cfg(not(unix))]` split (TCP on Windows).
-- **Never break the shell hook.** `history start`/`end` errors must stay swallowed/non-fatal exactly as today (`history.rs` already logs-and-continues).
-- **Respect `daemon.systemd_socket = true`:** never autostart in that mode (`ensure_autostart_supported`, `daemon.rs:335-346`); defer to systemd.
-- **Preserve `store_failed` semantics:** non-zero exit with `store_failed = false` must cancel/delete the in-flight entry, in both daemon and fallback paths (`history.rs:560-565`, `:511-518`).
-- Conventional-commit messages; frequent commits; one deliverable per task.
+- Toolchain per `rust-toolchain.toml` (currently 1.97); do not bump.
+- Keep Windows building/passing at every phase (no `fork`/unix-socket assumptions; use the existing `#[cfg(unix)]`/`#[cfg(not(unix))]` split).
+- `history start`/`end` must stay non-fatal on error, exactly as today.
+- Never autostart when `daemon.systemd_socket = true`; defer to systemd (`ensure_autostart_supported`, `daemon.rs:335-346`).
+- Preserve `store_failed` semantics: non-zero exit with `store_failed = false` cancels the in-flight entry (`history.rs:560-565`, `:511-518`).
+- Conventional commits; one shippable deliverable per phase; breaking changes flagged with `!` + changelog.
 
 ---
 
-### Task 1: Introduce a single "resolve the write path" seam (no behavior change)
+### Phase 0 — Make handlers generic over the storage traits (no behavior change)
 
-Refactor `start_history_entry`/`end_history_entry` so the daemon-vs-fallback decision lives in one function instead of being inlined at two call sites. Pure refactor; behavior identical; this is the seam every later task edits.
+Prerequisite refactor so a proxy can be substituted for `Sqlite`/`SqliteStore` later. Pure refactor; behavior identical.
 
-**Files:**
-- Modify: `crates/atuin/src/command/client/history.rs:570-610`
-- Test: `crates/atuin/src/command/client/history.rs` (inline `#[cfg(test)]` module) or `crates/atuin/tests/` if one exists.
+**Files (representative):** `crates/atuin/src/command/client.rs`, `.../history.rs`, `.../search*.rs`, `.../stats.rs`, `.../sync.rs`, `crates/atuin-client/src/history/store.rs` (make `HistoryStore` generic over `Store`).
 
-**Interfaces:**
-- Produces: `async fn write_backend(settings: &Settings) -> WriteBackend` where `enum WriteBackend { Daemon, Direct }`, chosen today by `cfg!(feature="daemon") && settings.daemon.enabled`. `start_history_entry`/`end_history_entry` match on it.
-
-- [ ] **Step 1: Write the failing test** — assert that with `daemon.enabled = false`, `write_backend(&settings)` returns `WriteBackend::Direct`; with `daemon.enabled = true` (and feature on), returns `WriteBackend::Daemon`.
-
-```rust
-#[tokio::test]
-async fn write_backend_follows_daemon_enabled() {
-    let mut settings = Settings::utils_test_config();
-    settings.daemon.enabled = false;
-    assert_eq!(write_backend(&settings).await, WriteBackend::Direct);
-    #[cfg(feature = "daemon")]
-    {
-        settings.daemon.enabled = true;
-        assert_eq!(write_backend(&settings).await, WriteBackend::Daemon);
-    }
-}
-```
-
-- [ ] **Step 2: Run it, confirm it fails** — `cargo test -p atuin --features daemon write_backend_follows_daemon_enabled` → FAIL (`write_backend` not found). (Check whether a `Settings::utils_test_config`-style helper exists; if not, construct `Settings` via the existing test pattern in `atuin-client`.)
-- [ ] **Step 3: Implement `WriteBackend` + `write_backend()`** and rewrite the two entry points to `match` on it, calling the *existing* `handle_daemon_*` / `handle_*` bodies unchanged.
-- [ ] **Step 4: Run test + full build both feature states** — `cargo test -p atuin --features daemon write_backend...` PASS; `cargo build -p atuin --no-default-features` and `cargo build -p atuin --features daemon` both succeed.
-- [ ] **Step 5: Commit** — `refactor(history): centralize daemon-vs-direct write backend selection`
+- [ ] **Step 1:** Add a compile-time assertion / test that the command handlers accept `&dyn Database` (e.g. a test that constructs a trivial `Database` mock and passes it to `run_non_interactive`).
+- [ ] **Step 2:** Run it; confirm it fails to compile (handlers currently demand concrete `Sqlite`).
+- [ ] **Step 3:** Change handler signatures from `&Sqlite`/`Sqlite` to `&dyn Database`/`impl Database`; make `HistoryStore<S: Store>` generic. Construction sites still pass concrete `Sqlite`/`SqliteStore`.
+- [ ] **Step 4:** `cargo test --workspace` + `cargo build -p atuin --no-default-features` + `--features daemon` all green.
+- [ ] **Step 5: Commit** — `refactor(client): make command handlers generic over Database/Store traits`
 
 ---
 
-### Task 2: Make the daemon write path autostart-on-demand by default
+### Phase 1 — `DaemonDatabase` read proxy + proto for the `Database` read surface
 
-Ensure that when `WriteBackend::Daemon` is selected, a missing daemon is spawned transparently (not only when `autostart` was explicitly set). This is the "spawn ephemeral daemon" behavior.
+Add gRPC methods mirroring the read half of `Database` (`search`, `query_history`, `list`, `range`, `load`, `last`, `before`, `history_count`, `stats`, `get_dups`, `all_with_count`/`all_paged` as streaming), a server impl backed by the daemon's `Sqlite`, and a client `DaemonDatabase` implementing those `Database` methods over gRPC. Writes still go direct in this phase.
 
-**Files:**
-- Modify: `crates/atuin/src/command/client/daemon.rs` (the `try_with_restart` / `start_history` / `end_history` wrappers around `daemon.rs:419-498`)
-- Modify: `crates/atuin/src/command/client/history.rs` (`handle_daemon_start`/`handle_daemon_end`)
+**Files:** `crates/atuin-daemon/proto/history.proto` (or a new `database.proto`); `crates/atuin-daemon/src/components/` (new service impl); `crates/atuin-daemon/src/client.rs` (new client); `crates/atuin/src/command/client/.../DaemonDatabase` proxy.
 
-**Interfaces:**
-- Consumes: `ensure_daemon_running(settings)` (`daemon.rs:355`), `try_with_restart` (`daemon.rs:419`).
-- Produces: daemon write RPCs that, on a connect/unavailable error, call `ensure_daemon_running` and retry **whenever the daemon write backend is in use**, independent of the legacy `autostart` opt-in (still gated off for `systemd_socket`).
-
-- [ ] **Step 1: Write the failing test** — a unit test around the retry decision: given a first call that returns a `DaemonClientErrorKind::Connect` error and `systemd_socket = false`, the wrapper attempts `ensure_daemon_running` exactly once and retries. Use a small injected closure/fake so no real socket is needed (mirror the existing `try_with_restart` signature which already takes a closure).
-
-```rust
-#[tokio::test]
-async fn daemon_write_spawns_on_connect_error() {
-    // fake sender: first call -> Connect error, second -> Ok
-    // assert ensure-hook invoked once, final result Ok
-}
-```
-
-- [ ] **Step 2: Run it, confirm it fails** — `cargo test -p atuin --features daemon daemon_write_spawns_on_connect_error` → FAIL.
-- [ ] **Step 3: Implement** — thread a "may autostart" decision that is `true` for the daemon write backend (except `systemd_socket`), so `try_with_restart` no longer requires `settings.daemon.autostart` for the write path specifically. Keep `ensure_autostart_supported`'s systemd guard.
-- [ ] **Step 4: Run test + `cargo clippy -p atuin --features daemon -- -D warnings`** → PASS/clean.
-- [ ] **Step 5: Commit** — `feat(daemon): autostart daemon on demand for the write path`
+- [ ] **Step 1:** Failing test — a round-trip: start an in-process daemon service over a `Sqlite`, seed rows, call `DaemonDatabase::search(...)`, assert the same rows as calling `Sqlite::search(...)` directly.
+- [ ] **Step 2:** Run it; confirm it fails (RPC/proxy absent).
+- [ ] **Step 3:** Add the proto methods + `prost`/`tonic` regen, server impl delegating to `Sqlite`, and `DaemonDatabase` client forwarding + type (de)serialization for `History`, `FilterMode`, `SearchMode`, `Context`.
+- [ ] **Step 4:** Test passes; clippy clean; both feature builds green.
+- [ ] **Step 5: Commit** — `feat(daemon): serve the Database read surface over gRPC`
 
 ---
 
-### Task 3: Add the explicit last-resort fallback (§2.3-item-1(2a))
+### Phase 2 — Route all history *reads* through `DaemonDatabase`; delete direct read construction
 
-When the daemon write backend is selected but the daemon cannot be spawned (spawn fails or never becomes ready within `startup_timeout`), fall back to the direct-DB write instead of dropping the record — and log a one-time-ish warning.
+Swap the read construction sites to build a `DaemonDatabase` (ensuring a daemon is running) instead of a `Sqlite`. This removes direct SQLite reads from `search`, `stats`, `wrapped`, interactive TUI, `history list/last`, `scripts new --last`, `ai`, `mcp`.
 
-**Files:**
-- Modify: `crates/atuin/src/command/client/history.rs` (`handle_daemon_start`/`handle_daemon_end` error handling)
+**Files:** `crates/atuin/src/command/client.rs:359`; `crates/atuin-ai/src/commands/inline.rs:64`, `mcp.rs:87`; `crates/atuin/src/command/client/search/engines/daemon.rs` (drop the local-hydrate fallback — the daemon now returns rows).
 
-**Interfaces:**
-- Consumes: existing `handle_start`/`handle_end` (the direct-DB writers) and `Sqlite`/`SqliteStore`/`HistoryStore` construction already present in `end_history_entry` (`history.rs:597-607`).
-- Produces: `handle_daemon_start`/`handle_daemon_end` that, on an unrecoverable daemon error, delegate to the direct writers and return `Ok`.
-
-- [ ] **Step 1: Write the failing test** — simulate `ensure_daemon_running` failing (e.g. point `socket_path`/`pidfile` at an unwritable/uncreatable location, or inject a failing spawn hook) and assert the record is still persisted to the local `Sqlite` DB afterward. Read it back with `db.load(id)`.
-- [ ] **Step 2: Run it, confirm it fails** — `cargo test -p atuin --features daemon daemon_write_falls_back_to_direct` → FAIL (record absent).
-- [ ] **Step 3: Implement the fallback** — wrap the daemon RPC; on terminal failure, `warn!` and call the direct writer. Preserve `store_failed`/exit-code cancel semantics in the fallback branch.
-- [ ] **Step 4: Run test + both-feature builds** — PASS; `--no-default-features` still builds (fallback body is the code that must survive with `daemon` off).
-- [ ] **Step 5: Commit** — `feat(history): fall back to direct DB write when daemon unavailable`
+- [ ] **Step 1:** Failing integration test — run `atuin search <q>` / `atuin stats` against a fixture with a daemon and assert correct output with **no** client-side `Sqlite::new` (assert via a build-time grep test or a seam that panics if the client opens the DB).
+- [ ] **Step 2:** Confirm failure.
+- [ ] **Step 3:** Replace read constructors with `DaemonDatabase` behind `ensure_daemon_running`; collapse the `SearchMode::DaemonFuzzy` engine into the single daemon-backed engine (`engines.rs:17-29`).
+- [ ] **Step 4:** Full suite + Windows-path build green.
+- [ ] **Step 5: Commit** — `feat(client): route history reads through the daemon; remove direct-read SQLite`
 
 ---
 
-### Task 4: Documentation — reference + migration note
+### Phase 3 — Write/delete/import over the daemon; delete the daemonless write branch
 
-Document the new behavior: the daemon is the blessed write path, spawned on demand; the direct write is a fallback; sync moves to the background loop for these users.
+Add write RPCs (`save`, `update`, `delete`, streaming `save_bulk`), route `history start/end/prune/dedup/init-store`, `import`, and interactive/`--delete` deletes through them, and **delete `handle_start`/`handle_end` direct bodies and the `settings.daemon.enabled` branch** at `history.rs:577/593`.
 
-**Files:**
-- Modify: `docs/docs/reference/daemon.md`
-- Modify: `docs/docs/reference/config.md` (or wherever `daemon.*` keys are documented) to describe the new default/behavior of `daemon.enabled`/`daemon.autostart`.
-- Modify: this file's Part 2 open questions → record the ratified decisions.
+**Files:** proto write methods; daemon server write impl; `crates/atuin/src/command/client/history.rs` (remove daemonless branch + direct constructors at `:582/600/601/607/1142/1150`); `import.rs` (streaming bulk).
 
-- [ ] **Step 1:** Update `daemon.md`: explain spawn-on-demand, the systemd-socket exception, and the fallback.
-- [ ] **Step 2:** Note the sync-timing change (inline → background) and its user-visible effect.
-- [ ] **Step 3:** Build the docs site if tooling is available (`mkdocs build` under `docs/`), else visually review the Markdown.
-- [ ] **Step 4: Commit** — `docs(daemon): document spawn-on-demand write path and fallback`
+- [ ] **Step 1:** Failing tests — `history start`→`end` persists via daemon and reads back; `import` streams N rows and count matches; failed-cmd cancel semantics preserved.
+- [ ] **Step 2:** Confirm failure.
+- [ ] **Step 3:** Implement write RPCs + streaming bulk; delete the direct write branch and constructors.
+- [ ] **Step 4:** Suite green; `--no-default-features` decision from Part 3.6 enforced.
+- [ ] **Step 5: Commit** — `feat(client)!: daemon owns all history writes; remove daemonless write path`
 
 ---
 
-### Task 5 (SEPARATE RELEASE — gated on §2.3-item-2): Flip defaults
+### Phase 4 — Record store, sync, and key ops behind the daemon
 
-**Do not bundle with Tasks 1–4.** Once telemetry/dogfooding shows spawn-on-demand is reliable, flip `daemon.enabled` (and/or `autostart`) defaults to `true` so new users get the daemon path without config.
+Move `store status/rebuild/rekey/purge/verify/push/pull`, `sync`/`sync status`, and `login`/`register` key re-encryption to daemon RPCs; delete the client's `SqliteStore`/`HistoryStore` construction and inline sync (`client.rs:360`, `history.rs:528-548/601-609`, `sync.rs`, `store/*`, `account/login.rs:263`).
 
-**Files:**
-- Modify: `crates/atuin-client/src/settings.rs:1583-1584` (`daemon.enabled` / `daemon.autostart` defaults)
-
-- [ ] **Step 1: Write/adjust the failing test** — assert the default `Settings` now reports the daemon write backend on a platform where autostart is supported.
-- [ ] **Step 2:** Confirm it fails against current defaults.
-- [ ] **Step 3:** Flip the `set_default` values.
-- [ ] **Step 4:** Full test suite `cargo test --workspace`; verify Windows CI green.
-- [ ] **Step 5: Commit** — `feat(daemon)!: default to daemon write path (spawn on demand)` (breaking-change footer; changelog + release-notes call-out).
+- [ ] **Step 1–5:** Per-operation TDD as above; the daemon becomes the sole sync driver and key holder; CLI sync/store commands become thin RPC triggers. Commit `feat(client)!: daemon owns record store, sync, and key rotation`.
 
 ---
 
-## Part 4 — Risks & mitigations (summary)
+### Phase 5 — Dotfiles / kv / scripts stores + final cleanup
 
-| Risk | Mitigation |
+Move `dotfiles alias/var`, `kv`, `scripts`, and `init <shell>` dotfiles reads behind the daemon; delete the last direct `*Store::new` sites; remove now-dead `#[cfg(feature = "daemon")]` branches per Part 3.6; delete the `daemon.enabled` setting (or repurpose).
+
+- [ ] **Step 1–5:** Per-store TDD; final grep-test asserts **zero** `Sqlite::new`/`SqliteStore::new`/`*Store::new` outside `crates/atuin-daemon/` and the daemon boot path. Commit `feat(client)!: complete removal of direct storage access from the CLI`.
+
+---
+
+## Part 5 — Risks & mitigations
+
+| Risk | Mitigation / decision |
 |---|---|
-| Daemon can't spawn in restricted envs | Task 3 direct-DB fallback keeps history recording working |
-| Cold-start latency on first shell command | Existing startup lock + `wait_until_ready`; latency paid once per daemon lifetime, not per command |
-| Windows (no fork) | Reuse existing detached-`spawn` + TCP path; keep CI on `windows-latest` |
-| systemd users double-managing the daemon | Keep `ensure_autostart_supported` guard; never autostart when `systemd_socket = true` |
-| Sync no longer inline-per-command | Documented behavior change (Task 4); matches what autostart users already experience |
-| Scripted one-off `atuin search` spawning daemons | Leave non-interactive search local (§2.3-item-4) |
+| Daemon can't spawn ⇒ atuin non-functional (no fallback) | Accepted per Part 3.1; invest in robust spawn + clear errors |
+| Cold-start on every one-shot command (CI/scripts) | Existing startup lock; keep boot fast; possible import-only escape hatch (Part 3.2/3.3) |
+| `import` of millions of rows over gRPC | Client-streaming `SaveBulk` RPC or in-daemon import (Part 3.3) |
+| skim engine loads *all* history (`all_with_count`) | Streaming read RPC, or reconsider skim under daemon |
+| Windows (no fork) | Existing detached-spawn + TCP loopback path; keep `windows-latest` CI |
+| systemd users double-managing daemon | Keep `ensure_autostart_supported` guard |
+| Encryption key now daemon-held | Centralizes key handling; audit key lifecycle during Phase 4 |
+| `--no-default-features` build loses its storage path | Ratify Part 3.6 (feature becomes non-optional vs minimal embedded path) |
+| Large blast radius / long migration | Phased; each phase ships independently and keeps the tree working |
 
-## Part 5 — Recommendation to the maintainer
+## Part 6 — Recommendation
 
-1. **Adopt Option B** (spawn-on-demand persistent daemon), not a truly ephemeral one.
-2. **Ratify the four §2.3 decisions** (fallback policy, default-flip timing, sync-latency acceptance, non-interactive search stays local).
-3. **Land Tasks 1–4 first** (plumbing + fallback + docs) behind current config, then **Task 5** (default flip) as a separate, announced release.
-4. The daemonless *read* path stays — it is not a maintenance problem and reads always use local SQLite anyway.
+1. **Proceed with complete removal** via the **trait-proxy architecture** (Part 2) — it is the only approach that deletes the duplication without rewriting every command.
+2. **Ratify the six Part 3 decisions** first; #3 (import), #4 (sync ownership), and #6 (no-default-features build) are load-bearing.
+3. **Land Phases 0–5 across several releases**, each shippable; do **not** attempt this in one PR.
+4. Accept and document that the daemon becomes a hard dependency (no degraded mode).
+
+---
+
+## Appendix A — Full census: direct history-DB (`Database`/`Sqlite`) access
+
+*(Excludes `crates/atuin-daemon/`, which is the intended sole owner.)*
+
+**CONSTRUCT sites:** `client.rs:359` (all non-early-return cmds); `history.rs:582` (start), `:600` (end), `:1142` (list/last/init-store/prune/dedup); `atuin-ai/src/commands/inline.rs:64` (ai); `atuin-ai/src/mcp.rs:87-88` (mcp). (`doctor.rs:360` opens only an in-memory DB for a version string.)
+
+**READ:** `search.rs:332` + delete-loop `:281`; `search/engines/db.rs:27`; `search/engines.rs:76`; `search/engines/skim.rs:60` (`all_with_count`); `search/engines/daemon.rs:88` (regex fallback), `:111` (`query_history` hydrate); `search/interactive.rs:1760` (`history_count`), `:1876` (`query_history`), `:1955` (`load`), `:1972` (`stats`), `:1935` (dispatch); `stats.rs:54` (`list`), `:58/62/66/70/74` (`range`); `wrapped.rs:319` (`range`); `history.rs:962` (`list`), `:991` (`list`), `:1053` (`get_dups`), `:1178` (`last`), `:499` (`load`); `sync.rs:99/130` (`history_count`); `sync/status.rs:31/32`; `scripts.rs:236` (`list`); `atuin-ai/src/tools/mod.rs:1206` (`search`, from `driver.rs:782` + `mcp.rs:52`); `atuin-ai/src/commands/inline.rs:73` (`last`).
+
+**WRITE:** `history.rs:441` (`save`), `:527` (`update`); `import.rs:155/168` (`save_bulk`).
+
+**DELETE:** `history.rs:515` (`delete`), `:1028` (prune), `:1089` (dedup).
+
+**INDIRECT (`&db` handed to `HistoryStore`/sync):** `history.rs:1196` (`init_store`), `:1026/1087` (`incremental_build`); `search.rs:278`; `search/interactive.rs:1861/1884`; `sync.rs:42` (`crate::sync::build`); `command/client/sync.rs:111/125`; `store/rebuild.rs:61` (`build`); `store/pull.rs:90`.
+
+## Appendix B — Full census: direct record-store (`Store`/`SqliteStore`/`HistoryStore`/…) access & sync
+
+*(Excludes `crates/atuin-daemon/`.)*
+
+**Shared CONSTRUCT:** `client.rs:360` opens `SqliteStore` for every non-early-return cmd.
+
+**Per-command (file:line → op):**
+- `history end`: `history.rs:601/607` construct; `:528` push; `:535` `record::sync::sync`; `:538` `crate::sync::build`; `:541` legacy sync.
+- `history init-store`: `:1143/1150` construct; `:1196` `init_store`.
+- `history prune`: `:1020` construct; `:1025` `delete`; `:1026` `incremental_build`.
+- `history dedup`: `:1078` construct; `:1086` `delete`; `:1087` `incremental_build`.
+- `sync`: `command/client/sync.rs:89` construct; `:91/116` `sync`; `:95/120` `build`; `:100` `len_tag`; `:111` `init_store`; `:125` legacy sync.
+- `search --delete`: `search.rs:226` construct; `:277` `delete_entries`; `:278` `incremental_build`.
+- `search -i` delete: `interactive.rs:1860/1883` `delete_entries`; `:1861/1884` `incremental_build`.
+- `store status`: `store.rs:58/76/91/92` `status/first/last`.
+- `store rebuild`: `store/rebuild.rs:59-61` history `build`; `:74-78` dotfiles; `:86-90` scripts.
+- `store rekey`: `store/rekey.rs:49` `re_encrypt`.
+- `store purge`: `store/purge.rs:19` `purge`.
+- `store verify`: `store/verify.rs:19` `verify`.
+- `store push`: `store/push.rs:63/73/106` diff/operations/`sync_remote`.
+- `store pull`: `store/pull.rs:41` `delete_all`; `:51/61/86` diff/operations/`sync_remote`; `:90` `build`.
+- `login`/`register`: `account/login.rs:263` `re_encrypt`; `account/register.rs:119` delegates.
+- `kv *`: `kv.rs:73` `KvStore::new`.
+- `dotfiles alias`: `dotfiles/alias.rs:164` `AliasStore::new`.
+- `dotfiles var`: `dotfiles/var.rs:164` `VarStore::new`.
+- `scripts *`: `scripts.rs:572` `ScriptStore::new`.
+- `init <shell>`: `init.rs:130` construct; `:137-138` alias/var read.
+- `wrapped`: `wrapped.rs:332` alias read.
+- `daemon start`: `daemon.rs:86/658/669` receive store, hand to `atuin_daemon::boot` (kept — this is the owner).
+- Shared projection `crate::sync::build`: `sync.rs:24` `load_key`, `:34` `HistoryStore::new`, `:35-38` alias/var/kv/script stores, `:42-62` `incremental_build`/`build`.
+
+**Underlying `.push` impls:** `atuin-client/src/history/store.rs:139/167`; `atuin-dotfiles/src/store.rs:251/287`, `store/var.rs:298/334`; `atuin-kv/src/store.rs:104`; `atuin-scripts/src/store.rs:49`.
+
+**Not implicated:** `crates/atuin-ai/` has no direct record-store/sync access. `import`, `stats`, `sync status`, `logout`, `account delete/change-password/link` open the store at dispatch but don't use it (would still need the lazy-construct change).

--- a/docs/dev/atu-538-ephemeral-daemon-investigation.md
+++ b/docs/dev/atu-538-ephemeral-daemon-investigation.md
@@ -1,0 +1,265 @@
+# ATU-538 — Ephemeral Daemon Investigation & Cutover Plan
+
+> **Status:** Investigation complete — recommendation and phased implementation plan below.
+> **Issue:** ATU-538 "Investigate whether making daemonless mode just spawn an ephemeral daemon is possible."
+> **Project:** Completely Cutover to Daemon.
+>
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement the plan in Part 3 task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking. **Do not begin implementation before the design decisions in Part 2 are ratified by a maintainer** — this is an investigation deliverable, and the plan is contingent on those decisions.
+
+**Goal of the investigation:** Determine whether the daemonless code path can be eliminated by having the client transparently spawn/talk to a daemon, so we stop maintaining two storage code paths.
+
+**One-line verdict:** **Yes, it is feasible — and most of the mechanism already exists.** The autostart feature already does `fork`/`spawn`-into-daemon and waits for readiness. The real work is not "make spawning possible" (it is), but "collapse the branch so the daemon path is the *only* write path," plus deciding the fallback story for environments where a daemon genuinely cannot run. A *truly* ephemeral (spawn → serve one request → die) daemon is **not** recommended; a **spawn-on-demand, persistent** daemon is.
+
+---
+
+## Part 1 — What exists today (grounded architecture map)
+
+### 1.1 There are two independent axes, not one switch
+
+The word "daemonless" hides two separate decisions:
+
+| Axis | Gate | Where |
+|---|---|---|
+| **Write path** (record `start`/`end`) | runtime `settings.daemon.enabled` | `crates/atuin/src/command/client/history.rs:577`, `:593` |
+| **Read path** (interactive TUI search only) | `settings.search_mode == SearchMode::DaemonFuzzy` | `crates/atuin/src/command/client/search/engines.rs:17-29` |
+
+Both are additionally behind the compile-time `#[cfg(feature = "daemon")]` gate. **Non-interactive `atuin search <query>` never uses the daemon at all** — it always queries local SQLite (`crates/atuin/src/command/client/search.rs:310-342`).
+
+This decoupling matters: "cutover to daemon" is really "collapse the *write* axis," because the read axis already has a sane story (see §1.4).
+
+### 1.2 The write path — the actual dual-maintenance burden
+
+`crates/atuin/src/command/client/history.rs`:
+
+```rust
+// start_history_entry — history.rs:570-584
+#[cfg(feature = "daemon")]
+if settings.daemon.enabled {
+    return handle_daemon_start(settings, command, author, intent).await; // gRPC to daemon
+}
+let db = Sqlite::new(db_path, settings.local_timeout).await?;             // daemonless: open DB directly
+handle_start(&db, settings, command, author, intent).await
+
+// end_history_entry — history.rs:586-610
+#[cfg(feature = "daemon")]
+if settings.daemon.enabled {
+    return handle_daemon_end(settings, id, exit, duration).await;        // gRPC to daemon
+}
+// daemonless: open Sqlite + SqliteStore + HistoryStore, then...
+handle_end(&db, store, history_store, settings, id, exit, duration).await
+```
+
+The daemonless `handle_end` (`history.rs:485-551`) does: `db.update()` → `history_store.push()` → **inline sync** (`history.rs:530-548`). The daemon replicates the exact same `db.save` / `history_store.push` server-side (`crates/atuin-daemon/src/components/history.rs:184-248`) and moves sync to a **background timer** (`crates/atuin-daemon/src/components/sync.rs`). So the two paths differ in *when sync happens* — a semantic difference the cutover must preserve or consciously change.
+
+### 1.3 The daemon can already be spawned on demand — this is the crux
+
+The autostart infrastructure in `crates/atuin/src/command/client/daemon.rs` **already implements the issue's proposed `fork+execve` idea**:
+
+- `spawn_daemon_process()` (`daemon.rs:253-269`): re-execs the current binary as `atuin daemon start` (+ `--daemonize` on unix), stdio nulled.
+- `ensure_daemon_running()` (`daemon.rs:355-389`): takes a cross-process startup lock, probes, removes a stale socket, spawns, then `wait_until_ready()`.
+- `try_with_restart()` (`daemon.rs:419-459`): on a retriable error and if `settings.daemon.autostart`, restarts and retries. Already wraps `start_history`/`end_history`/`cancel_history`.
+- Cold-start is serialized against thundering-herd shell hooks by a pidfile + `.startup.lock` (`daemon.rs:359-361`, `wait_for_pidfile_available` at `:379`).
+
+**Conclusion:** the question "is it *possible* to spawn a daemon and talk to it ephemerally?" is already answered by shipping code. Autostart is that mechanism, minus the "it stays resident afterward" part.
+
+### 1.4 The read path already depends on local SQLite regardless
+
+Even in `DaemonFuzzy` search mode, the daemon only returns **ranked UUIDs** from its in-memory index; the client still hydrates full rows from local SQLite (`crates/atuin/src/command/client/search/engines/daemon.rs:104-112`, `full_query` at `:118-228`), and falls back to `db.search` for regex. So the client *always* links and opens SQLite for reads. This means removing the daemonless *read* path is neither necessary nor clearly beneficial — keeping local reads is fine. **The cutover should focus on writes.**
+
+### 1.5 Lifecycle & platform facts that constrain the design
+
+- **No idle/ephemeral shutdown exists.** The daemon runs until `ShutdownRequested`/SIGTERM (`crates/atuin-daemon/src/daemon.rs:297-322`). There is no "serve one request then exit."
+- **Windows is a first-class target** (`dist-workspace.toml`, CI matrix `windows-latest`). It has **no `fork`/daemonize** — autostart just `cmd.spawn()`s a detached `atuin daemon start` and the daemon listens on **TCP loopback** `127.0.0.1:8889` (`crates/atuin-daemon/src/server.rs:120-170`, `client.rs` `#[cfg(not(unix))]` blocks). So "fork+execve" is unix-specific framing; the portable primitive is "spawn a detached child process."
+- **macOS** has no systemd; it relies on autostart or a manual launch (no launchd plist in-repo).
+- **systemd socket activation** exists on Linux (`server.rs:32-67`) and is *incompatible* with autostart (`ensure_autostart_supported` bails, `daemon.rs:335-346`). Any always-on-daemon design must keep deferring to systemd when `daemon.systemd_socket = true`.
+
+---
+
+## Part 2 — Design analysis & recommendation
+
+### 2.1 Option A — Truly ephemeral daemon (spawn → serve → die). NOT recommended.
+
+Spawn a fresh daemon per shell command (or per burst), serve the request, exit when idle.
+
+- **Cost:** every `history start`/`end` hook (i.e. every shell command) pays process-spawn + gRPC-connect + component-boot latency. Even with a short idle window, interactive shells fire these constantly; you'd thrash spawn/teardown.
+- **Loses the daemon's whole point:** the in-memory fuzzy index and the background sync loop only pay off if the process persists across commands. An ephemeral daemon rebuilds/dumps that state every time.
+- **Verdict:** technically possible, practically worse than both current modes. Reject.
+
+### 2.2 Option B — Spawn-on-demand, *persistent* daemon (RECOMMENDED)
+
+Keep exactly one resident daemon, spawned lazily on first need, reused thereafter — i.e. make autostart's behavior the default and remove the daemonless write branch.
+
+- The daemon becomes the single write path. The daemonless `handle_start`/`handle_end` inline-DB logic is deleted (or demoted to a narrow fallback — see §2.4).
+- Sync semantics converge on the daemon's background loop (a deliberate, documented change from inline-on-every-`end`).
+- Reuses all the hardening already built: startup lock, stale-socket cleanup, version negotiation, retry-on-restart.
+- "Ephemeral" in the issue's spirit is satisfied by *spawn-on-demand*: users who never opened a daemon still get one transparently, without adopting systemd.
+
+**This is the recommendation.** The rest of the plan implements Option B.
+
+### 2.3 The load-bearing open questions (need maintainer ratification before coding)
+
+1. **Fallback policy.** `atuin history start/end` runs on *every shell command*. If the daemon cannot be spawned (locked-down container, no fork, exhausted PIDs, read-only runtime dir), do we:
+   - **(2a)** fall back to the current direct-DB write (keep `handle_start`/`handle_end` alive as a fallback only), or
+   - **(2b)** fail the hook (history silently not recorded)?
+
+   Recommendation: **(2a) keep the direct-DB path as an explicit, last-resort fallback**, not as a co-equal mode. This retains reliability while removing it from the *happy path*. It does **not** fully eliminate the code — but it removes the *config-driven* dual maintenance and lets the fallback be tested as one narrow branch. If the goal is truly deleting the code, that is **(2b)**, which is riskier and should be a follow-up once telemetry shows autostart is reliable in the wild.
+2. **Default flip.** Do we flip `daemon.enabled`/`daemon.autostart` defaults to `true`, or keep them opt-in for a release and only change the *plumbing*? Flipping defaults changes behavior for every existing user (first command in a shell now spawns a daemon). Recommendation: land the plumbing first (Phase 1-3) behind existing config, then flip defaults in a separate, well-announced release (Phase 4).
+3. **Sync latency change.** Moving from inline-per-`end` sync to the background loop means the last command before a shell exits may not sync immediately. Acceptable? (The daemon already behaves this way for autostart users; this just makes it universal.) Recommendation: accept and document.
+4. **Non-interactive `atuin search` in scripts/CI.** Should a one-off `atuin search` in a script spawn a daemon? Today it never does (pure local read). Recommendation: **leave non-interactive search local** — it is a read, §1.4 shows reads always use local SQLite anyway, and spawning a daemon for a one-shot scripted query is pure overhead.
+
+### 2.4 What "unification" concretely reduces to
+
+After Option B, the only genuinely dual-maintained logic left is the §2.3-item-1 fallback. Everything else collapses:
+
+- `history.rs:577`/`:593` branch → single `ensure_daemon_running` + daemon RPC (with optional fallback).
+- Autostart stops being an opt-in feature and becomes the mechanism the write path always uses.
+- The daemon `search` engine and local `db` engine remain as-is (read axis unchanged, §1.4).
+
+---
+
+## Part 3 — Phased implementation plan (contingent on §2.3 ratification)
+
+> This plan implements **Option B with a §2.3-item-1(2a) fallback**: the daemon becomes the default write path, spawned on demand; the direct-DB write survives only as an explicit last-resort fallback. Each task ends with an independently testable deliverable. TDD throughout: write the failing test, watch it fail, implement, watch it pass, commit.
+
+### Global Constraints
+
+- **Rust edition/toolchain:** as pinned by `rust-toolchain.toml` (currently 1.97). Do not bump.
+- **Must compile with `--no-default-features` and with the `daemon` feature off.** All new daemon-path code stays behind `#[cfg(feature = "daemon")]`; the fallback path must remain the code that compiles when `daemon` is disabled.
+- **Windows must keep building and passing CI** (`windows-latest`). Never assume `fork`/unix sockets; use the existing `#[cfg(unix)]` / `#[cfg(not(unix))]` split (TCP on Windows).
+- **Never break the shell hook.** `history start`/`end` errors must stay swallowed/non-fatal exactly as today (`history.rs` already logs-and-continues).
+- **Respect `daemon.systemd_socket = true`:** never autostart in that mode (`ensure_autostart_supported`, `daemon.rs:335-346`); defer to systemd.
+- **Preserve `store_failed` semantics:** non-zero exit with `store_failed = false` must cancel/delete the in-flight entry, in both daemon and fallback paths (`history.rs:560-565`, `:511-518`).
+- Conventional-commit messages; frequent commits; one deliverable per task.
+
+---
+
+### Task 1: Introduce a single "resolve the write path" seam (no behavior change)
+
+Refactor `start_history_entry`/`end_history_entry` so the daemon-vs-fallback decision lives in one function instead of being inlined at two call sites. Pure refactor; behavior identical; this is the seam every later task edits.
+
+**Files:**
+- Modify: `crates/atuin/src/command/client/history.rs:570-610`
+- Test: `crates/atuin/src/command/client/history.rs` (inline `#[cfg(test)]` module) or `crates/atuin/tests/` if one exists.
+
+**Interfaces:**
+- Produces: `async fn write_backend(settings: &Settings) -> WriteBackend` where `enum WriteBackend { Daemon, Direct }`, chosen today by `cfg!(feature="daemon") && settings.daemon.enabled`. `start_history_entry`/`end_history_entry` match on it.
+
+- [ ] **Step 1: Write the failing test** — assert that with `daemon.enabled = false`, `write_backend(&settings)` returns `WriteBackend::Direct`; with `daemon.enabled = true` (and feature on), returns `WriteBackend::Daemon`.
+
+```rust
+#[tokio::test]
+async fn write_backend_follows_daemon_enabled() {
+    let mut settings = Settings::utils_test_config();
+    settings.daemon.enabled = false;
+    assert_eq!(write_backend(&settings).await, WriteBackend::Direct);
+    #[cfg(feature = "daemon")]
+    {
+        settings.daemon.enabled = true;
+        assert_eq!(write_backend(&settings).await, WriteBackend::Daemon);
+    }
+}
+```
+
+- [ ] **Step 2: Run it, confirm it fails** — `cargo test -p atuin --features daemon write_backend_follows_daemon_enabled` → FAIL (`write_backend` not found). (Check whether a `Settings::utils_test_config`-style helper exists; if not, construct `Settings` via the existing test pattern in `atuin-client`.)
+- [ ] **Step 3: Implement `WriteBackend` + `write_backend()`** and rewrite the two entry points to `match` on it, calling the *existing* `handle_daemon_*` / `handle_*` bodies unchanged.
+- [ ] **Step 4: Run test + full build both feature states** — `cargo test -p atuin --features daemon write_backend...` PASS; `cargo build -p atuin --no-default-features` and `cargo build -p atuin --features daemon` both succeed.
+- [ ] **Step 5: Commit** — `refactor(history): centralize daemon-vs-direct write backend selection`
+
+---
+
+### Task 2: Make the daemon write path autostart-on-demand by default
+
+Ensure that when `WriteBackend::Daemon` is selected, a missing daemon is spawned transparently (not only when `autostart` was explicitly set). This is the "spawn ephemeral daemon" behavior.
+
+**Files:**
+- Modify: `crates/atuin/src/command/client/daemon.rs` (the `try_with_restart` / `start_history` / `end_history` wrappers around `daemon.rs:419-498`)
+- Modify: `crates/atuin/src/command/client/history.rs` (`handle_daemon_start`/`handle_daemon_end`)
+
+**Interfaces:**
+- Consumes: `ensure_daemon_running(settings)` (`daemon.rs:355`), `try_with_restart` (`daemon.rs:419`).
+- Produces: daemon write RPCs that, on a connect/unavailable error, call `ensure_daemon_running` and retry **whenever the daemon write backend is in use**, independent of the legacy `autostart` opt-in (still gated off for `systemd_socket`).
+
+- [ ] **Step 1: Write the failing test** — a unit test around the retry decision: given a first call that returns a `DaemonClientErrorKind::Connect` error and `systemd_socket = false`, the wrapper attempts `ensure_daemon_running` exactly once and retries. Use a small injected closure/fake so no real socket is needed (mirror the existing `try_with_restart` signature which already takes a closure).
+
+```rust
+#[tokio::test]
+async fn daemon_write_spawns_on_connect_error() {
+    // fake sender: first call -> Connect error, second -> Ok
+    // assert ensure-hook invoked once, final result Ok
+}
+```
+
+- [ ] **Step 2: Run it, confirm it fails** — `cargo test -p atuin --features daemon daemon_write_spawns_on_connect_error` → FAIL.
+- [ ] **Step 3: Implement** — thread a "may autostart" decision that is `true` for the daemon write backend (except `systemd_socket`), so `try_with_restart` no longer requires `settings.daemon.autostart` for the write path specifically. Keep `ensure_autostart_supported`'s systemd guard.
+- [ ] **Step 4: Run test + `cargo clippy -p atuin --features daemon -- -D warnings`** → PASS/clean.
+- [ ] **Step 5: Commit** — `feat(daemon): autostart daemon on demand for the write path`
+
+---
+
+### Task 3: Add the explicit last-resort fallback (§2.3-item-1(2a))
+
+When the daemon write backend is selected but the daemon cannot be spawned (spawn fails or never becomes ready within `startup_timeout`), fall back to the direct-DB write instead of dropping the record — and log a one-time-ish warning.
+
+**Files:**
+- Modify: `crates/atuin/src/command/client/history.rs` (`handle_daemon_start`/`handle_daemon_end` error handling)
+
+**Interfaces:**
+- Consumes: existing `handle_start`/`handle_end` (the direct-DB writers) and `Sqlite`/`SqliteStore`/`HistoryStore` construction already present in `end_history_entry` (`history.rs:597-607`).
+- Produces: `handle_daemon_start`/`handle_daemon_end` that, on an unrecoverable daemon error, delegate to the direct writers and return `Ok`.
+
+- [ ] **Step 1: Write the failing test** — simulate `ensure_daemon_running` failing (e.g. point `socket_path`/`pidfile` at an unwritable/uncreatable location, or inject a failing spawn hook) and assert the record is still persisted to the local `Sqlite` DB afterward. Read it back with `db.load(id)`.
+- [ ] **Step 2: Run it, confirm it fails** — `cargo test -p atuin --features daemon daemon_write_falls_back_to_direct` → FAIL (record absent).
+- [ ] **Step 3: Implement the fallback** — wrap the daemon RPC; on terminal failure, `warn!` and call the direct writer. Preserve `store_failed`/exit-code cancel semantics in the fallback branch.
+- [ ] **Step 4: Run test + both-feature builds** — PASS; `--no-default-features` still builds (fallback body is the code that must survive with `daemon` off).
+- [ ] **Step 5: Commit** — `feat(history): fall back to direct DB write when daemon unavailable`
+
+---
+
+### Task 4: Documentation — reference + migration note
+
+Document the new behavior: the daemon is the blessed write path, spawned on demand; the direct write is a fallback; sync moves to the background loop for these users.
+
+**Files:**
+- Modify: `docs/docs/reference/daemon.md`
+- Modify: `docs/docs/reference/config.md` (or wherever `daemon.*` keys are documented) to describe the new default/behavior of `daemon.enabled`/`daemon.autostart`.
+- Modify: this file's Part 2 open questions → record the ratified decisions.
+
+- [ ] **Step 1:** Update `daemon.md`: explain spawn-on-demand, the systemd-socket exception, and the fallback.
+- [ ] **Step 2:** Note the sync-timing change (inline → background) and its user-visible effect.
+- [ ] **Step 3:** Build the docs site if tooling is available (`mkdocs build` under `docs/`), else visually review the Markdown.
+- [ ] **Step 4: Commit** — `docs(daemon): document spawn-on-demand write path and fallback`
+
+---
+
+### Task 5 (SEPARATE RELEASE — gated on §2.3-item-2): Flip defaults
+
+**Do not bundle with Tasks 1–4.** Once telemetry/dogfooding shows spawn-on-demand is reliable, flip `daemon.enabled` (and/or `autostart`) defaults to `true` so new users get the daemon path without config.
+
+**Files:**
+- Modify: `crates/atuin-client/src/settings.rs:1583-1584` (`daemon.enabled` / `daemon.autostart` defaults)
+
+- [ ] **Step 1: Write/adjust the failing test** — assert the default `Settings` now reports the daemon write backend on a platform where autostart is supported.
+- [ ] **Step 2:** Confirm it fails against current defaults.
+- [ ] **Step 3:** Flip the `set_default` values.
+- [ ] **Step 4:** Full test suite `cargo test --workspace`; verify Windows CI green.
+- [ ] **Step 5: Commit** — `feat(daemon)!: default to daemon write path (spawn on demand)` (breaking-change footer; changelog + release-notes call-out).
+
+---
+
+## Part 4 — Risks & mitigations (summary)
+
+| Risk | Mitigation |
+|---|---|
+| Daemon can't spawn in restricted envs | Task 3 direct-DB fallback keeps history recording working |
+| Cold-start latency on first shell command | Existing startup lock + `wait_until_ready`; latency paid once per daemon lifetime, not per command |
+| Windows (no fork) | Reuse existing detached-`spawn` + TCP path; keep CI on `windows-latest` |
+| systemd users double-managing the daemon | Keep `ensure_autostart_supported` guard; never autostart when `systemd_socket = true` |
+| Sync no longer inline-per-command | Documented behavior change (Task 4); matches what autostart users already experience |
+| Scripted one-off `atuin search` spawning daemons | Leave non-interactive search local (§2.3-item-4) |
+
+## Part 5 — Recommendation to the maintainer
+
+1. **Adopt Option B** (spawn-on-demand persistent daemon), not a truly ephemeral one.
+2. **Ratify the four §2.3 decisions** (fallback policy, default-flip timing, sync-latency acceptance, non-interactive search stays local).
+3. **Land Tasks 1–4 first** (plumbing + fallback + docs) behind current config, then **Task 5** (default flip) as a separate, announced release.
+4. The daemonless *read* path stays — it is not a maintenance problem and reads always use local SQLite anyway.

--- a/docs/dev/atu-538-ephemeral-daemon-investigation.md
+++ b/docs/dev/atu-538-ephemeral-daemon-investigation.md
@@ -1,6 +1,6 @@
 # ATU-538 — Removing the Daemonless Code Paths (Daemon-Only Client)
 
-> **Status:** Investigation complete — full census, feasibility verdict, architecture, and phased plan below.
+> **Status:** Investigation complete + **working proof-of-concept landed** (see Part 7). Full census, feasibility verdict, architecture, and phased plan below.
 > **Issue:** ATU-538 "Investigate whether making daemonless mode just spawn an ephemeral daemon is possible."
 > **Project:** Completely Cutover to Daemon.
 > **Goal (as clarified by maintainer):** **Completely remove** the client's direct-to-SQLite and direct-to-record-store code paths. No config toggle, no fallback. The daemon becomes the sole owner of all local storage; the CLI becomes a thin RPC client that spawns the daemon on demand.
@@ -203,6 +203,50 @@ Move `dotfiles alias/var`, `kv`, `scripts`, and `init <shell>` dotfiles reads be
 2. **Ratify the six Part 3 decisions** first; #3 (import), #4 (sync ownership), and #6 (no-default-features build) are load-bearing.
 3. **Land Phases 0–5 across several releases**, each shippable; do **not** attempt this in one PR.
 4. Accept and document that the daemon becomes a hard dependency (no degraded mode).
+
+---
+
+## Part 7 — Working proof of concept (landed in this branch)
+
+To de-risk the architecture in Part 2, a vertical slice of the trait-proxy is
+implemented and working end-to-end. It proves the core claim: **the CLI can
+serve a real read entirely through the daemon, never opening SQLite itself.**
+
+What was built:
+
+- **`crates/atuin-daemon/proto/database.proto`** — a `StorageDatabase` gRPC
+  service mirroring the read/write half of the `Database` trait
+  (`Save`/`SaveBulk`/`Load`/`List`/`Range`/`Update`/`HistoryCount`/`Last`/
+  `Before`/`Delete`/`DeleteRows`/`Deleted`/`Search`/`QueryHistory`/`GetDups`),
+  plus `HistoryRecord`/`Context`/`OptFiltersMsg` messages.
+- **`crates/atuin-daemon/src/database/mod.rs`** — `History ⇄ HistoryRecord`,
+  `Context`, `OptFilters`, `SearchMode`, `FilterMode` conversions.
+- **`crates/atuin-daemon/src/components/database.rs`** — server-side
+  `StorageDatabaseService`, delegating every call to the daemon's owned
+  `Sqlite` via the existing `Database` trait. Registered in `server.rs`
+  (unix + Windows) and `boot()`.
+- **`crates/atuin-daemon/src/proxy.rs`** — **`DaemonDatabase`**, a client-side
+  `impl Database` that forwards each call over gRPC. This is the drop-in that
+  replaces `Sqlite` at construction sites. `all_paged` works for free (it only
+  needs a boxed `Database` and drives itself via `query_history`).
+- **`crates/atuin/src/command/client/search.rs`** — non-interactive
+  `atuin search` now spawns the daemon on demand (`ensure_daemon_running`) and
+  runs the query through `DaemonDatabase` when `daemon.enabled` is set. The
+  command handler was **unchanged** — it already took `impl Database`, which
+  is exactly why the proxy approach is low-churn.
+
+Smoke test (isolated env, `daemon.enabled = true`): history written while
+daemonless, then `atuin search echo` transparently spawned the daemon and
+returned the right rows over gRPC; `search cargo` → 1 match; a non-matching
+query → exit 1; `daemon status`/`stop` behaved. No client-side `Sqlite::new`
+on the search read path.
+
+Deliberately stubbed for the slice (return a clear "not yet supported" error,
+wired up in the full cutover): `all_with_count` (skim engine) and `stats`
+(interactive inspector). Writes/records/sync/dotfiles are not yet routed — that
+is Phases 3–5. This PoC is Phase 1 + a sliver of Phase 2, and it compiles on
+all three feature configurations (`--features daemon`, default,
+`--no-default-features`).
 
 ---
 

--- a/docs/dev/atu-538-ephemeral-daemon-investigation.md
+++ b/docs/dev/atu-538-ephemeral-daemon-investigation.md
@@ -240,18 +240,29 @@ by the daemon; a single daemon owns the socket; `daemon status`/`stop` behave.
 The `atuin ai` interactive TUI and the MCP server are done too: `AppContext`'s
 history handle is now `Arc<dyn Database>` and both build the proxy.
 
-**Still on the direct path (next tranche — the record store):** everything
-built on the `Store` trait — `sync` (network), `store
-rebuild/rekey/purge/verify/push/pull`, `login`/`register` key rotation,
-`search --delete`/interactive delete, and the `dotfiles`/`kv`/`scripts` typed
-stores. This is a materially bigger change than the Database axis: the `Store`
-trait is ~18 methods over `Record<EncryptedData>`, and all five typed stores
-(`HistoryStore`/`AliasStore`/`VarStore`/`KvStore`/`ScriptStore`) hold a
-*concrete* `SqliteStore`, so a `DaemonStore` proxy requires genericizing them
-across `atuin-client`/`atuin-dotfiles`/`atuin-kv`/`atuin-scripts` plus ~10
-command signatures. Load-bearing design decision first: does the daemon stay a
-dumb encrypted-blob store (crypto stays client-side — least disruptive) or does
-key handling move server-side too?
+**Record-store axis — foundation built, routing pending.** Decisions ratified:
+daemon = encrypted-blob store (crypto stays client-side); and `daemon` will
+become a mandatory dependency so the daemonless code is physically deleted.
+
+Done for the record store:
+- `Store` made **object-safe** (`push_batch` takes `&mut dyn Iterator`), with
+  blanket `impl Store for ArcStore`/`BoxStore` and `Debug + Send + Sync`
+  supertraits.
+- All five typed stores (`HistoryStore`/`AliasStore`/`VarStore`/`KvStore`/
+  `ScriptStore`) now hold an `ArcStore` (`Arc<dyn Store>`); `new` takes
+  `impl Store` and wraps in `Arc`. Existing `SqliteStore` callers unchanged.
+- A **`StorageStore` gRPC service** (mirroring the 16-method `Store` surface
+  over `Record<EncryptedData>`) and a client-side **`DaemonStore` proxy**,
+  registered in the daemon server + boot. Records stay encrypted on the wire.
+
+Remaining (mechanical, given the above):
+- Route the CLI's record-store construction to a `DaemonStore`-backed
+  `ArcStore` (a `record_store()` helper like `history_database()`), updating the
+  ~8 command signatures that take `SqliteStore` and the direct-construction
+  sites in `history`/`search`/`sync`/`store`/`account`.
+- **Part B:** make `atuin-daemon` a non-optional dependency, remove the
+  `daemon` feature and every `#[cfg(not(feature = "daemon"))]` arm — physically
+  deleting the daemonless code.
 
 To *physically delete* the last daemonless code (the `cfg(not(daemon))` arms),
 promote `daemon` from an optional feature to a hard dependency — a Cargo change

--- a/docs/dev/atu-538-ephemeral-daemon-investigation.md
+++ b/docs/dev/atu-538-ephemeral-daemon-investigation.md
@@ -255,14 +255,28 @@ Done for the record store:
   over `Record<EncryptedData>`) and a client-side **`DaemonStore` proxy**,
   registered in the daemon server + boot. Records stay encrypted on the wire.
 
-Remaining (mechanical, given the above):
-- Route the CLI's record-store construction to a `DaemonStore`-backed
-  `ArcStore` (a `record_store()` helper like `history_database()`), updating the
-  ~8 command signatures that take `SqliteStore` and the direct-construction
-  sites in `history`/`search`/`sync`/`store`/`account`.
-- **Part B:** make `atuin-daemon` a non-optional dependency, remove the
-  `daemon` feature and every `#[cfg(not(feature = "daemon"))]` arm — physically
-  deleting the daemonless code.
+**Record store — routing DONE.** A `record_store()` helper (mirroring
+`history_database()`) returns a `DaemonStore`-backed `ArcStore` under the daemon
+feature; all ~8 dispatch commands and their subcommands (`sync`, `account`/
+`login` rekey, `kv`, `dotfiles alias/var`, `store rebuild/rekey/verify/purge/
+push/pull`, `scripts`, `wrapped`), the `history` subcommands, and `atuin init`'s
+dotfiles read now take an `ArcStore`. `crate::sync::build` is generic over
+`Store`. The product build has **zero** direct storage access in the CLI —
+`SqliteStore::new` survives only in the no-daemon build and the `daemon`
+subcommand (the owner). Verified: `kv set/get`, `store status`, `dotfiles`,
+`search`, history writes all served by the daemon.
+
+**The functional cutover is complete:** in the shipped build the daemon is the
+sole owner of both the history DB and the record store; the CLI is a pure gRPC
+client. The daemonless code is excluded from the product build.
+
+**Remaining — Part B (mechanical): physically delete the daemonless code.**
+Make `atuin-daemon` non-optional and remove the `daemon` feature plus all 71
+`#[cfg(feature = "daemon")]` / `#[cfg(not(feature = "daemon"))]` gates across
+`atuin` + `atuin-ai` (un-gate the daemon arms, delete the `not(daemon)` arms
+incl. `handle_start`/`handle_end` and the no-daemon `history_database`/
+`record_store` helpers). This is a wide sweep that drops the `--no-default-
+features` build; it must be done as one atomic green change.
 
 To *physically delete* the last daemonless code (the `cfg(not(daemon))` arms),
 promote `daemon` from an optional feature to a hard dependency — a Cargo change

--- a/docs/dev/atu-538-ephemeral-daemon-investigation.md
+++ b/docs/dev/atu-538-ephemeral-daemon-investigation.md
@@ -270,13 +270,20 @@ subcommand (the owner). Verified: `kv set/get`, `store status`, `dotfiles`,
 sole owner of both the history DB and the record store; the CLI is a pure gRPC
 client. The daemonless code is excluded from the product build.
 
-**Remaining — Part B (mechanical): physically delete the daemonless code.**
-Make `atuin-daemon` non-optional and remove the `daemon` feature plus all 71
-`#[cfg(feature = "daemon")]` / `#[cfg(not(feature = "daemon"))]` gates across
-`atuin` + `atuin-ai` (un-gate the daemon arms, delete the `not(daemon)` arms
-incl. `handle_start`/`handle_end` and the no-daemon `history_database`/
-`record_store` helpers). This is a wide sweep that drops the `--no-default-
-features` build; it must be done as one atomic green change.
+**Part B — DONE. The daemonless code is physically deleted.** `atuin-daemon`
+is now a mandatory (non-optional) dependency; the `daemon` cargo feature is
+removed from `atuin`/`atuin-client`/`atuin-ai`. All ~45 `#[cfg(feature =
+"daemon")]` gates were un-gated (daemon code is now unconditional) and all
+`#[cfg(not(feature = "daemon"))]` arms deleted — `handle_start`/`handle_end`,
+the no-daemon branches in `start`/`end_history_entry` and the history
+subcommands, the no-daemon `history_database`/`record_store`/`init`/`ai`
+fallbacks, the `DaemonFuzzy` search fallback, and the two `handle_start` tests.
+There is no longer any way to build a daemonless client. Both `default` and
+`--no-default-features` build (the latter now includes the daemon); clippy
+clean; 224 bin tests + workspace lib tests pass.
+
+**ATU-538 is complete: the CLI is a pure daemon client with zero direct
+storage access and zero daemonless code.**
 
 To *physically delete* the last daemonless code (the `cfg(not(daemon))` arms),
 promote `daemon` from an optional feature to a hard dependency — a Cargo change

--- a/docs/dev/atu-538-ephemeral-daemon-investigation.md
+++ b/docs/dev/atu-538-ephemeral-daemon-investigation.md
@@ -206,11 +206,55 @@ Move `dotfiles alias/var`, `kv`, `scripts`, and `init <shell>` dotfiles reads be
 
 ---
 
-## Part 7 — Working proof of concept (landed in this branch)
+## Part 7 — Implementation status (landed in this branch)
 
-To de-risk the architecture in Part 2, a vertical slice of the trait-proxy is
-implemented and working end-to-end. It proves the core claim: **the CLI can
-serve a real read entirely through the daemon, never opening SQLite itself.**
+**The entire history-`Database` axis is now daemon-only in the shipped build.**
+Under the default (`daemon`) feature, the CLI never opens the history SQLite
+database itself — every read and write is served by the daemon over gRPC. The
+daemonless code survives only under `#[cfg(not(feature = "daemon"))]` (the
+minimal no-daemon build) and behind `#[cfg(test)]`.
+
+What is routed through the daemon now:
+- **Writes:** `history start`/`end` always go through the daemon
+  (`start_history_entry`/`end_history_entry` call the daemon handlers
+  unconditionally; the direct `handle_start`/`handle_end` are `cfg(not(daemon))`).
+  The write hooks spawn the daemon on demand regardless of the old
+  `daemon.autostart` opt-in (`autostart_enabled()` = "not systemd-managed").
+- **Reads (all commands):** `search` (interactive + non-interactive), `stats`,
+  `wrapped`, `history list/last/prune/dedup/init-store`, `scripts new --last`,
+  `import`, `sync`/`store` history-count, and `mcp` — all receive a
+  `Box<dyn Database>` from a single `history_database()` helper that ensures the
+  daemon is running and returns a `DaemonDatabase` proxy.
+- **The linchpin:** a blanket `impl Database for Box<dyn Database>`
+  (`atuin-client/src/database.rs`) so every handler written against
+  `impl Database`/`&impl Database` accepts the boxed proxy **unchanged**. Only
+  `mcp` (concrete `&Sqlite` → `&dyn Database`) and the `daemon` subcommand
+  (opens its own real `Sqlite`, since it *is* the owner) needed edits.
+- The proxy is fully de-stubbed: `stats` and `all_with_count` now forward too.
+
+Verified end-to-end with no `daemon.enabled` set: history written via the
+daemon, then `history list`, `search` (fuzzy + prefix), and `stats` all served
+by the daemon; a single daemon owns the socket; `daemon status`/`stop` behave.
+`cargo build`/`clippy`/`test` are clean on default and `--no-default-features`.
+
+**Still on the direct path (next tranche):** the **record store** and everything
+built on it — `sync` (network), `store rebuild/rekey/purge/verify/push/pull`,
+`login`/`register` key rotation, `search --delete`/interactive delete, and the
+`dotfiles`/`kv`/`scripts` typed stores — plus the `atuin ai` interactive TUI
+(its `AppContext.history_db` is a concrete `Arc<Sqlite>`). These need new daemon
+RPCs (record-store `Store` surface + sync ownership) and are Phases 4–5.
+
+To *physically delete* the last daemonless code (the `cfg(not(daemon))` arms),
+promote `daemon` from an optional feature to a hard dependency — a Cargo change
+that drops the no-daemon build. Deferred pending that explicit call.
+
+---
+
+### Earlier proof of concept (superseded by the above)
+
+The first slice proved the core claim — **the CLI can serve a real read
+entirely through the daemon, never opening SQLite itself** — before the axis-wide
+cutover:
 
 What was built:
 

--- a/docs/dev/atu-538-ephemeral-daemon-investigation.md
+++ b/docs/dev/atu-538-ephemeral-daemon-investigation.md
@@ -237,12 +237,21 @@ daemon, then `history list`, `search` (fuzzy + prefix), and `stats` all served
 by the daemon; a single daemon owns the socket; `daemon status`/`stop` behave.
 `cargo build`/`clippy`/`test` are clean on default and `--no-default-features`.
 
-**Still on the direct path (next tranche):** the **record store** and everything
-built on it — `sync` (network), `store rebuild/rekey/purge/verify/push/pull`,
-`login`/`register` key rotation, `search --delete`/interactive delete, and the
-`dotfiles`/`kv`/`scripts` typed stores — plus the `atuin ai` interactive TUI
-(its `AppContext.history_db` is a concrete `Arc<Sqlite>`). These need new daemon
-RPCs (record-store `Store` surface + sync ownership) and are Phases 4–5.
+The `atuin ai` interactive TUI and the MCP server are done too: `AppContext`'s
+history handle is now `Arc<dyn Database>` and both build the proxy.
+
+**Still on the direct path (next tranche — the record store):** everything
+built on the `Store` trait — `sync` (network), `store
+rebuild/rekey/purge/verify/push/pull`, `login`/`register` key rotation,
+`search --delete`/interactive delete, and the `dotfiles`/`kv`/`scripts` typed
+stores. This is a materially bigger change than the Database axis: the `Store`
+trait is ~18 methods over `Record<EncryptedData>`, and all five typed stores
+(`HistoryStore`/`AliasStore`/`VarStore`/`KvStore`/`ScriptStore`) hold a
+*concrete* `SqliteStore`, so a `DaemonStore` proxy requires genericizing them
+across `atuin-client`/`atuin-dotfiles`/`atuin-kv`/`atuin-scripts` plus ~10
+command signatures. Load-bearing design decision first: does the daemon stay a
+dumb encrypted-blob store (crypto stays client-side — least disruptive) or does
+key handling move server-side too?
 
 To *physically delete* the last daemonless code (the `cfg(not(daemon))` arms),
 promote `daemon` from an optional feature to a hard dependency — a Cargo change


### PR DESCRIPTION
## What

ATU-538: make the daemon the sole owner of local storage and **completely remove** the daemonless code paths. Investigation in `docs/dev/atu-538-ephemeral-daemon-investigation.md`.

## Result: complete

The CLI is now a pure daemon client — **zero direct storage access, zero daemonless code**. There is no longer any way to build a daemonless variant.

**History `Database` axis** — all reads (search, stats, wrapped, history subcommands, scripts, import, mcp, ai TUI) and writes (start/end) go through the daemon. Linchpin: blanket `impl Database for Box<dyn Database>`.

**Record `Store` axis** — `Store` made object-safe; the five typed stores hold `Arc<dyn Store>`; new `StorageStore` gRPC service + `DaemonStore` proxy (encrypted-blob model, crypto stays client-side). All record-store commands (sync, account/login rekey, kv, dotfiles, store rebuild/rekey/verify/purge/push/pull, scripts, wrapped, init) routed through it.

**Daemonless code deleted (Part B)** — `atuin-daemon` is now a mandatory dependency; the `daemon` cargo feature is removed from `atuin`/`atuin-client`/`atuin-ai`. ~45 `#[cfg(feature="daemon")]` gates un-gated, all `#[cfg(not(feature="daemon"))]` arms deleted (`handle_start`/`handle_end`, no-daemon branches and fallbacks, the `DaemonFuzzy` fallback, two tests).

The `daemon` subcommand keeps the real `Sqlite`/`SqliteStore` (it *is* the owner). `settings.daemon.enabled`/`autostart` are now vestigial (removable in a follow-up).

## Verification

`default` and `--no-default-features` both build (the latter now includes the daemon); `clippy` clean; 224 bin tests + workspace lib tests pass; smoke-tested end-to-end (history write/search, stats, kv set/get, dotfiles, store status, daemon lifecycle) — all served by one spawn-on-demand daemon.

🤖 Generated with [Claude Code](https://claude.com/claude-code)