### PR TITLE
docs(stats): document period shortcuts and rolling windows

### DIFF
--- a/docs/docs/reference/stats.md
+++ b/docs/docs/reference/stats.md
@@ -3,11 +3,39 @@
 Atuin can also calculate stats based on your history - this is currently a
 little basic, but more features to come.
 
-## 1-day stats
+The optional `[PERIOD]...` argument selects the time range. Leave it blank (or
+pass `all`) for your entire history. Built-in shortcuts and free-form dates are
+described below.
 
-You provide the starting point, and Atuin computes the stats for 24h from that point.
-Date parsing is provided by `interim`, which supports different formats
-for full or relative dates. Certain formats rely on the dialect option in your
+## Period shortcuts
+
+These single-word values are recognized by `atuin stats` (matched after joining
+the period arguments into one string):
+
+| Period | Range |
+|--------|--------|
+| *(empty)* / `all` | Entire history |
+| `today` | From local midnight today to midnight tomorrow |
+| `week` | Rolling last 7 days, ending at local midnight today |
+| `month` | Rolling last 31 days, ending at local midnight today |
+| `year` | Rolling last 365 days, ending at local midnight today |
+
+```
+$ atuin stats today
+$ atuin stats week
+$ atuin stats month
+$ atuin stats year
+```
+
+`week` / `month` / `year` are rolling windows, not calendar weeks, months, or
+years. For example, `month` is the previous 31 days before today's midnight —
+not "the current calendar month."
+
+## Single-day stats (parsed dates)
+
+Any other period string is parsed as a start time with `interim`. Stats cover
+**24 hours from that start** (not the whole named calendar unit). Certain
+formats rely on the dialect option in your
 [configuration](../configuration/config.md#dialect) to differentiate day from month.
 Refer to [the module's documentation](https://docs.rs/interim/0.1.0/interim/#supported-formats) for more details on the supported date formats.
 
@@ -30,6 +58,12 @@ $ atuin stats April 1
 $ atuin stats 01/04/22
 $ atuin stats last thursday 3pm  # between last thursday 3:00pm and the following friday 3:00pm
 ```
+
+!!! note
+    A bare month name such as `june` is treated as a single date (typically the
+    1st of June in the current/previous year per `interim`), then expanded to a
+    24-hour window — **not** the whole of June. Prefer `month` for a rolling
+    31-day window, or pass an explicit date range start.
 
 ## Full history stats
 


### PR DESCRIPTION
## Summary

- Document the `today` / `week` / `month` / `year` period shortcuts for `atuin stats`.
- Clarify that free-form `interim` dates are 24h windows (e.g. `june` ≠ all of June), and that week/month/year are rolling, not calendar units.

## Motivation

Closes #1068.

`atuin stats --help` only says "compute statistics for the specified period". The docs covered free-form dates and full history, but not the built-in shortcuts that already exist in `crates/atuin/src/command/client/stats.rs`.

## Verification

- Matched wording to `stats.rs` range logic (`today` → midnight..+1d; `week`/`month`/`year` → rolling 7/31/365 ending at local midnight; else `interim` + 1 day).
- Docs-only; no code/runtime change.

## Checklist

- [x] I am happy for maintainers to push small adjustments to this PR
- [x] I have checked that there are no existing pull requests for the same thing

---
<!-- fleet-pr-claim: agent_id=sera platform=hermes -->
**Agent-Owner:** `sera` · **Platform:** hermes · **Claim-TTL:** 24h
