### PR TITLE
feat(search): add `--shell` option to `atuin search` to filter results by shell

### DIFF
--- a/crates/atuin-client/src/database.rs
+++ b/crates/atuin-client/src/database.rs
@@ -60,6 +60,7 @@ pub struct OptFilters {
     pub include_duplicates: bool,
     /// Author filter. Supports special values `$all-user` and `$all-agent`.
     pub authors: Vec<String>,
+    pub shells: Vec<String>,
 }
 
 /// Build a query [`Context`] without requiring a live shell session.
@@ -134,6 +135,31 @@ fn apply_author_filter(sql: &mut SqlBuilder, authors: &[String]) {
 
     if !conditions.is_empty() {
         sql.and_where(format!("({})", conditions.join(" OR ")));
+    }
+}
+
+fn apply_shell_filter<S>(sql: &mut SqlBuilder, shells: S)
+where
+    S: IntoIterator,
+    S::Item: AsRef<str>,
+{
+    let mut include_null = false;
+    let nonempty_shells = shells.into_iter().filter(|s| {
+        let is_empty = s.as_ref().is_empty();
+        if is_empty {
+            include_null = true;
+        }
+        !is_empty
+    });
+
+    let shell_list = nonempty_shells.map(|s| quote(s.as_ref())).join(", ");
+    let mut cond = (!shell_list.is_empty()).then(|| format!("shell in ({shell_list})"));
+
+    if include_null {
+        cond = Some(cond.map_or_else(String::new, |s| s + " OR ") + "shell IS NULL");
+    }
+    if let Some(cond) = cond {
+        sql.and_where(cond);
     }
 }
 
@@ -635,6 +661,7 @@ impl Database for Sqlite {
         if !filter_options.authors.is_empty() {
             apply_author_filter(&mut sql, &filter_options.authors);
         }
+        apply_shell_filter(&mut sql, &filter_options.shells);
 
         sql.and_where_is_null("deleted_at");
 

--- a/crates/atuin/src/command/client/search.rs
+++ b/crates/atuin/src/command/client/search.rs
@@ -35,7 +35,7 @@ pub struct Cmd {
     cwd: Option<String>,
 
     /// Exclude directory from results
-    #[arg(long = "exclude-cwd")]
+    #[arg(long)]
     exclude_cwd: Option<String>,
 
     /// Filter search result by exit code
@@ -43,7 +43,7 @@ pub struct Cmd {
     exit: Option<i64>,
 
     /// Exclude results with this exit code
-    #[arg(long = "exclude-exit")]
+    #[arg(long)]
     exclude_exit: Option<i64>,
 
     /// Only include results added before this date
@@ -67,19 +67,19 @@ pub struct Cmd {
     interactive: bool,
 
     /// Allow overriding filter mode over config
-    #[arg(long = "filter-mode")]
+    #[arg(long)]
     filter_mode: Option<FilterMode>,
 
     /// Allow overriding search mode over config
-    #[arg(long = "search-mode")]
+    #[arg(long)]
     search_mode: Option<SearchMode>,
 
     /// Marker argument used to inform atuin that it was invoked from a shell up-key binding (hidden from help to avoid confusion)
-    #[arg(long = "shell-up-key-binding", hide = true)]
+    #[arg(long, hide = true)]
     shell_up_key_binding: bool,
 
     /// Notify the keymap at the shell's side
-    #[arg(long = "keymap-mode", default_value = "auto")]
+    #[arg(long, default_value = "auto")]
     keymap_mode: KeymapMode,
 
     /// Use human-readable formatting for time
@@ -131,7 +131,7 @@ pub struct Cmd {
     format: Option<String>,
 
     /// Set the maximum number of lines Atuin's interface should take up.
-    #[arg(long = "inline-height")]
+    #[arg(long)]
     inline_height: Option<u16>,
 
     /// Filter by author. Supports $all-user (non-agents), $all-agent, or literal names.
@@ -145,8 +145,16 @@ pub struct Cmd {
     include_duplicates: bool,
 
     /// File name to write the result to (hidden from help as this is meant to be used from a script)
-    #[arg(long = "result-file", hide = true)]
+    #[arg(long, hide = true)]
     result_file: Option<String>,
+
+    /// Filter by the shell that was used to run the command
+    ///
+    /// If passed multiple times, commands from any of the shells will be shown.
+    ///
+    /// `--shell ""` will include commands for which the shell is unknown.
+    #[arg(long)]
+    shell: Vec<String>,
 }
 
 impl Cmd {
@@ -260,7 +268,8 @@ impl Cmd {
                 offset: self.offset,
                 reverse: self.reverse,
                 include_duplicates: self.include_duplicates,
-                authors: self.author.clone(),
+                authors: self.author,
+                shells: self.shell,
             };
 
             let mut entries =
@@ -309,7 +318,6 @@ impl Cmd {
 
 // This is supposed to more-or-less mirror the command line version, so ofc
 // it is going to have a lot of args
-#[allow(clippy::too_many_arguments, clippy::cast_possible_truncation)]
 async fn run_non_interactive(
     settings: &Settings,
     filter_options: OptFilters,


### PR DESCRIPTION
Add a new `--shell` option to `atuin search` to filter the results by the shell that was used to run the command. Passing the option multiple times has disjunctive semantics; e.g., `atuin search --shell bash --shell zsh` will show commands run from Bash or Zsh. To include commands for which the shell was not recorded (e.g., any commands from before the addition of the `shell` field), use `--shell ""`.