### PR TITLE
chore(clap): simplify clap field types and fix help message formatting

### DIFF
--- a/crates/atuin/src/command/client/history.rs
+++ b/crates/atuin/src/command/client/history.rs
@@ -116,12 +116,14 @@ pub enum Cmd {
         /// Display the command time in another timezone other than the configured default.
         ///
         /// This option takes one of the following kinds of values:
+        ///
         /// - the special value "local" (or "l") which refers to the system time zone
         /// - an offset from UTC (e.g. "+9", "-2:30")
-        #[arg(long, visible_alias = "tz")]
+        #[arg(long, visible_alias = "tz", verbatim_doc_comment)]
         timezone: Option<Timezone>,
 
         /// Available variables: {command}, {directory}, {duration}, {user}, {host}, {author}, {intent}, {exit}, {time}, {session}, and {uuid}
+        ///
         /// Example: --format "{time} - [{duration}] - {directory}$\t{command}"
         #[arg(long, short)]
         format: Option<String>,
@@ -139,12 +141,14 @@ pub enum Cmd {
         /// Display the command time in another timezone other than the configured default.
         ///
         /// This option takes one of the following kinds of values:
+        ///
         /// - the special value "local" (or "l") which refers to the system time zone
         /// - an offset from UTC (e.g. "+9", "-2:30")
-        #[arg(long, visible_alias = "tz")]
+        #[arg(long, visible_alias = "tz", verbatim_doc_comment)]
         timezone: Option<Timezone>,
 
         /// Available variables: {command}, {directory}, {duration}, {user}, {host}, {author}, {intent}, {time}, {session}, {uuid} and {relativetime}.
+        ///
         /// Example: --format "{time} - [{duration}] - {directory}$\t{command}"
         #[arg(long, short)]
         format: Option<String>,

--- a/crates/atuin/src/command/client/scripts.rs
+++ b/crates/atuin/src/command/client/scripts.rs
@@ -36,6 +36,7 @@ pub struct NewScript {
     #[allow(clippy::option_option)]
     #[arg(long)]
     /// Use the last command as the script content
+    ///
     /// Optionally specify a number to use the last N commands
     pub last: Option<Option<usize>>,
 
@@ -49,6 +50,7 @@ pub struct Run {
     pub name: String,
 
     /// Specify template variables in the format KEY=VALUE
+    ///
     /// Example: -v name=John -v greeting="Hello there"
     #[arg(short, long = "var")]
     pub var: Vec<String>,

--- a/crates/atuin/src/command/client/search.rs
+++ b/crates/atuin/src/command/client/search.rs
@@ -87,7 +87,7 @@ pub struct Cmd {
     human: bool,
 
     #[arg(allow_hyphen_values = true)]
-    query: Option<Vec<String>>,
+    query: Vec<String>,
 
     /// Show only the text of the command
     #[arg(long)]
@@ -134,7 +134,7 @@ pub struct Cmd {
     /// Filter by author. Supports $all-user (non-agents), $all-agent, or literal names.
     /// Can be specified multiple times.
     #[arg(long)]
-    author: Option<Vec<String>>,
+    author: Vec<String>,
 
     /// Include duplicate commands in the output (non-interactive only)
     #[arg(long)]
@@ -162,7 +162,7 @@ impl Cmd {
         store: SqliteStore,
         theme: &Theme,
     ) -> Result<()> {
-        let query = self.query.unwrap_or_else(|| {
+        let query = if self.query.is_empty() {
             std::env::var("ATUIN_QUERY").map_or_else(
                 |_| vec![],
                 |query| {
@@ -172,7 +172,9 @@ impl Cmd {
                         .collect()
                 },
             )
-        });
+        } else {
+            self.query
+        };
 
         if (self.delete_it_all || self.delete) && self.limit.is_some() {
             // Because of how deletion is implemented, it will always delete all matches
@@ -254,7 +256,7 @@ impl Cmd {
                 offset: self.offset,
                 reverse: self.reverse,
                 include_duplicates: self.include_duplicates,
-                authors: self.author.clone().unwrap_or_default(),
+                authors: self.author.clone(),
             };
 
             let mut entries =
@@ -352,7 +354,7 @@ mod tests {
         let cmd = Cmd::try_parse_from(["search", "---"]);
         assert!(cmd.is_ok(), "Failed to parse '---' as a query: {cmd:?}");
         let cmd = cmd.unwrap();
-        assert_eq!(cmd.query, Some(vec!["---".to_string()]));
+        assert_eq!(cmd.query, vec!["---".to_string()]);
     }
 
     #[test]
@@ -361,16 +363,13 @@ mod tests {
         let cmd = Cmd::try_parse_from(["search", "--", "--foo"]);
         assert!(cmd.is_ok());
         let cmd = cmd.unwrap();
-        assert_eq!(cmd.query, Some(vec!["--foo".to_string()]));
+        assert_eq!(cmd.query, vec!["--foo".to_string()]);
     }
 
     #[test]
     fn search_author_cli_flag() {
         let cmd =
             Cmd::try_parse_from(["search", "--author", "codex", "--author", "ellie"]).unwrap();
-        assert_eq!(
-            cmd.author,
-            Some(vec!["codex".to_string(), "ellie".to_string()])
-        );
+        assert_eq!(cmd.author, vec!["codex".to_string(), "ellie".to_string()]);
     }
 }

--- a/crates/atuin/src/command/client/search.rs
+++ b/crates/atuin/src/command/client/search.rs
@@ -290,7 +290,7 @@ impl Cmd {
                 let format = self
                     .format
                     .as_deref()
-                    .unwrap_or_else(|| settings.history_format.as_str());
+                    .unwrap_or(settings.history_format.as_str());
                 let tz = self.timezone.unwrap_or(settings.timezone);
 
                 super::history::print_list(

--- a/crates/atuin/src/command/client/search.rs
+++ b/crates/atuin/src/command/client/search.rs
@@ -112,17 +112,20 @@ pub struct Cmd {
     /// Display the command time in another timezone other than the configured default.
     ///
     /// This option takes one of the following kinds of values:
+    ///
     /// - the special value "local" (or "l") which refers to the system time zone
     /// - an offset from UTC (e.g. "+9", "-2:30")
-    #[arg(long, visible_alias = "tz")]
-    #[arg(allow_hyphen_values = true)]
-    // Clippy warns about `Option<Option<T>>`, but we suppress it because we need
-    // this distinction for proper argument handling.
-    #[allow(clippy::option_option)]
-    timezone: Option<Option<Timezone>>,
+    #[arg(long, visible_alias = "tz", verbatim_doc_comment)]
+    // `num_args = 0..=1` allows a user to run `atuin search --tz` with no argument to `--tz`. This
+    // does the same thing as not providing the flag, but we previously allowed it (via an
+    // `Option<Option<T>>` field type), so let's keep supporting it to avoid breaking existing
+    // scripts.
+    #[arg(allow_hyphen_values = true, num_args = 0..=1)]
+    timezone: Option<Timezone>,
 
     /// Available variables: {command}, {directory}, {duration}, {user}, {host}, {time}, {exit} and
     /// {relativetime}.
+    ///
     /// Example: --format "{time} - [{duration}] - {directory}$\t{command}"
     #[arg(long, short)]
     format: Option<String>,
@@ -132,6 +135,7 @@ pub struct Cmd {
     inline_height: Option<u16>,
 
     /// Filter by author. Supports $all-user (non-agents), $all-agent, or literal names.
+    ///
     /// Can be specified multiple times.
     #[arg(long)]
     author: Vec<String>,
@@ -283,19 +287,16 @@ impl Cmd {
                         run_non_interactive(settings, opt_filter.clone(), &query, &db).await?;
                 }
             } else {
-                let format = match self.format {
-                    None => Some(settings.history_format.as_str()),
-                    _ => self.format.as_deref(),
-                };
-                let tz = match self.timezone {
-                    Some(Some(tz)) => tz,                   // User provided a value
-                    Some(None) | None => settings.timezone, // No value was provided
-                };
+                let format = self
+                    .format
+                    .as_deref()
+                    .unwrap_or_else(|| settings.history_format.as_str());
+                let tz = self.timezone.unwrap_or(settings.timezone);
 
                 super::history::print_list(
                     &entries,
                     ListMode::from_flags(self.human, self.cmd_only),
-                    format,
+                    Some(format),
                     self.print0,
                     true,
                     tz,

--- a/crates/atuin/src/command/client/store/pull.rs
+++ b/crates/atuin/src/command/client/store/pull.rs
@@ -17,11 +17,13 @@ pub struct Pull {
     pub tag: Option<String>,
 
     /// Force push records
+    ///
     /// This will first wipe the local store, and then download all records from the remote
     #[arg(long, default_value = "false")]
     pub force: bool,
 
     /// Page Size
+    ///
     /// How many records to download at once. Defaults to 100
     #[arg(long, default_value = "100")]
     pub page: u64,

--- a/crates/atuin/src/command/client/store/push.rs
+++ b/crates/atuin/src/command/client/store/push.rs
@@ -22,12 +22,14 @@ pub struct Push {
     pub host: Option<Uuid>,
 
     /// Force push records
+    ///
     /// This will override both host and tag, to be all hosts and all tags. First clear the remote store, then upload all of the
     /// local store
     #[arg(long, default_value = "false")]
     pub force: bool,
 
     /// Page Size
+    ///
     /// How many records to upload at once. Defaults to 100
     #[arg(long, default_value = "100")]
     pub page: u64,


### PR DESCRIPTION
* Simplify `Option<Vec<T>>` to `Vec<T>` and `Option<Option<T>>` to `Option<T>` without losing the ability to distinguish what was passed
* Fix formatting of several help messages. clap removes the newline between sequential non-blank lines; this was causing some unintended formatting.