### PR TITLE
fix(deps): update unsound/vulnerable dependencies in Cargo.lock

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -100,9 +100,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "approx"
@@ -356,7 +356,7 @@ dependencies = [
  "notify",
  "palette",
  "pretty_assertions",
- "rand 0.8.5",
+ "rand 0.8.7",
  "regex",
  "reqwest",
  "rmp",
@@ -426,7 +426,7 @@ dependencies = [
  "prost",
  "prost-types",
  "protox",
- "rand 0.8.5",
+ "rand 0.8.7",
  "tempfile",
  "time",
  "tokio",
@@ -451,7 +451,7 @@ dependencies = [
  "crypto_secretbox",
  "derive_more",
  "eyre",
- "rand 0.8.5",
+ "rand 0.8.7",
  "rmp",
  "serde",
  "tokio",
@@ -465,7 +465,7 @@ dependencies = [
  "atuin-client",
  "crossterm",
  "divan",
- "rand 0.8.5",
+ "rand 0.8.7",
  "serde",
  "time",
  "unicode-segmentation",
@@ -566,7 +566,7 @@ dependencies = [
  "fs-err",
  "metrics",
  "metrics-exporter-prometheus",
- "rand 0.8.5",
+ "rand 0.8.7",
  "reqwest",
  "semver",
  "serde",
@@ -605,7 +605,7 @@ dependencies = [
  "eyre",
  "futures-util",
  "metrics",
- "rand 0.8.5",
+ "rand 0.8.7",
  "serde",
  "sqlx",
  "time",
@@ -1127,9 +1127,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]
@@ -2852,7 +2852,7 @@ dependencies = [
  "hashbrown 0.16.1",
  "metrics",
  "quanta",
- "rand 0.9.2",
+ "rand 0.9.5",
  "rand_xoshiro",
  "sketches-ddsketch",
 ]
@@ -3035,7 +3035,7 @@ dependencies = [
  "num-integer",
  "num-iter",
  "num-traits",
- "rand 0.8.5",
+ "rand 0.8.7",
  "smallvec",
  "zeroize",
 ]
@@ -3421,7 +3421,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
 dependencies = [
  "phf_shared",
- "rand 0.8.5",
+ "rand 0.8.7",
 ]
 
 [[package]]
@@ -3769,9 +3769,9 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
-version = "0.8.5"
+version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+checksum = "22f6172bdec972074665ed81ed53b71da00bfc44b65a753cfde883ec4c702a1a"
 dependencies = [
  "libc",
  "rand_chacha 0.3.1",
@@ -3780,9 +3780,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.9.2"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+checksum = "b9ef1d0d795eb7d84685bca4f72f3649f064e6641543d3a8c415898726a57b41"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.5",
@@ -4274,9 +4274,9 @@ checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.9"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7df23109aa6c1567d1c575b9952556388da57401e4ace1d15f79eedad0d8f53"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "ring",
  "rustls-pki-types",
@@ -4305,7 +4305,7 @@ dependencies = [
  "digest",
  "ed25519-dalek",
  "generic-array",
- "rand 0.8.5",
+ "rand 0.8.7",
  "rusty_paseto",
  "serde",
  "sha2",
@@ -4726,9 +4726,9 @@ dependencies = [
 
 [[package]]
 name = "spin"
-version = "0.9.8"
+version = "0.9.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+checksum = "3763264f6b73151db08c50ff20d7d8a0b8796e021cdea7ceedad07b80155fa0e"
 dependencies = [
  "lock_api",
 ]
@@ -4871,7 +4871,7 @@ dependencies = [
  "memchr",
  "once_cell",
  "percent-encoding",
- "rand 0.8.5",
+ "rand 0.8.7",
  "rsa",
  "serde",
  "sha1",
@@ -4911,7 +4911,7 @@ dependencies = [
  "md-5",
  "memchr",
  "once_cell",
- "rand 0.8.5",
+ "rand 0.8.7",
  "serde",
  "serde_json",
  "sha2",
@@ -5271,7 +5271,7 @@ checksum = "a30fd743a02bf35236f6faf99adb03089bb77e91c998dac2c2ad76bb424f668c"
 dependencies = [
  "once_cell",
  "pbkdf2",
- "rand 0.8.5",
+ "rand 0.8.7",
  "rustc-hash",
  "sha2",
  "thiserror 1.0.69",


### PR DESCRIPTION
`cargo audit` diff:

```diff
-Crate:     crossbeam-epoch
-Version:   0.9.18
-Title:     Invalid pointer dereference in `fmt::Pointer` impl for `Atomic` and `Shared` when the underlying pointer is invalid
-Date:      2026-07-06
-ID:        RUSTSEC-2026-0204
-URL:       https://rustsec.org/advisories/RUSTSEC-2026-0204
-Solution:  Upgrade to >=0.9.20
-
 Crate:     quick-xml
 Version:   0.39.2
 Title:     Quadratic run time when checking a start tag for duplicate attribute names
 Date:      2026-06-29
 ID:        RUSTSEC-2026-0194
 URL:       https://rustsec.org/advisories/RUSTSEC-2026-0194
 Severity:  7.5 (high)
 Solution:  Upgrade to >=0.41.0
 
 Crate:     quick-xml
 Version:   0.39.2
 Title:     Unbounded namespace-declaration allocation in `NsReader` enables memory-exhaustion denial of service
 Date:      2026-06-29
 ID:        RUSTSEC-2026-0195
 URL:       https://rustsec.org/advisories/RUSTSEC-2026-0195
 Severity:  7.5 (high)
 Solution:  Upgrade to >=0.41.0
 
-Crate:     rustls-webpki
-Version:   0.103.9
-Title:     CRLs not considered authoritative by Distribution Point due to faulty matching logic
-Date:      2026-03-20
-ID:        RUSTSEC-2026-0049
-URL:       https://rustsec.org/advisories/RUSTSEC-2026-0049
-Solution:  Upgrade to >=0.103.10
-
-Crate:     rustls-webpki
-Version:   0.103.9
-Title:     Name constraints for URI names were incorrectly accepted
-Date:      2026-04-14
-ID:        RUSTSEC-2026-0098
-URL:       https://rustsec.org/advisories/RUSTSEC-2026-0098
-Solution:  Upgrade to >=0.103.12, <0.104.0-alpha.1 OR >=0.104.0-alpha.6
-
-Crate:     rustls-webpki
-Version:   0.103.9
-Title:     Name constraints were accepted for certificates asserting a wildcard name
-Date:      2026-04-14
-ID:        RUSTSEC-2026-0099
-URL:       https://rustsec.org/advisories/RUSTSEC-2026-0099
-Solution:  Upgrade to >=0.103.12, <0.104.0-alpha.1 OR >=0.104.0-alpha.6
-
-Crate:     rustls-webpki
-Version:   0.103.9
-Title:     Reachable panic in certificate revocation list parsing
-Date:      2026-04-22
-ID:        RUSTSEC-2026-0104
-URL:       https://rustsec.org/advisories/RUSTSEC-2026-0104
-Solution:  Upgrade to >=0.103.13, <0.104.0-alpha.1 OR >=0.104.0-alpha.7
-
 Crate:     daemonize
 Version:   0.5.0
 Warning:   unmaintained
 Title:     `daemonize` is Unmaintained
 Date:      2025-09-14
 ID:        RUSTSEC-2025-0069
 URL:       https://rustsec.org/advisories/RUSTSEC-2025-0069
 
 Crate:     instant
 Version:   0.1.13
 Warning:   unmaintained
 Title:     `instant` is unmaintained
 Date:      2024-09-01
 ID:        RUSTSEC-2024-0384
 URL:       https://rustsec.org/advisories/RUSTSEC-2024-0384
 
-Crate:     anyhow
-Version:   1.0.102
-Warning:   unsound
-Title:     Unsoundness in `Error::downcast_mut()`
-Date:      2026-06-25
-ID:        RUSTSEC-2026-0190
-URL:       https://rustsec.org/advisories/RUSTSEC-2026-0190
-
-Crate:     rand
-Version:   0.8.5
-Warning:   unsound
-Title:     Rand is unsound with a custom logger using `rand::rng()`
-Date:      2026-04-09
-ID:        RUSTSEC-2026-0097
-URL:       https://rustsec.org/advisories/RUSTSEC-2026-0097
-
-Crate:     rand
-Version:   0.9.2
-Warning:   unsound
-Title:     Rand is unsound with a custom logger using `rand::rng()`
-Date:      2026-04-09
-ID:        RUSTSEC-2026-0097
-URL:       https://rustsec.org/advisories/RUSTSEC-2026-0097
-
-Crate:     spin
-Version:   0.9.8
-Warning:   yanked
```

We can't upgrade quick-xml to a non-vulnerable version; it's a transitive dependency of wayland-scanner and the latest version of wayland-scanner depends on quick-xml 0.39.

It's not in the `cargo audit` output but the reason `spin` was yanked was due to unsoundness; see [this commit](https://codeberg.org/zesterer/spin/commit/5a4291384eff1ab3d21dffa6f0eab065ae38f998).