### PR TITLE
chore(ci): bump GitHub Actions to latest versions

### DIFF
--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -18,9 +18,9 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
       - name: Codespell
-        uses: codespell-project/actions-codespell@v2
+        uses: codespell-project/actions-codespell@v2.2
         with:
           # This is regenerated from commit history
           # we cannot rewrite commit history, and I'd rather not correct it

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -18,7 +18,7 @@ jobs:
 
     runs-on: depot-ubuntu-24.04
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - name: Get Repo Owner
         id: get_repo_owner
@@ -27,7 +27,7 @@ jobs:
       - uses: depot/setup-action@v1
 
       - name: Login to container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
@@ -35,7 +35,7 @@ jobs:
 
       - name: Docker meta
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: ghcr.io/${{ env.REPO_OWNER }}/atuin
           flavor: |

--- a/.github/workflows/installer.yml
+++ b/.github/workflows/installer.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - name: Install zsh for ubuntu
         if: matrix.os == 'depot-ubuntu-24.04' 

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: depot-ubuntu-24.04
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - uses: cachix/install-nix-action@v31
 
       - name: Run nix flake check
@@ -27,7 +27,7 @@ jobs:
     runs-on: depot-ubuntu-24.04
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - uses: cachix/install-nix-action@v31
 
       - name: Run nix build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,7 +56,7 @@ jobs:
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           persist-credentials: false
           submodules: recursive
@@ -66,7 +66,7 @@ jobs:
         shell: bash
         run: "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/v0.31.0/cargo-dist-installer.sh | sh"
       - name: Cache dist
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: cargo-dist-cache
           path: ~/.cargo/bin/dist
@@ -82,7 +82,7 @@ jobs:
           cat plan-dist-manifest.json
           echo "manifest=$(jq -c "." plan-dist-manifest.json)" >> "$GITHUB_OUTPUT"
       - name: "Upload dist-manifest.json"
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: artifacts-plan-dist-manifest
           path: plan-dist-manifest.json
@@ -120,7 +120,7 @@ jobs:
       - name: enable windows longpaths
         run: |
           git config --global core.longpaths true
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           persist-credentials: false
           submodules: recursive
@@ -135,7 +135,7 @@ jobs:
         run: ${{ matrix.install_dist.run }}
       # Get the dist-manifest
       - name: Fetch local artifacts
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@v8
         with:
           pattern: artifacts-*
           path: target/distrib/
@@ -149,7 +149,7 @@ jobs:
           dist build ${{ needs.plan.outputs.tag-flag }} --print=linkage --output-format=json ${{ matrix.dist_args }} > dist-manifest.json
           echo "dist ran successfully"
       - name: Attest
-        uses: actions/attest-build-provenance@v3
+        uses: actions/attest-build-provenance@v4
         with:
           subject-path: "target/distrib/*${{ join(matrix.targets, ', ') }}*"
       - id: cargo-dist
@@ -166,7 +166,7 @@ jobs:
 
           cp dist-manifest.json "$BUILD_MANIFEST_NAME"
       - name: "Upload artifacts"
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: artifacts-build-local-${{ join(matrix.targets, '_') }}
           path: |
@@ -183,19 +183,19 @@ jobs:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       BUILD_MANIFEST_NAME: target/distrib/global-dist-manifest.json
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           persist-credentials: false
           submodules: recursive
       - name: Install cached dist
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@v8
         with:
           name: cargo-dist-cache
           path: ~/.cargo/bin/
       - run: chmod +x ~/.cargo/bin/dist
       # Get all the local artifacts for the global tasks to use (for e.g. checksums)
       - name: Fetch local artifacts
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@v8
         with:
           pattern: artifacts-*
           path: target/distrib/
@@ -213,7 +213,7 @@ jobs:
 
           cp dist-manifest.json "$BUILD_MANIFEST_NAME"
       - name: "Upload artifacts"
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: artifacts-build-global
           path: |
@@ -233,19 +233,19 @@ jobs:
     outputs:
       val: ${{ steps.host.outputs.manifest }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           persist-credentials: false
           submodules: recursive
       - name: Install cached dist
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@v8
         with:
           name: cargo-dist-cache
           path: ~/.cargo/bin/
       - run: chmod +x ~/.cargo/bin/dist
       # Fetch artifacts from scratch-storage
       - name: Fetch artifacts
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@v8
         with:
           pattern: artifacts-*
           path: target/distrib/
@@ -258,14 +258,14 @@ jobs:
           cat dist-manifest.json
           echo "manifest=$(jq -c "." dist-manifest.json)" >> "$GITHUB_OUTPUT"
       - name: "Upload dist-manifest.json"
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           # Overwrite the previous copy
           name: artifacts-dist-manifest
           path: dist-manifest.json
       # Create a GitHub Release while uploading all files to it
       - name: "Download GitHub Artifacts"
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@v8
         with:
           pattern: artifacts-*
           path: artifacts
@@ -298,7 +298,7 @@ jobs:
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           persist-credentials: false
           submodules: recursive

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -21,14 +21,14 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - name: Install rust
         uses: dtolnay/rust-toolchain@master
         with:
           toolchain: 1.97.0
 
-      - uses: actions/cache@v5
+      - uses: actions/cache@v6
         with:
           path: |
             ~/.cargo/registry
@@ -57,14 +57,14 @@ jobs:
         target: [x86_64-unknown-illumos]
     runs-on: depot-ubuntu-24.04
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - name: Install cross
         uses: taiki-e/install-action@v2
         with:
           tool: cross
 
-      - uses: actions/cache@v5
+      - uses: actions/cache@v6
         with:
           path: |
             ~/.cargo/registry
@@ -92,7 +92,7 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - name: Install rust
         uses: dtolnay/rust-toolchain@master
@@ -104,7 +104,7 @@ jobs:
         with:
           tool: cargo-nextest
 
-      - uses: actions/cache@v5
+      - uses: actions/cache@v6
         with:
           path: |
             ~/.cargo/registry
@@ -122,14 +122,14 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - name: Install rust
         uses: dtolnay/rust-toolchain@master
         with:
           toolchain: 1.97.0
 
-      - uses: actions/cache@v5
+      - uses: actions/cache@v6
         with:
           path: |
             ~/.cargo/registry
@@ -166,7 +166,7 @@ jobs:
           - 5432:5432
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - name: Install rust
         uses: dtolnay/rust-toolchain@master
@@ -178,7 +178,7 @@ jobs:
         with:
           tool: cargo-nextest
 
-      - uses: actions/cache@v5
+      - uses: actions/cache@v6
         with:
           path: |
             ~/.cargo/registry
@@ -195,7 +195,7 @@ jobs:
     runs-on: depot-ubuntu-24.04
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - name: Install latest rust
         uses: dtolnay/rust-toolchain@master
@@ -203,7 +203,7 @@ jobs:
           toolchain: 1.97.0
           components: clippy
 
-      - uses: actions/cache@v5
+      - uses: actions/cache@v6
         with:
           path: |
             ~/.cargo/registry
@@ -218,7 +218,7 @@ jobs:
     runs-on: depot-ubuntu-24.04
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - name: Install latest rust
         uses: dtolnay/rust-toolchain@master

--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -11,8 +11,8 @@ jobs:
     runs-on: depot-ubuntu-24.04
 
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@v7
     - name: Run shellcheck
-      uses: ludeeus/action-shellcheck@master
+      uses: ludeeus/action-shellcheck@2.0.0
       env:
         SHELLCHECK_OPTS: "-e SC2148"

--- a/.github/workflows/update-nix-deps.yml
+++ b/.github/workflows/update-nix-deps.yml
@@ -10,11 +10,11 @@ jobs:
     if: github.repository == 'atuinsh/atuin'
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
       - name: Install Nix
-        uses: DeterminateSystems/nix-installer-action@main
+        uses: DeterminateSystems/nix-installer-action@v22
       - name: Update flake.lock
-        uses: DeterminateSystems/update-flake-lock@main
+        uses: DeterminateSystems/update-flake-lock@v28
         with:
           pr-title: "chore(deps): update flake.lock"
           pr-labels: |

--- a/dist-workspace.toml
+++ b/dist-workspace.toml
@@ -27,3 +27,13 @@ aarch64-unknown-linux-gnu = "depot-ubuntu-24.04-arm-8"
 aarch64-unknown-linux-musl = "depot-ubuntu-24.04-arm-8"
 x86_64-unknown-linux-gnu = "depot-ubuntu-24.04-8"
 x86_64-unknown-linux-musl = "depot-ubuntu-24.04-8"
+
+# Pin the actions dist generates into release.yml. Without these, `dist generate`
+# emits the versions baked into dist 0.31.0 (checkout@v6, upload-artifact@v6,
+# download-artifact@v7, attest-build-provenance@v3) and `dist plan` fails CI as
+# out-of-date. Drop entries here once a dist upgrade makes them the default.
+[dist.github-action-commits]
+"actions/checkout" = "v7"
+"actions/upload-artifact" = "v7"
+"actions/download-artifact" = "v8"
+"actions/attest-build-provenance" = "v4"


### PR DESCRIPTION
Bumps every GitHub Action we use to its latest version, and pins the three actions we were tracking on a moving `@master`/`@main` ref to tagged releases.

## Version changes

| Action | From | To |
| --- | --- | --- |
| `actions/checkout` | v6 | **v7** |
| `actions/cache` | v5 | **v6** |
| `actions/upload-artifact` | v6 | **v7** |
| `actions/download-artifact` | v7 | **v8** |
| `actions/attest-build-provenance` | v3 | **v4** |
| `docker/login-action` | v3 | **v4** |
| `docker/metadata-action` | v5 | **v6** |
| `codespell-project/actions-codespell` | v2 | **v2.2** |
| `ludeeus/action-shellcheck` | `@master` | **2.0.0** |
| `DeterminateSystems/nix-installer-action` | `@main` | **v22** |
| `DeterminateSystems/update-flake-lock` | `@main` | **v28** |

No workflow inputs needed changing — none of these majors renamed or removed an input we pass.

Already current, left alone: `actions/upload-pages-artifact@v5`, `actions/deploy-pages@v5`, `cachix/install-nix-action@v31`, `depot/setup-action@v1`, `depot/build-push-action@v1`, `taiki-e/install-action@v2`, `astral-sh/setup-uv@v8.3.2`.

`dtolnay/rust-toolchain` stays on `@master` — that is the ref its README prescribes when you pass an explicit `toolchain:` input, which we do (`1.97.0`). Its only tag, `v1`, is vestigial.

## What this means for atuin

Most of these majors are just Node 20 → Node 24 runtime bumps with no behavior change. The parts that actually touch us:

- **`download-artifact` v8 now fails on a digest mismatch** (new `digest-mismatch` input, defaults to `error`; v7 only warned). `release.yml` only ever downloads artifacts produced earlier in the same run, so this is free integrity checking on the release pipeline rather than a new failure mode. If it ever misfires, the escape hatch is `digest-mismatch: warn`, not pinning back.
- **`upload-artifact` v7 + `download-artifact` v8 is the intended pairing.** The artifact format is unchanged since v4, so the two sides are not required to move in lockstep, and the release workflow's upload/download round-trip is unaffected.
- **`checkout` v7 blocks checking out fork PR code under `pull_request_target`/`workflow_run` by default.** We use neither trigger anywhere, and a bare `actions/checkout@v7` with no `ref` is explicitly exempt, so this is a no-op for us. Worth knowing it was also backported to v6/v5/v4, so staying put would not have avoided it.
- **`cache` v6 no longer fails the save step when the token is read-only** (fork PRs) — it warns instead. Cache keys and entries are unchanged, so existing caches stay warm; no cold-rebuild across the matrix.
- **`nix-installer-action` and `update-flake-lock` were floating on `@main`**, 43 and 91 commits past their latest releases respectively — arbitrary upstream changes were landing in a workflow that opens PRs against this repo. v22 preserves current behavior (the `determinate: true` default arrived in v21, so it is already what we have been running); v28 is the first `update-flake-lock` release compatible with `actions/checkout@v6`+.
- **`codespell@v2` was silently stale** — upstream stopped moving the `v2` tag at v2.1, so `@v2` was not actually the latest release. `@v2.2` picks up the real one.
- **`action-shellcheck@master` is behaviorally identical to `2.0.0`** (the two commits past the tag are repo-internal CI/docs only) on a repo dormant since mid-2024, so this is a pure supply-chain determinism win with no lint-behavior change. The ShellCheck binary itself is still resolved as `stable` at runtime, unchanged by this PR.

`release.yml` is generated by dist, and `dist plan` fails CI if the file does not match what dist would emit — so the first push of this PR broke that job. The action versions in it are owned by dist 0.31.0, which defaults to checkout@v6 / upload-artifact@v6 / download-artifact@v7 / attest-build-provenance@v3. Rather than hand-edit a generated file, this PR sets them in `dist-workspace.toml` under `[dist.github-action-commits]`, so `dist generate` produces them and the file stays in sync. Verified locally with dist 0.31.0: the regenerated `release.yml` is byte-identical to the version here, and `dist plan` exits 0.

Those overrides can be dropped once a dist upgrade makes them the defaults. For reference, dist 0.32.0 defaults to upload-artifact@v7 and download-artifact@v8, but still checkout@v6, and it replaces `attest-build-provenance` with `actions/attest` — that upgrade is a separate change to the release pipeline, not folded in here.

## Verification

- Every ref resolves upstream (checked each `owner/repo@ref` against the GitHub API).
- All 9 workflows parse.
- `actionlint` reports the same 21 findings before and after this change — no new issues. The pre-existing ones are the `depot-ubuntu-24.04` custom runner labels and one SC2086 in dist-generated code.

CI on this PR exercises rust.yml, nix.yml, shellcheck, codespell, installer, and release.yml's `plan` job. The docker, docs-deploy, and update-nix-deps workflows do not run on PRs and will first execute on merge to main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
