### PR TITLE
docs: document built-in bash-preexec

### DIFF
--- a/docs/docs/guide/installation.md
+++ b/docs/docs/guide/installation.md
@@ -204,14 +204,15 @@ After installing, remember to restart your shell.
 
     === "bash-preexec"
 
-        [Bash-preexec](https://github.com/rcaloras/bash-preexec) can also be used, but you may experience
+        [bash-preexec](https://github.com/rcaloras/bash-preexec) can also be used, but you may experience
          some minor problems with the recorded duration and exit status of some commands.
 
         !!! warning "Please note"
 
-            bash-preexec currently has an issue where it will stop honoring `ignorespace`.
-            While Atuin will ignore commands prefixed with whitespace, they may still end up in your bash history.
-            Please check your configuration! All other shells do not have this issue.
+            bash-preexec currently has [an issue][bp-ignorespace] where it will stop
+            honoring `ignorespace`. While Atuin will ignore commands prefixed with
+            whitespace, they may still end up in your bash history. Please check your
+            configuration! All other shells do not have this issue.
 
             To use `atuin < 18.10.0` in `bash < 4` with bash-preexec, the option
             `enter_accept` needs to be turned on (which is so by default).  There is no
@@ -222,14 +223,22 @@ After installing, remember to restart your shell.
             i in; do ...; done`, etc., so those commands and duration may not be recorded
             in the Atuin's history correctly.
 
-        To use bash-preexec, download and initialize it
+        As of Atuin 18.18.0, `atuin init bash` will automatically load bash-preexec if no other
+        preexec backend has been loaded (ble.sh or an external copy of bash-preexec). To disable
+        this behavior, pass `ATUIN_NO_BUILTIN_PREEXEC=1` to `atuin init`, e.g.:
+
+        ```shell
+        eval "$(ATUIN_NO_BUILTIN_PREEXEC=1 atuin init bash)"
+        ```
+
+        If you prefer, you can also download and install bash-preexec separately:
 
         ```shell
         curl https://raw.githubusercontent.com/rcaloras/bash-preexec/master/bash-preexec.sh -o ~/.bash-preexec.sh
         echo '[[ -f ~/.bash-preexec.sh ]] && source ~/.bash-preexec.sh' >> ~/.bashrc
         ```
 
-        Then set up Atuin
+        Then set up Atuin:
 
         ```shell
         echo 'eval "$(atuin init bash)"' >> ~/.bashrc
@@ -306,3 +315,5 @@ If you used a package manager to install Atuin, then you should also use your pa
 ## Uninstall
 
 If you'd like to uninstall Atuin, please check out [the uninstall page](../uninstall.md).
+
+[bp-ignorespace]: https://github.com/rcaloras/bash-preexec/issues/115

--- a/install.sh
+++ b/install.sh
@@ -63,12 +63,6 @@ fi
 # Use of single quotes around $() is intentional here
 # shellcheck disable=SC2016
 
-if ! grep -q "atuin init bash" ~/.bashrc; then
-  curl --proto '=https' --tlsv1.2 -LsSf https://raw.githubusercontent.com/rcaloras/bash-preexec/master/bash-preexec.sh -o ~/.bash-preexec.sh
-  printf '\n[[ -f ~/.bash-preexec.sh ]] && source ~/.bash-preexec.sh\n' >> ~/.bashrc
-  echo 'eval "$(atuin init bash)"' >> ~/.bashrc
-fi
-
 if [ -f "$HOME/.config/fish/config.fish" ]; then
   if ! grep -q "atuin init fish" "$HOME/.config/fish/config.fish"; then
     printf '\nif status is-interactive\n    atuin init fish | source\nend\n' >> "$HOME/.config/fish/config.fish"

--- a/install.sh
+++ b/install.sh
@@ -63,6 +63,12 @@ fi
 # Use of single quotes around $() is intentional here
 # shellcheck disable=SC2016
 
+if ! grep -q "atuin init bash" ~/.bashrc; then
+  curl --proto '=https' --tlsv1.2 -LsSf https://raw.githubusercontent.com/rcaloras/bash-preexec/master/bash-preexec.sh -o ~/.bash-preexec.sh
+  printf '\n[[ -f ~/.bash-preexec.sh ]] && source ~/.bash-preexec.sh\n' >> ~/.bashrc
+  echo 'eval "$(atuin init bash)"' >> ~/.bashrc
+fi
+
 if [ -f "$HOME/.config/fish/config.fish" ]; then
   if ! grep -q "atuin init fish" "$HOME/.config/fish/config.fish"; then
     printf '\nif status is-interactive\n    atuin init fish | source\nend\n' >> "$HOME/.config/fish/config.fish"


### PR DESCRIPTION
This PR updates the docs with respect to the fact that bash-preexec is now automatically loaded by `atuin init bash`.