### PR TITLE
fix(search): reject non-interactive daemon-fuzzy

### DIFF
--- a/crates/atuin/src/command/client.rs
+++ b/crates/atuin/src/command/client.rs
@@ -163,6 +163,10 @@ impl Cmd {
     ) -> Result<()> {
         tracing::trace!(command = ?self, "client command");
 
+        if let Self::Search(search) = &self {
+            settings.search_mode = search.effective_search_mode(&settings)?;
+        }
+
         // Skip initializing any databases for history
         // This is a pretty hot path, as it runs before and after every single command the user
         // runs

--- a/crates/atuin/src/command/client/search.rs
+++ b/crates/atuin/src/command/client/search.rs
@@ -186,11 +186,6 @@ impl Cmd {
         store: SqliteStore,
         theme: &Theme,
     ) -> Result<()> {
-        if let Some(search_mode) = self.search_mode {
-            settings.search_mode = search_mode;
-        }
-        self.validate_search_mode(settings)?;
-
         let query = if self.query.is_empty() {
             std::env::var("ATUIN_QUERY").map_or_else(
                 |_| vec![],

--- a/crates/atuin/src/command/client/search.rs
+++ b/crates/atuin/src/command/client/search.rs
@@ -163,6 +163,18 @@ impl Cmd {
         self.interactive
     }
 
+    pub(super) fn effective_search_mode(&self, settings: &Settings) -> Result<SearchMode> {
+        let search_mode = self.search_mode.unwrap_or(settings.search_mode);
+
+        if !self.interactive && search_mode == SearchMode::DaemonFuzzy {
+            eyre::bail!(
+                "search mode 'daemon-fuzzy' is only supported with --interactive; use '--search-mode fuzzy' for non-interactive search"
+            );
+        }
+
+        Ok(search_mode)
+    }
+
     // clippy: please write this instead
     // clippy: now it has too many lines
     // me: I'll do it later OKAY
@@ -214,9 +226,6 @@ impl Cmd {
             return Ok(());
         }
 
-        if let Some(search_mode) = self.search_mode {
-            settings.search_mode = search_mode;
-        }
         if let Some(filter_mode) = self.filter_mode {
             settings.filter_mode = Some(filter_mode);
         }
@@ -355,7 +364,15 @@ async fn run_non_interactive(
 #[cfg(test)]
 mod tests {
     use super::Cmd;
+    use atuin_client::settings::{SearchMode, Settings};
     use clap::Parser;
+
+    fn settings_with_search_mode(search_mode: SearchMode) -> Settings {
+        Settings {
+            search_mode,
+            ..Settings::default()
+        }
+    }
 
     #[test]
     fn search_for_triple_dash() {
@@ -380,5 +397,55 @@ mod tests {
         let cmd =
             Cmd::try_parse_from(["search", "--author", "codex", "--author", "ellie"]).unwrap();
         assert_eq!(cmd.author, vec!["codex".to_string(), "ellie".to_string()]);
+    }
+
+    #[test]
+    fn interactive_daemon_fuzzy_is_valid() {
+        let cmd = Cmd::try_parse_from(["search", "--interactive"]).unwrap();
+        let settings = settings_with_search_mode(SearchMode::DaemonFuzzy);
+
+        assert_eq!(
+            cmd.effective_search_mode(&settings).unwrap(),
+            SearchMode::DaemonFuzzy
+        );
+    }
+
+    #[test]
+    fn non_interactive_daemon_fuzzy_is_invalid() {
+        let cmd = Cmd::try_parse_from(["search"]).unwrap();
+        let settings = settings_with_search_mode(SearchMode::DaemonFuzzy);
+
+        let error = cmd.effective_search_mode(&settings).unwrap_err();
+        assert_eq!(
+            error.to_string(),
+            "search mode 'daemon-fuzzy' is only supported with --interactive; use '--search-mode fuzzy' for non-interactive search"
+        );
+    }
+
+    #[test]
+    fn non_interactive_fuzzy_is_valid() {
+        let cmd = Cmd::try_parse_from(["search"]).unwrap();
+        let settings = settings_with_search_mode(SearchMode::Fuzzy);
+
+        assert_eq!(
+            cmd.effective_search_mode(&settings).unwrap(),
+            SearchMode::Fuzzy
+        );
+    }
+
+    #[test]
+    fn cli_search_mode_overrides_config_before_validation() {
+        let cmd = Cmd::try_parse_from(["search", "--search-mode", "fuzzy"]).unwrap();
+        let settings = settings_with_search_mode(SearchMode::DaemonFuzzy);
+
+        assert_eq!(
+            cmd.effective_search_mode(&settings).unwrap(),
+            SearchMode::Fuzzy
+        );
+
+        let cmd = Cmd::try_parse_from(["search", "--search-mode", "daemon-fuzzy"]).unwrap();
+        let settings = settings_with_search_mode(SearchMode::Fuzzy);
+
+        assert!(cmd.effective_search_mode(&settings).is_err());
     }
 }

--- a/crates/atuin/src/command/client/search.rs
+++ b/crates/atuin/src/command/client/search.rs
@@ -163,6 +163,18 @@ impl Cmd {
         self.interactive
     }
 
+    fn validate_search_mode(&self, settings: &Settings) -> Result<SearchMode> {
+        let search_mode = self.search_mode.unwrap_or(settings.search_mode);
+
+        if !self.interactive && search_mode == SearchMode::DaemonFuzzy {
+            eyre::bail!(
+                "search mode 'daemon-fuzzy' is only supported with --interactive; use '--search-mode fuzzy' for non-interactive search"
+            );
+        }
+
+        Ok(search_mode)
+    }
+
     // clippy: please write this instead
     // clippy: now it has too many lines
     // me: I'll do it later OKAY
@@ -174,6 +186,11 @@ impl Cmd {
         store: SqliteStore,
         theme: &Theme,
     ) -> Result<()> {
+        if let Some(search_mode) = self.search_mode {
+            settings.search_mode = search_mode;
+        }
+        self.validate_search_mode(settings)?;
+
         let query = if self.query.is_empty() {
             std::env::var("ATUIN_QUERY").map_or_else(
                 |_| vec![],
@@ -214,9 +231,6 @@ impl Cmd {
             return Ok(());
         }
 
-        if let Some(search_mode) = self.search_mode {
-            settings.search_mode = search_mode;
-        }
         if let Some(filter_mode) = self.filter_mode {
             settings.filter_mode = Some(filter_mode);
         }
@@ -355,7 +369,15 @@ async fn run_non_interactive(
 #[cfg(test)]
 mod tests {
     use super::Cmd;
+    use atuin_client::settings::{SearchMode, Settings};
     use clap::Parser;
+
+    fn settings_with_search_mode(search_mode: SearchMode) -> Settings {
+        Settings {
+            search_mode,
+            ..Settings::default()
+        }
+    }
 
     #[test]
     fn search_for_triple_dash() {
@@ -380,5 +402,55 @@ mod tests {
         let cmd =
             Cmd::try_parse_from(["search", "--author", "codex", "--author", "ellie"]).unwrap();
         assert_eq!(cmd.author, vec!["codex".to_string(), "ellie".to_string()]);
+    }
+
+    #[test]
+    fn interactive_daemon_fuzzy_is_valid() {
+        let cmd = Cmd::try_parse_from(["search", "--interactive"]).unwrap();
+        let settings = settings_with_search_mode(SearchMode::DaemonFuzzy);
+
+        assert_eq!(
+            cmd.validate_search_mode(&settings).unwrap(),
+            SearchMode::DaemonFuzzy
+        );
+    }
+
+    #[test]
+    fn non_interactive_daemon_fuzzy_is_invalid() {
+        let cmd = Cmd::try_parse_from(["search"]).unwrap();
+        let settings = settings_with_search_mode(SearchMode::DaemonFuzzy);
+
+        let error = cmd.validate_search_mode(&settings).unwrap_err();
+        assert_eq!(
+            error.to_string(),
+            "search mode 'daemon-fuzzy' is only supported with --interactive; use '--search-mode fuzzy' for non-interactive search"
+        );
+    }
+
+    #[test]
+    fn non_interactive_fuzzy_is_valid() {
+        let cmd = Cmd::try_parse_from(["search"]).unwrap();
+        let settings = settings_with_search_mode(SearchMode::Fuzzy);
+
+        assert_eq!(
+            cmd.validate_search_mode(&settings).unwrap(),
+            SearchMode::Fuzzy
+        );
+    }
+
+    #[test]
+    fn cli_search_mode_overrides_config_before_validation() {
+        let cmd = Cmd::try_parse_from(["search", "--search-mode", "fuzzy"]).unwrap();
+        let settings = settings_with_search_mode(SearchMode::DaemonFuzzy);
+
+        assert_eq!(
+            cmd.validate_search_mode(&settings).unwrap(),
+            SearchMode::Fuzzy
+        );
+
+        let cmd = Cmd::try_parse_from(["search", "--search-mode", "daemon-fuzzy"]).unwrap();
+        let settings = settings_with_search_mode(SearchMode::Fuzzy);
+
+        assert!(cmd.validate_search_mode(&settings).is_err());
     }
 }


### PR DESCRIPTION
## Summary

- Resolve and validate the effective search mode before database and record-store initialization.
- Reject `daemon-fuzzy` for non-interactive searches instead of silently using the database path.
- Apply CLI search-mode overrides before validation.
- Preserve interactive `daemon-fuzzy` and ordinary non-interactive `fuzzy`.

Fixes #3670

## Tests

- `cargo test -p atuin --bin atuin command::client::search::tests:: --locked`
- `cargo fmt --all -- --check`
- `cargo check -p atuin --all-targets --locked`
- `cargo clippy -p atuin --all-targets --locked -- -D warnings -D clippy::redundant_clone`

## Disclosure

This change was developed with AI assistance and reviewed and tested against the reported control flow. The final implementation was also exercised with invalid database paths to verify that mode validation happens before database setup.

## Checks

- [x] I am happy for maintainers to push small adjustments to this PR, to speed up the review cycle
- [x] I have checked that there are no existing pull requests for the same thing
