### PR TITLE
feat: Add 'yolo' setting to Atuin AI options

### DIFF
--- a/crates/atuin-ai/src/commands/inline.rs
+++ b/crates/atuin-ai/src/commands/inline.rs
@@ -90,6 +90,7 @@ pub(crate) async fn run(
         git_root,
         capabilities: settings.ai.capabilities.clone(),
         daemon_enabled: settings.daemon.enabled,
+        yolo: settings.ai.yolo,
     };
 
     let action = run_inline_tui(ctx, initial_command, settings).await?;

--- a/crates/atuin-ai/src/context.rs
+++ b/crates/atuin-ai/src/context.rs
@@ -29,6 +29,7 @@ pub(crate) struct AppContext {
     pub git_root: Option<PathBuf>,
     pub capabilities: AiCapabilities,
     pub daemon_enabled: bool,
+    pub yolo: bool,
 }
 
 pub(crate) fn history_output_capability_available(daemon_enabled: bool) -> bool {

--- a/crates/atuin-ai/src/driver.rs
+++ b/crates/atuin-ai/src/driver.rs
@@ -565,7 +565,7 @@ fn execute_effect(effect: &Effect, ctx: DriverContext) {
             let tx = tx.clone();
 
             // Auto-approved tools (e.g. load_skill) bypass permission checks entirely
-            if tool.is_auto_approved() {
+            if io.app_ctx.yolo || tool.is_auto_approved() {
                 let _ = tx.send(DriverEvent::Fsm(Event::PermissionResolved {
                     tool_id,
                     response: PermissionResponse::Allowed,

--- a/crates/atuin-ai/src/user_context/interpolate.rs
+++ b/crates/atuin-ai/src/user_context/interpolate.rs
@@ -1,4 +1,4 @@
-//! Parse `.atuin/ai-context.md` files and execute embedded commands.
+//! Parse `.atuin/TERMINAL.md` files and execute embedded commands.
 //!
 //! Two interpolation syntaxes are supported:
 //!

--- a/crates/atuin-ai/src/user_context/mod.rs
+++ b/crates/atuin-ai/src/user_context/mod.rs
@@ -93,7 +93,7 @@ impl UserContextCache {
 /// Discover context files and interpolate embedded commands.
 ///
 /// Walks from `start` up to the filesystem root looking for
-/// `.atuin/ai-context.md`, then checks `global_path`. Returns contexts
+/// `.atuin/TERMINAL.md`, then checks `global_path`. Returns contexts
 /// ordered from most general (global/root) to most specific (deepest).
 pub(crate) async fn gather(
     start: &Path,

--- a/crates/atuin-client/src/settings.rs
+++ b/crates/atuin-client/src/settings.rs
@@ -668,6 +668,10 @@ pub struct Ai {
     /// The AI model to use for AI chats, based on the Atuin AI model alias.
     pub model: Option<String>,
 
+    /// Whether to enable YOLO mode (skips all permission checks)
+    #[serde(default)]
+    pub yolo: bool,
+
     /// Deprecated: use opening.send_cwd instead. Kept for backwards compatibility.
     #[serde(default)]
     pub send_cwd: Option<bool>,

--- a/docs/docs/ai/settings.md
+++ b/docs/docs/ai/settings.md
@@ -50,6 +50,14 @@ How the client talks to the configured `endpoint`. One of:
 
 With the default of `"auto"`, pointing `endpoint` at your own server just works: set `api_token` if your server requires one.
 
+### yolo
+
+Default: `false`
+
+Enables YOLO mode, which automatically allows all permission checks. **Use this setting with caution.**
+
+This setting does _not_ enable any capabilities; it simply bypasses any permission checks.
+
 ## Capabilities
 
 Settings that control what capabilities are sent to the LLM, which the LLM uses to understand what features the client has available. These are specified under `[ai.capabilities]`.


### PR DESCRIPTION
This PR implements a new setting, `ai.yolo`; when set to `true`, all Atuin AI permission checks are skipped. This is similar to `claude --dangerously-skip-permissions`, `codex --yolo`, or just using `pi`.