### PR TITLE
fix(install): make /dev/tty authoritative for interactivity detection

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -11,22 +11,12 @@ for arg in "$@"; do
 done
 
 if [ "$ATUIN_NON_INTERACTIVE" != "yes" ]; then
-  # Every prompt below reads from /dev/tty, never stdin (stdin is the script
-  # itself under `curl | sh`), so /dev/tty is the only thing worth testing.
-  # Opening it is not enough: it may exist as a device node that opens fine
-  # but isn't backed by a real terminal (containers, CI, headless), so verify
-  # with `test -t`. The subshell keeps the redirect -- and a failing `exec`,
-  # which is a special built-in -- from affecting the parent shell.
-  if ( exec </dev/tty && [ -t 0 ] ) 2>/dev/null; then
-    ATUIN_NON_INTERACTIVE="no"
-  else
-    ATUIN_NON_INTERACTIVE="yes"
   ATUIN_NON_INTERACTIVE=yes
   if { exec 3</dev/tty; } 2>/dev/null; then
-      if [ -t 3 ]; then
-          ATUIN_NON_INTERACTIVE=no
-      fi
-      exec 3<&-
+    if [ -t 3 ]; then
+        ATUIN_NON_INTERACTIVE=no
+    fi
+    exec 3<&-
   fi
 fi
 

--- a/install.sh
+++ b/install.sh
@@ -11,13 +11,13 @@ for arg in "$@"; do
 done
 
 if [ "$ATUIN_NON_INTERACTIVE" != "yes" ]; then
-  # Check if we have a usable interactive terminal.
-  # Using `true </dev/tty` is not sufficient: /dev/tty may exist as a device
-  # node that can be opened, but not actually be backed by a real terminal
-  # (e.g. in containers, CI, or headless environments). This causes the later
-  # `read </dev/tty` calls to fail or hang.
-  # Instead, open /dev/tty and verify it is a terminal with `test -t`.
-  if [ -t 0 ] || ( exec </dev/tty && [ -t 0 ] ) 2>/dev/null; then
+  # Every prompt below reads from /dev/tty, never stdin (stdin is the script
+  # itself under `curl | sh`), so /dev/tty is the only thing worth testing.
+  # Opening it is not enough: it may exist as a device node that opens fine
+  # but isn't backed by a real terminal (containers, CI, headless), so verify
+  # with `test -t`. The subshell keeps the redirect -- and a failing `exec`,
+  # which is a special built-in -- from affecting the parent shell.
+  if ( exec </dev/tty && [ -t 0 ] ) 2>/dev/null; then
     ATUIN_NON_INTERACTIVE="no"
   else
     ATUIN_NON_INTERACTIVE="yes"
@@ -176,7 +176,10 @@ else
 fi
 
 if [ "$ATUIN_NON_INTERACTIVE" != "yes" ]; then
-  "$ATUIN_BIN" setup </dev/tty
+  if ! "$ATUIN_BIN" setup </dev/tty; then
+    echo ""
+    echo "Setup did not complete. You can run 'atuin setup' any time to finish."
+  fi
 fi
 
 cat << EOF

--- a/install.sh
+++ b/install.sh
@@ -21,6 +21,12 @@ if [ "$ATUIN_NON_INTERACTIVE" != "yes" ]; then
     ATUIN_NON_INTERACTIVE="no"
   else
     ATUIN_NON_INTERACTIVE="yes"
+  ATUIN_NON_INTERACTIVE=yes
+  if { exec 3</dev/tty; } 2>/dev/null; then
+      if [ -t 3 ]; then
+          ATUIN_NON_INTERACTIVE=no
+      fi
+      exec 3<&-
   fi
 fi
 


### PR DESCRIPTION
follow-up to #3315.

the tty check there sits behind a `[ -t 0 ] ||` fast path, so it never runs when stdin is a tty but theres no controlling terminal. thats the container/ci case from #3294, so the bug is still reachable.

two changes:

1. drop the `[ -t 0 ]`. everything interactive in this script reads `/dev/tty`, not stdin (under `curl | sh` stdin is the script itself), so it was testing the wrong fd.
2. guard `atuin setup </dev/tty`. it was the only `/dev/tty` consumer without an `if !` wrapper, so under `set -eu` a failed redirect killed the script after the binary was already installed and ate the closing banner.

tested with stdin on a pty and no controlling terminal: before, it detects interactive and exits 1 before the banner. after, it detects non-interactive and exits 0. with a real controlling terminal (setsid + TIOCSCTTY) the interactive path is unchanged.

draft because i havent run shellcheck locally, leaving that to ci.
