### PR TITLE
docs: advise users to pass `--locked` when installing from Cargo

### DIFF
--- a/docs/docs/guide/installation.md
+++ b/docs/docs/guide/installation.md
@@ -56,7 +56,7 @@ If you don't wish to use the installer, the manual installation steps are as fol
     toolchain, then you can run:
 
     ```shell
-    cargo install atuin
+    cargo install atuin --locked
     ```
 
 === "Homebrew"
@@ -149,7 +149,7 @@ If you don't wish to use the installer, the manual installation steps are as fol
     ```shell
     git clone https://github.com/atuinsh/atuin.git
     cd atuin/crates/atuin
-    cargo install --path .
+    cargo install --path . --locked
     ```
 
 !!! warning "Please be advised"

--- a/docs/docs/guide/installation.md
+++ b/docs/docs/guide/installation.md
@@ -148,8 +148,8 @@ If you don't wish to use the installer, the manual installation steps are as fol
 
     ```shell
     git clone https://github.com/atuinsh/atuin.git
-    cd atuin/crates/atuin
-    cargo install --path . --locked
+    cd atuin
+    cargo install --path crates/atuin --locked
     ```
 
 !!! warning "Please be advised"


### PR DESCRIPTION
The binaries published on GitHub are built using the lockfile; when installing from Cargo, we should suggest users pass `--locked` so they arrive at a similar binary.