### PR TITLE
fix: set correct umask for pty-proxy

### DIFF
--- a/crates/atuin-pty-proxy/src/pty_proxy.rs
+++ b/crates/atuin-pty-proxy/src/pty_proxy.rs
@@ -50,6 +50,7 @@ pub(crate) struct RuntimeOptions {
     pub(crate) debug_osc133: bool,
     pub(crate) shell: Option<PathBuf>,
     pub(crate) command_capture_sink: Option<CommandCaptureSink>,
+    pub(crate) child_umask: Option<u32>,
 }
 
 impl RuntimeOptions {
@@ -57,17 +58,22 @@ impl RuntimeOptions {
         debug_osc133: bool,
         shell: Option<PathBuf>,
         command_capture_sink: Option<CommandCaptureSink>,
+        child_umask: Option<u32>,
     ) -> Self {
         Self {
             debug_osc133: debug_osc133 || env_flag("ATUIN_PTY_PROXY_DEBUG"),
             shell,
             command_capture_sink,
+            child_umask,
         }
     }
 }
 
 impl PtyProxy {
-    pub fn run(self, command_capture_sink: Option<CommandCaptureSink>) {
+    /// `child_umask` is the umask to restore in the spawned shell. Atuin sets
+    /// a restrictive process-wide umask early in startup, which the shell
+    /// would otherwise inherit (#3695).
+    pub fn run(self, command_capture_sink: Option<CommandCaptureSink>, child_umask: Option<u32>) {
         if self.cmd.is_some() && self.shell.is_some() {
             eprintln!("atuin pty-proxy: --shell only applies when no subcommand is given");
             std::process::exit(2);
@@ -83,6 +89,7 @@ impl PtyProxy {
                 self.debug_osc133,
                 self.shell,
                 command_capture_sink,
+                child_umask,
             )),
         }
     }

--- a/crates/atuin-pty-proxy/src/runtime.rs
+++ b/crates/atuin-pty-proxy/src/runtime.rs
@@ -49,6 +49,13 @@ fn run(options: RuntimeOptions) -> eyre::Result<()> {
     }
     cmd.env("ATUIN_PTY_PROXY_SOCKET", sock_path.as_os_str());
     cmd.env("ATUIN_PTY_PROXY_ACTIVE", "1");
+    // Atuin sets a restrictive process-wide umask on startup to protect the
+    // files it creates. The shell must not inherit it (#3695) — restore the
+    // umask the user launched us with. Applied in the child between fork and
+    // exec, so the proxy's own umask stays restrictive.
+    if let Some(mask) = options.child_umask {
+        cmd.umask(Some(mask as _));
+    }
 
     let mut child = pair
         .slave

--- a/crates/atuin/src/command/mod.rs
+++ b/crates/atuin/src/command/mod.rs
@@ -41,13 +41,12 @@ pub enum AtuinCmd {
 
 impl AtuinCmd {
     pub fn run(self) -> Result<()> {
+        // set umask before we potentially open/create files
+        // or in other words, 077. Do not allow any access to any other user.
+        // Keep the previous umask so pty-proxy can restore it in the shell it
+        // spawns — the shell must not inherit ours (#3695).
         #[cfg(not(windows))]
-        {
-            // set umask before we potentially open/create files
-            // or in other words, 077. Do not allow any access to any other user
-            let mode = Mode::RWXG | Mode::RWXO;
-            umask(mode);
-        }
+        let prev_umask = umask(Mode::RWXG | Mode::RWXO);
 
         match self {
             // Client commands initialize their own logging
@@ -62,6 +61,9 @@ impl AtuinCmd {
 
             #[cfg(feature = "pty-proxy")]
             Self::PtyProxy(proxy) => {
+                #[cfg(unix)]
+                run_pty_proxy(proxy, prev_umask);
+                #[cfg(not(unix))]
                 run_pty_proxy(proxy);
                 Ok(())
             }
@@ -81,12 +83,14 @@ impl AtuinCmd {
 }
 
 #[cfg(all(feature = "pty-proxy", unix))]
-fn run_pty_proxy(proxy: atuin_pty_proxy::PtyProxy) {
+fn run_pty_proxy(proxy: atuin_pty_proxy::PtyProxy, prev_umask: Mode) {
+    let child_umask = Some(u32::from(prev_umask.bits()));
+
     #[cfg(feature = "daemon")]
-    proxy.run(semantic_command_capture_sink());
+    proxy.run(semantic_command_capture_sink(), child_umask);
 
     #[cfg(not(feature = "daemon"))]
-    proxy.run(None);
+    proxy.run(None, child_umask);
 }
 
 #[cfg(all(feature = "pty-proxy", not(unix)))]

--- a/crates/atuin/src/command/mod.rs
+++ b/crates/atuin/src/command/mod.rs
@@ -59,13 +59,16 @@ impl AtuinCmd {
             #[cfg(feature = "client")]
             Self::Client(client) => client.run(),
 
-            #[cfg(feature = "pty-proxy")]
+            #[cfg(all(feature = "pty-proxy", unix))]
             Self::PtyProxy(proxy) => {
-                #[cfg(unix)]
                 run_pty_proxy(proxy, prev_umask);
-                #[cfg(not(unix))]
-                run_pty_proxy(proxy);
                 Ok(())
+            }
+
+            #[cfg(all(feature = "pty-proxy", not(unix)))]
+            Self::PtyProxy(_) => {
+                eprintln!("atuin pty-proxy currently supports unix platforms");
+                std::process::exit(1);
             }
 
             Self::Contributors => {
@@ -91,12 +94,6 @@ fn run_pty_proxy(proxy: atuin_pty_proxy::PtyProxy, prev_umask: Mode) {
 
     #[cfg(not(feature = "daemon"))]
     proxy.run(None, child_umask);
-}
-
-#[cfg(all(feature = "pty-proxy", not(unix)))]
-fn run_pty_proxy(_proxy: atuin_pty_proxy::PtyProxy) {
-    eprintln!("atuin pty-proxy currently supports unix platforms");
-    std::process::exit(1);
 }
 
 #[cfg(all(feature = "daemon", feature = "pty-proxy", unix))]

--- a/crates/atuin/src/command/mod.rs
+++ b/crates/atuin/src/command/mod.rs
@@ -87,6 +87,9 @@ impl AtuinCmd {
 
 #[cfg(all(feature = "pty-proxy", unix))]
 fn run_pty_proxy(proxy: atuin_pty_proxy::PtyProxy, prev_umask: Mode) {
+    // `Mode::bits()` returns u16 on macOS/BSD but u32 on Linux, where this
+    // conversion is a no-op.
+    #[allow(clippy::useless_conversion)]
     let child_umask = Some(u32::from(prev_umask.bits()));
 
     #[cfg(feature = "daemon")]


### PR DESCRIPTION
Atuin sets umask 0077 early on in the process start, which is great for most of what the cli does.

However, in the case of the cli proxy, this ends up being over-restrictive and can cause issues with newly created files.

Resolves #3695

<!-- Thank you for making a PR! Bug fixes are always welcome, but if you're adding a new feature or changing an existing one, we'd really appreciate if you open an issue, post on the forum, or drop in on Discord -->

## Checks
- [ ] I am happy for maintainers to push small adjustments to this PR, to speed up the review cycle
- [ ] I have checked that there are no existing pull requests for the same thing
