### PR TITLE
chore(release): prepare for release 18.18.0-beta.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,76 @@
 
 All notable changes to this project will be documented in this file.
 
+## [unreleased]
+
+### Bug Fixes
+
+- *(daemon)* Index synced history directly instead of malformed SQL ([#3627](https://github.com/atuinsh/atuin/issues/3627)) ([#3641](https://github.com/atuinsh/atuin/issues/3641))
+- *(deps)* Update unsound/vulnerable dependencies in Cargo.lock ([#3632](https://github.com/atuinsh/atuin/issues/3632))
+- *(hook)* Drop agent commands containing NUL bytes via NonNulStr ([#3589](https://github.com/atuinsh/atuin/issues/3589)) ([#3660](https://github.com/atuinsh/atuin/issues/3660))
+- *(init)* Fix include guard in Bash init script; chore(init): improve inclusion of shell init scripts in Rust ([#3645](https://github.com/atuinsh/atuin/issues/3645))
+- Search functionality to respect character offsets and non-ASCII ([#3659](https://github.com/atuinsh/atuin/issues/3659))
+- Quote argument-hint YAML values so Copilot CLI ≥1.0.65 loads all skills ([#3613](https://github.com/atuinsh/atuin/issues/3613)) ([#3614](https://github.com/atuinsh/atuin/issues/3614))
+- Correct grammar in 'history last' help text ([#3430](https://github.com/atuinsh/atuin/issues/3430))
+- Work around rust nightly warning on eyre bail ([#3680](https://github.com/atuinsh/atuin/issues/3680))
+- Improve non-interactive TTY detection in install.sh ([#3315](https://github.com/atuinsh/atuin/issues/3315))
+- Add /model hint to status bar ([#3687](https://github.com/atuinsh/atuin/issues/3687))
+
+
+### Documentation
+
+- *(ai)* Add self hosting + slash command docs ([#3623](https://github.com/atuinsh/atuin/issues/3623))
+- *(config)* Standardize TOML examples for config options ([#3441](https://github.com/atuinsh/atuin/issues/3441))
+- Advise users to pass `--locked` when installing from Cargo ([#3630](https://github.com/atuinsh/atuin/issues/3630))
+- Add docs for store_failed and default for enter_accept ([#2696](https://github.com/atuinsh/atuin/issues/2696))
+- Serve docs.atuin.sh from this repo; remove Desktop docs ([#3684](https://github.com/atuinsh/atuin/issues/3684))
+- Version docs.atuin.sh with mike (per-release + main) ([#3688](https://github.com/atuinsh/atuin/issues/3688))
+- Hotfix bad path ([#3690](https://github.com/atuinsh/atuin/issues/3690))
+
+
+### Features
+
+- *(bash)* Bundle bash-preexec with Atuin; automatically load if no other preexec backend is loaded ([#3650](https://github.com/atuinsh/atuin/issues/3650))
+- *(search)* Add `--shell` option to `atuin search` to filter results by shell ([#3658](https://github.com/atuinsh/atuin/issues/3658))
+- *(string)* EllipsizeExt -- General-purpose utility for adding ellipses to strings ([#3639](https://github.com/atuinsh/atuin/issues/3639))
+- Add 'yolo' setting to Atuin AI options ([#3637](https://github.com/atuinsh/atuin/issues/3637))
+- Add `shell` field to history entries ([#3636](https://github.com/atuinsh/atuin/issues/3636))
+- Add hickory-dns resolver for musl target to improve DNS resolution ([#3647](https://github.com/atuinsh/atuin/issues/3647))
+- Add atuin stats --filter-mode ([#1737](https://github.com/atuinsh/atuin/issues/1737))
+- More aggressive optimizations for dist release ([#3683](https://github.com/atuinsh/atuin/issues/3683))
+
+
+### Miscellaneous Tasks
+
+- *(atuin-common)* Add ellipsize_or_pad for unicode pad ([#3663](https://github.com/atuinsh/atuin/issues/3663))
+- *(clap)* Simplify clap field types and fix help message formatting ([#3640](https://github.com/atuinsh/atuin/issues/3640))
+- *(logging)* Refactor logging ([#3622](https://github.com/atuinsh/atuin/issues/3622))
+- *(release-skill)* Time label-gated PR merges around the release ([#3654](https://github.com/atuinsh/atuin/issues/3654))
+- Remove fossier ([#3629](https://github.com/atuinsh/atuin/issues/3629))
+- Trigger docs repo deploy ([#3631](https://github.com/atuinsh/atuin/issues/3631))
+- Remove redundant test ([#3635](https://github.com/atuinsh/atuin/issues/3635))
+- Add `.editorconfig` and `.nvim.lua` ([#3648](https://github.com/atuinsh/atuin/issues/3648))
+- Clean up `WordJumper` in atuin/src/command/client/search/cursor.rs ([#3662](https://github.com/atuinsh/atuin/issues/3662))
+- Don't panic if clipboard cannot be accessed ([#2648](https://github.com/atuinsh/atuin/issues/2648))
+- Update some dependency versions ([#3666](https://github.com/atuinsh/atuin/issues/3666))
+- Update sqlx to v9 ([#3668](https://github.com/atuinsh/atuin/issues/3668))
+- Follow-up on #1737 ([#3649](https://github.com/atuinsh/atuin/issues/3649))
+- Update Atuin AI to eye-declare v0.6.1 ([#3686](https://github.com/atuinsh/atuin/issues/3686))
+
+
+### Refactor
+
+- *(hook)* Typed protocol for agent hook events ([#3638](https://github.com/atuinsh/atuin/issues/3638))
+- *(render)* Slightly nicer and more correct non-printable escaping ([#3633](https://github.com/atuinsh/atuin/issues/3633))
+- *(sync)* Remove deprecated V1 sync protocol ([#3634](https://github.com/atuinsh/atuin/issues/3634))
+- Use typed Url instead of hand-built string URLs ([#3644](https://github.com/atuinsh/atuin/issues/3644))
+- Extract shared vt100 logic into atuin-common ([#3664](https://github.com/atuinsh/atuin/issues/3664))
+
+
+### Testing
+
+- Parametrize tests with rstest across 8 crates ([#3653](https://github.com/atuinsh/atuin/issues/3653))
+
 ## 18.17.1
 
 ### Bug Fixes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -214,7 +214,7 @@ checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "atuin"
-version = "18.17.1"
+version = "18.18.0-beta.1"
 dependencies = [
  "arboard",
  "async-trait",
@@ -278,7 +278,7 @@ dependencies = [
 
 [[package]]
 name = "atuin-ai"
-version = "18.17.1"
+version = "18.18.0-beta.1"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -335,7 +335,7 @@ dependencies = [
 
 [[package]]
 name = "atuin-client"
-version = "18.17.1"
+version = "18.18.0-beta.1"
 dependencies = [
  "async-trait",
  "atuin-common",
@@ -390,7 +390,7 @@ dependencies = [
 
 [[package]]
 name = "atuin-common"
-version = "18.17.1"
+version = "18.18.0-beta.1"
 dependencies = [
  "base64",
  "derive_more",
@@ -420,7 +420,7 @@ dependencies = [
 
 [[package]]
 name = "atuin-daemon"
-version = "18.17.1"
+version = "18.18.0-beta.1"
 dependencies = [
  "atuin-client",
  "atuin-common",
@@ -456,7 +456,7 @@ dependencies = [
 
 [[package]]
 name = "atuin-dotfiles"
-version = "18.17.1"
+version = "18.18.0-beta.1"
 dependencies = [
  "atuin-client",
  "atuin-common",
@@ -473,7 +473,7 @@ dependencies = [
 
 [[package]]
 name = "atuin-history"
-version = "18.17.1"
+version = "18.18.0-beta.1"
 dependencies = [
  "atuin-client",
  "crossterm",
@@ -487,7 +487,7 @@ dependencies = [
 
 [[package]]
 name = "atuin-kv"
-version = "18.17.1"
+version = "18.18.0-beta.1"
 dependencies = [
  "atuin-client",
  "atuin-common",
@@ -531,7 +531,7 @@ dependencies = [
 
 [[package]]
 name = "atuin-pty-proxy"
-version = "18.17.1"
+version = "18.18.0-beta.1"
 dependencies = [
  "atuin-common",
  "clap",
@@ -545,7 +545,7 @@ dependencies = [
 
 [[package]]
 name = "atuin-scripts"
-version = "18.17.1"
+version = "18.18.0-beta.1"
 dependencies = [
  "atuin-client",
  "atuin-common",
@@ -568,7 +568,7 @@ dependencies = [
 
 [[package]]
 name = "atuin-server"
-version = "18.17.1"
+version = "18.18.0-beta.1"
 dependencies = [
  "argon2",
  "atuin-common",
@@ -595,7 +595,7 @@ dependencies = [
 
 [[package]]
 name = "atuin-server-database"
-version = "18.17.1"
+version = "18.18.0-beta.1"
 dependencies = [
  "async-trait",
  "atuin-common",
@@ -610,7 +610,7 @@ dependencies = [
 
 [[package]]
 name = "atuin-server-postgres"
-version = "18.17.1"
+version = "18.18.0-beta.1"
 dependencies = [
  "async-trait",
  "atuin-common",
@@ -628,7 +628,7 @@ dependencies = [
 
 [[package]]
 name = "atuin-server-sqlite"
-version = "18.17.1"
+version = "18.18.0-beta.1"
 dependencies = [
  "async-trait",
  "atuin-common",
@@ -5261,7 +5261,7 @@ dependencies = [
 
 [[package]]
 name = "tests-database"
-version = "18.17.1"
+version = "18.18.0-beta.1"
 dependencies = [
  "async-trait",
  "atuin-common",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ resolver = "2"
 exclude = ["ui/backend", "crates/atuin-nucleo/matcher/fuzz"]
 
 [workspace.package]
-version = "18.17.1"
+version = "18.18.0-beta.1"
 authors = ["Ellie Huxtable <ellie@atuin.sh>"]
 rust-version = "1.97.0"
 license = "MIT"
@@ -19,17 +19,17 @@ readme = "README.md"
 
 [workspace.dependencies]
 async-trait = "0.1.58"
-atuin-client = { path = "crates/atuin-client", version = "18.17.1" }
-atuin-common = { path = "crates/atuin-common", version = "18.17.1" }
-atuin-daemon = { path = "crates/atuin-daemon", version = "18.17.1" }
-atuin-dotfiles = { path = "crates/atuin-dotfiles", version = "18.17.1" }
-atuin-history = { path = "crates/atuin-history", version = "18.17.1" }
-atuin-kv = { path = "crates/atuin-kv", version = "18.17.1" }
-atuin-scripts = { path = "crates/atuin-scripts", version = "18.17.1" }
-atuin-server = { path = "crates/atuin-server", version = "18.17.1" }
-atuin-server-database = { path = "crates/atuin-server-database", version = "18.17.1" }
-atuin-server-postgres = { path = "crates/atuin-server-postgres", version = "18.17.1" }
-atuin-server-sqlite = { path = "crates/atuin-server-sqlite", version = "18.17.1" }
+atuin-client = { path = "crates/atuin-client", version = "18.18.0-beta.1" }
+atuin-common = { path = "crates/atuin-common", version = "18.18.0-beta.1" }
+atuin-daemon = { path = "crates/atuin-daemon", version = "18.18.0-beta.1" }
+atuin-dotfiles = { path = "crates/atuin-dotfiles", version = "18.18.0-beta.1" }
+atuin-history = { path = "crates/atuin-history", version = "18.18.0-beta.1" }
+atuin-kv = { path = "crates/atuin-kv", version = "18.18.0-beta.1" }
+atuin-scripts = { path = "crates/atuin-scripts", version = "18.18.0-beta.1" }
+atuin-server = { path = "crates/atuin-server", version = "18.18.0-beta.1" }
+atuin-server-database = { path = "crates/atuin-server-database", version = "18.18.0-beta.1" }
+atuin-server-postgres = { path = "crates/atuin-server-postgres", version = "18.18.0-beta.1" }
+atuin-server-sqlite = { path = "crates/atuin-server-sqlite", version = "18.18.0-beta.1" }
 atuin-nucleo = { path = "crates/atuin-nucleo", version = "0.6.0" }
 atuin-nucleo-matcher = { path = "crates/atuin-nucleo/matcher", version = "0.3.1" }
 base64 = "0.22"

--- a/crates/atuin-client/Cargo.toml
+++ b/crates/atuin-client/Cargo.toml
@@ -77,7 +77,7 @@ strum = { version = "0.27", features = ["strum_macros"] }
 
 [dependencies.atuin-common]
 path = "../atuin-common"
-version = "18.17.1"
+version = "18.18.0-beta.1"
 features = ["tracing"]
 
 [dev-dependencies]
@@ -90,7 +90,7 @@ tempfile = "3"
 # This crate's tests require the `test-utils` feature in atuin-common.
 [dev-dependencies.atuin-common]
 path = "../atuin-common"
-version = "18.17.1"
+version = "18.18.0-beta.1"
 features = ["test-utils"]
 
 [[bench]]

--- a/crates/atuin-daemon/Cargo.toml
+++ b/crates/atuin-daemon/Cargo.toml
@@ -14,11 +14,11 @@ readme.workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-atuin-client = { path = "../atuin-client", version = "18.17.1" }
-atuin-common = { path = "../atuin-common", version = "18.17.1" }
+atuin-client = { path = "../atuin-client", version = "18.18.0-beta.1" }
+atuin-common = { path = "../atuin-common", version = "18.18.0-beta.1" }
 derive_more = { workspace = true }
-atuin-dotfiles = { path = "../atuin-dotfiles", version = "18.17.1" }
-atuin-history = { path = "../atuin-history", version = "18.17.1" }
+atuin-dotfiles = { path = "../atuin-dotfiles", version = "18.18.0-beta.1" }
+atuin-history = { path = "../atuin-history", version = "18.18.0-beta.1" }
 
 time = { workspace = true }
 uuid = { workspace = true }

--- a/crates/atuin-dotfiles/Cargo.toml
+++ b/crates/atuin-dotfiles/Cargo.toml
@@ -14,8 +14,8 @@ readme.workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-atuin-common = { path = "../atuin-common", version = "18.17.1" }
-atuin-client = { path = "../atuin-client", version = "18.17.1" }
+atuin-common = { path = "../atuin-common", version = "18.18.0-beta.1" }
+atuin-client = { path = "../atuin-client", version = "18.18.0-beta.1" }
 derive_more = { workspace = true }
 
 eyre = { workspace = true }

--- a/crates/atuin-history/Cargo.toml
+++ b/crates/atuin-history/Cargo.toml
@@ -14,7 +14,7 @@ readme.workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-atuin-client = { path = "../atuin-client", version = "18.17.1" }
+atuin-client = { path = "../atuin-client", version = "18.18.0-beta.1" }
 
 time = { workspace = true }
 serde = { workspace = true }

--- a/crates/atuin-kv/Cargo.toml
+++ b/crates/atuin-kv/Cargo.toml
@@ -14,8 +14,8 @@ readme.workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-atuin-client = { path = "../atuin-client", version = "18.17.1" }
-atuin-common = { path = "../atuin-common", version = "18.17.1" }
+atuin-client = { path = "../atuin-client", version = "18.18.0-beta.1" }
+atuin-common = { path = "../atuin-common", version = "18.18.0-beta.1" }
 derive_more = { workspace = true }
 
 tracing = { workspace = true }

--- a/crates/atuin-scripts/Cargo.toml
+++ b/crates/atuin-scripts/Cargo.toml
@@ -14,8 +14,8 @@ readme.workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-atuin-client = { path = "../atuin-client", version = "18.17.1" }
-atuin-common = { path = "../atuin-common", version = "18.17.1" }
+atuin-client = { path = "../atuin-client", version = "18.18.0-beta.1" }
+atuin-common = { path = "../atuin-common", version = "18.18.0-beta.1" }
 derive_more = { workspace = true }
 
 tracing = { workspace = true }

--- a/crates/atuin-server-database/Cargo.toml
+++ b/crates/atuin-server-database/Cargo.toml
@@ -10,7 +10,7 @@ homepage = { workspace = true }
 repository = { workspace = true }
 
 [dependencies]
-atuin-common = { path = "../atuin-common", version = "18.17.1" }
+atuin-common = { path = "../atuin-common", version = "18.18.0-beta.1" }
 derive_more = { workspace = true }
 
 async-trait = { workspace = true }

--- a/crates/atuin-server-postgres/Cargo.toml
+++ b/crates/atuin-server-postgres/Cargo.toml
@@ -10,8 +10,8 @@ homepage = { workspace = true }
 repository = { workspace = true }
 
 [dependencies]
-atuin-common = { path = "../atuin-common", version = "18.17.1" }
-atuin-server-database = { path = "../atuin-server-database", version = "18.17.1" }
+atuin-common = { path = "../atuin-common", version = "18.18.0-beta.1" }
+atuin-server-database = { path = "../atuin-server-database", version = "18.18.0-beta.1" }
 derive_more = { workspace = true }
 
 eyre = { workspace = true }

--- a/crates/atuin-server-sqlite/Cargo.toml
+++ b/crates/atuin-server-sqlite/Cargo.toml
@@ -10,8 +10,8 @@ homepage = { workspace = true }
 repository = { workspace = true }
 
 [dependencies]
-atuin-common = { path = "../atuin-common", version = "18.17.1" }
-atuin-server-database = { path = "../atuin-server-database", version = "18.17.1" }
+atuin-common = { path = "../atuin-common", version = "18.18.0-beta.1" }
+atuin-server-database = { path = "../atuin-server-database", version = "18.18.0-beta.1" }
 derive_more = { workspace = true }
 
 eyre = { workspace = true }

--- a/crates/atuin/Cargo.toml
+++ b/crates/atuin/Cargo.toml
@@ -44,13 +44,13 @@ clipboard = ["arboard"]
 check-update = ["atuin-client/check-update"]
 
 [dependencies]
-atuin-ai = { path = "../atuin-ai", version = "18.17.1", optional = true, default-features = false }
-atuin-client = { path = "../atuin-client", version = "18.17.1", optional = true, default-features = false }
+atuin-ai = { path = "../atuin-ai", version = "18.18.0-beta.1", optional = true, default-features = false }
+atuin-client = { path = "../atuin-client", version = "18.18.0-beta.1", optional = true, default-features = false }
 atuin-common = { workspace = true, features = ["tracing", "unicode"] }
 atuin-dotfiles = { workspace = true }
 atuin-history = { workspace = true }
-atuin-daemon = { path = "../atuin-daemon", version = "18.17.1", optional = true, default-features = false }
-atuin-pty-proxy = { path = "../atuin-pty-proxy", version = "18.17.1", optional = true, default-features = false }
+atuin-daemon = { path = "../atuin-daemon", version = "18.18.0-beta.1", optional = true, default-features = false }
+atuin-pty-proxy = { path = "../atuin-pty-proxy", version = "18.18.0-beta.1", optional = true, default-features = false }
 atuin-scripts = { workspace = true }
 atuin-kv = { workspace = true }
 derive_more = { workspace = true }
@@ -112,7 +112,7 @@ daemonize = "0.5.0"
 # compiles cleanly. tree-sitter 0.26's portable/endian.h fails on illumos,
 # Windows cross-compiles, and potentially other exotic targets.
 [target.'cfg(any(target_os = "linux", target_os = "macos"))'.dependencies]
-atuin-ai = { path = "../atuin-ai", version = "18.17.1", optional = true, default-features = false, features = ["tree-sitter"] }
+atuin-ai = { path = "../atuin-ai", version = "18.18.0-beta.1", optional = true, default-features = false, features = ["tree-sitter"] }
 
 [target.'cfg(windows)'.dependencies]
 windows-sys = { version = "0.61.2", features = ["Win32_System_Console"] }


### PR DESCRIPTION
### Bug Fixes

- *(daemon)* Index synced history directly instead of malformed SQL ([#3627](https://github.com/atuinsh/atuin/issues/3627)) ([#3641](https://github.com/atuinsh/atuin/issues/3641))
- *(deps)* Update unsound/vulnerable dependencies in Cargo.lock ([#3632](https://github.com/atuinsh/atuin/issues/3632))
- *(hook)* Drop agent commands containing NUL bytes via NonNulStr ([#3589](https://github.com/atuinsh/atuin/issues/3589)) ([#3660](https://github.com/atuinsh/atuin/issues/3660))
- *(init)* Fix include guard in Bash init script; chore(init): improve inclusion of shell init scripts in Rust ([#3645](https://github.com/atuinsh/atuin/issues/3645))
- Search functionality to respect character offsets and non-ASCII ([#3659](https://github.com/atuinsh/atuin/issues/3659))
- Quote argument-hint YAML values so Copilot CLI ≥1.0.65 loads all skills ([#3613](https://github.com/atuinsh/atuin/issues/3613)) ([#3614](https://github.com/atuinsh/atuin/issues/3614))
- Correct grammar in 'history last' help text ([#3430](https://github.com/atuinsh/atuin/issues/3430))
- Work around rust nightly warning on eyre bail ([#3680](https://github.com/atuinsh/atuin/issues/3680))
- Improve non-interactive TTY detection in install.sh ([#3315](https://github.com/atuinsh/atuin/issues/3315))
- Add /model hint to status bar ([#3687](https://github.com/atuinsh/atuin/issues/3687))


### Documentation

- *(ai)* Add self hosting + slash command docs ([#3623](https://github.com/atuinsh/atuin/issues/3623))
- *(config)* Standardize TOML examples for config options ([#3441](https://github.com/atuinsh/atuin/issues/3441))
- Advise users to pass `--locked` when installing from Cargo ([#3630](https://github.com/atuinsh/atuin/issues/3630))
- Add docs for store_failed and default for enter_accept ([#2696](https://github.com/atuinsh/atuin/issues/2696))
- Serve docs.atuin.sh from this repo; remove Desktop docs ([#3684](https://github.com/atuinsh/atuin/issues/3684))
- Version docs.atuin.sh with mike (per-release + main) ([#3688](https://github.com/atuinsh/atuin/issues/3688))
- Hotfix bad path ([#3690](https://github.com/atuinsh/atuin/issues/3690))


### Features

- *(bash)* Bundle bash-preexec with Atuin; automatically load if no other preexec backend is loaded ([#3650](https://github.com/atuinsh/atuin/issues/3650))
- *(search)* Add `--shell` option to `atuin search` to filter results by shell ([#3658](https://github.com/atuinsh/atuin/issues/3658))
- *(string)* EllipsizeExt -- General-purpose utility for adding ellipses to strings ([#3639](https://github.com/atuinsh/atuin/issues/3639))
- Add 'yolo' setting to Atuin AI options ([#3637](https://github.com/atuinsh/atuin/issues/3637))
- Add `shell` field to history entries ([#3636](https://github.com/atuinsh/atuin/issues/3636))
- Add hickory-dns resolver for musl target to improve DNS resolution ([#3647](https://github.com/atuinsh/atuin/issues/3647))
- Add atuin stats --filter-mode ([#1737](https://github.com/atuinsh/atuin/issues/1737))
- More aggressive optimizations for dist release ([#3683](https://github.com/atuinsh/atuin/issues/3683))


### Miscellaneous Tasks

- *(atuin-common)* Add ellipsize_or_pad for unicode pad ([#3663](https://github.com/atuinsh/atuin/issues/3663))
- *(clap)* Simplify clap field types and fix help message formatting ([#3640](https://github.com/atuinsh/atuin/issues/3640))
- *(logging)* Refactor logging ([#3622](https://github.com/atuinsh/atuin/issues/3622))
- *(release-skill)* Time label-gated PR merges around the release ([#3654](https://github.com/atuinsh/atuin/issues/3654))
- Remove fossier ([#3629](https://github.com/atuinsh/atuin/issues/3629))
- Trigger docs repo deploy ([#3631](https://github.com/atuinsh/atuin/issues/3631))
- Remove redundant test ([#3635](https://github.com/atuinsh/atuin/issues/3635))
- Add `.editorconfig` and `.nvim.lua` ([#3648](https://github.com/atuinsh/atuin/issues/3648))
- Clean up `WordJumper` in atuin/src/command/client/search/cursor.rs ([#3662](https://github.com/atuinsh/atuin/issues/3662))
- Don't panic if clipboard cannot be accessed ([#2648](https://github.com/atuinsh/atuin/issues/2648))
- Update some dependency versions ([#3666](https://github.com/atuinsh/atuin/issues/3666))
- Update sqlx to v9 ([#3668](https://github.com/atuinsh/atuin/issues/3668))
- Follow-up on #1737 ([#3649](https://github.com/atuinsh/atuin/issues/3649))
- Update Atuin AI to eye-declare v0.6.1 ([#3686](https://github.com/atuinsh/atuin/issues/3686))


### Refactor

- *(hook)* Typed protocol for agent hook events ([#3638](https://github.com/atuinsh/atuin/issues/3638))
- *(render)* Slightly nicer and more correct non-printable escaping ([#3633](https://github.com/atuinsh/atuin/issues/3633))
- *(sync)* Remove deprecated V1 sync protocol ([#3634](https://github.com/atuinsh/atuin/issues/3634))
- Use typed Url instead of hand-built string URLs ([#3644](https://github.com/atuinsh/atuin/issues/3644))
- Extract shared vt100 logic into atuin-common ([#3664](https://github.com/atuinsh/atuin/issues/3664))


### Testing

- Parametrize tests with rstest across 8 crates ([#3653](https://github.com/atuinsh/atuin/issues/3653))
