### PR TITLE
fix(pty-proxy): scope proxy screen restore to its own terminal via ex…

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,7 +67,7 @@ parking_lot = "0.12.5"
 zeroize = "1"
 rstest = "0.26.1"
 thiserror = "2"
-rustix = { version = "1.1.4", features = ["process", "fs"] }
+rustix = { version = "1.1.4", features = ["process", "fs", "termios"] }
 tower = "0.5"
 tracing = "0.1"
 tree-sitter = "0.26.8"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -111,7 +111,7 @@ rmp = "0.8.14"
 rpassword = "7.0"
 rstest = "0.26.1"
 runtime-format = "0.1.3"
-rustix = { version = "1.1.4", features = ["process", "fs"] }
+rustix = { version = "1.1.4", features = ["process", "fs", "termios"] }
 rusty_paserk = { version = "0.5.0", default-features = false, features = ["v4", "serde"] }
 # rusty_paserk 0.5.0 (latest) requires rusty_paseto 0.8.0 unfortunately
 rusty_paseto = { version = "0.8.0", default-features = false }

--- a/crates/atuin-pty-proxy/src/pty_proxy.rs
+++ b/crates/atuin-pty-proxy/src/pty_proxy.rs
@@ -175,8 +175,22 @@ fn render_init(shell: Shell) -> &'static str {
             r#"if [[ "$-" == *i* ]] && [[ -t 0 ]] && [[ -t 1 ]]; then
   _atuin_pty_proxy_tmux_current="${TMUX:-}"
   _atuin_pty_proxy_tmux_previous="${ATUIN_PTY_PROXY_TMUX:-}"
+  _atuin_pty_proxy_tty_current="$(command tty 2>/dev/null || true)"
+  _atuin_pty_proxy_tty_previous="${ATUIN_PTY_PROXY_TTY:-}"
 
-  if [[ -z "${ATUIN_PTY_PROXY_ACTIVE:-}" ]] || [[ "$_atuin_pty_proxy_tmux_current" != "$_atuin_pty_proxy_tmux_previous" ]]; then
+  _atuin_pty_proxy_start=""
+  if [[ -z "${ATUIN_PTY_PROXY_ACTIVE:-}" ]]; then
+    _atuin_pty_proxy_start=1
+  elif [[ "$_atuin_pty_proxy_tmux_current" != "$_atuin_pty_proxy_tmux_previous" ]]; then
+    _atuin_pty_proxy_start=1
+  elif [[ -n "$_atuin_pty_proxy_tty_previous" ]] && [[ -n "$_atuin_pty_proxy_tty_current" ]] && [[ "$_atuin_pty_proxy_tty_current" != "$_atuin_pty_proxy_tty_previous" ]]; then
+    # The shell runs on a different terminal surface (e.g. a multiplexer
+    # pane) than the proxy that exported these variables, so its screen
+    # state does not describe this surface. Start a proxy of our own.
+    _atuin_pty_proxy_start=1
+  fi
+
+  if [[ -n "$_atuin_pty_proxy_start" ]]; then
     export ATUIN_PTY_PROXY_ACTIVE=1
     export ATUIN_PTY_PROXY_TMUX="$_atuin_pty_proxy_tmux_current"
     if [[ -n "${BASH_VERSION:-}" ]]; then
@@ -193,7 +207,7 @@ fn render_init(shell: Shell) -> &'static str {
     fi
   fi
 
-  unset _atuin_pty_proxy_tmux_current _atuin_pty_proxy_tmux_previous
+  unset _atuin_pty_proxy_tmux_current _atuin_pty_proxy_tmux_previous _atuin_pty_proxy_tty_current _atuin_pty_proxy_tty_previous _atuin_pty_proxy_start
 fi
 "#
         }
@@ -209,11 +223,25 @@ fi
         set _atuin_pty_proxy_tmux_previous "$ATUIN_PTY_PROXY_TMUX"
     end
 
+    set -l _atuin_pty_proxy_tty_current (command tty 2>/dev/null)
+    set -l _atuin_pty_proxy_tty_previous ""
+    if set -q ATUIN_PTY_PROXY_TTY
+        set _atuin_pty_proxy_tty_previous "$ATUIN_PTY_PROXY_TTY"
+    end
+
+    set -l _atuin_pty_proxy_start 0
     if not set -q ATUIN_PTY_PROXY_ACTIVE
-        set -gx ATUIN_PTY_PROXY_ACTIVE 1
-        set -gx ATUIN_PTY_PROXY_TMUX "$_atuin_pty_proxy_tmux_current"
-        exec atuin pty-proxy --shell (status fish-path)
+        set _atuin_pty_proxy_start 1
     else if test "$_atuin_pty_proxy_tmux_current" != "$_atuin_pty_proxy_tmux_previous"
+        set _atuin_pty_proxy_start 1
+    else if test -n "$_atuin_pty_proxy_tty_previous"; and test -n "$_atuin_pty_proxy_tty_current"; and test "$_atuin_pty_proxy_tty_current" != "$_atuin_pty_proxy_tty_previous"
+        # The shell runs on a different terminal surface (e.g. a multiplexer
+        # pane) than the proxy that exported these variables, so its screen
+        # state does not describe this surface. Start a proxy of our own.
+        set _atuin_pty_proxy_start 1
+    end
+
+    if test $_atuin_pty_proxy_start -eq 1
         set -gx ATUIN_PTY_PROXY_ACTIVE 1
         set -gx ATUIN_PTY_PROXY_TMUX "$_atuin_pty_proxy_tmux_current"
         exec atuin pty-proxy --shell (status fish-path)
@@ -228,8 +256,16 @@ end
             r#"if (is-terminal --stdin) and (is-terminal --stdout) {
     let tmux_current = ($env.TMUX? | default "")
     let tmux_previous = ($env.ATUIN_PTY_PROXY_TMUX? | default "")
+    let tty_current = (try { ^tty | str trim } catch { "" })
+    let tty_previous = ($env.ATUIN_PTY_PROXY_TTY? | default "")
 
-    if (($env.ATUIN_PTY_PROXY_ACTIVE? | default "") | is-empty) or ($tmux_current != $tmux_previous) {
+    # A non-empty tty_previous that differs from tty_current means the shell
+    # runs on a different terminal surface (e.g. a multiplexer pane) than the
+    # proxy that exported these variables, so its screen state does not
+    # describe this surface. Start a proxy of our own.
+    let tty_changed = (not ($tty_previous | is-empty)) and (not ($tty_current | is-empty)) and ($tty_current != $tty_previous)
+
+    if (($env.ATUIN_PTY_PROXY_ACTIVE? | default "") | is-empty) or ($tmux_current != $tmux_previous) or $tty_changed {
         $env.ATUIN_PTY_PROXY_ACTIVE = "1"
         $env.ATUIN_PTY_PROXY_TMUX = $tmux_current
         exec atuin pty-proxy --shell $nu.current-exe
@@ -253,6 +289,134 @@ mod tests {
     #[case::nu_bare("nu", Shell::Nu)]
     fn shell_from_name_maps(#[case] input: &str, #[case] expected: Shell) {
         assert_eq!(shell_from_name(input), Some(expected));
+    }
+
+    /// How `ATUIN_PTY_PROXY_TTY` should look to the shell under test.
+    enum ProxyTty {
+        /// The PTY the shell actually runs on — a proxy owning this surface.
+        OwnDevice,
+        /// A different device — env inherited across a multiplexer boundary.
+        Foreign,
+        /// Not set — environment from a proxy that predates the variable.
+        Unset,
+    }
+
+    /// Run the rendered bash init guard inside a real PTY, with `exec atuin
+    /// pty-proxy` replaced by an echo marker, and return everything the
+    /// shell printed.
+    fn run_bash_guard(active: bool, proxy_tty: &ProxyTty) -> String {
+        use std::io::Read;
+
+        use portable_pty::{CommandBuilder, PtySize, native_pty_system};
+
+        let script = render_init(Shell::Bash).replace(
+            "exec atuin pty-proxy",
+            "echo WOULD_EXEC_PTY_PROXY # atuin pty-proxy",
+        );
+        let script_path = std::env::temp_dir().join(format!(
+            "atuin-pty-proxy-guard-test-{}-{active}-{}.sh",
+            std::process::id(),
+            match proxy_tty {
+                ProxyTty::OwnDevice => "own",
+                ProxyTty::Foreign => "foreign",
+                ProxyTty::Unset => "unset",
+            },
+        ));
+        std::fs::write(&script_path, script).expect("write init script");
+
+        let pty = native_pty_system();
+        let pair = pty
+            .openpty(PtySize {
+                rows: 24,
+                cols: 80,
+                pixel_width: 0,
+                pixel_height: 0,
+            })
+            .expect("openpty");
+        let slave_device = pair.master.tty_name().expect("pty slave device name");
+
+        let mut cmd = CommandBuilder::new("bash");
+        let source_line = format!("source '{}'; echo GUARD_RAN", script_path.display());
+        cmd.args(["--noprofile", "--norc", "-i", "-c", &source_line]);
+        // Pin every variable the guard reads: the test process may itself be
+        // running under tmux or an atuin pty-proxy, and the base environment
+        // is inherited.
+        cmd.env("TMUX", "");
+        cmd.env("ATUIN_PTY_PROXY_TMUX", "");
+        if active {
+            cmd.env("ATUIN_PTY_PROXY_ACTIVE", "1");
+        } else {
+            cmd.env_remove("ATUIN_PTY_PROXY_ACTIVE");
+        }
+        match proxy_tty {
+            ProxyTty::OwnDevice => cmd.env("ATUIN_PTY_PROXY_TTY", &slave_device),
+            ProxyTty::Foreign => cmd.env("ATUIN_PTY_PROXY_TTY", "/dev/atuin-test-elsewhere"),
+            ProxyTty::Unset => cmd.env_remove("ATUIN_PTY_PROXY_TTY"),
+        }
+
+        let mut child = pair.slave.spawn_command(cmd).expect("spawn bash");
+        drop(pair.slave);
+
+        let mut reader = pair.master.try_clone_reader().expect("clone reader");
+        let output_thread = std::thread::spawn(move || {
+            let mut buf = Vec::new();
+            let _ = reader.read_to_end(&mut buf);
+            String::from_utf8_lossy(&buf).into_owned()
+        });
+
+        child.wait().expect("wait for bash");
+        let output = output_thread.join().expect("join reader thread");
+        let _ = std::fs::remove_file(&script_path);
+        output
+    }
+
+    #[test]
+    fn bash_guard_starts_proxy_when_inactive() {
+        let output = run_bash_guard(false, &ProxyTty::Unset);
+        assert!(output.contains("WOULD_EXEC_PTY_PROXY"), "output: {output}");
+    }
+
+    #[test]
+    fn bash_guard_skips_proxy_on_own_device() {
+        let output = run_bash_guard(true, &ProxyTty::OwnDevice);
+        assert!(!output.contains("WOULD_EXEC_PTY_PROXY"), "output: {output}");
+        assert!(output.contains("GUARD_RAN"), "output: {output}");
+    }
+
+    #[test]
+    fn bash_guard_starts_proxy_on_foreign_device() {
+        // A multiplexer pane (e.g. herdr) inherits ATUIN_PTY_PROXY_ACTIVE and
+        // ATUIN_PTY_PROXY_TTY from a proxy wrapping an outer shell, but runs
+        // on its own PTY — the guard must start a proxy for this surface.
+        let output = run_bash_guard(true, &ProxyTty::Foreign);
+        assert!(output.contains("WOULD_EXEC_PTY_PROXY"), "output: {output}");
+    }
+
+    #[test]
+    fn bash_guard_skips_proxy_when_tty_unknown() {
+        // Environment from a proxy that could not name its slave device (or
+        // an older atuin): fall back to the previous behavior of trusting
+        // ATUIN_PTY_PROXY_ACTIVE rather than exec-looping.
+        let output = run_bash_guard(true, &ProxyTty::Unset);
+        assert!(!output.contains("WOULD_EXEC_PTY_PROXY"), "output: {output}");
+        assert!(output.contains("GUARD_RAN"), "output: {output}");
+    }
+
+    #[test]
+    fn init_scripts_guard_on_tty_change() {
+        let posix = render_init(Shell::Bash);
+        assert!(
+            posix.contains(r#"_atuin_pty_proxy_tty_current="$(command tty 2>/dev/null || true)""#)
+        );
+        assert!(posix.contains(r#"_atuin_pty_proxy_tty_previous="${ATUIN_PTY_PROXY_TTY:-}""#));
+
+        let fish = render_init(Shell::Fish);
+        assert!(fish.contains("ATUIN_PTY_PROXY_TTY"));
+        assert!(fish.contains("command tty"));
+
+        let nu = render_init(Shell::Nu);
+        assert!(nu.contains("ATUIN_PTY_PROXY_TTY"));
+        assert!(nu.contains("^tty"));
     }
 
     #[rstest]

--- a/crates/atuin-pty-proxy/src/pty_proxy.rs
+++ b/crates/atuin-pty-proxy/src/pty_proxy.rs
@@ -166,8 +166,22 @@ fn render_init(shell: Shell) -> &'static str {
             r#"if [[ "$-" == *i* ]] && [[ -t 0 ]] && [[ -t 1 ]]; then
   _atuin_pty_proxy_tmux_current="${TMUX:-}"
   _atuin_pty_proxy_tmux_previous="${ATUIN_PTY_PROXY_TMUX:-}"
+  _atuin_pty_proxy_tty_current="$(command tty 2>/dev/null || true)"
+  _atuin_pty_proxy_tty_previous="${ATUIN_PTY_PROXY_TTY:-}"
 
-  if [[ -z "${ATUIN_PTY_PROXY_ACTIVE:-}" ]] || [[ "$_atuin_pty_proxy_tmux_current" != "$_atuin_pty_proxy_tmux_previous" ]]; then
+  _atuin_pty_proxy_start=""
+  if [[ -z "${ATUIN_PTY_PROXY_ACTIVE:-}" ]]; then
+    _atuin_pty_proxy_start=1
+  elif [[ "$_atuin_pty_proxy_tmux_current" != "$_atuin_pty_proxy_tmux_previous" ]]; then
+    _atuin_pty_proxy_start=1
+  elif [[ -n "$_atuin_pty_proxy_tty_previous" ]] && [[ -n "$_atuin_pty_proxy_tty_current" ]] && [[ "$_atuin_pty_proxy_tty_current" != "$_atuin_pty_proxy_tty_previous" ]]; then
+    # The shell runs on a different terminal surface (e.g. a multiplexer
+    # pane) than the proxy that exported these variables, so its screen
+    # state does not describe this surface. Start a proxy of our own.
+    _atuin_pty_proxy_start=1
+  fi
+
+  if [[ -n "$_atuin_pty_proxy_start" ]]; then
     export ATUIN_PTY_PROXY_ACTIVE=1
     export ATUIN_PTY_PROXY_TMUX="$_atuin_pty_proxy_tmux_current"
     if [[ -n "${BASH_VERSION:-}" ]]; then
@@ -184,7 +198,7 @@ fn render_init(shell: Shell) -> &'static str {
     fi
   fi
 
-  unset _atuin_pty_proxy_tmux_current _atuin_pty_proxy_tmux_previous
+  unset _atuin_pty_proxy_tmux_current _atuin_pty_proxy_tmux_previous _atuin_pty_proxy_tty_current _atuin_pty_proxy_tty_previous _atuin_pty_proxy_start
 fi
 "#
         }
@@ -200,11 +214,25 @@ fi
         set _atuin_pty_proxy_tmux_previous "$ATUIN_PTY_PROXY_TMUX"
     end
 
+    set -l _atuin_pty_proxy_tty_current (command tty 2>/dev/null)
+    set -l _atuin_pty_proxy_tty_previous ""
+    if set -q ATUIN_PTY_PROXY_TTY
+        set _atuin_pty_proxy_tty_previous "$ATUIN_PTY_PROXY_TTY"
+    end
+
+    set -l _atuin_pty_proxy_start 0
     if not set -q ATUIN_PTY_PROXY_ACTIVE
-        set -gx ATUIN_PTY_PROXY_ACTIVE 1
-        set -gx ATUIN_PTY_PROXY_TMUX "$_atuin_pty_proxy_tmux_current"
-        exec atuin pty-proxy --shell (status fish-path)
+        set _atuin_pty_proxy_start 1
     else if test "$_atuin_pty_proxy_tmux_current" != "$_atuin_pty_proxy_tmux_previous"
+        set _atuin_pty_proxy_start 1
+    else if test -n "$_atuin_pty_proxy_tty_previous"; and test -n "$_atuin_pty_proxy_tty_current"; and test "$_atuin_pty_proxy_tty_current" != "$_atuin_pty_proxy_tty_previous"
+        # The shell runs on a different terminal surface (e.g. a multiplexer
+        # pane) than the proxy that exported these variables, so its screen
+        # state does not describe this surface. Start a proxy of our own.
+        set _atuin_pty_proxy_start 1
+    end
+
+    if test $_atuin_pty_proxy_start -eq 1
         set -gx ATUIN_PTY_PROXY_ACTIVE 1
         set -gx ATUIN_PTY_PROXY_TMUX "$_atuin_pty_proxy_tmux_current"
         exec atuin pty-proxy --shell (status fish-path)
@@ -219,8 +247,16 @@ end
             r#"if (is-terminal --stdin) and (is-terminal --stdout) {
     let tmux_current = ($env.TMUX? | default "")
     let tmux_previous = ($env.ATUIN_PTY_PROXY_TMUX? | default "")
+    let tty_current = (try { ^tty | str trim } catch { "" })
+    let tty_previous = ($env.ATUIN_PTY_PROXY_TTY? | default "")
 
-    if (($env.ATUIN_PTY_PROXY_ACTIVE? | default "") | is-empty) or ($tmux_current != $tmux_previous) {
+    # A non-empty tty_previous that differs from tty_current means the shell
+    # runs on a different terminal surface (e.g. a multiplexer pane) than the
+    # proxy that exported these variables, so its screen state does not
+    # describe this surface. Start a proxy of our own.
+    let tty_changed = (not ($tty_previous | is-empty)) and (not ($tty_current | is-empty)) and ($tty_current != $tty_previous)
+
+    if (($env.ATUIN_PTY_PROXY_ACTIVE? | default "") | is-empty) or ($tmux_current != $tmux_previous) or $tty_changed {
         $env.ATUIN_PTY_PROXY_ACTIVE = "1"
         $env.ATUIN_PTY_PROXY_TMUX = $tmux_current
         exec atuin pty-proxy --shell $nu.current-exe
@@ -244,6 +280,132 @@ mod tests {
     #[case::nu_bare("nu", Shell::Nu)]
     fn shell_from_name_maps(#[case] input: &str, #[case] expected: Shell) {
         assert_eq!(shell_from_name(input), Some(expected));
+    }
+
+    /// How `ATUIN_PTY_PROXY_TTY` should look to the shell under test.
+    enum ProxyTty {
+        /// The PTY the shell actually runs on — a proxy owning this surface.
+        OwnDevice,
+        /// A different device — env inherited across a multiplexer boundary.
+        Foreign,
+        /// Not set — environment from a proxy that predates the variable.
+        Unset,
+    }
+
+    /// Run the rendered bash init guard inside a real PTY, with `exec atuin
+    /// pty-proxy` replaced by an echo marker, and return everything the
+    /// shell printed.
+    fn run_bash_guard(active: bool, proxy_tty: &ProxyTty) -> String {
+        use std::io::Read;
+
+        use portable_pty::{CommandBuilder, PtySize, native_pty_system};
+
+        let script = render_init(Shell::Bash)
+            .replace("exec atuin pty-proxy", "echo WOULD_EXEC_PTY_PROXY # atuin pty-proxy");
+        let script_path = std::env::temp_dir().join(format!(
+            "atuin-pty-proxy-guard-test-{}-{active}-{}.sh",
+            std::process::id(),
+            match proxy_tty {
+                ProxyTty::OwnDevice => "own",
+                ProxyTty::Foreign => "foreign",
+                ProxyTty::Unset => "unset",
+            },
+        ));
+        std::fs::write(&script_path, script).expect("write init script");
+
+        let pty = native_pty_system();
+        let pair = pty
+            .openpty(PtySize {
+                rows: 24,
+                cols: 80,
+                pixel_width: 0,
+                pixel_height: 0,
+            })
+            .expect("openpty");
+        let slave_device = pair.master.tty_name().expect("pty slave device name");
+
+        let mut cmd = CommandBuilder::new("bash");
+        let source_line = format!("source '{}'; echo GUARD_RAN", script_path.display());
+        cmd.args(["--noprofile", "--norc", "-i", "-c", &source_line]);
+        // Pin every variable the guard reads: the test process may itself be
+        // running under tmux or an atuin pty-proxy, and the base environment
+        // is inherited.
+        cmd.env("TMUX", "");
+        cmd.env("ATUIN_PTY_PROXY_TMUX", "");
+        if active {
+            cmd.env("ATUIN_PTY_PROXY_ACTIVE", "1");
+        } else {
+            cmd.env_remove("ATUIN_PTY_PROXY_ACTIVE");
+        }
+        match proxy_tty {
+            ProxyTty::OwnDevice => cmd.env("ATUIN_PTY_PROXY_TTY", &slave_device),
+            ProxyTty::Foreign => cmd.env("ATUIN_PTY_PROXY_TTY", "/dev/atuin-test-elsewhere"),
+            ProxyTty::Unset => cmd.env_remove("ATUIN_PTY_PROXY_TTY"),
+        }
+
+        let mut child = pair.slave.spawn_command(cmd).expect("spawn bash");
+        drop(pair.slave);
+
+        let mut reader = pair.master.try_clone_reader().expect("clone reader");
+        let output_thread = std::thread::spawn(move || {
+            let mut buf = Vec::new();
+            let _ = reader.read_to_end(&mut buf);
+            String::from_utf8_lossy(&buf).into_owned()
+        });
+
+        child.wait().expect("wait for bash");
+        let output = output_thread.join().expect("join reader thread");
+        let _ = std::fs::remove_file(&script_path);
+        output
+    }
+
+    #[test]
+    fn bash_guard_starts_proxy_when_inactive() {
+        let output = run_bash_guard(false, &ProxyTty::Unset);
+        assert!(output.contains("WOULD_EXEC_PTY_PROXY"), "output: {output}");
+    }
+
+    #[test]
+    fn bash_guard_skips_proxy_on_own_device() {
+        let output = run_bash_guard(true, &ProxyTty::OwnDevice);
+        assert!(!output.contains("WOULD_EXEC_PTY_PROXY"), "output: {output}");
+        assert!(output.contains("GUARD_RAN"), "output: {output}");
+    }
+
+    #[test]
+    fn bash_guard_starts_proxy_on_foreign_device() {
+        // A multiplexer pane (e.g. herdr) inherits ATUIN_PTY_PROXY_ACTIVE and
+        // ATUIN_PTY_PROXY_TTY from a proxy wrapping an outer shell, but runs
+        // on its own PTY — the guard must start a proxy for this surface.
+        let output = run_bash_guard(true, &ProxyTty::Foreign);
+        assert!(output.contains("WOULD_EXEC_PTY_PROXY"), "output: {output}");
+    }
+
+    #[test]
+    fn bash_guard_skips_proxy_when_tty_unknown() {
+        // Environment from a proxy that could not name its slave device (or
+        // an older atuin): fall back to the previous behavior of trusting
+        // ATUIN_PTY_PROXY_ACTIVE rather than exec-looping.
+        let output = run_bash_guard(true, &ProxyTty::Unset);
+        assert!(!output.contains("WOULD_EXEC_PTY_PROXY"), "output: {output}");
+        assert!(output.contains("GUARD_RAN"), "output: {output}");
+    }
+
+    #[test]
+    fn init_scripts_guard_on_tty_change() {
+        let posix = render_init(Shell::Bash);
+        assert!(
+            posix.contains(r#"_atuin_pty_proxy_tty_current="$(command tty 2>/dev/null || true)""#)
+        );
+        assert!(posix.contains(r#"_atuin_pty_proxy_tty_previous="${ATUIN_PTY_PROXY_TTY:-}""#));
+
+        let fish = render_init(Shell::Fish);
+        assert!(fish.contains("ATUIN_PTY_PROXY_TTY"));
+        assert!(fish.contains("command tty"));
+
+        let nu = render_init(Shell::Nu);
+        assert!(nu.contains("ATUIN_PTY_PROXY_TTY"));
+        assert!(nu.contains("^tty"));
     }
 
     #[rstest]

--- a/crates/atuin-pty-proxy/src/runtime.rs
+++ b/crates/atuin-pty-proxy/src/runtime.rs
@@ -14,6 +14,20 @@ use crate::debug::{Osc133DebugHighlighter, RESET};
 use crate::pty_proxy::RuntimeOptions;
 use crate::screen::{self, Msg};
 
+/// Environment for the spawned shell: the socket path for screen requests,
+/// an active flag so nested shells don't start another proxy, and the PTY
+/// slave device so shells and clients can tell whether the proxy still owns
+/// their terminal surface. When the slave device is unknown, any inherited
+/// `ATUIN_PTY_PROXY_TTY` is removed so children never see a stale value.
+fn apply_proxy_env(cmd: &mut CommandBuilder, sock_path: &Path, tty_name: Option<&Path>) {
+    cmd.env("ATUIN_PTY_PROXY_SOCKET", sock_path.as_os_str());
+    cmd.env("ATUIN_PTY_PROXY_ACTIVE", "1");
+    match tty_name {
+        Some(tty) => cmd.env("ATUIN_PTY_PROXY_TTY", tty.as_os_str()),
+        None => cmd.env_remove("ATUIN_PTY_PROXY_TTY"),
+    }
+}
+
 pub(crate) fn main(options: RuntimeOptions) {
     if let Err(e) = run(options) {
         let _ = terminal::disable_raw_mode();
@@ -57,8 +71,7 @@ fn run(options: RuntimeOptions) -> eyre::Result<()> {
     if let Some(ref path) = options.shell {
         cmd.env("SHELL", path);
     }
-    cmd.env("ATUIN_PTY_PROXY_SOCKET", sock_path.as_os_str());
-    cmd.env("ATUIN_PTY_PROXY_ACTIVE", "1");
+    apply_proxy_env(&mut cmd, &sock_path, pair.master.tty_name().as_deref());
     // Atuin sets a restrictive process-wide umask on startup to protect the
     // files it creates. The shell must not inherit it (#3695) — restore the
     // umask the user launched us with. Applied in the child between fork and
@@ -355,6 +368,20 @@ fn spawn_stdin_pump(input_tx: SyncSender<Vec<u8>>) {
     });
 }
 
+/// Read the current terminal size and propagate it to the child pty, the
+/// column tracker, and the screen parser.
+fn apply_terminal_size(master: &dyn portable_pty::MasterPty, handle: &ProxyHandle) {
+    if let Ok((cols, rows)) = terminal::size() {
+        let _ = master.resize(PtySize {
+            rows,
+            cols,
+            pixel_width: 0,
+            pixel_height: 0,
+        });
+        handle.resize(rows, cols);
+    }
+}
+
 fn spawn_resize_handler(
     master: Box<dyn portable_pty::MasterPty + Send>,
     handle: ProxyHandle,
@@ -362,19 +389,21 @@ fn spawn_resize_handler(
     use signal_hook::consts::SIGWINCH;
     use signal_hook::iterator::Signals;
 
+    // Register for SIGWINCH before spawning the thread, so any resize that
+    // arrives once this returns is queued rather than lost.
     let mut signals = Signals::new([SIGWINCH])?;
 
     std::thread::spawn(move || {
+        // The terminal may have been resized between the initial size query in
+        // `run` and this handler being armed — a multiplexer settling its pane
+        // layout right after spawning the shell does exactly this. That resize
+        // predates the SIGWINCH registration above, so no signal is waiting for
+        // it; apply the current size once up front so we don't stay stuck at a
+        // stale startup size until the next resize.
+        apply_terminal_size(&*master, &handle);
+
         for _ in signals.forever() {
-            if let Ok((cols, rows)) = terminal::size() {
-                let _ = master.resize(PtySize {
-                    rows,
-                    cols,
-                    pixel_width: 0,
-                    pixel_height: 0,
-                });
-                handle.resize(rows, cols);
-            }
+            apply_terminal_size(&*master, &handle);
         }
     });
 
@@ -387,8 +416,63 @@ fn process_exit_code(code: u32) -> i32 {
 
 #[cfg(test)]
 mod tests {
-    use super::process_exit_code;
+    use std::ffi::OsStr;
+    use std::path::Path;
+
+    use portable_pty::CommandBuilder;
     use rstest::rstest;
+
+    use super::{apply_proxy_env, process_exit_code};
+
+    #[test]
+    fn proxy_env_exports_socket_active_flag_and_tty() {
+        let mut cmd = CommandBuilder::new("sh");
+        apply_proxy_env(
+            &mut cmd,
+            Path::new("/tmp/test.sock"),
+            Some(Path::new("/dev/ttys009")),
+        );
+
+        assert_eq!(
+            cmd.get_env("ATUIN_PTY_PROXY_SOCKET"),
+            Some(OsStr::new("/tmp/test.sock"))
+        );
+        assert_eq!(cmd.get_env("ATUIN_PTY_PROXY_ACTIVE"), Some(OsStr::new("1")));
+        assert_eq!(
+            cmd.get_env("ATUIN_PTY_PROXY_TTY"),
+            Some(OsStr::new("/dev/ttys009"))
+        );
+    }
+
+    #[test]
+    fn proxy_env_overrides_inherited_tty() {
+        let mut cmd = CommandBuilder::new("sh");
+        // Simulate a value inherited from an outer proxy's environment.
+        cmd.env("ATUIN_PTY_PROXY_TTY", "/dev/ttys001");
+        apply_proxy_env(
+            &mut cmd,
+            Path::new("/tmp/test.sock"),
+            Some(Path::new("/dev/ttys009")),
+        );
+
+        assert_eq!(
+            cmd.get_env("ATUIN_PTY_PROXY_TTY"),
+            Some(OsStr::new("/dev/ttys009"))
+        );
+    }
+
+    #[test]
+    fn proxy_env_removes_inherited_tty_when_unknown() {
+        let mut cmd = CommandBuilder::new("sh");
+        // Simulate a value inherited from an outer proxy's environment. If
+        // this proxy cannot name its own slave device, the stale path must
+        // not leak through — a wrong value would make shells and popup
+        // clients misjudge which terminal surface they are on.
+        cmd.env("ATUIN_PTY_PROXY_TTY", "/dev/ttys001");
+        apply_proxy_env(&mut cmd, Path::new("/tmp/test.sock"), None);
+
+        assert_eq!(cmd.get_env("ATUIN_PTY_PROXY_TTY"), None);
+    }
 
     #[rstest]
     #[case::zero(0, 0)]

--- a/crates/atuin-pty-proxy/src/runtime.rs
+++ b/crates/atuin-pty-proxy/src/runtime.rs
@@ -1,4 +1,5 @@
 use std::io::{Read, Write};
+use std::path::Path;
 use std::sync::mpsc;
 
 use crossterm::terminal;
@@ -7,6 +8,23 @@ use portable_pty::{CommandBuilder, PtySize, native_pty_system};
 use crate::debug::{Osc133DebugHighlighter, RESET};
 use crate::pty_proxy::RuntimeOptions;
 use crate::screen::{self, Msg};
+
+/// Environment for the spawned shell: the socket path for screen requests,
+/// an active flag so nested shells don't start another proxy, and the PTY
+/// slave device so shells and clients can tell whether the proxy still owns
+/// their terminal surface. When the slave device is unknown, any inherited
+/// `ATUIN_PTY_PROXY_TTY` is removed so children never see a stale value.
+fn apply_proxy_env(cmd: &mut CommandBuilder, sock_path: Option<&Path>, tty_name: Option<&Path>) {
+    match sock_path {
+        Some(path) => cmd.env("ATUIN_PTY_PROXY_SOCKET", path.as_os_str()),
+        None => cmd.env_remove("ATUIN_PTY_PROXY_SOCKET"),
+    }
+    cmd.env("ATUIN_PTY_PROXY_ACTIVE", "1");
+    match tty_name {
+        Some(tty) => cmd.env("ATUIN_PTY_PROXY_TTY", tty.as_os_str()),
+        None => cmd.env_remove("ATUIN_PTY_PROXY_TTY"),
+    }
+}
 
 pub fn main(options: RuntimeOptions) {
     if let Err(e) = run(options) {
@@ -55,12 +73,7 @@ fn run(options: RuntimeOptions) -> eyre::Result<()> {
     if let Some(ref path) = options.shell {
         cmd.env("SHELL", path);
     }
-    if let Some(path) = &sock_path {
-        cmd.env("ATUIN_PTY_PROXY_SOCKET", path);
-    } else {
-        cmd.env_remove("ATUIN_PTY_PROXY_SOCKET");
-    }
-    cmd.env("ATUIN_PTY_PROXY_ACTIVE", "1");
+    apply_proxy_env(&mut cmd, sock_path.as_deref(), pair.master.tty_name().as_deref());
     // Atuin sets a restrictive process-wide umask on startup to protect the
     // files it creates. The shell must not inherit it (#3695) — restore the
     // umask the user launched us with. Applied in the child between fork and
@@ -150,6 +163,20 @@ fn run(options: RuntimeOptions) -> eyre::Result<()> {
     std::process::exit(process_exit_code(status.exit_code()));
 }
 
+/// Read the current terminal size and propagate it to the child pty, the
+/// column tracker, and the screen parser.
+fn apply_terminal_size(master: &dyn portable_pty::MasterPty, resize_tx: &mpsc::SyncSender<Msg>) {
+    if let Ok((cols, rows)) = terminal::size() {
+        let _ = master.resize(PtySize {
+            rows,
+            cols,
+            pixel_width: 0,
+            pixel_height: 0,
+        });
+        let _ = resize_tx.send(Msg::Resize { rows, cols });
+    }
+}
+
 fn spawn_resize_handler(
     master: Box<dyn portable_pty::MasterPty + Send>,
     resize_tx: mpsc::SyncSender<Msg>,
@@ -157,19 +184,21 @@ fn spawn_resize_handler(
     use signal_hook::consts::SIGWINCH;
     use signal_hook::iterator::Signals;
 
+    // Register for SIGWINCH before spawning the thread, so any resize that
+    // arrives once this returns is queued rather than lost.
     let mut signals = Signals::new([SIGWINCH])?;
 
     std::thread::spawn(move || {
+        // The terminal may have been resized between the initial size query in
+        // `run` and this handler being armed — a multiplexer settling its pane
+        // layout right after spawning the shell does exactly this. That resize
+        // predates the SIGWINCH registration above, so no signal is waiting for
+        // it; apply the current size once up front so we don't stay stuck at a
+        // stale startup size until the next resize.
+        apply_terminal_size(&*master, &resize_tx);
+
         for _ in signals.forever() {
-            if let Ok((cols, rows)) = terminal::size() {
-                let _ = master.resize(PtySize {
-                    rows,
-                    cols,
-                    pixel_width: 0,
-                    pixel_height: 0,
-                });
-                let _ = resize_tx.send(Msg::Resize { rows, cols });
-            }
+            apply_terminal_size(&*master, &resize_tx);
         }
     });
 
@@ -182,10 +211,55 @@ fn process_exit_code(code: u32) -> i32 {
 
 #[cfg(test)]
 mod tests {
+    use std::ffi::OsStr;
+    use std::path::Path;
+
     use easy_cast::Conv;
+    use portable_pty::CommandBuilder;
     use rstest::rstest;
 
-    use super::process_exit_code;
+    use super::{apply_proxy_env, process_exit_code};
+
+    #[test]
+    fn proxy_env_exports_socket_active_flag_and_tty() {
+        let mut cmd = CommandBuilder::new("sh");
+        apply_proxy_env(
+            &mut cmd,
+            Some(Path::new("/tmp/test.sock")),
+            Some(Path::new("/dev/ttys009")),
+        );
+
+        assert_eq!(cmd.get_env("ATUIN_PTY_PROXY_SOCKET"), Some(OsStr::new("/tmp/test.sock")));
+        assert_eq!(cmd.get_env("ATUIN_PTY_PROXY_ACTIVE"), Some(OsStr::new("1")));
+        assert_eq!(cmd.get_env("ATUIN_PTY_PROXY_TTY"), Some(OsStr::new("/dev/ttys009")));
+    }
+
+    #[test]
+    fn proxy_env_overrides_inherited_tty() {
+        let mut cmd = CommandBuilder::new("sh");
+        // Simulate a value inherited from an outer proxy's environment.
+        cmd.env("ATUIN_PTY_PROXY_TTY", "/dev/ttys001");
+        apply_proxy_env(
+            &mut cmd,
+            Some(Path::new("/tmp/test.sock")),
+            Some(Path::new("/dev/ttys009")),
+        );
+
+        assert_eq!(cmd.get_env("ATUIN_PTY_PROXY_TTY"), Some(OsStr::new("/dev/ttys009")));
+    }
+
+    #[test]
+    fn proxy_env_removes_inherited_tty_when_unknown() {
+        let mut cmd = CommandBuilder::new("sh");
+        // Simulate a value inherited from an outer proxy's environment. If
+        // this proxy cannot name its own slave device, the stale path must
+        // not leak through — a wrong value would make shells and popup
+        // clients misjudge which terminal surface they are on.
+        cmd.env("ATUIN_PTY_PROXY_TTY", "/dev/ttys001");
+        apply_proxy_env(&mut cmd, Some(Path::new("/tmp/test.sock")), None);
+
+        assert_eq!(cmd.get_env("ATUIN_PTY_PROXY_TTY"), None);
+    }
 
     #[rstest]
     #[case::zero(0, 0)]

--- a/crates/atuin/src/command/client/search/interactive.rs
+++ b/crates/atuin/src/command/client/search/interactive.rs
@@ -1495,6 +1495,49 @@ fn fetch_screen_state(socket_path: &str) -> Option<SavedScreen> {
     })
 }
 
+/// Decide whether a screen snapshot from atuin pty-proxy describes the
+/// terminal surface this process is drawing on.
+///
+/// `ATUIN_PTY_PROXY_SOCKET` is inherited through the environment, so it can
+/// leak across terminal surfaces — e.g. into the panes of a terminal
+/// multiplexer launched from a proxied shell. Restoring such a snapshot
+/// would paint another surface's contents (sidebars, other panes) into this
+/// one. The snapshot is only trusted when the proxy's PTY device matches the
+/// tty this process runs on (when both are known) and the snapshot
+/// dimensions match the live terminal size. Sizes are `(rows, cols)`.
+#[cfg(unix)]
+fn popup_screen_is_current(
+    proxy_tty: Option<&str>,
+    client_tty: Option<&str>,
+    saved_size: (u16, u16),
+    term_size: (u16, u16),
+) -> bool {
+    if let (Some(proxy_tty), Some(client_tty)) = (proxy_tty, client_tty)
+        && !proxy_tty.is_empty()
+        && proxy_tty != client_tty
+    {
+        return false;
+    }
+    saved_size == term_size
+}
+
+/// The tty device this process is attached to, from the first standard
+/// stream that is a terminal. Returns `None` when no standard stream is a
+/// tty (in which case popup mode is not usable anyway).
+#[cfg(unix)]
+fn client_tty_name() -> Option<String> {
+    let stdout = std::io::stdout();
+    let stdin = std::io::stdin();
+    let stderr = std::io::stderr();
+    let streams: [&dyn std::os::fd::AsFd; 3] = [&stdout, &stdin, &stderr];
+    for stream in streams {
+        if let Ok(name) = rustix::termios::ttyname(stream, Vec::new()) {
+            return name.into_string().ok();
+        }
+    }
+    None
+}
+
 /// Restore the screen area that was covered by the popup.
 ///
 /// Writes the pre-formatted per-row ANSI bytes received from atuin pty-proxy
@@ -1702,7 +1745,21 @@ pub async fn history(
             && inline_height > 0
         {
             let saved = fetch_screen_state(path);
-            if let Some(ref s) = saved {
+            // A snapshot describing some other terminal surface — e.g. a
+            // socket inherited across a multiplexer boundary — must not be
+            // used: restoring it would paint foreign content into this
+            // surface. Fall back to plain inline mode instead.
+            let usable = saved.as_ref().is_some_and(|s| {
+                let (term_cols, term_rows) = terminal::size().unwrap_or((s.cols, s.rows));
+                let proxy_tty = std::env::var("ATUIN_PTY_PROXY_TTY").ok();
+                popup_screen_is_current(
+                    proxy_tty.as_deref(),
+                    client_tty_name().as_deref(),
+                    (s.rows, s.cols),
+                    (term_rows, term_cols),
+                )
+            });
+            if usable && let Some(ref s) = saved {
                 let (term_cols, term_rows) = terminal::size().unwrap_or((s.cols, s.rows));
                 let (popup_rect, scroll) =
                     compute_popup_placement(s.cursor_row, term_rows, term_cols, inline_height);
@@ -2839,5 +2896,72 @@ mod tests {
             matches!(result, super::InputAction::ReturnQuery),
             "Tab configured as return-query should return InputAction::ReturnQuery"
         );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn popup_screen_current_when_tty_and_size_match() {
+        assert!(super::popup_screen_is_current(
+            Some("/dev/ttys009"),
+            Some("/dev/ttys009"),
+            (40, 120),
+            (40, 120),
+        ));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn popup_screen_stale_when_proxy_tty_differs() {
+        // A multiplexer pane (e.g. herdr) inherits the proxy environment of
+        // an outer shell but runs on its own PTY. The snapshot describes the
+        // outer surface and must not be used here.
+        assert!(!super::popup_screen_is_current(
+            Some("/dev/ttys001"),
+            Some("/dev/ttys014"),
+            (40, 120),
+            (40, 120),
+        ));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn popup_screen_stale_when_size_differs() {
+        assert!(!super::popup_screen_is_current(
+            Some("/dev/ttys009"),
+            Some("/dev/ttys009"),
+            (60, 200),
+            (40, 120),
+        ));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn popup_screen_falls_back_to_size_when_a_tty_is_unknown() {
+        // Older proxies don't export ATUIN_PTY_PROXY_TTY, and the client tty
+        // may be undeterminable; in those cases only the size check applies.
+        assert!(super::popup_screen_is_current(
+            None,
+            Some("/dev/ttys009"),
+            (40, 120),
+            (40, 120),
+        ));
+        assert!(super::popup_screen_is_current(
+            Some("/dev/ttys009"),
+            None,
+            (40, 120),
+            (40, 120),
+        ));
+        assert!(super::popup_screen_is_current(
+            Some(""),
+            Some("/dev/ttys009"),
+            (40, 120),
+            (40, 120),
+        ));
+        assert!(!super::popup_screen_is_current(
+            None,
+            Some("/dev/ttys009"),
+            (60, 200),
+            (40, 120),
+        ));
     }
 }

--- a/crates/atuin/src/command/client/search/interactive.rs
+++ b/crates/atuin/src/command/client/search/interactive.rs
@@ -1549,6 +1549,49 @@ fn fetch_screen_state(socket_path: &str) -> Option<SavedScreen> {
     })
 }
 
+/// Decide whether a screen snapshot from atuin pty-proxy describes the
+/// terminal surface this process is drawing on.
+///
+/// `ATUIN_PTY_PROXY_SOCKET` is inherited through the environment, so it can
+/// leak across terminal surfaces — e.g. into the panes of a terminal
+/// multiplexer launched from a proxied shell. Restoring such a snapshot
+/// would paint another surface's contents (sidebars, other panes) into this
+/// one. The snapshot is only trusted when the proxy's PTY device matches the
+/// tty this process runs on (when both are known) and the snapshot
+/// dimensions match the live terminal size. Sizes are `(rows, cols)`.
+#[cfg(unix)]
+fn popup_screen_is_current(
+    proxy_tty: Option<&str>,
+    client_tty: Option<&str>,
+    saved_size: (u16, u16),
+    term_size: (u16, u16),
+) -> bool {
+    if let (Some(proxy_tty), Some(client_tty)) = (proxy_tty, client_tty)
+        && !proxy_tty.is_empty()
+        && proxy_tty != client_tty
+    {
+        return false;
+    }
+    saved_size == term_size
+}
+
+/// The tty device this process is attached to, from the first standard
+/// stream that is a terminal. Returns `None` when no standard stream is a
+/// tty (in which case popup mode is not usable anyway).
+#[cfg(unix)]
+fn client_tty_name() -> Option<String> {
+    let stdout = std::io::stdout();
+    let stdin = std::io::stdin();
+    let stderr = std::io::stderr();
+    let streams: [&dyn std::os::fd::AsFd; 3] = [&stdout, &stdin, &stderr];
+    for stream in streams {
+        if let Ok(name) = rustix::termios::ttyname(stream, Vec::new()) {
+            return name.into_string().ok();
+        }
+    }
+    None
+}
+
 /// Restore the screen area that was covered by the popup.
 ///
 /// Writes the pre-formatted per-row ANSI bytes received from atuin pty-proxy
@@ -1743,7 +1786,21 @@ pub async fn history(
             && inline_height > 0
         {
             let saved = fetch_screen_state(path);
-            if let Some(ref s) = saved {
+            // A snapshot describing some other terminal surface — e.g. a
+            // socket inherited across a multiplexer boundary — must not be
+            // used: restoring it would paint foreign content into this
+            // surface. Fall back to plain inline mode instead.
+            let usable = saved.as_ref().is_some_and(|s| {
+                let (term_cols, term_rows) = terminal::size().unwrap_or((s.cols, s.rows));
+                let proxy_tty = std::env::var("ATUIN_PTY_PROXY_TTY").ok();
+                popup_screen_is_current(
+                    proxy_tty.as_deref(),
+                    client_tty_name().as_deref(),
+                    (s.rows, s.cols),
+                    (term_rows, term_cols),
+                )
+            });
+            if usable && let Some(ref s) = saved {
                 let (term_cols, term_rows) = terminal::size().unwrap_or((s.cols, s.rows));
                 let (popup_rect, scroll) =
                     compute_popup_placement(s.cursor_row, term_rows, term_cols, inline_height);
@@ -2916,5 +2973,57 @@ mod tests {
             matches!(result, super::InputAction::ReturnQuery),
             "Tab configured as return-query should return InputAction::ReturnQuery"
         );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn popup_screen_current_when_tty_and_size_match() {
+        assert!(super::popup_screen_is_current(
+            Some("/dev/ttys009"),
+            Some("/dev/ttys009"),
+            (40, 120),
+            (40, 120),
+        ));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn popup_screen_stale_when_proxy_tty_differs() {
+        // A multiplexer pane (e.g. herdr) inherits the proxy environment of
+        // an outer shell but runs on its own PTY. The snapshot describes the
+        // outer surface and must not be used here.
+        assert!(!super::popup_screen_is_current(
+            Some("/dev/ttys001"),
+            Some("/dev/ttys014"),
+            (40, 120),
+            (40, 120),
+        ));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn popup_screen_stale_when_size_differs() {
+        assert!(!super::popup_screen_is_current(
+            Some("/dev/ttys009"),
+            Some("/dev/ttys009"),
+            (60, 200),
+            (40, 120),
+        ));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn popup_screen_falls_back_to_size_when_a_tty_is_unknown() {
+        // Older proxies don't export ATUIN_PTY_PROXY_TTY, and the client tty
+        // may be undeterminable; in those cases only the size check applies.
+        assert!(super::popup_screen_is_current(None, Some("/dev/ttys009"), (40, 120), (40, 120),));
+        assert!(super::popup_screen_is_current(Some("/dev/ttys009"), None, (40, 120), (40, 120),));
+        assert!(super::popup_screen_is_current(
+            Some(""),
+            Some("/dev/ttys009"),
+            (40, 120),
+            (40, 120),
+        ));
+        assert!(!super::popup_screen_is_current(None, Some("/dev/ttys009"), (60, 200), (40, 120),));
     }
 }


### PR DESCRIPTION
## Summary

Fixes the redraw corruption reported in #3566: activating the atuin search popup inside a terminal multiplexer pane (e.g. herdr) paints content from *outside* the pane — sidebars, other panes — into it on exit.

## Root cause

`atuin pty-proxy` mirrors the shell's output into a vt100 screen model and serves snapshots over a unix socket, exporting `ATUIN_PTY_PROXY_SOCKET` and `ATUIN_PTY_PROXY_ACTIVE=1` into the shell's environment. Environment variables are inherited by every descendant, so a multiplexer launched from a proxied shell passes both into every pane it creates.

The init guard only started a fresh proxy when `ATUIN_PTY_PROXY_ACTIVE` was
unset or `$TMUX` changed, so panes of any non-tmux multiplexer kept pointing at
the **outer** proxy. `atuin search` popup mode then fetched the outer proxy's
full-terminal screen — including the multiplexer's chrome — and
`restore_popup_area` blitted those full-width rows into the pane on exit.

## Fix

We now export `ATUIN_PTY_PROXY_TTY`, and whenever the shells tty differes from it we spawn a new proxy.
This means that any multiplexer that uses a new tty for each pane will get a new pty-proxy for each pane.

As I am not a rust expert, I had a bit of help from Claude.

Closes #3566

## Checks

- [x] I am happy for maintainers to push small adjustments to this PR, to speed up the review cycle
- [x] I have checked that there are no existing pull requests for the same thing
