### PR TITLE
fix(win32): cargo-binstall package metadata

### DIFF
--- a/crates/atuin/Cargo.toml
+++ b/crates/atuin/Cargo.toml
@@ -16,6 +16,11 @@ pkg-url = "{ repo }/releases/download/v{ version }/{ name }-{ target }.tar.gz"
 bin-dir = "{ name }-{ target }/{ bin }{ binary-ext }"
 pkg-fmt = "tgz"
 
+[package.metadata.binstall.overrides.'cfg(target_os = "windows")']
+pkg-url = "{ repo }/releases/download/v{ version }/{ name }-{ target }.zip"
+bin-dir = "{ bin }{ binary-ext }"
+pkg-fmt = "zip"
+
 [package.metadata.deb]
 maintainer = "Ellie Huxtable <ellie@elliehuxtable.com>"
 copyright = "2021, Ellie Huxtable <ellie@elliehuxtable.com>"


### PR DESCRIPTION
I encountered this earlier today:

```
❯ cargo binstall atuin --dry-run
 INFO resolve: Resolving package: 'atuin'
 INFO resolve: Verified signature for package 'atuin-18.17.1-x86_64-pc-windows-msvc': timestamp:1784118766      file:atuin-18.17.1-x86_64-pc-windows-msvc.tar.gz        hashed
 WARN The package atuin v18.17.1 (x86_64-pc-windows-msvc) has been downloaded from third-party source QuickInstall
 INFO This will install the following binaries:
 INFO   - atuin.exe => C:\Users\ofek\.cargo\bin\atuin.exe
 INFO Dry-run: Not proceeding to install fetched binaries
 INFO Done in 2.5760683s
```

## Checks

- [X] I am happy for maintainers to push small adjustments to this PR, to speed up the review cycle
- [X] I have checked that there are no existing pull requests for the same thing
