### PR TITLE
docs(config): document smart_sort and tmux popup settings

### DIFF
--- a/crates/atuin-client/config.toml
+++ b/crates/atuin-client/config.toml
@@ -199,6 +199,11 @@
 ## Defaults to true. Configures whether to store commands that failed (those with non-zero exit status) or not.
 # store_failed = true
 
+## Defaults to false. When enabled, interactive search reorders results after the
+## chosen search mode runs: prefix matches first, then whole-substring matches,
+## then a light preference for more recent commands. Applies to all search modes.
+# smart_sort = false
+
 [stats]
 ## Set commands where we should consider the subcommand for statistics. Eg, kubectl get vs just kubectl
 # common_subcommands = [

--- a/docs/docs/configuration/config.md
+++ b/docs/docs/configuration/config.md
@@ -738,9 +738,11 @@ When `true` and Atuin is started inside a tmux session (tmux >= 3.2), interactiv
 search uses `tmux display-popup` instead of drawing inline in the current pane.
 Supported shell integrations: zsh, bash, and fish.
 
-`atuin init` exports `ATUIN_TMUX_POPUP` / `ATUIN_TMUX_POPUP_WIDTH` /
-`ATUIN_TMUX_POPUP_HEIGHT` from this section. You can also override those env vars
-in your shell (set `ATUIN_TMUX_POPUP=false` to force-disable).
+`atuin init` reflects this section into the shell environment: when `enabled =
+true` it exports `ATUIN_TMUX_POPUP_WIDTH` / `ATUIN_TMUX_POPUP_HEIGHT`; when
+`enabled = false` it exports `ATUIN_TMUX_POPUP=false`. You can also override these
+env vars in your shell (set `ATUIN_TMUX_POPUP=false` to force-disable, or set
+`ATUIN_TMUX_POPUP_WIDTH` / `ATUIN_TMUX_POPUP_HEIGHT` to resize).
 
 !!! note "iTerm2 native tmux"
 

--- a/docs/docs/configuration/config.md
+++ b/docs/docs/configuration/config.md
@@ -595,6 +595,26 @@ Alternatively, set env var NO_MOTION
 prefers_reduced_motion = false
 ```
 
+### `smart_sort`
+
+Atuin version: >= 18.0
+
+Default: `false`
+
+When enabled, interactive search reorders returned history after the active
+search mode runs. Ranking prefers:
+
+1. Commands that are **prefixed** by the query
+2. Commands that contain the query as a **whole substring**
+3. More **recent** commands (lightly — time does not dominate match quality)
+
+This applies on top of prefix, fulltext, fuzzy, skim, and daemon-fuzzy modes in
+the interactive TUI. It does not change non-interactive `atuin search` output.
+
+```toml
+smart_sort = true
+```
+
 ## search
 
 ### `filters`
@@ -698,6 +718,43 @@ authors = ["$all-user"]
 # Show commands from you and Claude Code
 # authors = ["$all-user", "claude-code"]
 ```
+
+## tmux
+
+```toml
+[tmux]
+enabled = false
+width = "80%"
+height = "60%"
+```
+
+### `enabled`
+
+Atuin version: >= 18.12
+
+Default: `false`
+
+When `true` and Atuin is started inside a tmux session (tmux >= 3.2), interactive
+search uses `tmux display-popup` instead of drawing inline in the current pane.
+Supported shell integrations: zsh, bash, and fish.
+
+`atuin init` exports `ATUIN_TMUX_POPUP` / `ATUIN_TMUX_POPUP_WIDTH` /
+`ATUIN_TMUX_POPUP_HEIGHT` from this section. You can also override those env vars
+in your shell (set `ATUIN_TMUX_POPUP=false` to force-disable).
+
+!!! note "iTerm2 native tmux"
+
+    iTerm2's native tmux integration does not support `display-popup`. Leave
+    `enabled = false` (the default) if you rely on that integration.
+
+### `width` / `height`
+
+Atuin version: >= 18.12
+
+Defaults: `width = "80%"`, `height = "60%"`
+
+Popup size. Each value may be a percentage string (for example `"80%"`) or an
+integer character/line count (for example `"100"`).
 
 ## Stats
 


### PR DESCRIPTION
## Summary

- Document `smart_sort` in the config reference and example `config.toml`.
- Document the `[tmux]` popup settings (enabled/width/height), including the iTerm2 limitation.

## Motivation

Closes #2167.
Closes #3165.

`smart_sort` has been available for a while (default off) but was only discoverable via source/PR #1885. Users keep asking what it does. Ellie previously noted it was ready to document once proven.

The tmux popup shipped in 18.12 (`[tmux]` in the example config) but never landed on the docs site; #3165 also needs the iTerm2 native-tmux caveat.

## Verification

- Compared `smart_sort` text to `atuin-history::sort::sort` and the interactive-only call sites in `search/interactive.rs`.
- Compared `[tmux]` docs to `settings.rs` defaults, shell `ATUIN_TMUX_POPUP*` usage, and CHANGELOG 18.12.0 (#3058).
- Docs-only; no code/runtime change.

## Checklist

- [x] I am happy for maintainers to push small adjustments to this PR
- [x] I have checked that there are no existing pull requests for the same thing

---
<!-- fleet-pr-claim: agent_id=sera platform=hermes -->
**Agent-Owner:** `sera` · **Platform:** hermes · **Claim-TTL:** 48h