### PR TITLE
docs: Fix broken README links

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,10 +63,10 @@ I wanted to. And I **really** don't want to.
 ## Documentation
 
 - [Quickstart](#quickstart)
-- [Install](https://docs.atuin.sh/guide/installation/)
-- [Setting up sync](https://docs.atuin.sh/guide/sync/)
-- [Import history](https://docs.atuin.sh/guide/import/)
-- [Basic usage](https://docs.atuin.sh/guide/basic-usage/)
+- [Install](https://docs.atuin.sh/latest/guide/installation/)
+- [Setting up sync](https://docs.atuin.sh/latest/guide/sync/)
+- [Import history](https://docs.atuin.sh/latest/guide/import/)
+- [Basic usage](https://docs.atuin.sh/latest/guide/basic-usage/)
 
 ## Supported Shells
 
@@ -111,7 +111,7 @@ Then restart your shell!
 >
 > **For Bash users**: The above sets up `bash-preexec` for necessary hooks, but
 > `bash-preexec` has limitations. For details, please see the
-> [Bash](https://docs.atuin.sh/guide/installation/#installing-the-shell-plugin)
+> [Bash](https://docs.atuin.sh/latest/guide/installation/#installing-the-shell-plugin)
 > section of the shell plugin documentation.
 
 # Security


### PR DESCRIPTION
The atuin.sh docs links lead to a 404 because of a missing /latest/ url part

## Checks
- [x] I am happy for maintainers to push small adjustments to this PR, to speed up the review cycle
- [ ] I have checked that there are no existing pull requests for the same thing
