### PR TITLE
chore: trigger docs repo deploy

### DIFF
--- a/.github/workflows/trigger-docs-deploy.yml
+++ b/.github/workflows/trigger-docs-deploy.yml
@@ -1,0 +1,16 @@
+name: Trigger docs deploy
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "docs/**"
+
+jobs:
+  trigger:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Dispatch to atuinsh/docs
+        run: gh api repos/atuinsh/docs/dispatches -f event_type=docs-updated
+        env:
+          GH_TOKEN: ${{ secrets.DOCS_DEPLOY_TOKEN }}


### PR DESCRIPTION
Trigger the docs repo to deploy whenever someone changes the contents of docs/

## Checks
- [ ] I am happy for maintainers to push small adjustments to this PR, to speed up the review cycle
- [ ] I have checked that there are no existing pull requests for the same thing
