### PR TITLE
feat: More aggressive optimizations for dist release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -96,5 +96,6 @@ features = ["runtime-tokio", "time", "uuid"]
 # The profile that 'cargo dist' will build with
 [profile.dist]
 inherits = "release"
-lto = "thin"
+lto = "fat"
 strip = "symbols"
+codegen-units = 1


### PR DESCRIPTION
Improves the release build of atuin:

- Binary size went from `29MB` to `20MB`.
- **No statistically significant search performance increase**

Trade-off is that compile time performance suffers, but this profile gets built once in a [blue moon](https://www.youtube.com/watch?v=dqwSde_eEv4).