### PR TITLE
refactor: use typed Url instead of hand-built string URLs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -269,6 +269,7 @@ dependencies = [
  "tracing-subscriber",
  "tracing-tree",
  "unicode-width 0.2.2",
+ "url",
  "uuid",
  "windows-sys 0.61.2",
 ]
@@ -359,6 +360,7 @@ dependencies = [
  "regex",
  "reqwest",
  "rmp",
+ "rstest",
  "rusty_paserk",
  "rusty_paseto",
  "semver",
@@ -378,6 +380,7 @@ dependencies = [
  "tokio",
  "tracing",
  "typed-builder",
+ "url",
  "uuid",
  "whoami 2.1.1",
 ]
@@ -406,6 +409,7 @@ dependencies = [
  "typed-builder",
  "unicode-segmentation",
  "unicode-width 0.2.2",
+ "url",
  "uuid",
 ]
 
@@ -575,6 +579,7 @@ dependencies = [
  "tower-http",
  "tracing",
  "tracing-subscriber",
+ "url",
 ]
 
 [[package]]
@@ -585,6 +590,7 @@ dependencies = [
  "atuin-common",
  "derive_more",
  "eyre",
+ "rstest",
  "serde",
  "sqlx",
  "time",
@@ -5968,6 +5974,7 @@ dependencies = [
  "idna",
  "percent-encoding",
  "serde",
+ "serde_derive",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -78,6 +78,7 @@ xxhash-rust = { version = "0.8", features = ["xxh3"] }
 vt100 = "0.16"
 regex = "1.10.5"
 toml_edit = "0.25.4"
+url = { version = "2.5", features = ["serde"] }
 
 [workspace.dependencies.tracing-subscriber]
 version = "0.3"

--- a/crates/atuin-ai/src/commands/inline.rs
+++ b/crates/atuin-ai/src/commands/inline.rs
@@ -42,14 +42,15 @@ pub(crate) async fn run(
         }
     }
 
-    let endpoint = api_endpoint.as_deref().unwrap_or(
-        settings
+    let endpoint = match api_endpoint.as_deref() {
+        Some(raw) => reqwest::Url::parse(raw).context("invalid --api-endpoint URL")?,
+        None => settings
             .ai
             .endpoint
-            .as_deref()
-            .unwrap_or("https://hub.atuin.sh"),
-    );
-    let endpoint_is_hub = settings.is_hub_ai_endpoint(endpoint);
+            .clone()
+            .unwrap_or_else(|| atuin_client::settings::DEFAULT_HUB_URL.clone()),
+    };
+    let endpoint_is_hub = settings.is_hub_ai_endpoint(&endpoint);
     let api_token = api_token.as_deref().or(settings.ai.api_token.as_deref());
 
     let (token, token_from_hub_session) = match api_token {
@@ -80,7 +81,7 @@ pub(crate) async fn run(
         .and_then(|cwd| atuin_common::utils::in_git_repo(cwd.to_str()?));
 
     let ctx = AppContext {
-        endpoint: endpoint.to_string(),
+        endpoint,
         token,
         endpoint_is_hub,
         token_from_hub_session,
@@ -105,7 +106,7 @@ async fn ensure_hub_session(settings: &atuin_client::settings::Settings) -> Resu
         return Ok(token);
     }
 
-    let hub_address = settings.active_hub_endpoint().unwrap_or_default();
+    let hub_address = settings.hub_endpoint();
     let will_sync = settings.is_hub_sync();
 
     info!("No Hub session found, prompting for authentication");
@@ -127,7 +128,7 @@ async fn ensure_hub_session(settings: &atuin_client::settings::Settings) -> Resu
     debug!("Starting Atuin Hub authentication...");
     println!("Authenticating with Atuin Hub...");
 
-    let session = atuin_client::hub::HubAuthSession::start(hub_address.as_ref()).await?;
+    let session = atuin_client::hub::HubAuthSession::start(&hub_address).await?;
     println!("Open this URL to continue:");
     println!("{}", session.auth_url);
 
@@ -145,7 +146,7 @@ async fn ensure_hub_session(settings: &atuin_client::settings::Settings) -> Resu
         && let Ok(Some(cli_token)) = meta.session_token().await
     {
         debug!("CLI session found, attempting to link accounts");
-        if let Err(e) = atuin_client::hub::link_account(hub_address.as_ref(), &cli_token).await {
+        if let Err(e) = atuin_client::hub::link_account(&hub_address, &cli_token).await {
             debug!("Could not link CLI account to Hub: {}", e);
         } else {
             info!("Successfully linked CLI account to Hub");

--- a/crates/atuin-ai/src/context.rs
+++ b/crates/atuin-ai/src/context.rs
@@ -9,7 +9,7 @@ use atuin_client::settings::AiCapabilities;
 /// Holds the API configuration and client settings needed by the event loop and stream task.
 #[derive(Clone, Debug)]
 pub(crate) struct AppContext {
-    pub endpoint: String,
+    pub endpoint: reqwest::Url,
     /// Bearer token for `endpoint`. Empty means unauthenticated — no
     /// Authorization header is sent (an OSS server may not require auth).
     pub token: String,

--- a/crates/atuin-ai/src/models.rs
+++ b/crates/atuin-ai/src/models.rs
@@ -6,6 +6,7 @@
 
 use std::time::Duration;
 
+use atuin_common::url::UrlAppendExt;
 use eyre::{Context, Result};
 use reqwest::header::USER_AGENT;
 use serde::Deserialize;
@@ -26,9 +27,9 @@ pub(crate) struct ModelList {
 
 /// Fetch the models available to this user. Sent authenticated because the
 /// server includes feature-flag-gated models only for entitled users.
-pub(crate) async fn fetch_models(endpoint: &str, token: &str) -> Result<ModelList> {
+pub(crate) async fn fetch_models(endpoint: &reqwest::Url, token: &str) -> Result<ModelList> {
     atuin_common::tls::ensure_crypto_provider();
-    let url = crate::stream::hub_url(endpoint, "/api/cli/models")?;
+    let url = endpoint.append_path("api/cli/models")?;
 
     let mut request = reqwest::Client::new()
         .get(url)

--- a/crates/atuin-ai/src/stream.rs
+++ b/crates/atuin-ai/src/stream.rs
@@ -7,9 +7,10 @@ use atuin_client::settings::AiCapabilities;
 
 use crate::context::history_output_capability_available;
 use atuin_common::tls::ensure_crypto_provider;
+use atuin_common::url::UrlAppendExt;
 
 use eventsource_stream::Eventsource;
-use eyre::{Context, Result};
+use eyre::Result;
 use futures::StreamExt;
 use reqwest::Url;
 use reqwest::header::USER_AGENT;
@@ -117,7 +118,7 @@ impl ChatRequest {
 
 #[allow(clippy::too_many_arguments)]
 pub(crate) fn create_chat_stream(
-    hub_address: String,
+    hub_address: Url,
     token: String,
     token_from_hub_session: bool,
     request: ChatRequest,
@@ -130,10 +131,10 @@ pub(crate) fn create_chat_stream(
 ) -> std::pin::Pin<Box<dyn futures::Stream<Item = Result<StreamFrame>> + Send>> {
     Box::pin(async_stream::stream! {
         ensure_crypto_provider();
-        let endpoint = match hub_url(&hub_address, "/api/cli/chat") {
+        let endpoint = match hub_address.append_path("api/cli/chat") {
             Ok(url) => url,
             Err(e) => {
-                yield Err(e);
+                yield Err(e.into());
                 return;
             }
         };
@@ -300,16 +301,4 @@ pub(crate) fn create_chat_stream(
             }
         }
     })
-}
-
-pub(crate) fn hub_url(base: &str, path: &str) -> Result<Url> {
-    let base_with_slash = if base.ends_with('/') {
-        base.to_string()
-    } else {
-        format!("{base}/")
-    };
-    let stripped = path.strip_prefix('/').unwrap_or(path);
-    Url::parse(&base_with_slash)?
-        .join(stripped)
-        .context("failed to build hub URL")
 }

--- a/crates/atuin-ai/src/usage.rs
+++ b/crates/atuin-ai/src/usage.rs
@@ -8,6 +8,7 @@
 
 use std::time::Duration;
 
+use atuin_common::url::UrlAppendExt;
 use eyre::{Context, Result};
 use reqwest::header::USER_AGENT;
 use serde::{Deserialize, Serialize};
@@ -88,9 +89,9 @@ pub(crate) fn cache_key(token: &str) -> String {
 
 /// Fetch current usage from the hub. Mirrors the `credits` object on the
 /// chat `done` event, for refreshing without starting a chat.
-pub(crate) async fn fetch_usage(endpoint: &str, token: &str) -> Result<UsageSnapshot> {
+pub(crate) async fn fetch_usage(endpoint: &reqwest::Url, token: &str) -> Result<UsageSnapshot> {
     atuin_common::tls::ensure_crypto_provider();
-    let url = crate::stream::hub_url(endpoint, "/api/cli/usage")?;
+    let url = endpoint.append_path("api/cli/usage")?;
 
     let response = reqwest::Client::new()
         .get(url)

--- a/crates/atuin-client/Cargo.toml
+++ b/crates/atuin-client/Cargo.toml
@@ -34,6 +34,7 @@ interim = { workspace = true }
 config = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
+url = { workspace = true }
 humantime = "2.1.0"
 async-trait = { workspace = true }
 itertools = { workspace = true }
@@ -83,6 +84,7 @@ features = ["tracing"]
 [dev-dependencies]
 tokio = { version = "1", features = ["full"] }
 pretty_assertions = { workspace = true }
+rstest = { workspace = true }
 divan = "0.1.14"
 tempfile = "3"
 

--- a/crates/atuin-client/src/api_client.rs
+++ b/crates/atuin-client/src/api_client.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 use std::env;
 use std::time::Duration;
 
-use eyre::{Result, bail, eyre};
+use eyre::{Result, bail};
 use reqwest::{
     Response, StatusCode, Url,
     header::{AUTHORIZATION, HeaderMap, USER_AGENT},
@@ -12,6 +12,7 @@ use atuin_common::{
     api::{ATUIN_CARGO_VERSION, ATUIN_HEADER_VERSION, ATUIN_VERSION},
     record::{EncryptedData, HostId, Record, RecordIdx},
     tls::ensure_crypto_provider,
+    url::UrlAppendExt,
 };
 use atuin_common::{
     api::{
@@ -52,31 +53,12 @@ impl AuthToken {
 }
 
 pub struct Client<'a> {
-    sync_addr: &'a str,
+    sync_addr: &'a Url,
     client: reqwest::Client,
 }
 
-fn make_url(address: &str, path: &str) -> Result<String> {
-    // `join()` expects a trailing `/` in order to join paths
-    // e.g. it treats `http://host:port/subdir` as a file called `subdir`
-    let address = if address.ends_with("/") {
-        address
-    } else {
-        &format!("{address}/")
-    };
-
-    // passing a path with a leading `/` will cause `join()` to replace the entire URL path
-    let path = path.strip_prefix("/").unwrap_or(path);
-
-    let url = Url::parse(address)
-        .map(|url| url.join(path))?
-        .map_err(|_| eyre!("invalid address"))?;
-
-    Ok(url.to_string())
-}
-
 pub async fn register(
-    address: &str,
+    address: &Url,
     username: &str,
     email: &str,
     password: &str,
@@ -87,14 +69,14 @@ pub async fn register(
     map.insert("email", email);
     map.insert("password", password);
 
-    let url = make_url(address, &format!("/user/{username}"))?;
+    let url = address.append(["user", username])?;
     let resp = reqwest::get(url).await?;
 
     if resp.status().is_success() {
         bail!("username already in use");
     }
 
-    let url = make_url(address, "/register")?;
+    let url = address.append(["register"])?;
     let client = reqwest::Client::new();
     let resp = client
         .post(url)
@@ -113,9 +95,9 @@ pub async fn register(
     Ok(session)
 }
 
-pub async fn login(address: &str, req: LoginRequest) -> Result<LoginResponse> {
+pub async fn login(address: &Url, req: LoginRequest) -> Result<LoginResponse> {
     ensure_crypto_provider();
-    let url = make_url(address, "/login")?;
+    let url = address.append(["login"])?;
     let client = reqwest::Client::new();
 
     let resp = client
@@ -139,7 +121,7 @@ pub async fn latest_version() -> Result<Version> {
     use atuin_common::api::IndexResponse;
 
     ensure_crypto_provider();
-    let url = "https://api.atuin.sh";
+    let url = crate::settings::DEFAULT_SYNC_URL.clone();
     let client = reqwest::Client::new();
 
     let resp = client
@@ -218,7 +200,7 @@ async fn handle_resp_error(resp: Response) -> Result<Response> {
 
 impl<'a> Client<'a> {
     pub fn new(
-        sync_addr: &'a str,
+        sync_addr: &'a Url,
         auth: AuthToken,
         connect_timeout: u64,
         timeout: u64,
@@ -242,8 +224,7 @@ impl<'a> Client<'a> {
     }
 
     pub async fn me(&self) -> Result<MeResponse> {
-        let url = make_url(self.sync_addr, "/api/v0/me")?;
-        let url = Url::parse(url.as_str())?;
+        let url = self.sync_addr.append_path("api/v0/me")?;
 
         let resp = self.client.get(url).send().await?;
         let resp = handle_resp_error(resp).await?;
@@ -254,8 +235,7 @@ impl<'a> Client<'a> {
     }
 
     pub async fn delete_store(&self) -> Result<()> {
-        let url = make_url(self.sync_addr, "/api/v0/store")?;
-        let url = Url::parse(url.as_str())?;
+        let url = self.sync_addr.append_path("api/v0/store")?;
 
         let resp = self.client.delete(url).send().await?;
 
@@ -265,8 +245,7 @@ impl<'a> Client<'a> {
     }
 
     pub async fn post_records(&self, records: &[Record<EncryptedData>]) -> Result<()> {
-        let url = make_url(self.sync_addr, "/api/v0/record")?;
-        let url = Url::parse(url.as_str())?;
+        let url = self.sync_addr.append_path("api/v0/record")?;
 
         debug!("uploading {} records to {url}", records.len());
 
@@ -285,15 +264,12 @@ impl<'a> Client<'a> {
     ) -> Result<Vec<Record<EncryptedData>>> {
         debug!("fetching record/s from host {}/{}/{}", host.0, tag, start);
 
-        let url = make_url(
-            self.sync_addr,
-            &format!(
-                "/api/v0/record/next?host={}&tag={}&count={}&start={}",
-                host.0, tag, count, start
-            ),
-        )?;
-
-        let url = Url::parse(url.as_str())?;
+        let mut url = self.sync_addr.append_path("api/v0/record/next")?;
+        url.query_pairs_mut()
+            .append_pair("host", &host.0.to_string())
+            .append_pair("tag", &tag)
+            .append_pair("count", &count.to_string())
+            .append_pair("start", &start.to_string());
 
         let resp = self.client.get(url).send().await?;
         let resp = handle_resp_error(resp).await?;
@@ -304,8 +280,7 @@ impl<'a> Client<'a> {
     }
 
     pub async fn record_status(&self) -> Result<RecordStatus> {
-        let url = make_url(self.sync_addr, "/api/v0/record")?;
-        let url = Url::parse(url.as_str())?;
+        let url = self.sync_addr.append_path("api/v0/record")?;
 
         let resp = self.client.get(url).send().await?;
         let resp = handle_resp_error(resp).await?;
@@ -322,8 +297,7 @@ impl<'a> Client<'a> {
     }
 
     pub async fn delete(&self) -> Result<()> {
-        let url = make_url(self.sync_addr, "/account")?;
-        let url = Url::parse(url.as_str())?;
+        let url = self.sync_addr.append(["account"])?;
 
         let resp = self.client.delete(url).send().await?;
 
@@ -341,8 +315,7 @@ impl<'a> Client<'a> {
         current_password: String,
         new_password: String,
     ) -> Result<()> {
-        let url = make_url(self.sync_addr, "/account/password")?;
-        let url = Url::parse(url.as_str())?;
+        let url = self.sync_addr.append_path("account/password")?;
 
         let resp = self
             .client

--- a/crates/atuin-client/src/auth.rs
+++ b/crates/atuin-client/src/auth.rs
@@ -9,6 +9,7 @@ use atuin_common::{
         LoginResponse, RegisterResponse,
     },
     tls::ensure_crypto_provider,
+    url::UrlAppendExt,
 };
 
 use crate::settings::Settings;
@@ -75,9 +76,9 @@ pub trait AuthClient: Send + Sync {
 /// Resolve the appropriate [`AuthClient`] for the current settings.
 pub async fn auth_client(settings: &Settings) -> Box<dyn AuthClient> {
     if settings.is_hub_sync() {
-        let endpoint = settings.active_hub_endpoint().unwrap_or_default();
+        let endpoint = settings.hub_endpoint();
         Box::new(HubAuthClient::new(
-            endpoint.as_ref(),
+            &endpoint,
             settings.hub_session_token().await.ok(),
         )) as Box<dyn AuthClient>
     } else {
@@ -95,7 +96,7 @@ pub async fn auth_client(settings: &Settings) -> Box<dyn AuthClient> {
 // ---------------------------------------------------------------------------
 
 pub struct LegacyAuthClient {
-    address: String,
+    address: Url,
     session_token: Option<String>,
     connect_timeout: u64,
     timeout: u64,
@@ -103,13 +104,13 @@ pub struct LegacyAuthClient {
 
 impl LegacyAuthClient {
     pub fn new(
-        address: &str,
+        address: &Url,
         session_token: Option<String>,
         connect_timeout: u64,
         timeout: u64,
     ) -> Self {
         Self {
-            address: address.to_string(),
+            address: address.clone(),
             session_token,
             connect_timeout,
             timeout,
@@ -178,10 +179,10 @@ impl AuthClient for LegacyAuthClient {
         _totp_code: Option<&str>,
     ) -> Result<MutateResponse> {
         let client = self.authenticated_client()?;
-        let url = make_url(&self.address, "/account/password")?;
+        let url = self.address.append_path("account/password")?;
 
         let resp = client
-            .patch(&url)
+            .patch(url)
             .json(&ChangePasswordRequest {
                 current_password: current_password.to_string(),
                 new_password: new_password.to_string(),
@@ -203,10 +204,10 @@ impl AuthClient for LegacyAuthClient {
         _totp_code: Option<&str>,
     ) -> Result<MutateResponse> {
         let client = self.authenticated_client()?;
-        let url = make_url(&self.address, "/account")?;
+        let url = self.address.append(["account"])?;
 
         let resp = client
-            .delete(&url)
+            .delete(url)
             .json(&serde_json::json!({ "password": password }))
             .send()
             .await?;
@@ -225,14 +226,14 @@ impl AuthClient for LegacyAuthClient {
 // ---------------------------------------------------------------------------
 
 pub struct HubAuthClient {
-    address: String,
+    address: Url,
     hub_token: Option<String>,
 }
 
 impl HubAuthClient {
-    pub fn new(address: &str, hub_token: Option<String>) -> Self {
+    pub fn new(address: &Url, hub_token: Option<String>) -> Self {
         Self {
-            address: address.trim_end_matches('/').to_string(),
+            address: address.clone(),
             hub_token,
         }
     }
@@ -255,7 +256,7 @@ impl AuthClient for HubAuthClient {
         totp_code: Option<&str>,
     ) -> Result<AuthResponse> {
         ensure_crypto_provider();
-        let url = make_url(&self.address, "/api/v0/login")?;
+        let url = self.address.append_path("api/v0/login")?;
         let client = reqwest::Client::new();
 
         let mut body = serde_json::json!({
@@ -267,7 +268,7 @@ impl AuthClient for HubAuthClient {
         }
 
         let resp = client
-            .post(&url)
+            .post(url)
             .header(USER_AGENT, APP_USER_AGENT)
             .header(ATUIN_HEADER_VERSION, ATUIN_CARGO_VERSION)
             .json(&body)
@@ -303,11 +304,11 @@ impl AuthClient for HubAuthClient {
 
     async fn register(&self, username: &str, email: &str, password: &str) -> Result<AuthResponse> {
         ensure_crypto_provider();
-        let url = make_url(&self.address, "/api/v0/register")?;
+        let url = self.address.append_path("api/v0/register")?;
         let client = reqwest::Client::new();
 
         let resp = client
-            .post(&url)
+            .post(url)
             .header(USER_AGENT, APP_USER_AGENT)
             .header(ATUIN_HEADER_VERSION, ATUIN_CARGO_VERSION)
             .json(&serde_json::json!({
@@ -357,7 +358,7 @@ impl AuthClient for HubAuthClient {
         }
 
         ensure_crypto_provider();
-        let url = make_url(&self.address, "/api/v0/account/password")?;
+        let url = self.address.append_path("api/v0/account/password")?;
         let client = reqwest::Client::new();
 
         let mut body = serde_json::json!({
@@ -369,7 +370,7 @@ impl AuthClient for HubAuthClient {
         }
 
         let resp = client
-            .patch(&url)
+            .patch(url)
             .header(USER_AGENT, APP_USER_AGENT)
             .header(ATUIN_HEADER_VERSION, ATUIN_CARGO_VERSION)
             .bearer_auth(hub_token)
@@ -419,7 +420,7 @@ impl AuthClient for HubAuthClient {
         }
 
         ensure_crypto_provider();
-        let url = make_url(&self.address, "/api/v0/account")?;
+        let url = self.address.append_path("api/v0/account")?;
         let client = reqwest::Client::new();
 
         let mut body = serde_json::json!({
@@ -430,7 +431,7 @@ impl AuthClient for HubAuthClient {
         }
 
         let resp = client
-            .delete(&url)
+            .delete(url)
             .header(USER_AGENT, APP_USER_AGENT)
             .header(ATUIN_HEADER_VERSION, ATUIN_CARGO_VERSION)
             .bearer_auth(hub_token)
@@ -459,25 +460,4 @@ impl AuthClient for HubAuthClient {
             _ => bail!("Hub account deletion failed with status {status}"),
         }
     }
-}
-
-// ---------------------------------------------------------------------------
-// Shared helpers
-// ---------------------------------------------------------------------------
-
-fn make_url(address: &str, path: &str) -> Result<String> {
-    let address = if address.ends_with('/') {
-        address.to_string()
-    } else {
-        format!("{address}/")
-    };
-
-    let path = path.strip_prefix('/').unwrap_or(path);
-
-    let url = Url::parse(&address)
-        .context("failed to parse server address")?
-        .join(path)
-        .context("failed to join URL path")?;
-
-    Ok(url.to_string())
 }

--- a/crates/atuin-client/src/hub.rs
+++ b/crates/atuin-client/src/hub.rs
@@ -19,6 +19,7 @@ use atuin_common::{
         ErrorResponse,
     },
     tls::ensure_crypto_provider,
+    url::UrlAppendExt,
 };
 
 use crate::settings::Settings;
@@ -31,9 +32,9 @@ pub struct HubAuthSession {
     /// The code to be verified
     pub code: String,
     /// The URL the user should visit to authenticate
-    pub auth_url: String,
+    pub auth_url: Url,
     /// The hub address being used
-    pub hub_address: String,
+    pub hub_address: Url,
 }
 
 /// The result of polling for hub auth completion
@@ -57,10 +58,9 @@ impl HubAuthSession {
     /// Start a new hub authentication session
     ///
     /// Returns a session containing the code and auth URL that the user should visit.
-    pub async fn start(hub_address: &str) -> Result<Self> {
+    pub async fn start(hub_address: &Url) -> Result<Self> {
         debug!("Starting Hub authentication process...");
 
-        let hub_address = hub_address.trim_end_matches('/');
         let code_response = request_code(hub_address)
             .await
             .context("Failed to request authentication code from Hub")?;
@@ -68,12 +68,13 @@ impl HubAuthSession {
         debug!("Received code from Hub");
 
         let code = code_response.code;
-        let auth_url = format!("{}/auth/cli?code={}", hub_address, code);
+        let mut auth_url = hub_address.append_path("auth/cli")?;
+        auth_url.query_pairs_mut().append_pair("code", &code);
 
         Ok(Self {
             code,
             auth_url,
-            hub_address: hub_address.to_string(),
+            hub_address: hub_address.clone(),
         })
     }
 
@@ -183,12 +184,12 @@ pub async fn get_session_token() -> Result<Option<String>> {
 /// - Not logged in to Hub
 /// - CLI token is invalid
 /// - CLI account is already linked to a different Hub account
-pub async fn link_account(hub_address: &str, cli_token: &str) -> Result<()> {
+pub async fn link_account(hub_address: &Url, cli_token: &str) -> Result<()> {
     let hub_token = get_session_token()
         .await?
         .ok_or_else(|| eyre::eyre!("Not logged in to Hub - cannot link account"))?;
 
-    let url = make_url(hub_address, "/api/v0/account/link")?;
+    let url = hub_address.append_path("api/v0/account/link")?;
 
     debug!("Linking CLI account to Hub at {}", hub_address);
 
@@ -196,7 +197,7 @@ pub async fn link_account(hub_address: &str, cli_token: &str) -> Result<()> {
     let client = reqwest::Client::new();
 
     let resp = client
-        .post(&url)
+        .post(url)
         .header(USER_AGENT, APP_USER_AGENT)
         .header(ATUIN_HEADER_VERSION, ATUIN_CARGO_VERSION)
         .bearer_auth(&hub_token)
@@ -219,23 +220,6 @@ pub async fn link_account(hub_address: &str, cli_token: &str) -> Result<()> {
 }
 
 // --- Internal HTTP functions ---
-
-fn make_url(address: &str, path: &str) -> Result<String> {
-    let address = if address.ends_with('/') {
-        address.to_string()
-    } else {
-        format!("{address}/")
-    };
-
-    let path = path.strip_prefix('/').unwrap_or(path);
-
-    let url = Url::parse(&address)
-        .context("failed to parse hub address")?
-        .join(path)
-        .context("failed to join hub URL path")?;
-
-    Ok(url.to_string())
-}
 
 async fn handle_resp_error(resp: reqwest::Response) -> Result<reqwest::Response> {
     let status = resp.status();
@@ -263,15 +247,15 @@ async fn handle_resp_error(resp: reqwest::Response) -> Result<reqwest::Response>
 }
 
 /// Request a CLI auth code from the Atuin Hub
-async fn request_code(address: &str) -> Result<CliCodeResponse> {
+async fn request_code(address: &Url) -> Result<CliCodeResponse> {
     ensure_crypto_provider();
-    let url = make_url(address, "/auth/cli/code")?;
+    let url = address.append_path("auth/cli/code")?;
     let client = reqwest::Client::new();
 
     debug!("Requesting code from Hub at {url}");
 
     let resp = client
-        .post(&url)
+        .post(url)
         .header(USER_AGENT, APP_USER_AGENT)
         .header(ATUIN_HEADER_VERSION, ATUIN_CARGO_VERSION)
         .send()
@@ -283,16 +267,18 @@ async fn request_code(address: &str) -> Result<CliCodeResponse> {
 }
 
 /// Poll to verify the CLI auth code and get the session token
-async fn verify_code(address: &str, code: &str) -> Result<CliVerifyResponse> {
+async fn verify_code(address: &Url, code: &str) -> Result<CliVerifyResponse> {
     ensure_crypto_provider();
-    let base = make_url(address, "/auth/cli/verify")?;
-    let url = format!("{base}?code={code}");
+    let mut url = address.append_path("auth/cli/verify")?;
     let client = reqwest::Client::new();
 
-    debug!("Verifying code with Hub at {base}?code=******");
+    // Logged before the code is appended, so the secret stays out of the logs.
+    debug!("Verifying code with Hub at {url}");
+
+    url.query_pairs_mut().append_pair("code", code);
 
     let resp = client
-        .post(&url)
+        .post(url)
         .header(USER_AGENT, APP_USER_AGENT)
         .header(ATUIN_HEADER_VERSION, ATUIN_CARGO_VERSION)
         .send()

--- a/crates/atuin-client/src/login.rs
+++ b/crates/atuin-client/src/login.rs
@@ -72,11 +72,8 @@ pub async fn login(
         }
     }
 
-    let session = api_client::login(
-        settings.sync_address.as_str(),
-        LoginRequest { username, password },
-    )
-    .await?;
+    let session =
+        api_client::login(&settings.sync_address, LoginRequest { username, password }).await?;
 
     Settings::meta_store()
         .await?

--- a/crates/atuin-client/src/register.rs
+++ b/crates/atuin-client/src/register.rs
@@ -9,7 +9,7 @@ pub async fn register_classic(
     password: String,
 ) -> Result<String> {
     let session =
-        api_client::register(settings.sync_address.as_str(), &username, &email, &password).await?;
+        api_client::register(&settings.sync_address, &username, &email, &password).await?;
 
     let meta = Settings::meta_store().await?;
     meta.save_session(&session.session).await?;

--- a/crates/atuin-client/src/settings.rs
+++ b/crates/atuin-client/src/settings.rs
@@ -12,9 +12,16 @@ use regex::RegexSet;
 use semver::Version;
 use serde::{Deserialize, Serialize};
 use serde_with::DeserializeFromStr;
-use std::{collections::HashMap, io::prelude::*, path::PathBuf, str::FromStr, sync::OnceLock};
+use std::{
+    collections::HashMap,
+    io::prelude::*,
+    path::PathBuf,
+    str::FromStr,
+    sync::{LazyLock, OnceLock},
+};
 use time::{OffsetDateTime, UtcOffset, format_description::FormatItem, macros::format_description};
 use tokio::sync::OnceCell;
+use url::Url;
 
 static EXAMPLE_CONFIG: &str = include_str!("../config.toml");
 
@@ -28,21 +35,13 @@ pub(crate) mod meta;
 mod scripts;
 pub mod watcher;
 
-#[derive(derive_more::AsRef)]
-#[as_ref(str)]
-pub struct HubEndpoint(String);
+/// Default sync address for Atuin's hosted service, parsed once.
+pub static DEFAULT_SYNC_URL: LazyLock<Url> =
+    LazyLock::new(|| Url::parse("https://api.atuin.sh").expect("default sync address is valid"));
 
-/// Default sync address for Atuin's hosted service
-pub const DEFAULT_SYNC_ADDRESS: &str = "https://api.atuin.sh";
-
-/// Default Hub web/API endpoint for Atuin's hosted service
-pub const DEFAULT_HUB_ENDPOINT: &str = "https://hub.atuin.sh";
-
-impl Default for HubEndpoint {
-    fn default() -> Self {
-        HubEndpoint(DEFAULT_HUB_ENDPOINT.to_string())
-    }
-}
+/// Default Hub web/API endpoint for Atuin's hosted service, parsed once.
+pub static DEFAULT_HUB_URL: LazyLock<Url> =
+    LazyLock::new(|| Url::parse("https://hub.atuin.sh").expect("default hub endpoint is valid"));
 
 #[derive(Clone, Debug, Deserialize, Copy, ValueEnum, PartialEq, Serialize)]
 pub enum SearchMode {
@@ -649,7 +648,7 @@ pub struct Ai {
 
     /// The address of the Atuin AI endpoint. Used for AI features like command generation.
     /// Only necessary for custom AI endpoints.
-    pub endpoint: Option<String>,
+    pub endpoint: Option<Url>,
 
     /// How to talk to `endpoint`. See [`AiEndpointProtocol`].
     #[serde(default)]
@@ -1001,7 +1000,7 @@ pub struct Settings {
     pub update_check: bool,
 
     /// The sync address for atuin.
-    pub sync_address: String,
+    pub sync_address: Url,
 
     /// Sync protocol for authentication. When set to "auto" (default), the protocol
     /// is inferred from sync_address. Set to "hub" to force Hub auth with a custom
@@ -1191,16 +1190,10 @@ impl Settings {
         }
     }
 
-    /// Normalize a URL for comparison by trimming trailing slashes
-    fn normalize_url(url: &str) -> &str {
-        url.trim_end_matches('/')
-    }
-
-    /// Check if a URL matches one of Atuin's official hosted addresses
-    fn is_official_address(url: &str) -> bool {
-        let normalized = Self::normalize_url(url);
-        normalized == Self::normalize_url(DEFAULT_SYNC_ADDRESS)
-            || normalized == Self::normalize_url(DEFAULT_HUB_ENDPOINT)
+    /// Check if a URL matches one of Atuin's official hosted addresses.
+    fn is_official_address(url: &Url) -> bool {
+        let origin = url.origin();
+        origin == DEFAULT_SYNC_URL.origin() || origin == DEFAULT_HUB_URL.origin()
     }
 
     /// Returns whether this configuration uses Hub-style sync.
@@ -1224,7 +1217,7 @@ impl Settings {
     /// `endpoint` is the resolved AI endpoint — the `--api-endpoint` flag or
     /// `ai.endpoint` setting, after defaults are applied — which is why it's a
     /// parameter rather than read from `self.ai.endpoint`.
-    pub fn is_hub_ai_endpoint(&self, endpoint: &str) -> bool {
+    pub fn is_hub_ai_endpoint(&self, endpoint: &Url) -> bool {
         match self.ai.endpoint_protocol {
             AiEndpointProtocol::Hub => true,
             AiEndpointProtocol::Oss => false,
@@ -1232,20 +1225,16 @@ impl Settings {
         }
     }
 
-    /// Returns the base URL for the Hub endpoint.
+    /// The base URL for the Hub endpoint.
     ///
-    /// For Atuin's official hosted service, this always returns `https://hub.atuin.sh`
+    /// For Atuin's official hosted service this is always `https://hub.atuin.sh`,
     /// regardless of whether `sync_address` is `api.atuin.sh` or `hub.atuin.sh`.
-    /// For self-hosted instances, returns the configured `sync_address`.
-    pub fn active_hub_endpoint(&self) -> Option<HubEndpoint> {
-        if self.is_hub_sync() {
-            if Self::is_official_address(&self.sync_address) {
-                Some(HubEndpoint::default())
-            } else {
-                Some(HubEndpoint(self.sync_address.clone()))
-            }
+    /// For a self-hosted Hub, it is the configured `sync_address`.
+    pub fn hub_endpoint(&self) -> Url {
+        if self.is_hub_sync() && !Self::is_official_address(&self.sync_address) {
+            self.sync_address.clone()
         } else {
-            None
+            DEFAULT_HUB_URL.clone()
         }
     }
 
@@ -1429,7 +1418,7 @@ impl Settings {
             .set_default("timezone", "local")?
             .set_default("auto_sync", true)?
             .set_default("update_check", cfg!(feature = "check-update"))?
-            .set_default("sync_address", "https://api.atuin.sh")?
+            .set_default("sync_address", DEFAULT_SYNC_URL.as_str())?
             .set_default("sync_frequency", "5m")?
             .set_default("search_mode", "fuzzy")?
             .set_default("filter_mode", None::<String>)?
@@ -1789,55 +1778,73 @@ mod tests {
     use std::str::FromStr;
 
     use eyre::Result;
+    use rstest::rstest;
 
-    use super::Timezone;
+    use super::{AiEndpointProtocol, Settings, Timezone};
+    use url::Url;
 
-    #[test]
-    fn can_parse_offset_timezone_spec() -> Result<()> {
-        assert_eq!(Timezone::from_str("+02")?.0.as_hms(), (2, 0, 0));
-        assert_eq!(Timezone::from_str("-04")?.0.as_hms(), (-4, 0, 0));
-        assert_eq!(Timezone::from_str("+05:30")?.0.as_hms(), (5, 30, 0));
-        assert_eq!(Timezone::from_str("-09:30")?.0.as_hms(), (-9, -30, 0));
-
-        // single digit hours are allowed
-        assert_eq!(Timezone::from_str("+2")?.0.as_hms(), (2, 0, 0));
-        assert_eq!(Timezone::from_str("-4")?.0.as_hms(), (-4, 0, 0));
-        assert_eq!(Timezone::from_str("+5:30")?.0.as_hms(), (5, 30, 0));
-        assert_eq!(Timezone::from_str("-9:30")?.0.as_hms(), (-9, -30, 0));
-
-        // fully qualified form
-        assert_eq!(Timezone::from_str("+09:30:00")?.0.as_hms(), (9, 30, 0));
-        assert_eq!(Timezone::from_str("-09:30:00")?.0.as_hms(), (-9, -30, 0));
-
-        // these offsets don't really exist but are supported anyway
-        assert_eq!(Timezone::from_str("+0:5")?.0.as_hms(), (0, 5, 0));
-        assert_eq!(Timezone::from_str("-0:5")?.0.as_hms(), (0, -5, 0));
-        assert_eq!(Timezone::from_str("+01:23:45")?.0.as_hms(), (1, 23, 45));
-        assert_eq!(Timezone::from_str("-01:23:45")?.0.as_hms(), (-1, -23, -45));
-
-        // require a leading sign for clarity
-        assert!(Timezone::from_str("5").is_err());
-        assert!(Timezone::from_str("10:30").is_err());
-
+    #[rstest]
+    #[case("+02", (2, 0, 0))]
+    #[case("-04", (-4, 0, 0))]
+    #[case("+05:30", (5, 30, 0))]
+    #[case("-09:30", (-9, -30, 0))]
+    // single digit hours are allowed
+    #[case("+2", (2, 0, 0))]
+    #[case("-4", (-4, 0, 0))]
+    #[case("+5:30", (5, 30, 0))]
+    #[case("-9:30", (-9, -30, 0))]
+    // fully qualified form
+    #[case("+09:30:00", (9, 30, 0))]
+    #[case("-09:30:00", (-9, -30, 0))]
+    // these offsets don't really exist but are supported anyway
+    #[case("+0:5", (0, 5, 0))]
+    #[case("-0:5", (0, -5, 0))]
+    #[case("+01:23:45", (1, 23, 45))]
+    #[case("-01:23:45", (-1, -23, -45))]
+    fn parses_offset_timezone_spec(
+        #[case] spec: &str,
+        #[case] expected: (i8, i8, i8),
+    ) -> Result<()> {
+        assert_eq!(Timezone::from_str(spec)?.0.as_hms(), expected);
         Ok(())
     }
 
+    #[rstest]
+    #[case("5")]
+    #[case("10:30")]
+    fn rejects_timezone_spec_without_a_leading_sign(#[case] spec: &str) {
+        assert!(Timezone::from_str(spec).is_err());
+    }
+
+    #[rstest]
+    // Auto: official addresses are Hub, anything else is OSS
+    #[case(AiEndpointProtocol::Auto, "https://hub.atuin.sh", true)]
+    #[case(AiEndpointProtocol::Auto, "https://api.atuin.sh", true)]
+    #[case(AiEndpointProtocol::Auto, "https://ai.example.com", false)]
+    #[case(AiEndpointProtocol::Auto, "http://localhost:4000", false)]
+    // An explicit protocol overrides the address check
+    #[case(AiEndpointProtocol::Hub, "http://localhost:4000", true)]
+    #[case(AiEndpointProtocol::Oss, "https://hub.atuin.sh", false)]
+    fn ai_endpoint_protocol_resolution(
+        #[case] protocol: AiEndpointProtocol,
+        #[case] endpoint: &str,
+        #[case] expected: bool,
+    ) {
+        let mut settings = Settings::default();
+        settings.ai.endpoint_protocol = protocol;
+
+        assert_eq!(
+            settings.is_hub_ai_endpoint(&Url::parse(endpoint).unwrap()),
+            expected,
+        );
+    }
+
+    /// Forces both `LazyLock`s, so a typo in either constant fails here rather
+    /// than panicking at runtime.
     #[test]
-    fn ai_endpoint_protocol_resolution() {
-        let mut settings = super::Settings::default();
-
-        // Auto: official addresses are Hub, anything else is OSS
-        assert!(settings.is_hub_ai_endpoint("https://hub.atuin.sh"));
-        assert!(settings.is_hub_ai_endpoint("https://api.atuin.sh"));
-        assert!(!settings.is_hub_ai_endpoint("https://ai.example.com"));
-        assert!(!settings.is_hub_ai_endpoint("http://localhost:4000"));
-
-        // Explicit settings override the address check
-        settings.ai.endpoint_protocol = super::AiEndpointProtocol::Hub;
-        assert!(settings.is_hub_ai_endpoint("http://localhost:4000"));
-
-        settings.ai.endpoint_protocol = super::AiEndpointProtocol::Oss;
-        assert!(!settings.is_hub_ai_endpoint("https://hub.atuin.sh"));
+    fn default_addresses_parse() {
+        assert_eq!(super::DEFAULT_SYNC_URL.host_str(), Some("api.atuin.sh"));
+        assert_eq!(super::DEFAULT_HUB_URL.host_str(), Some("hub.atuin.sh"));
     }
 
     #[test]

--- a/crates/atuin-common/Cargo.toml
+++ b/crates/atuin-common/Cargo.toml
@@ -26,6 +26,7 @@ serde = { workspace = true }
 uuid = { workspace = true }
 typed-builder = { workspace = true }
 eyre = { workspace = true }
+url = { workspace = true }
 sqlx = { workspace = true }
 semver = { workspace = true }
 thiserror = { workspace = true }

--- a/crates/atuin-common/src/lib.rs
+++ b/crates/atuin-common/src/lib.rs
@@ -65,4 +65,5 @@ pub mod string;
 #[cfg(feature = "test-utils")]
 pub mod test_utils;
 pub mod tls;
+pub mod url;
 pub mod utils;

--- a/crates/atuin-common/src/url.rs
+++ b/crates/atuin-common/src/url.rs
@@ -78,23 +78,22 @@ impl UrlAppendExt for Url {
         });
 
         let mut url = self.clone();
-        {
-            let mut path = url
-                .path_segments_mut()
-                .map_err(|()| UrlAppendError::NonSplittable)?;
+        let mut path = url
+            .path_segments_mut()
+            .map_err(|()| UrlAppendError::NonSplittable)?;
 
-            for _ in 0..trailing_empty {
-                path.pop_if_empty();
-            }
-
-            for segment in segments {
-                let segment = segment.as_ref();
-                if matches!(segment, "." | "..") {
-                    return Err(UrlAppendError::DotSegment);
-                }
-                path.push(segment);
-            }
+        for _ in 0..trailing_empty {
+            path.pop_if_empty();
         }
+
+        for segment in segments {
+            let segment = segment.as_ref();
+            if matches!(segment, "." | "..") {
+                return Err(UrlAppendError::DotSegment);
+            }
+            path.push(segment);
+        }
+        drop(path);
 
         Ok(url)
     }

--- a/crates/atuin-common/src/url.rs
+++ b/crates/atuin-common/src/url.rs
@@ -3,12 +3,17 @@
 use ::url::Url;
 use thiserror::Error;
 
-/// The URL given cannot be a base URL (e.g. `mailto:` or `data:`).
-///
-/// These are usually URLs which do not support file-path-like semantics.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Error)]
-#[error("URL cannot be a base: it has no hierarchical path to append segments to")]
-pub struct NonSplittableUrlError;
+#[derive(Debug, Clone, PartialEq, Eq, Error)]
+pub enum UrlAppendError {
+    /// The URL given cannot be a base URL (e.g. `mailto:` or `data:`).
+    ///
+    /// These are usually URLs which do not support file-path-like semantics.
+    #[error("URL cannot be a base: it has no hierarchical path to append segments to")]
+    NonSplittable,
+
+    #[error("segment {0:?} is a dot segment, which cannot be a literal path segment")]
+    DotSegment(String),
+}
 
 /// Extension methods for [`Url`].
 pub trait UrlAppendExt {
@@ -27,13 +32,13 @@ pub trait UrlAppendExt {
     ///
     /// // Url::join behavior:
     /// assert_eq!(base.join("foo/bar").unwrap().as_str(), "https://host.example/foo/bar");
-    /// # Ok::<(), atuin_common::url::NonSplittableUrlError>(())
+    /// # Ok::<(), atuin_common::url::UrlAppendError>(())
     /// ```
     ///
     /// # Errors
     ///
-    /// See [`NonSplittableUrlError`].
-    fn append<I, S>(&self, segments: I) -> Result<Url, NonSplittableUrlError>
+    /// See [`UrlAppendError`].
+    fn append<I, S>(&self, segments: I) -> Result<Url, UrlAppendError>
     where
         I: IntoIterator<Item = S>,
         S: AsRef<str>;
@@ -51,31 +56,48 @@ pub trait UrlAppendExt {
     ///     base.append_path("api/v0/me")?.as_str(),
     ///     "https://host.example/atuin/api/v0/me",
     /// );
-    /// # Ok::<(), atuin_common::url::NonSplittableUrlError>(())
+    /// # Ok::<(), atuin_common::url::UrlAppendError>(())
     /// ```
     ///
     /// # Errors
     ///
-    /// See [`NonSplittableUrlError`].
-    fn append_path(&self, path: &'static str) -> Result<Url, NonSplittableUrlError>;
+    /// See [`UrlAppendError`].
+    fn append_path(&self, path: &'static str) -> Result<Url, UrlAppendError>;
 }
 
 impl UrlAppendExt for Url {
-    fn append<I, S>(&self, segments: I) -> Result<Url, NonSplittableUrlError>
+    fn append<I, S>(&self, segments: I) -> Result<Url, UrlAppendError>
     where
         I: IntoIterator<Item = S>,
         S: AsRef<str>,
     {
+        let trailing_empty = self.path_segments().map_or(0, |segments| {
+            segments.rev().take_while(|s| s.is_empty()).count()
+        });
+
         let mut url = self.clone();
-        url.path_segments_mut()
-            .map_err(|()| NonSplittableUrlError)?
-            // A base like `https://h.example/atuin/` ends in an empty segment. Drop it.
-            .pop_if_empty()
-            .extend(segments);
+        {
+            let mut path = url
+                .path_segments_mut()
+                .map_err(|()| UrlAppendError::NonSplittable)?;
+
+            for _ in 0..trailing_empty {
+                path.pop_if_empty();
+            }
+
+            for segment in segments {
+                let segment = segment.as_ref();
+                if matches!(segment, "." | "..") {
+                    return Err(UrlAppendError::DotSegment(segment.to_owned()));
+                }
+                path.push(segment);
+            }
+        }
+
         Ok(url)
     }
 
-    fn append_path(&self, path: &'static str) -> Result<Url, NonSplittableUrlError> {
+    fn append_path(&self, path: &'static str) -> Result<Url, UrlAppendError> {
         self.append(path.split('/').filter(|s| !s.is_empty()))
     }
 }
@@ -103,10 +125,55 @@ mod tests {
     #[case("https://h.example", "john doe", "https://h.example/john%20doe")]
     #[case("https://h.example", "a?b#c", "https://h.example/a%3Fb%23c")]
     #[case("https://h.example:8443/x", "y", "https://h.example:8443/x/y")]
-    #[case("https://host.example/atuin", ".", "https://host.example/atuin")]
-    #[case("https://host.example/atuin", "..", "https://host.example/atuin")]
+    #[case(
+        "https://host.example/atuin//",
+        "api",
+        "https://host.example/atuin/api"
+    )]
+    #[case(
+        "https://host.example/atuin////",
+        "api",
+        "https://host.example/atuin/api"
+    )]
+    #[case("https://h.example//", "me", "https://h.example/me")]
+    #[case("https://h.example////", "me", "https://h.example/me")]
+    #[case("https://h.example/a//b", "me", "https://h.example/a//b/me")]
+    #[case("https://h.example/a//b//", "me", "https://h.example/a//b/me")]
     fn append_cases(#[case] base: &str, #[case] segment: &str, #[case] expected: &str) {
         assert_eq!(parse(base).append([segment]).unwrap().as_str(), expected);
+    }
+
+    #[rstest]
+    #[case(".")]
+    #[case("..")]
+    fn dot_segments_are_rejected(#[case] segment: &str) {
+        assert_eq!(
+            parse("https://host.example/atuin").append([segment]),
+            Err(UrlAppendError::DotSegment(segment.to_owned())),
+        );
+        assert_eq!(
+            parse("https://host.example/atuin").append(["user", segment]),
+            Err(UrlAppendError::DotSegment(segment.to_owned())),
+        );
+    }
+
+    #[test]
+    fn dot_segments_are_rejected_by_append_path() {
+        assert_eq!(
+            parse("https://h.example").append_path("api/../v0"),
+            Err(UrlAppendError::DotSegment("..".to_owned())),
+        );
+    }
+
+    #[test]
+    fn dot_lookalikes_are_still_appended() {
+        assert_eq!(
+            parse("https://h.example")
+                .append(["...", ".hidden", "a.b"])
+                .unwrap()
+                .as_str(),
+            "https://h.example/.../.hidden/a.b",
+        );
     }
 
     #[test]
@@ -146,6 +213,12 @@ mod tests {
     )]
     #[case("https://h.example", "/api/v0/me", "https://h.example/api/v0/me")]
     #[case("https://h.example", "account", "https://h.example/account")]
+    #[case("https://h.example//", "api/v0/me", "https://h.example/api/v0/me")]
+    #[case(
+        "https://host.example/atuin//",
+        "api/v0/me",
+        "https://host.example/atuin/api/v0/me"
+    )]
     fn append_path_cases(#[case] base: &str, #[case] path: &'static str, #[case] expected: &str) {
         assert_eq!(parse(base).append_path(path).unwrap().as_str(), expected);
     }
@@ -153,7 +226,7 @@ mod tests {
     #[test]
     fn cannot_be_a_base_url_is_an_error() {
         let url = parse("mailto:me@example.com");
-        assert_eq!(url.append(["x"]), Err(NonSplittableUrlError));
-        assert_eq!(url.append_path("a/b"), Err(NonSplittableUrlError));
+        assert_eq!(url.append(["x"]), Err(UrlAppendError::NonSplittable));
+        assert_eq!(url.append_path("a/b"), Err(UrlAppendError::NonSplittable));
     }
 }

--- a/crates/atuin-common/src/url.rs
+++ b/crates/atuin-common/src/url.rs
@@ -1,0 +1,159 @@
+//! General-purpose URL utilities.
+
+use ::url::Url;
+use thiserror::Error;
+
+/// The URL given cannot be a base URL (e.g. `mailto:` or `data:`).
+///
+/// These are usually URLs which do not support file-path-like semantics.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Error)]
+#[error("URL cannot be a base: it has no hierarchical path to append segments to")]
+pub struct NonSplittableUrlError;
+
+/// Extension methods for [`Url`].
+pub trait UrlAppendExt {
+    /// Append `segments`, each as its own percent-encoded path segment.
+    ///
+    /// Unlike [`Url::join`], which drops a base's `/prefix` (see example) this always appends.
+    /// Note that `/` are encoded to `%2F` rather than treated as a separator.
+    ///
+    /// ```
+    /// use atuin_common::url::UrlAppendExt;
+    ///
+    /// let base = url::Url::parse("https://host.example/atuin").unwrap();
+    ///
+    /// assert_eq!(base.append(["foo/bar"])?.as_str(), "https://host.example/atuin/foo%2Fbar");
+    /// assert_eq!(base.append(["foo", "bar"])?.as_str(), "https://host.example/atuin/foo/bar");
+    ///
+    /// // Url::join behavior:
+    /// assert_eq!(base.join("foo/bar").unwrap().as_str(), "https://host.example/foo/bar");
+    /// # Ok::<(), atuin_common::url::NonSplittableUrlError>(())
+    /// ```
+    ///
+    /// # Errors
+    ///
+    /// See [`NonSplittableUrlError`].
+    fn append<I, S>(&self, segments: I) -> Result<Url, NonSplittableUrlError>
+    where
+        I: IntoIterator<Item = S>,
+        S: AsRef<str>;
+
+    /// Append a fixed, multi-segment `path` in which `/` separates segments.
+    ///
+    /// It is your responsibility to ensure you do not want `/` characters to be encoded. See
+    /// [`UrlAppendExt::append`] for the safer version.
+    ///
+    /// ```
+    /// use atuin_common::url::UrlAppendExt;
+    ///
+    /// let base = url::Url::parse("https://host.example/atuin").unwrap();
+    /// assert_eq!(
+    ///     base.append_path("api/v0/me")?.as_str(),
+    ///     "https://host.example/atuin/api/v0/me",
+    /// );
+    /// # Ok::<(), atuin_common::url::NonSplittableUrlError>(())
+    /// ```
+    ///
+    /// # Errors
+    ///
+    /// See [`NonSplittableUrlError`].
+    fn append_path(&self, path: &'static str) -> Result<Url, NonSplittableUrlError>;
+}
+
+impl UrlAppendExt for Url {
+    fn append<I, S>(&self, segments: I) -> Result<Url, NonSplittableUrlError>
+    where
+        I: IntoIterator<Item = S>,
+        S: AsRef<str>,
+    {
+        let mut url = self.clone();
+        url.path_segments_mut()
+            .map_err(|()| NonSplittableUrlError)?
+            // A base like `https://h.example/atuin/` ends in an empty segment. Drop it.
+            .pop_if_empty()
+            .extend(segments);
+        Ok(url)
+    }
+
+    fn append_path(&self, path: &'static str) -> Result<Url, NonSplittableUrlError> {
+        self.append(path.split('/').filter(|s| !s.is_empty()))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rstest::rstest;
+
+    fn parse(s: &str) -> Url {
+        Url::parse(s).unwrap()
+    }
+
+    #[rstest]
+    #[case("https://api.atuin.sh", "me", "https://api.atuin.sh/me")]
+    #[case("https://api.atuin.sh/", "me", "https://api.atuin.sh/me")]
+    #[case("https://host.example/atuin", "api", "https://host.example/atuin/api")]
+    #[case("https://host.example/atuin/", "api", "https://host.example/atuin/api")]
+    #[case("https://h.example", "a/b", "https://h.example/a%2Fb")]
+    #[case(
+        "https://h.example/x",
+        "../../etc",
+        "https://h.example/x/..%2F..%2Fetc"
+    )]
+    #[case("https://h.example", "john doe", "https://h.example/john%20doe")]
+    #[case("https://h.example", "a?b#c", "https://h.example/a%3Fb%23c")]
+    #[case("https://h.example:8443/x", "y", "https://h.example:8443/x/y")]
+    #[case("https://host.example/atuin", ".", "https://host.example/atuin")]
+    #[case("https://host.example/atuin", "..", "https://host.example/atuin")]
+    fn append_cases(#[case] base: &str, #[case] segment: &str, #[case] expected: &str) {
+        assert_eq!(parse(base).append([segment]).unwrap().as_str(), expected);
+    }
+
+    #[test]
+    fn append_encodes_each_segment_independently() {
+        // Two segments: each is encoded on its own, so the space in "john doe"
+        // becomes %20 but does not merge with "user".
+        assert_eq!(
+            parse("https://h.example")
+                .append(["user", "john doe"])
+                .unwrap()
+                .as_str(),
+            "https://h.example/user/john%20doe",
+        );
+
+        // A `/` inside one element still doesn't act as a separator: it's
+        // encoded to %2F, landing as part of that single segment.
+        assert_eq!(
+            parse("https://h.example")
+                .append(["a", "b/c"])
+                .unwrap()
+                .as_str(),
+            "https://h.example/a/b%2Fc",
+        );
+    }
+
+    #[rstest]
+    #[case("https://api.atuin.sh", "api/v0/me", "https://api.atuin.sh/api/v0/me")]
+    #[case(
+        "https://host.example/atuin",
+        "api/v0/me",
+        "https://host.example/atuin/api/v0/me"
+    )]
+    #[case(
+        "https://host.example/atuin/",
+        "api/v0/me",
+        "https://host.example/atuin/api/v0/me"
+    )]
+    #[case("https://h.example", "/api/v0/me", "https://h.example/api/v0/me")]
+    #[case("https://h.example", "account", "https://h.example/account")]
+    fn append_path_cases(#[case] base: &str, #[case] path: &'static str, #[case] expected: &str) {
+        assert_eq!(parse(base).append_path(path).unwrap().as_str(), expected);
+    }
+
+    #[test]
+    fn cannot_be_a_base_url_is_an_error() {
+        let url = parse("mailto:me@example.com");
+        assert_eq!(url.append(["x"]), Err(NonSplittableUrlError));
+        assert_eq!(url.append_path("a/b"), Err(NonSplittableUrlError));
+    }
+}

--- a/crates/atuin-common/src/url.rs
+++ b/crates/atuin-common/src/url.rs
@@ -3,7 +3,7 @@
 use thiserror::Error;
 use url::Url;
 
-#[derive(Debug, Clone, PartialEq, Eq, Error)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Error)]
 pub enum UrlAppendError {
     /// The URL given cannot be a base URL (e.g. `mailto:` or `data:`).
     ///

--- a/crates/atuin-common/src/url.rs
+++ b/crates/atuin-common/src/url.rs
@@ -1,7 +1,7 @@
 //! General-purpose URL utilities.
 
-use url::Url;
 use thiserror::Error;
+use url::Url;
 
 #[derive(Debug, Clone, PartialEq, Eq, Error)]
 pub enum UrlAppendError {

--- a/crates/atuin-common/src/url.rs
+++ b/crates/atuin-common/src/url.rs
@@ -1,6 +1,6 @@
 //! General-purpose URL utilities.
 
-use ::url::Url;
+use url::Url;
 use thiserror::Error;
 
 #[derive(Debug, Clone, PartialEq, Eq, Error)]
@@ -11,8 +11,8 @@ pub enum UrlAppendError {
     #[error("URL cannot be a base: it has no hierarchical path to append segments to")]
     NonSplittable,
 
-    #[error("segment {0:?} is a dot segment, which cannot be a literal path segment")]
-    DotSegment(String),
+    #[error("path segments cannot be . or ..")]
+    DotSegment,
 }
 
 /// Extension methods for [`Url`].
@@ -62,7 +62,9 @@ pub trait UrlAppendExt {
     /// # Errors
     ///
     /// See [`UrlAppendError`].
-    fn append_path(&self, path: &'static str) -> Result<Url, UrlAppendError>;
+    fn append_path(&self, path: &'static str) -> Result<Url, UrlAppendError> {
+        self.append(path.split('/').filter(|s| !s.is_empty()))
+    }
 }
 
 impl UrlAppendExt for Url {
@@ -88,17 +90,13 @@ impl UrlAppendExt for Url {
             for segment in segments {
                 let segment = segment.as_ref();
                 if matches!(segment, "." | "..") {
-                    return Err(UrlAppendError::DotSegment(segment.to_owned()));
+                    return Err(UrlAppendError::DotSegment);
                 }
                 path.push(segment);
             }
         }
 
         Ok(url)
-    }
-
-    fn append_path(&self, path: &'static str) -> Result<Url, UrlAppendError> {
-        self.append(path.split('/').filter(|s| !s.is_empty()))
     }
 }
 
@@ -149,11 +147,11 @@ mod tests {
     fn dot_segments_are_rejected(#[case] segment: &str) {
         assert_eq!(
             parse("https://host.example/atuin").append([segment]),
-            Err(UrlAppendError::DotSegment(segment.to_owned())),
+            Err(UrlAppendError::DotSegment),
         );
         assert_eq!(
             parse("https://host.example/atuin").append(["user", segment]),
-            Err(UrlAppendError::DotSegment(segment.to_owned())),
+            Err(UrlAppendError::DotSegment),
         );
     }
 
@@ -161,7 +159,7 @@ mod tests {
     fn dot_segments_are_rejected_by_append_path() {
         assert_eq!(
             parse("https://h.example").append_path("api/../v0"),
-            Err(UrlAppendError::DotSegment("..".to_owned())),
+            Err(UrlAppendError::DotSegment),
         );
     }
 

--- a/crates/atuin-server-database/Cargo.toml
+++ b/crates/atuin-server-database/Cargo.toml
@@ -18,4 +18,7 @@ eyre = { workspace = true }
 serde = { workspace = true }
 sqlx = { workspace = true }
 time = { workspace = true }
-url = "2.5.2"
+url = { workspace = true }
+
+[dev-dependencies]
+rstest = { workspace = true }

--- a/crates/atuin-server/Cargo.toml
+++ b/crates/atuin-server/Cargo.toml
@@ -35,6 +35,7 @@ fs-err = { workspace = true }
 tower = { workspace = true }
 tower-http = { version = "0.6", features = ["trace"] }
 reqwest = { workspace = true }
+url = { workspace = true }
 argon2 = "0.5"
 metrics-exporter-prometheus = { version = "0.18", default-features = false }
 metrics = "0.24"

--- a/crates/atuin-server/src/handlers/user.rs
+++ b/crates/atuin-server/src/handlers/user.rs
@@ -39,7 +39,7 @@ pub fn verify_str(hash: &str, password: &str) -> bool {
 
 // Try to send a Discord webhook once - if it fails, we don't retry. "At most once", and best effort.
 // Don't return the status because if this fails, we don't really care.
-async fn send_register_hook(url: &str, username: String, registered: String) {
+async fn send_register_hook(url: &url::Url, username: String, registered: String) {
     ensure_crypto_provider();
     let hook = HashMap::from([
         ("username", username),
@@ -49,7 +49,7 @@ async fn send_register_hook(url: &str, username: String, registered: String) {
     let client = reqwest::Client::new();
 
     let resp = client
-        .post(url)
+        .post(url.clone())
         .timeout(Duration::new(5, 0))
         .header(CONTENT_TYPE, "application/json")
         .json(&hook)

--- a/crates/atuin-server/src/settings.rs
+++ b/crates/atuin-server/src/settings.rs
@@ -33,7 +33,7 @@ pub struct Settings {
     pub path: String,
     pub open_registration: bool,
     pub max_record_size: usize,
-    pub register_webhook_url: Option<String>,
+    pub register_webhook_url: Option<url::Url>,
     pub register_webhook_username: String,
     pub metrics: Metrics,
 

--- a/crates/atuin/Cargo.toml
+++ b/crates/atuin/Cargo.toml
@@ -57,6 +57,7 @@ derive_more = { workspace = true }
 
 time = { workspace = true }
 eyre = { workspace = true }
+url = { workspace = true }
 indicatif = "0.18.0"
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/atuin/src/command/client/account/link.rs
+++ b/crates/atuin/src/command/client/account/link.rs
@@ -12,14 +12,14 @@ pub async fn run(settings: &Settings) -> Result<()> {
         bail!("No CLI session found. Please log in first with 'atuin login'.");
     };
 
-    let hub_address = settings.active_hub_endpoint().unwrap_or_default();
+    let hub_address = settings.hub_endpoint();
 
     if hub_token.is_some() {
         println!("Found both Hub and CLI sessions. Linking accounts...");
     } else {
         println!("Found CLI session but no Hub session. Logging in to Hub first...");
 
-        let session = atuin_client::hub::HubAuthSession::start(hub_address.as_ref()).await?;
+        let session = atuin_client::hub::HubAuthSession::start(&hub_address).await?;
         println!("Open this URL to authenticate with Atuin Hub:");
         println!("{}", session.auth_url);
 
@@ -34,7 +34,7 @@ pub async fn run(settings: &Settings) -> Result<()> {
         println!("Hub authentication complete.");
     }
 
-    atuin_client::hub::link_account(hub_address.as_ref(), &cli_token).await?;
+    atuin_client::hub::link_account(&hub_address, &cli_token).await?;
     println!("Successfully linked CLI account to Hub.");
 
     Ok(())

--- a/crates/atuin/src/command/client/account/login.rs
+++ b/crates/atuin/src/command/client/account/login.rs
@@ -73,7 +73,7 @@ impl Cmd {
 
     /// Hub login: use the browser flow unless the username was provided for headless use.
     async fn run_hub_login(&self, settings: &Settings, store: &SqliteStore) -> Result<()> {
-        let endpoint = settings.active_hub_endpoint().unwrap_or_default();
+        let endpoint = settings.hub_endpoint();
 
         if let Some(username) = &self.username {
             // Headless login via v0 API (for CI / scripting).
@@ -118,12 +118,12 @@ impl Cmd {
                 self.prompt_and_store_key(settings, store).await?;
             }
 
-            self.ensure_hub_session(settings, endpoint.as_ref()).await?;
+            self.ensure_hub_session(settings, &endpoint).await?;
         }
 
         // Silently attempt to link CLI account to Hub if one exists
         if let Ok(cli_token) = settings.session_token().await
-            && let Err(e) = atuin_client::hub::link_account(endpoint.as_ref(), &cli_token).await
+            && let Err(e) = atuin_client::hub::link_account(&endpoint, &cli_token).await
         {
             tracing::debug!("Could not link CLI account to Hub: {}", e);
         }
@@ -157,7 +157,7 @@ impl Cmd {
         Ok(())
     }
 
-    async fn ensure_hub_session(&self, _settings: &Settings, hub_address: &str) -> Result<()> {
+    async fn ensure_hub_session(&self, _settings: &Settings, hub_address: &url::Url) -> Result<()> {
         tracing::info!("Authenticating with Atuin Hub...");
 
         let session = atuin_client::hub::HubAuthSession::start(hub_address).await?;

--- a/crates/atuin/src/command/client/account/register.rs
+++ b/crates/atuin/src/command/client/account/register.rs
@@ -135,7 +135,7 @@ impl Cmd {
             }
 
             let session = atuin_client::api_client::register(
-                settings.sync_address.as_str(),
+                &settings.sync_address,
                 &username,
                 &email,
                 &password,

--- a/crates/atuin/tests/common/mod.rs
+++ b/crates/atuin/tests/common/mod.rs
@@ -10,7 +10,7 @@ use tokio::{net::TcpListener, sync::oneshot, task::JoinHandle};
 use tracing::{Dispatch, dispatcher};
 use tracing_subscriber::{EnvFilter, layer::SubscriberExt};
 
-pub async fn start_server(path: &str) -> (String, oneshot::Sender<()>, JoinHandle<()>) {
+pub async fn start_server(path: &str) -> (url::Url, oneshot::Sender<()>, JoinHandle<()>) {
     let formatting_layer = tracing_tree::HierarchicalLayer::default()
         .with_writer(tracing_subscriber::fmt::TestWriter::new())
         .with_indent_lines(true)
@@ -63,11 +63,14 @@ pub async fn start_server(path: &str) -> (String, oneshot::Sender<()>, JoinHandl
     // let the server come online
     tokio::time::sleep(Duration::from_millis(200)).await;
 
-    (format!("http://{addr}{path}"), shutdown_tx, server)
+    let url = url::Url::parse(&format!("http://{addr}{path}"))
+        .expect("test server address is a valid URL");
+
+    (url, shutdown_tx, server)
 }
 
 pub async fn register_inner<'a>(
-    address: &'a str,
+    address: &'a url::Url,
     username: &str,
     password: &str,
 ) -> api_client::Client<'a> {
@@ -88,7 +91,11 @@ pub async fn register_inner<'a>(
 }
 
 #[allow(dead_code)]
-pub async fn login(address: &str, username: String, password: String) -> api_client::Client<'_> {
+pub async fn login(
+    address: &url::Url,
+    username: String,
+    password: String,
+) -> api_client::Client<'_> {
     // registration works
     let login_response = api_client::login(
         address,
@@ -107,7 +114,7 @@ pub async fn login(address: &str, username: String, password: String) -> api_cli
 }
 
 #[allow(dead_code)]
-pub async fn register(address: &str) -> api_client::Client<'_> {
+pub async fn register(address: &url::Url) -> api_client::Client<'_> {
     let username = uuid_v7().as_simple().to_string();
     let password = uuid_v7().as_simple().to_string();
     register_inner(address, &username, &password).await


### PR DESCRIPTION
This PR replaces a large number of `String`, `&str` usages we've had in the codebase with `Url` and `&Url`.

This is motivated by a number of bugs that have been introduced due to our relatively loose use of URLs:

- #389
- #190
- #2455
- #1099

The following new user-facing features are supported:
- **Usernames can now safely contain special characters** (and will be gracefully URL-encoded)
- **Host names can now contain weird characters** and nothing will break
- **Query parameters are safely encoded** in `crates/atuin-client/src/api_client.rs`.
- **Ports and trailing slashes** no longer misclassify in `crates/atuin-client/src/settings.rs:is_official_address`.
- **Malformed URLs in the config abort early** -- we fail on bad configs.
- **Tiny breaking change**: `atuin sync status` now prints `https://api.atuin.sh/` (with the trailing slash, this catch courtesy of Claude)

Internally, this creates a new useful `UrlAppendExt` trait extension which allows you to quite gracefully:

```rust
use atuin_common::url::UrlAppendExt;

let base = url::Url::parse("https://host.example/atuin").unwrap();

assert_eq!(base.append(["foo/bar"])?.as_str(), "https://host.example/atuin/foo%2Fbar");
assert_eq!(base.append(["foo", "bar"])?.as_str(), "https://host.example/atuin/foo/bar");

// Url::join behavior:
assert_eq!(base.join("foo/bar").unwrap().as_str(), "https://host.example/foo/bar");

let base = url::Url::parse("https://host.example/atuin").unwrap();
assert_eq!(
    base.append_path("api/v0/me")?.as_str(),
    "https://host.example/atuin/api/v0/me",
);
```

Which handles the legacy `make_url` functions we had repeated and sprinkled around.