### PR TITLE
feat(string): EllipsizeExt -- General-purpose utility for adding ellipses to strings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -403,7 +403,9 @@ dependencies = [
  "time",
  "tracing",
  "tracing-subscriber",
- "typed-builder",
+ "typed-builder 0.18.2",
+ "unicode-segmentation",
+ "unicode-width 0.2.2",
  "uuid",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -403,7 +403,7 @@ dependencies = [
  "time",
  "tracing",
  "tracing-subscriber",
- "typed-builder 0.18.2",
+ "typed-builder",
  "unicode-segmentation",
  "unicode-width 0.2.2",
  "uuid",

--- a/crates/atuin-ai/Cargo.toml
+++ b/crates/atuin-ai/Cargo.toml
@@ -21,7 +21,7 @@ tree-sitter = ["dep:tree-sitter-lib", "dep:tree-sitter-bash", "dep:tree-sitter-f
 async-trait = { workspace = true }
 atuin-client = { workspace = true }
 derive_more = { workspace = true }
-atuin-common = { workspace = true }
+atuin-common = { workspace = true, features = ["unicode"] }
 atuin-daemon = { workspace = true }
 tokio = { workspace = true }
 eyre = { workspace = true }

--- a/crates/atuin-ai/src/skills/mod.rs
+++ b/crates/atuin-ai/src/skills/mod.rs
@@ -9,6 +9,8 @@ pub(crate) mod walker;
 
 use std::path::Path;
 
+use atuin_common::string::EllipsizeExt as _;
+use atuin_common::string::ellipsis::{Budget, Indicator, Pos};
 use eyre::{Result, eyre};
 
 use crate::user_context::interpolate;
@@ -132,7 +134,16 @@ impl SkillRegistry {
         let mut overflow_names = Vec::new();
 
         for skill in &eligible {
-            let truncated_desc = truncate_description(&skill.description, MAX_DESCRIPTION_LEN);
+            // Truncate to a byte budget (not display columns): descriptions are
+            // packed into a byte-bounded LLM prompt budget.
+            let truncated_desc = skill
+                .description
+                .ellipsize(
+                    Budget::Bytes(MAX_DESCRIPTION_LEN),
+                    Pos::End,
+                    Indicator::ASCII,
+                )
+                .to_string();
             let entry_size = skill.name.len() + truncated_desc.len() + PER_ENTRY_OVERHEAD;
 
             if used + entry_size > budget && !summaries.is_empty() {
@@ -235,19 +246,6 @@ fn first_paragraph(body: &str) -> Option<String> {
     if para.is_empty() { None } else { Some(para) }
 }
 
-/// Truncate a description to `max_len` characters, adding ellipsis if cut.
-fn truncate_description(desc: &str, max_len: usize) -> String {
-    if desc.len() <= max_len {
-        return desc.to_string();
-    }
-    let mut end = max_len.saturating_sub(3);
-    // Avoid splitting a multi-byte char
-    while !desc.is_char_boundary(end) && end > 0 {
-        end -= 1;
-    }
-    format!("{}...", &desc[..end])
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -271,11 +269,6 @@ mod tests {
             first_paragraph("Single line"),
             Some("Single line".to_string())
         );
-    }
-
-    #[test]
-    fn truncate_description_short() {
-        assert_eq!(truncate_description("short", 100), "short");
     }
 
     #[test]
@@ -314,14 +307,6 @@ mod tests {
     fn substitute_arguments_no_args_clears_placeholder() {
         let body = "Deploy $ARGUMENTS to production.";
         assert_eq!(substitute_arguments(body, None), "Deploy  to production.");
-    }
-
-    #[test]
-    fn truncate_description_long() {
-        let long = "a".repeat(600);
-        let result = truncate_description(&long, 512);
-        assert!(result.len() <= 512);
-        assert!(result.ends_with("..."));
     }
 
     #[test]

--- a/crates/atuin-common/Cargo.toml
+++ b/crates/atuin-common/Cargo.toml
@@ -15,6 +15,9 @@ repository = { workspace = true }
 [features]
 # Enables the `test_utils` module.
 test-utils = ["tracing", "dep:tracing-subscriber"]
+# The `string::ellipsis` module: budget-aware, grapheme/display-width-correct
+# string truncation. The module is compiled only when this feature is enabled.
+unicode = ["dep:unicode-width", "dep:unicode-segmentation"]
 
 [dependencies]
 derive_more = { workspace = true }
@@ -33,6 +36,8 @@ getrandom = "0.2"
 rustls = { workspace = true }
 tracing = { workspace = true, optional = true }
 tracing-subscriber = { workspace = true, optional = true }
+unicode-width = { version = "0.2", optional = true }
+unicode-segmentation = { version = "1.11.0", optional = true }
 
 [dev-dependencies]
 pretty_assertions = { workspace = true }

--- a/crates/atuin-common/proptest-regressions/string/ellipsis.txt
+++ b/crates/atuin-common/proptest-regressions/string/ellipsis.txt
@@ -1,0 +1,10 @@
+# Seeds for failure cases proptest has generated in the past. It is
+# automatically read and these particular cases re-run before any
+# novel cases are generated.
+#
+# It is recommended to check this file in to source control so that
+# everyone who runs the test benefits from these saved cases.
+cc da6eb43387d201d07041fafc6e0f53d358449a4b6df066b8aba18665a565fff5 # shrinks to s = "", n = 0
+cc 15ae2f29c8c35ce4f9fb4eab37c6873e90ae10955689422b0d54b40a061dbe0b # shrinks to s = "", n = 0
+cc de5489ef9d95ea75579e828715ef6cdc7da8be4bc3961e784d5d55f141ab3a05 # shrinks to s = "", n = 0
+cc fe00e930d925422cea5940f9c9e5697c879860acadab7c4a29d2d6329896387b # shrinks to s = "AAA𐀀\00A𐀀¡ ", n = 1

--- a/crates/atuin-common/src/string/ellipsis.rs
+++ b/crates/atuin-common/src/string/ellipsis.rs
@@ -46,12 +46,10 @@ impl Default for Indicator<'_> {
 /// How much room to truncate into, and the unit it is measured in.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Budget {
-    /// A UTF-8 byte budget. Cuts on `char` boundaries, so the result is valid
-    /// UTF-8 and its byte length never exceeds the budget. Use for storage or
-    /// prompt byte budgets.
+    /// A UTF-8 byte budget.
     Bytes(usize),
-    /// A display-column budget via `unicode-width` — a double-width glyph such
-    /// as `世` or `🦀` counts as two. Use for TUI column layout.
+    /// A display-column budget via `unicode-width` - a double-width glyph such
+    /// as `世` or `🦀` counts as two. Use for presentation.
     Columns(usize),
 }
 
@@ -75,7 +73,7 @@ impl Budget {
 pub trait EllipsizeExt: AsRef<str> {
     /// Truncate this string to fit within `budget`, splicing in `indicator` on
     /// `side` if any content had to be dropped. Returns a lazy [`Ellipsized`]
-    /// view — no allocation until you ask for an owned string.
+    /// view - no allocation until you ask for an owned string.
     fn ellipsize<'a>(
         &'a self,
         budget: Budget,
@@ -88,7 +86,7 @@ pub trait EllipsizeExt: AsRef<str> {
         // The boundary helpers only need a per-grapheme cost, not the budget.
         let cost = |seg: &str| budget.cost(seg);
 
-        // Fast path: already fits — a single contiguous slice.
+        // Fast path: already fits - a single contiguous slice.
         if cost(s) <= amount {
             return Ellipsized::contiguous(s, 0);
         }
@@ -124,13 +122,11 @@ pub trait EllipsizeExt: AsRef<str> {
 
 impl<T: AsRef<str>> EllipsizeExt for T {}
 
-/// A budget-truncated view of a source string — either a single contiguous
+/// A budget-truncated view of a source string - either a single contiguous
 /// slice (it fit, or there was no room even for the indicator) or a head +
-/// indicator + tail with content elided between them. Cheap (`Copy`); `Display`
-/// writes the pieces straight to the formatter with no intermediate `String`.
+/// indicator + tail with content elided between them.
 ///
-/// The spliced form always carries an indicator, so a gap between head and tail
-/// can never be rendered without a marker — that state is unrepresentable.
+/// Cheap `Copy`. `Display` writes the pieces straight to the formatter.
 #[derive(Debug, Clone, Copy)]
 pub struct Ellipsized<'a>(Repr<'a>);
 
@@ -139,7 +135,7 @@ enum Repr<'a> {
     /// The whole result is one contiguous slice of the source; `source_offset`
     /// is the slice's byte offset in the source.
     Contiguous { text: &'a str, source_offset: usize },
-    /// A head slice, an indicator, and a tail slice — always with a marker.
+    /// A head slice, an indicator, and a tail slice - always with a marker.
     Spliced {
         head: &'a str,
         indicator: Indicator<'a>,
@@ -157,8 +153,6 @@ impl<'a> Ellipsized<'a> {
         })
     }
 
-    /// Build a spliced view from the source and the head/tail byte boundaries;
-    /// the slicing happens once here.
     fn spliced(
         source: &'a str,
         head_end: usize,
@@ -249,39 +243,36 @@ impl PartialEq<&str> for Ellipsized<'_> {
     }
 }
 
-/// Byte end index of the longest prefix of `s` whose summed per-grapheme `cost`
-/// is at most `max`.
-///
-/// Iterates whole grapheme clusters, so it never splits one — the returned index
-/// is always a valid slice point, and width context effects (a variation
-/// selector or combining mark adjusting the width of the character it follows)
-/// stay contained within a single cluster.
-fn prefix_boundary(s: &str, max: usize, cost: impl Fn(&str) -> usize) -> usize {
+/// Total byte length of the longest leading run of `graphemes` whose summed
+/// `cost` is at most `max`.
+fn fitting_bytes<'a>(
+    graphemes: impl Iterator<Item = &'a str>,
+    max: usize,
+    cost: impl Fn(&str) -> usize,
+) -> usize {
     let mut used = 0;
-    for (idx, seg) in s.grapheme_indices(true) {
-        let seg_cost = cost(seg);
-        if used + seg_cost > max {
-            return idx;
-        }
-        used += seg_cost;
-    }
-    s.len()
-}
-
-/// Byte start index of the longest suffix of `s` whose summed per-grapheme
-/// `cost` is at most `max`. Iterates grapheme clusters like [`prefix_boundary`].
-fn suffix_boundary(s: &str, max: usize, cost: impl Fn(&str) -> usize) -> usize {
-    let mut used = 0;
-    let mut start = s.len();
-    for (idx, seg) in s.grapheme_indices(true).rev() {
+    let mut bytes = 0;
+    for seg in graphemes {
         let seg_cost = cost(seg);
         if used + seg_cost > max {
             break;
         }
         used += seg_cost;
-        start = idx;
+        bytes += seg.len();
     }
-    start
+    bytes
+}
+
+/// Byte end index of the longest prefix of `s` whose summed per-grapheme cost is
+/// at most `max`.
+fn prefix_boundary(s: &str, max: usize, cost: impl Fn(&str) -> usize) -> usize {
+    fitting_bytes(s.graphemes(true), max, cost)
+}
+
+/// Byte start index of the longest suffix of `s` whose summed per-grapheme cost
+/// is at most `max`.
+fn suffix_boundary(s: &str, max: usize, cost: impl Fn(&str) -> usize) -> usize {
+    s.len() - fitting_bytes(s.graphemes(true).rev(), max, cost)
 }
 
 #[cfg(test)]
@@ -292,8 +283,6 @@ mod tests {
     use rstest::rstest;
     use unicode_width::UnicodeWidthStr;
 
-    /// Test-local mirror of a budget's inner amount — the crate's own cost
-    /// accessors are private to the production module.
     fn amount(b: Budget) -> usize {
         match b {
             Budget::Bytes(n) => n,
@@ -301,8 +290,6 @@ mod tests {
         }
     }
 
-    /// Test-local mirror of how a budget measures a string's cost: byte
-    /// length for `Bytes`, display-column width for `Columns`.
     fn cost(b: Budget, s: &str) -> usize {
         match b {
             Budget::Bytes(_) => s.len(),
@@ -310,10 +297,6 @@ mod tests {
         }
     }
 
-    /// Table-driven examples covering both units, all three sides, both
-    /// ellipsis glyphs, wide (CJK/emoji) content, and the below-ellipsis-cost
-    /// hard-truncation edge case. Each case is its own test, so a failure
-    /// names precisely which input broke.
     #[rstest]
     // Fits unchanged (borrowed).
     #[case("hello", Budget::Columns(10), Pos::End, Indicator::ASCII, "hello")]
@@ -423,9 +406,6 @@ mod tests {
     proptest! {
         #![proptest_config(ProptestConfig::with_cases(2048))]
 
-        /// The result never costs more than the budget's amount, in the
-        /// budget's own unit. Also proves the call never panics for any
-        /// input across every side/ellipsis/unit combination.
         #[test]
         fn never_overflows(
             s in r"(?s).*",
@@ -437,8 +417,6 @@ mod tests {
             prop_assert!(cost(budget, out.as_ref()) <= amount(budget));
         }
 
-        /// When the input already fits, it is returned borrowed and
-        /// byte-for-byte unchanged (zero-copy fast path).
         #[test]
         fn borrowed_when_it_fits(
             s in r"(?s).*",
@@ -456,7 +434,6 @@ mod tests {
             }
         }
 
-        /// Truncation never makes a string cost more than it started with.
         #[test]
         fn never_grows(
             s in r"(?s).*",
@@ -468,9 +445,6 @@ mod tests {
             prop_assert!(cost(budget, out.as_ref()) <= cost(budget, &s));
         }
 
-        /// Byte budgets specifically: the result's byte length never exceeds
-        /// `n`. This is subsumed by `never_overflows` but is asserted
-        /// explicitly since it is the `truncate_description` invariant.
         #[test]
         fn valid_byte_cut(
             s in r"(?s).*",
@@ -482,8 +456,6 @@ mod tests {
             prop_assert!(out.len() <= n);
         }
 
-        /// When content had to be dropped and the budget can afford the
-        /// ellipsis glyph, the glyph appears in the result.
         #[test]
         fn ellipsis_present_when_needed(
             s in r"(?s).*",
@@ -499,9 +471,6 @@ mod tests {
             }
         }
 
-        /// Every kept output byte maps back (via `source_index`) to the source
-        /// char it came from; indicator bytes map to `None`. Exercises all
-        /// shapes: contiguous fit/prefix/suffix and spliced start/middle/end.
         #[test]
         fn source_index_round_trips(
             s in r"(?s).*",

--- a/crates/atuin-common/src/string/ellipsis.rs
+++ b/crates/atuin-common/src/string/ellipsis.rs
@@ -83,16 +83,13 @@ pub trait EllipsizeExt: AsRef<str> {
         let s = self.as_ref();
         let amount = budget.amount();
         let len = s.len();
-        // The boundary helpers only need a per-grapheme cost, not the budget.
         let cost = |seg: &str| budget.cost(seg);
 
-        // Fast path: already fits - a single contiguous slice.
         if cost(s) <= amount {
             return Ellipsized::contiguous(s, 0);
         }
 
-        // Not enough room for the indicator itself: hard-truncate to a bare,
-        // unmarked slice.
+        // Not enough room for the indicator itself: hard-truncate to a bare, unmarked slice.
         let indicator_cost = cost(indicator.as_ref());
         if amount < indicator_cost {
             return match side {
@@ -112,7 +109,6 @@ pub trait EllipsizeExt: AsRef<str> {
             Pos::Start => Ellipsized::spliced(s, 0, suffix_boundary(s, content, cost), indicator),
             Pos::Middle => {
                 let end = prefix_boundary(s, content.div_ceil(2), cost);
-                // Clamp so prefix and suffix never overlap (zero-width graphemes).
                 let start = suffix_boundary(s, content / 2, cost).max(end);
                 Ellipsized::spliced(s, end, start, indicator)
             }
@@ -298,10 +294,8 @@ mod tests {
     }
 
     #[rstest]
-    // Fits unchanged (borrowed).
     #[case("hello", Budget::Columns(10), Pos::End, Indicator::ASCII, "hello")]
     #[case("hello", Budget::Columns(5), Pos::End, Indicator::ASCII, "hello")]
-    // Basic Right/Left/Middle truncation with Dots.
     #[case(
         "hello world",
         Budget::Columns(8),
@@ -323,7 +317,6 @@ mod tests {
         Indicator::ASCII,
         "he...ld"
     )]
-    // Unicode ellipsis costs 1 column, so more content survives.
     #[case(
         "hello world",
         Budget::Columns(6),
@@ -338,11 +331,9 @@ mod tests {
         Indicator::UNICODE,
         "…world"
     )]
-    // Wide (double-width) glyphs: CJK.
     #[case("你好世界", Budget::Columns(5), Pos::End, Indicator::ASCII, "你...")]
     #[case("你好世界", Budget::Columns(4), Pos::End, Indicator::ASCII, "...")]
     #[case("你好世界", Budget::Columns(8), Pos::End, Indicator::ASCII, "你好世界")]
-    // Wide glyphs: emoji.
     #[case("🐢🦀🐢🦀", Budget::Columns(5), Pos::End, Indicator::UNICODE, "🐢🦀…")]
     #[case(
         "🐢🦀🐢🦀",
@@ -351,13 +342,10 @@ mod tests {
         Indicator::UNICODE,
         "🐢🦀🐢🦀"
     )]
-    // Amount below ellipsis cost: hard-truncate, no ellipsis.
     #[case("hello", Budget::Columns(2), Pos::End, Indicator::ASCII, "he")]
     #[case("hello", Budget::Columns(2), Pos::Start, Indicator::ASCII, "lo")]
     #[case("hello", Budget::Columns(0), Pos::End, Indicator::ASCII, "")]
-    // Empty input.
     #[case("", Budget::Columns(5), Pos::End, Indicator::ASCII, "")]
-    // Byte budgets: ASCII bytes == columns.
     #[case(
         "hello world",
         Budget::Bytes(8),
@@ -365,8 +353,6 @@ mod tests {
         Indicator::ASCII,
         "hello..."
     )]
-    // Contrast: the same `hello…` output fits in 6 columns (the Columns(6) case
-    // above) but needs 8 bytes, since `…` is 1 column but 3 bytes.
     #[case(
         "hello world",
         Budget::Bytes(8),
@@ -374,7 +360,6 @@ mod tests {
         Indicator::UNICODE,
         "hello…"
     )]
-    // Multi-byte (but single-column) content under a byte budget.
     #[case("café", Budget::Bytes(4), Pos::End, Indicator::ASCII, "c...")]
     #[case("café", Budget::Bytes(5), Pos::End, Indicator::ASCII, "café")]
     #[case("你好", Budget::Bytes(5), Pos::End, Indicator::ASCII, "...")]
@@ -482,7 +467,6 @@ mod tests {
             let out = e.to_string();
             for (i, ch) in out.char_indices() {
                 if let Some(j) = e.source_index(i) {
-                    // The output char at byte `i` is the source char at byte `j`.
                     prop_assert_eq!(s[j..].chars().next(), Some(ch));
                 }
             }
@@ -491,15 +475,14 @@ mod tests {
 
     #[test]
     fn source_index_middle_maps_head_gap_tail() {
-        // "hello world" -> Columns(7) Middle Dots = "he...ld"
         let e = "hello world".ellipsize(Budget::Columns(7), Pos::Middle, Indicator::ASCII);
         assert_eq!(e.to_string(), "he...ld");
-        assert_eq!(e.source_index(0), Some(0)); // 'h' head identity
-        assert_eq!(e.source_index(1), Some(1)); // 'e' head identity
-        assert_eq!(e.source_index(2), None); // '.' on the indicator
-        assert_eq!(e.source_index(4), None); // '.' on the indicator
-        assert_eq!(e.source_index(5), Some(9)); // 'l' tail: 5 - 2 - 3 + 9
-        assert_eq!(e.source_index(6), Some(10)); // 'd' tail
+        assert_eq!(e.source_index(0), Some(0));
+        assert_eq!(e.source_index(1), Some(1));
+        assert_eq!(e.source_index(2), None);
+        assert_eq!(e.source_index(4), None);
+        assert_eq!(e.source_index(5), Some(9));
+        assert_eq!(e.source_index(6), Some(10));
     }
 
     #[test]

--- a/crates/atuin-common/src/string/ellipsis.rs
+++ b/crates/atuin-common/src/string/ellipsis.rs
@@ -1,0 +1,562 @@
+//! Extension trait for truncating a string to a budget (display columns or
+//! bytes) with an ellipsis.
+
+use std::borrow::Cow;
+use std::fmt;
+
+use unicode_segmentation::UnicodeSegmentation;
+use unicode_width::UnicodeWidthStr;
+
+/// Which side of the string to elide when it does not fit.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Pos {
+    /// Keep the tail, elide the head: `…orld`.
+    Start,
+    /// Keep both ends, elide the middle: `he…ld`.
+    Middle,
+    /// Keep the head, elide the tail: `hello…`.
+    End,
+}
+
+/// The marker spliced in where content was dropped: [`Indicator::ASCII`]
+/// (`...`), [`Indicator::UNICODE`] (`…`), or any custom string via
+/// [`Indicator::new`] (e.g. `[output truncated]`).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, derive_more::AsRef)]
+pub struct Indicator<'a>(#[as_ref(str)] &'a str);
+
+impl<'a> Indicator<'a> {
+    /// Three ASCII periods `...` (3 columns, 3 bytes).
+    pub const ASCII: Self = Self("...");
+    /// The single Unicode ellipsis `…` (U+2026): 1 column, 3 bytes.
+    pub const UNICODE: Self = Self("…");
+
+    /// Wrap an arbitrary marker string.
+    pub const fn new(marker: &'a str) -> Self {
+        Self(marker)
+    }
+}
+
+impl Default for Indicator<'_> {
+    /// The Unicode ellipsis `…`.
+    fn default() -> Self {
+        Self::UNICODE
+    }
+}
+
+/// How much room to truncate into, and the unit it is measured in.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Budget {
+    /// A UTF-8 byte budget. Cuts on `char` boundaries, so the result is valid
+    /// UTF-8 and its byte length never exceeds the budget. Use for storage or
+    /// prompt byte budgets.
+    Bytes(usize),
+    /// A display-column budget via `unicode-width` — a double-width glyph such
+    /// as `世` or `🦀` counts as two. Use for TUI column layout.
+    Columns(usize),
+}
+
+impl Budget {
+    /// The numeric limit, in this budget's own unit.
+    fn amount(self) -> usize {
+        match self {
+            Budget::Bytes(n) | Budget::Columns(n) => n,
+        }
+    }
+
+    /// Total cost of `s` in this budget's unit.
+    fn cost(self, s: &str) -> usize {
+        match self {
+            Budget::Bytes(_) => s.len(),
+            Budget::Columns(_) => s.width(),
+        }
+    }
+}
+
+pub trait EllipsizeExt: AsRef<str> {
+    /// Truncate this string to fit within `budget`, splicing in `indicator` on
+    /// `side` if any content had to be dropped. Returns a lazy [`Ellipsized`]
+    /// view — no allocation until you ask for an owned string.
+    fn ellipsize<'a>(
+        &'a self,
+        budget: Budget,
+        side: Pos,
+        indicator: Indicator<'a>,
+    ) -> Ellipsized<'a> {
+        let s = self.as_ref();
+        let amount = budget.amount();
+        let len = s.len();
+        // The boundary helpers only need a per-grapheme cost, not the budget.
+        let cost = |seg: &str| budget.cost(seg);
+
+        // Fast path: already fits — a single contiguous slice.
+        if cost(s) <= amount {
+            return Ellipsized::contiguous(s, 0);
+        }
+
+        // Not enough room for the indicator itself: hard-truncate to a bare,
+        // unmarked slice.
+        let indicator_cost = cost(indicator.as_ref());
+        if amount < indicator_cost {
+            return match side {
+                Pos::Start => {
+                    let start = suffix_boundary(s, amount, cost);
+                    Ellipsized::contiguous(&s[start..], start)
+                }
+                Pos::Middle | Pos::End => {
+                    Ellipsized::contiguous(&s[..prefix_boundary(s, amount, cost)], 0)
+                }
+            };
+        }
+
+        let content = amount - indicator_cost;
+        match side {
+            Pos::End => Ellipsized::spliced(s, prefix_boundary(s, content, cost), len, indicator),
+            Pos::Start => Ellipsized::spliced(s, 0, suffix_boundary(s, content, cost), indicator),
+            Pos::Middle => {
+                let end = prefix_boundary(s, content.div_ceil(2), cost);
+                // Clamp so prefix and suffix never overlap (zero-width graphemes).
+                let start = suffix_boundary(s, content / 2, cost).max(end);
+                Ellipsized::spliced(s, end, start, indicator)
+            }
+        }
+    }
+}
+
+impl<T: AsRef<str>> EllipsizeExt for T {}
+
+/// A budget-truncated view of a source string — either a single contiguous
+/// slice (it fit, or there was no room even for the indicator) or a head +
+/// indicator + tail with content elided between them. Cheap (`Copy`); `Display`
+/// writes the pieces straight to the formatter with no intermediate `String`.
+///
+/// The spliced form always carries an indicator, so a gap between head and tail
+/// can never be rendered without a marker — that state is unrepresentable.
+#[derive(Debug, Clone, Copy)]
+pub struct Ellipsized<'a>(Repr<'a>);
+
+#[derive(Debug, Clone, Copy)]
+enum Repr<'a> {
+    /// The whole result is one contiguous slice of the source; `source_offset`
+    /// is the slice's byte offset in the source.
+    Contiguous { text: &'a str, source_offset: usize },
+    /// A head slice, an indicator, and a tail slice — always with a marker.
+    Spliced {
+        head: &'a str,
+        indicator: Indicator<'a>,
+        tail: &'a str,
+        /// Byte offset of `tail` in the source, for [`Ellipsized::source_index`].
+        tail_source_offset: usize,
+    },
+}
+
+impl<'a> Ellipsized<'a> {
+    fn contiguous(text: &'a str, source_offset: usize) -> Self {
+        Self(Repr::Contiguous {
+            text,
+            source_offset,
+        })
+    }
+
+    /// Build a spliced view from the source and the head/tail byte boundaries;
+    /// the slicing happens once here.
+    fn spliced(
+        source: &'a str,
+        head_end: usize,
+        tail_start: usize,
+        indicator: Indicator<'a>,
+    ) -> Self {
+        Self(Repr::Spliced {
+            head: &source[..head_end],
+            tail: &source[tail_start..],
+            tail_source_offset: tail_start,
+            indicator,
+        })
+    }
+
+    /// Map a byte offset in the output back to its byte offset in the source,
+    /// or `None` if it lands on the spliced indicator.
+    pub fn source_index(self, output_byte: usize) -> Option<usize> {
+        match self.0 {
+            Repr::Contiguous { source_offset, .. } => Some(output_byte + source_offset),
+            Repr::Spliced {
+                head,
+                indicator,
+                tail_source_offset,
+                ..
+            } => {
+                let indicator_len = indicator.as_ref().len();
+                if output_byte < head.len() {
+                    Some(output_byte)
+                } else if output_byte >= head.len() + indicator_len {
+                    Some(output_byte - head.len() - indicator_len + tail_source_offset)
+                } else {
+                    None
+                }
+            }
+        }
+    }
+}
+
+impl fmt::Display for Ellipsized<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self.0 {
+            Repr::Contiguous { text, .. } => f.write_str(text),
+            Repr::Spliced {
+                head,
+                indicator,
+                tail,
+                ..
+            } => {
+                f.write_str(head)?;
+                f.write_str(indicator.as_ref())?;
+                f.write_str(tail)
+            }
+        }
+    }
+}
+
+impl<'a> From<Ellipsized<'a>> for Cow<'a, str> {
+    /// Borrowed for a contiguous slice; owned only when an indicator is spliced.
+    fn from(ellipsized: Ellipsized<'a>) -> Self {
+        match ellipsized.0 {
+            Repr::Contiguous { text, .. } => Cow::Borrowed(text),
+            Repr::Spliced { .. } => Cow::Owned(ellipsized.to_string()),
+        }
+    }
+}
+
+impl PartialEq<str> for Ellipsized<'_> {
+    /// Compares against the concatenated output without allocating.
+    fn eq(&self, other: &str) -> bool {
+        match self.0 {
+            Repr::Contiguous { text, .. } => text == other,
+            Repr::Spliced {
+                head,
+                indicator,
+                tail,
+                ..
+            } => [head, indicator.as_ref(), tail]
+                .into_iter()
+                .try_fold(other, |rest, piece| rest.strip_prefix(piece))
+                .is_some_and(str::is_empty),
+        }
+    }
+}
+
+impl PartialEq<&str> for Ellipsized<'_> {
+    fn eq(&self, other: &&str) -> bool {
+        self == *other
+    }
+}
+
+/// Byte end index of the longest prefix of `s` whose summed per-grapheme `cost`
+/// is at most `max`.
+///
+/// Iterates whole grapheme clusters, so it never splits one — the returned index
+/// is always a valid slice point, and width context effects (a variation
+/// selector or combining mark adjusting the width of the character it follows)
+/// stay contained within a single cluster.
+fn prefix_boundary(s: &str, max: usize, cost: impl Fn(&str) -> usize) -> usize {
+    let mut used = 0;
+    for (idx, seg) in s.grapheme_indices(true) {
+        let seg_cost = cost(seg);
+        if used + seg_cost > max {
+            return idx;
+        }
+        used += seg_cost;
+    }
+    s.len()
+}
+
+/// Byte start index of the longest suffix of `s` whose summed per-grapheme
+/// `cost` is at most `max`. Iterates grapheme clusters like [`prefix_boundary`].
+fn suffix_boundary(s: &str, max: usize, cost: impl Fn(&str) -> usize) -> usize {
+    let mut used = 0;
+    let mut start = s.len();
+    for (idx, seg) in s.grapheme_indices(true).rev() {
+        let seg_cost = cost(seg);
+        if used + seg_cost > max {
+            break;
+        }
+        used += seg_cost;
+        start = idx;
+    }
+    start
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{Budget, EllipsizeExt, Indicator, Pos};
+    use pretty_assertions::assert_eq;
+    use proptest::prelude::*;
+    use rstest::rstest;
+    use unicode_width::UnicodeWidthStr;
+
+    /// Test-local mirror of a budget's inner amount — the crate's own cost
+    /// accessors are private to the production module.
+    fn amount(b: Budget) -> usize {
+        match b {
+            Budget::Bytes(n) => n,
+            Budget::Columns(n) => n,
+        }
+    }
+
+    /// Test-local mirror of how a budget measures a string's cost: byte
+    /// length for `Bytes`, display-column width for `Columns`.
+    fn cost(b: Budget, s: &str) -> usize {
+        match b {
+            Budget::Bytes(_) => s.len(),
+            Budget::Columns(_) => UnicodeWidthStr::width(s),
+        }
+    }
+
+    /// Table-driven examples covering both units, all three sides, both
+    /// ellipsis glyphs, wide (CJK/emoji) content, and the below-ellipsis-cost
+    /// hard-truncation edge case. Each case is its own test, so a failure
+    /// names precisely which input broke.
+    #[rstest]
+    // Fits unchanged (borrowed).
+    #[case("hello", Budget::Columns(10), Pos::End, Indicator::ASCII, "hello")]
+    #[case("hello", Budget::Columns(5), Pos::End, Indicator::ASCII, "hello")]
+    // Basic Right/Left/Middle truncation with Dots.
+    #[case(
+        "hello world",
+        Budget::Columns(8),
+        Pos::End,
+        Indicator::ASCII,
+        "hello..."
+    )]
+    #[case(
+        "hello world",
+        Budget::Columns(8),
+        Pos::Start,
+        Indicator::ASCII,
+        "...world"
+    )]
+    #[case(
+        "hello world",
+        Budget::Columns(7),
+        Pos::Middle,
+        Indicator::ASCII,
+        "he...ld"
+    )]
+    // Unicode ellipsis costs 1 column, so more content survives.
+    #[case(
+        "hello world",
+        Budget::Columns(6),
+        Pos::End,
+        Indicator::UNICODE,
+        "hello…"
+    )]
+    #[case(
+        "hello world",
+        Budget::Columns(6),
+        Pos::Start,
+        Indicator::UNICODE,
+        "…world"
+    )]
+    // Wide (double-width) glyphs: CJK.
+    #[case("你好世界", Budget::Columns(5), Pos::End, Indicator::ASCII, "你...")]
+    #[case("你好世界", Budget::Columns(4), Pos::End, Indicator::ASCII, "...")]
+    #[case("你好世界", Budget::Columns(8), Pos::End, Indicator::ASCII, "你好世界")]
+    // Wide glyphs: emoji.
+    #[case("🐢🦀🐢🦀", Budget::Columns(5), Pos::End, Indicator::UNICODE, "🐢🦀…")]
+    #[case(
+        "🐢🦀🐢🦀",
+        Budget::Columns(8),
+        Pos::End,
+        Indicator::UNICODE,
+        "🐢🦀🐢🦀"
+    )]
+    // Amount below ellipsis cost: hard-truncate, no ellipsis.
+    #[case("hello", Budget::Columns(2), Pos::End, Indicator::ASCII, "he")]
+    #[case("hello", Budget::Columns(2), Pos::Start, Indicator::ASCII, "lo")]
+    #[case("hello", Budget::Columns(0), Pos::End, Indicator::ASCII, "")]
+    // Empty input.
+    #[case("", Budget::Columns(5), Pos::End, Indicator::ASCII, "")]
+    // Byte budgets: ASCII bytes == columns.
+    #[case(
+        "hello world",
+        Budget::Bytes(8),
+        Pos::End,
+        Indicator::ASCII,
+        "hello..."
+    )]
+    // Contrast: the same `hello…` output fits in 6 columns (the Columns(6) case
+    // above) but needs 8 bytes, since `…` is 1 column but 3 bytes.
+    #[case(
+        "hello world",
+        Budget::Bytes(8),
+        Pos::End,
+        Indicator::UNICODE,
+        "hello…"
+    )]
+    // Multi-byte (but single-column) content under a byte budget.
+    #[case("café", Budget::Bytes(4), Pos::End, Indicator::ASCII, "c...")]
+    #[case("café", Budget::Bytes(5), Pos::End, Indicator::ASCII, "café")]
+    #[case("你好", Budget::Bytes(5), Pos::End, Indicator::ASCII, "...")]
+    fn truncates_per_table(
+        #[case] input: &str,
+        #[case] budget: Budget,
+        #[case] side: Pos,
+        #[case] ellipsis: Indicator<'static>,
+        #[case] expected: &str,
+    ) {
+        assert_eq!(input.ellipsize(budget, side, ellipsis), *expected);
+    }
+
+    fn any_pos() -> impl Strategy<Value = Pos> {
+        prop_oneof![Just(Pos::Start), Just(Pos::Middle), Just(Pos::End)]
+    }
+
+    fn any_indicator() -> impl Strategy<Value = Indicator<'static>> {
+        prop_oneof![Just(Indicator::ASCII), Just(Indicator::UNICODE)]
+    }
+
+    fn any_budget() -> impl Strategy<Value = Budget> {
+        prop_oneof![
+            (0usize..40).prop_map(Budget::Bytes),
+            (0usize..40).prop_map(Budget::Columns),
+        ]
+    }
+
+    proptest! {
+        #![proptest_config(ProptestConfig::with_cases(2048))]
+
+        /// The result never costs more than the budget's amount, in the
+        /// budget's own unit. Also proves the call never panics for any
+        /// input across every side/ellipsis/unit combination.
+        #[test]
+        fn never_overflows(
+            s in r"(?s).*",
+            budget in any_budget(),
+            side in any_pos(),
+            ellipsis in any_indicator(),
+        ) {
+            let out = s.ellipsize(budget, side, ellipsis).to_string();
+            prop_assert!(cost(budget, out.as_ref()) <= amount(budget));
+        }
+
+        /// When the input already fits, it is returned borrowed and
+        /// byte-for-byte unchanged (zero-copy fast path).
+        #[test]
+        fn borrowed_when_it_fits(
+            s in r"(?s).*",
+            budget in any_budget(),
+            side in any_pos(),
+            ellipsis in any_indicator(),
+        ) {
+            if cost(budget, &s) <= amount(budget) {
+                let result = s.ellipsize(budget, side, ellipsis);
+                prop_assert!(matches!(
+                    std::borrow::Cow::from(result),
+                    std::borrow::Cow::Borrowed(_)
+                ));
+                prop_assert!(result == s.as_str());
+            }
+        }
+
+        /// Truncation never makes a string cost more than it started with.
+        #[test]
+        fn never_grows(
+            s in r"(?s).*",
+            budget in any_budget(),
+            side in any_pos(),
+            ellipsis in any_indicator(),
+        ) {
+            let out = s.ellipsize(budget, side, ellipsis).to_string();
+            prop_assert!(cost(budget, out.as_ref()) <= cost(budget, &s));
+        }
+
+        /// Byte budgets specifically: the result's byte length never exceeds
+        /// `n`. This is subsumed by `never_overflows` but is asserted
+        /// explicitly since it is the `truncate_description` invariant.
+        #[test]
+        fn valid_byte_cut(
+            s in r"(?s).*",
+            n in 0usize..40,
+            side in any_pos(),
+            ellipsis in any_indicator(),
+        ) {
+            let out = s.ellipsize(Budget::Bytes(n), side, ellipsis).to_string();
+            prop_assert!(out.len() <= n);
+        }
+
+        /// When content had to be dropped and the budget can afford the
+        /// ellipsis glyph, the glyph appears in the result.
+        #[test]
+        fn ellipsis_present_when_needed(
+            s in r"(?s).*",
+            budget in any_budget(),
+            side in any_pos(),
+            ellipsis in any_indicator(),
+        ) {
+            let glyph = ellipsis.as_ref();
+            let ellipsis_cost = cost(budget, glyph);
+            if cost(budget, &s) > amount(budget) && amount(budget) >= ellipsis_cost {
+                let out = s.ellipsize(budget, side, ellipsis).to_string();
+                prop_assert!(out.contains(glyph));
+            }
+        }
+
+        /// Every kept output byte maps back (via `source_index`) to the source
+        /// char it came from; indicator bytes map to `None`. Exercises all
+        /// shapes: contiguous fit/prefix/suffix and spliced start/middle/end.
+        #[test]
+        fn source_index_round_trips(
+            s in r"(?s).*",
+            budget in any_budget(),
+            side in any_pos(),
+            indicator in any_indicator(),
+        ) {
+            let e = s.ellipsize(budget, side, indicator);
+            let out = e.to_string();
+            for (i, ch) in out.char_indices() {
+                if let Some(j) = e.source_index(i) {
+                    // The output char at byte `i` is the source char at byte `j`.
+                    prop_assert_eq!(s[j..].chars().next(), Some(ch));
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn source_index_middle_maps_head_gap_tail() {
+        // "hello world" -> Columns(7) Middle Dots = "he...ld"
+        let e = "hello world".ellipsize(Budget::Columns(7), Pos::Middle, Indicator::ASCII);
+        assert_eq!(e.to_string(), "he...ld");
+        assert_eq!(e.source_index(0), Some(0)); // 'h' head identity
+        assert_eq!(e.source_index(1), Some(1)); // 'e' head identity
+        assert_eq!(e.source_index(2), None); // '.' on the indicator
+        assert_eq!(e.source_index(4), None); // '.' on the indicator
+        assert_eq!(e.source_index(5), Some(9)); // 'l' tail: 5 - 2 - 3 + 9
+        assert_eq!(e.source_index(6), Some(10)); // 'd' tail
+    }
+
+    #[test]
+    fn source_index_fits_is_identity() {
+        let e = "hi".ellipsize(Budget::Columns(10), Pos::Middle, Indicator::ASCII);
+        assert!(matches!(
+            std::borrow::Cow::from(e),
+            std::borrow::Cow::Borrowed(_)
+        ));
+        assert_eq!(e.source_index(0), Some(0));
+        assert_eq!(e.source_index(1), Some(1));
+    }
+
+    #[test]
+    fn display_writes_without_allocating_via_cow() {
+        let e = "hello world".ellipsize(Budget::Columns(8), Pos::End, Indicator::ASCII);
+        assert_eq!(e.to_string(), "hello...");
+        assert!(matches!(
+            std::borrow::Cow::from(e),
+            std::borrow::Cow::Owned(_)
+        ));
+
+        let fits = "hi".ellipsize(Budget::Columns(8), Pos::End, Indicator::ASCII);
+        assert!(matches!(
+            std::borrow::Cow::from(fits),
+            std::borrow::Cow::Borrowed(_)
+        ));
+    }
+}

--- a/crates/atuin-common/src/string/mod.rs
+++ b/crates/atuin-common/src/string/mod.rs
@@ -1,4 +1,8 @@
 //! String-related utilities and extension traits.
+#[cfg(feature = "unicode")]
+pub mod ellipsis;
 mod escape_non_printable_posix_ext;
 
+#[cfg(feature = "unicode")]
+pub use ellipsis::EllipsizeExt;
 pub use escape_non_printable_posix_ext::EscapeNonPrintablePosixExt;

--- a/crates/atuin/Cargo.toml
+++ b/crates/atuin/Cargo.toml
@@ -46,7 +46,7 @@ check-update = ["atuin-client/check-update"]
 [dependencies]
 atuin-ai = { path = "../atuin-ai", version = "18.17.1", optional = true, default-features = false }
 atuin-client = { path = "../atuin-client", version = "18.17.1", optional = true, default-features = false }
-atuin-common = { workspace = true, features = ["tracing"] }
+atuin-common = { workspace = true, features = ["tracing", "unicode"] }
 atuin-dotfiles = { workspace = true }
 atuin-history = { workspace = true }
 atuin-daemon = { path = "../atuin-daemon", version = "18.17.1", optional = true, default-features = false }

--- a/crates/atuin/src/command/client/search/history_list.rs
+++ b/crates/atuin/src/command/client/search/history_list.rs
@@ -7,7 +7,9 @@ use atuin_client::{
     settings::{UiColumn, UiColumnType},
     theme::{Meaning, Theme},
 };
+use atuin_common::string::EllipsizeExt as _;
 use atuin_common::string::EscapeNonPrintablePosixExt as _;
+use atuin_common::string::ellipsis::{Budget, Indicator, Pos};
 use itertools::Itertools;
 use ratatui::{
     backend::FromCrossterm,
@@ -18,6 +20,7 @@ use ratatui::{
     widgets::{Block, StatefulWidget, Widget},
 };
 use time::OffsetDateTime;
+use unicode_width::UnicodeWidthStr;
 
 pub struct HistoryHighlighter<'a> {
     pub engine: &'a dyn SearchEngine,
@@ -310,28 +313,27 @@ impl DrawState<'_> {
 
         // Truncate long commands from the middle to show both start and end,
         // so users can identify commands even in narrow terminals (issue #3596).
-        let (display, display_to_original) = truncate_middle(&normalized, avail);
-        let normalized_byte_len = normalized.len();
-
-        // Render each character of the display string, applying highlights
-        // where the original position matches a highlight index.
-        for (ch, &original_byte_pos) in display.chars().zip(display_to_original.iter()) {
+        let ellipsized =
+            normalized.ellipsize(Budget::Columns(avail), Pos::Middle, Indicator::UNICODE);
+        let display = ellipsized.to_string();
+        for (i, ch) in display.char_indices() {
             if self.x > self.list_area.width {
                 return;
             }
-
+            // Map each output cell back to its source byte and test the existing
+            // highlight set; a cell on the spliced ellipsis maps to None and is
+            // never highlighted (this is why the "…" is never bolded).
+            let highlighted = ellipsized
+                .source_index(i)
+                .is_some_and(|b| highlight_indices.contains(&b));
             let mut char_style = style;
-            if original_byte_pos < normalized_byte_len
-                && highlight_indices.contains(&original_byte_pos)
-            {
+            if highlighted {
                 if row_highlighted {
                     char_style = self.theme.as_style(Meaning::AlertWarn);
                 }
                 char_style.attributes.set(style::Attribute::Bold);
             }
-
-            let s = ch.to_string();
-            self.draw(&s, Style::from_crossterm(char_style));
+            self.draw(&ch.to_string(), Style::from_crossterm(char_style));
         }
     }
 
@@ -358,12 +360,11 @@ impl DrawState<'_> {
         let style = self.theme.as_style(Meaning::Annotation);
         let w = width as usize;
         let cwd = &h.cwd;
-        let char_count = cwd.chars().count();
-        // Truncate from the left with "..." if too long, plus trailing space
-        // Use character count for comparison and skip for UTF-8 safety
-        let display = if char_count > w && w >= 4 {
-            let truncated: String = cwd.chars().skip(char_count - (w - 3)).collect();
-            format!("...{truncated}")
+        // Elide from the left with "..." so the leaf directory stays visible;
+        // pad to the column width when it already fits.
+        let display = if cwd.width() > w {
+            cwd.ellipsize(Budget::Columns(w), Pos::Start, Indicator::UNICODE)
+                .to_string()
         } else {
             format!("{cwd:w$}")
         };
@@ -376,11 +377,9 @@ impl DrawState<'_> {
         let w = width as usize;
         // Database stores hostname as "hostname:username"
         let host = h.hostname.split(':').next().unwrap_or(&h.hostname);
-        let char_count = host.chars().count();
-        // Use character count for comparison and take for UTF-8 safety
-        let display = if char_count > w && w >= 4 {
-            let truncated: String = host.chars().take(w.saturating_sub(4)).collect();
-            format!("{truncated}...")
+        let display = if host.width() > w {
+            host.ellipsize(Budget::Columns(w), Pos::End, Indicator::UNICODE)
+                .to_string()
         } else {
             format!("{host:w$}")
         };
@@ -393,11 +392,9 @@ impl DrawState<'_> {
         let w = width as usize;
         // Database stores hostname as "hostname:username"
         let user = h.hostname.split(':').nth(1).unwrap_or("");
-        let char_count = user.chars().count();
-        // Use character count for comparison and take for UTF-8 safety
-        let display = if char_count > w && w >= 4 {
-            let truncated: String = user.chars().take(w.saturating_sub(4)).collect();
-            format!("{truncated}...")
+        let display = if user.width() > w {
+            user.ellipsize(Budget::Columns(w), Pos::End, Indicator::UNICODE)
+                .to_string()
         } else {
             format!("{user:w$}")
         };
@@ -432,130 +429,5 @@ impl DrawState<'_> {
 
         let w = (self.list_area.width - self.x) as usize;
         self.x += self.buf.set_stringn(cx, cy, s, w, style).0 - cx;
-    }
-}
-
-/// Truncate a string from the middle to fit within `avail` characters,
-/// showing the start and end separated by "...".
-///
-/// Returns the truncated display string and a mapping from each display
-/// character's byte position to the corresponding byte position in the
-/// original string. Characters in the "..." sentinel map to
-/// `original.len()` (an out-of-range value that will never match any
-/// real highlight index).
-///
-/// If the string fits within `avail`, or `avail < 7` (too small to
-/// truncate meaningfully), the original string is returned as-is with
-/// a 1:1 mapping.
-fn truncate_middle(original: &str, avail: usize) -> (String, Vec<usize>) {
-    let char_byte_offsets: Vec<usize> = original.char_indices().map(|(bp, _)| bp).collect();
-    let char_count = char_byte_offsets.len();
-
-    if char_count <= avail || avail < 7 {
-        return (original.to_string(), char_byte_offsets);
-    }
-
-    let remaining = avail - 3;
-    let prefix_len = remaining.div_ceil(2);
-    let suffix_len = remaining / 2;
-
-    let prefix: String = original.chars().take(prefix_len).collect();
-    let suffix: String = original.chars().skip(char_count - suffix_len).collect();
-    let display = format!("{prefix}...{suffix}");
-
-    let original_byte_len = original.len();
-    let mut mapping = Vec::with_capacity(avail);
-    mapping.extend_from_slice(&char_byte_offsets[..prefix_len]);
-    mapping.extend(std::iter::repeat_n(original_byte_len, 3));
-    for i in 0..suffix_len {
-        mapping.push(char_byte_offsets[char_count - suffix_len + i]);
-    }
-
-    (display, mapping)
-}
-
-#[cfg(test)]
-mod tests {
-    use super::truncate_middle;
-
-    #[test]
-    fn test_no_truncation_when_fits() {
-        let (display, mapping) = truncate_middle("hello", 10);
-        assert_eq!(display, "hello");
-        assert_eq!(mapping.len(), 5);
-        // Mapping should be 1:1 with byte offsets
-        assert_eq!(mapping, vec![0, 1, 2, 3, 4]);
-    }
-
-    #[test]
-    fn test_no_truncation_exact_fit() {
-        let (display, _) = truncate_middle("hello", 5);
-        assert_eq!(display, "hello");
-    }
-
-    #[test]
-    fn test_no_truncation_when_too_small() {
-        // avail < 7 — too small to truncate, return as-is
-        let (display, _) = truncate_middle("hello world this is long", 6);
-        assert_eq!(display, "hello world this is long");
-    }
-
-    #[test]
-    fn test_truncation_shows_start_and_end() {
-        let (display, _) = truncate_middle("abcdefghijklmnopqrstuvwxyz", 11);
-        // avail=11, remaining=8, prefix=4, suffix=4
-        // "abcd...wxyz"
-        assert_eq!(display, "abcd...wxyz");
-        assert_eq!(display.len(), 11);
-    }
-
-    #[test]
-    fn test_truncation_preserves_byte_mapping() {
-        let original = "abcdefghij";
-        let (display, mapping) = truncate_middle(original, 7);
-        // avail=7, remaining=4, prefix=2, suffix=2
-        // "ab...ij"
-        assert_eq!(display, "ab...ij");
-
-        // Prefix chars map to original positions 0, 1
-        assert_eq!(mapping[0], 0); // 'a'
-        assert_eq!(mapping[1], 1); // 'b'
-        // "..." maps to original.len() (out of range)
-        assert_eq!(mapping[2], original.len());
-        assert_eq!(mapping[3], original.len());
-        assert_eq!(mapping[4], original.len());
-        // Suffix chars map to original positions 8, 9
-        assert_eq!(mapping[5], 8); // 'i'
-        assert_eq!(mapping[6], 9); // 'j'
-    }
-
-    #[test]
-    fn test_truncation_with_unicode() {
-        let original = "héllo wörld thïs ïs ä löng cömmänd";
-        let (display, mapping) = truncate_middle(original, 15);
-        // Should still be 15 chars
-        assert_eq!(display.chars().count(), 15);
-        // Should contain "..."
-        assert!(display.contains("..."));
-        // Mapping length matches display char count
-        assert_eq!(mapping.len(), 15);
-    }
-
-    #[test]
-    fn test_truncation_minimum_width() {
-        // avail=7 is the minimum for truncation
-        let original = "abcdefghij";
-        let (display, _) = truncate_middle(original, 7);
-        assert_eq!(display, "ab...ij");
-    }
-
-    #[test]
-    fn test_truncation_odd_remaining() {
-        // avail=10, remaining=7, prefix=4 (ceil), suffix=3
-        let original = "abcdefghijklmno"; // 15 chars
-        let (display, _) = truncate_middle(original, 10);
-        // "abcd...mno"
-        assert_eq!(display, "abcd...mno");
-        assert_eq!(display.len(), 10);
     }
 }


### PR DESCRIPTION
This PR adds an `EllipsizeExt` string extension to help commonize and remove some of the duplicated code we've had with ellipses. The main goal is to be slightly tidier, with a common helper utility that's generic, well-tested, etc.

You can now do

```rust
use EllipsizeExt as _;

fn your_fxn() {
  return "hello-world".ellipsize(Budget::Columns(5), Pos::Middle, Indicator::UNICODE); // "he…ld"
}
```

### Impact

This actually fixes a tiny bug according to claude:

>   1. Wide-character column misalignment (real, user-visible). This is the actual fix.
  The old directory/host/user renderers in the interactive search list budgeted
  truncation in chars().count(). A CJK glyph or emoji is 1 char but 2 terminal 
  columns, so a column sized for width N could render into up to 2N cells —
  overflowing its column and shoving every column to its right out of alignment
  whenever your history contained e.g. a /世界/… path or an emoji. The new code
  measures in display columns (unicode-width), so those truncate to actually fit. If
  you have any wide-char history entries, the search UI was visibly misaligned before
  and isn't now. (Two smaller correctness bumps ride along: the old host/user had an
  off-by-one that under-filled their column by one cell vs directory, now unified; and
  at very narrow widths w < 4 the old code fell through to a non-truncating format!
  that overflowed, where the new code hard-truncates.)
  
Also, it uses unicode ellipses now in the history list!

### Testing

There's a bunch of unit tests, and I also tested it manually:

```
$ ./target/debug/atuin search -i
```

Before:

<img width="437" height="515" alt="image" src="https://github.com/user-attachments/assets/3dd1b90a-87a0-4d66-bb1e-fa5dcaa05589" />

After:

<img width="427" height="334" alt="image" src="https://github.com/user-attachments/assets/dae134d0-4e28-4cae-a39e-37013bc32128" />

Looks like a nice improvement to me!