### PR TITLE
ci: preview environments for docs pull requests

### DIFF
--- a/.github/workflows/docs-preview-build.yml
+++ b/.github/workflows/docs-preview-build.yml
@@ -1,0 +1,73 @@
+name: Docs preview (build)
+
+# Half one of a two-workflow preview deployment.
+#
+# This half builds the docs from the pull request and uploads the result as an
+# artifact. It runs UNTRUSTED code -- the PR owns docs/mkdocs.yml, and mkdocs
+# plugins execute arbitrary Python at build time -- so it deliberately holds no
+# secrets and no write permissions. The deploy half
+# (docs-preview-deploy.yml) picks the artifact up.
+#
+# Do NOT be tempted to merge these into one workflow using
+# `pull_request_target` to get at the deploy credentials. That trigger runs
+# with secrets against the pull request's own code, so any fork could ship a
+# mkdocs plugin that exfiltrates the Cloudflare token.
+
+on:
+  pull_request:
+    paths:
+      - "docs/**"
+      - ".github/workflows/docs-preview-build.yml"
+      - ".github/workflows/docs-preview-deploy.yml"
+      - ".github/actions/docs-setup/**"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: docs-preview-build-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    name: Build docs
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout pull request
+        uses: actions/checkout@v7
+        with:
+          # git-revision-date-localized reads the commit history to date each
+          # page; a shallow clone makes every page show the same date.
+          fetch-depth: 0
+
+      - uses: ./.github/actions/docs-setup
+
+      # --strict turns warnings into failures, which is what makes this a gate
+      # rather than decoration. It catches broken internal links and, thanks to
+      # `validation.anchors` in mkdocs.yml, deep-links to a #section that no
+      # longer exists. mkdocs.yml keeps those at `warn` so `mkdocs serve` stays
+      # usable locally; CI is where they should stop a merge.
+      - name: Build
+        working-directory: docs
+        run: uv run mkdocs build --strict --site-dir "${GITHUB_WORKSPACE}/site"
+
+      # The deploy half cannot reliably read the PR number off a workflow_run
+      # event for fork pull requests, so pass it explicitly.
+      - name: Record pull request number
+        run: |
+          mkdir -p meta
+          echo "${{ github.event.pull_request.number }}" > meta/pr-number
+
+      - name: Upload site
+        uses: actions/upload-artifact@v7
+        with:
+          name: docs-preview-site
+          path: site/
+          retention-days: 3
+
+      - name: Upload metadata
+        uses: actions/upload-artifact@v7
+        with:
+          name: docs-preview-meta
+          path: meta/
+          retention-days: 3

--- a/.github/workflows/docs-preview-build.yml
+++ b/.github/workflows/docs-preview-build.yml
@@ -39,6 +39,10 @@ jobs:
           # git-revision-date-localized reads the commit history to date each
           # page; a shallow clone makes every page show the same date.
           fetch-depth: 0
+          # This job runs untrusted code. The token is read-only, so leaking it
+          # gains an attacker nothing on a public repo, but there is no reason
+          # to leave it in .git/config where build tooling could reach it.
+          persist-credentials: false
 
       - uses: ./.github/actions/docs-setup
 
@@ -51,23 +55,9 @@ jobs:
         working-directory: docs
         run: uv run mkdocs build --strict --site-dir "${GITHUB_WORKSPACE}/site"
 
-      # The deploy half cannot reliably read the PR number off a workflow_run
-      # event for fork pull requests, so pass it explicitly.
-      - name: Record pull request number
-        run: |
-          mkdir -p meta
-          echo "${{ github.event.pull_request.number }}" > meta/pr-number
-
       - name: Upload site
         uses: actions/upload-artifact@v7
         with:
           name: docs-preview-site
           path: site/
-          retention-days: 3
-
-      - name: Upload metadata
-        uses: actions/upload-artifact@v7
-        with:
-          name: docs-preview-meta
-          path: meta/
           retention-days: 3

--- a/.github/workflows/docs-preview-deploy.yml
+++ b/.github/workflows/docs-preview-deploy.yml
@@ -42,21 +42,34 @@ jobs:
           run-id: ${{ github.event.workflow_run.id }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Download metadata
-        uses: actions/download-artifact@v8
-        with:
-          name: docs-preview-meta
-          path: meta
-          run-id: ${{ github.event.workflow_run.id }}
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Read pull request number
+      # The pull request number is derived from the head SHA on the trusted
+      # `workflow_run` event, NOT from the build artifact.
+      #
+      # This matters. The build job runs the pull request's own code, so it
+      # controls everything it uploads. An earlier version of this workflow
+      # read the number out of the artifact, which let a fork claim to be any
+      # pull request it liked -- and since this job holds `pull-requests:
+      # write`, that meant a github-actions[bot] comment linking to
+      # attacker-controlled content could be planted on ANY issue in the repo.
+      #
+      # `github.event.workflow_run.pull_requests` is empty for forks, which is
+      # what tempted the artifact in the first place; asking the API which pull
+      # request owns the head SHA works for forks and cannot be influenced by
+      # the build.
+      - name: Resolve the pull request
         id: pr
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SHA: ${{ github.event.workflow_run.head_sha }}
         run: |
           set -euo pipefail
-          number="$(tr -dc '0-9' < meta/pr-number)"
+          number="$(gh api "repos/${GITHUB_REPOSITORY}/commits/${SHA}/pulls" \
+            --jq 'map(select(.state == "open")) | .[0].number // empty')"
+          # Belt and braces: the API returns an integer, but this value reaches
+          # a shell command line and a GITHUB_OUTPUT write.
+          number="$(printf '%s' "$number" | tr -dc '0-9')"
           if [ -z "$number" ]; then
-            echo "::error::no pull request number in the build artifact"
+            echo "::error::no open pull request found for ${SHA}"
             exit 1
           fi
           echo "number=${number}" >> "$GITHUB_OUTPUT"
@@ -67,7 +80,12 @@ jobs:
       # deployment, so this never touches production.
       - name: Deploy to Cloudflare Pages
         id: deploy
-        uses: cloudflare/wrangler-action@v3
+        # Pinned to a commit rather than a tag: this is the only third-party
+        # action in the repo that receives credentials (the Cloudflare token
+        # and GITHUB_TOKEN), and a tag can be repointed. v3 was stale -- v4.0.0
+        # shipped 2026-05-12; its only breaking change is the default Wrangler
+        # version, so inputs and outputs are unchanged.
+        uses: cloudflare/wrangler-action@ebbaa1584979971c8614a24965b4405ff95890e0 # v4.0.0
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}

--- a/.github/workflows/docs-preview-deploy.yml
+++ b/.github/workflows/docs-preview-deploy.yml
@@ -1,0 +1,111 @@
+name: Docs preview (deploy)
+
+# Half two of a two-workflow preview deployment.
+#
+# `workflow_run` runs the copy of this file on the DEFAULT BRANCH, not the copy
+# in the pull request, so holding secrets here is safe even when the build half
+# was triggered by a fork. This workflow never checks out pull request code --
+# it only downloads the already-built static site and hands it to Cloudflare.
+#
+# The artifact itself is still untrusted content: it is attacker-influenced
+# HTML and JavaScript. That is inherent to preview deployments. It is contained
+# by deploying to a dedicated Pages project on a *.pages.dev domain, never to
+# docs.atuin.sh.
+
+on:
+  workflow_run:
+    workflows: ["Docs preview (build)"]
+    types: [completed]
+
+permissions:
+  contents: read
+  actions: read # download artifacts from the triggering run
+  deployments: write # record the Cloudflare deployment
+  pull-requests: write # post the preview link
+
+concurrency:
+  group: docs-preview-deploy-${{ github.event.workflow_run.id }}
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    name: Deploy preview
+    # A failed build has nothing worth publishing.
+    if: github.event.workflow_run.conclusion == 'success'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download site
+        uses: actions/download-artifact@v8
+        with:
+          name: docs-preview-site
+          path: site
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Download metadata
+        uses: actions/download-artifact@v8
+        with:
+          name: docs-preview-meta
+          path: meta
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Read pull request number
+        id: pr
+        run: |
+          set -euo pipefail
+          number="$(tr -dc '0-9' < meta/pr-number)"
+          if [ -z "$number" ]; then
+            echo "::error::no pull request number in the build artifact"
+            exit 1
+          fi
+          echo "number=${number}" >> "$GITHUB_OUTPUT"
+
+      # --branch gives each pull request a stable preview alias, so pushing
+      # again reuses the same URL instead of minting a new one every time.
+      # Anything other than the project's production branch is a preview
+      # deployment, so this never touches production.
+      - name: Deploy to Cloudflare Pages
+        id: deploy
+        uses: cloudflare/wrangler-action@v3
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          gitHubToken: ${{ secrets.GITHUB_TOKEN }}
+          command: >-
+            pages deploy site
+            --project-name=atuin-docs-preview
+            --branch=pr-${{ steps.pr.outputs.number }}
+
+      # Upsert a single comment rather than adding one per push. Uses `gh api`
+      # instead of a third-party action to keep the credentialed workflow's
+      # dependency surface small.
+      - name: Comment the preview link
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR: ${{ steps.pr.outputs.number }}
+          URL: ${{ steps.deploy.outputs.pages-deployment-alias-url || steps.deploy.outputs.deployment-url }}
+          SHA: ${{ github.event.workflow_run.head_sha }}
+        run: |
+          set -euo pipefail
+          marker="<!-- atuin-docs-preview -->"
+          body="${marker}
+          **Docs preview** — [\`${SHA:0:7}\`](${URL})
+
+          ${URL}
+
+          Built with \`mkdocs build --strict\`, so a broken link or a dead
+          \`#anchor\` fails this check rather than shipping."
+
+          existing="$(gh api "repos/${GITHUB_REPOSITORY}/issues/${PR}/comments" \
+            --paginate --jq "map(select(.body | startswith(\"${marker}\"))) | .[0].id // empty")"
+
+          if [ -n "$existing" ]; then
+            gh api --method PATCH "repos/${GITHUB_REPOSITORY}/issues/comments/${existing}" \
+              -f body="$body" >/dev/null
+            echo "updated comment ${existing}"
+          else
+            gh api --method POST "repos/${GITHUB_REPOSITORY}/issues/${PR}/comments" \
+              -f body="$body" >/dev/null
+            echo "created comment"
+          fi

--- a/.github/workflows/docs-preview-deploy.yml
+++ b/.github/workflows/docs-preview-deploy.yml
@@ -42,6 +42,42 @@ jobs:
           run-id: ${{ github.event.workflow_run.id }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
+      # Cloudflare Pages does not merely serve what it is handed. A
+      # `_worker.js` file or a `functions/` directory at the root of the upload
+      # becomes a Pages Function -- server-side code running on Cloudflare's
+      # edge, in this account. The dashboard's Direct Upload does not support
+      # Functions, but `wrangler pages deploy` does, and that is the path used
+      # here.
+      #
+      # That turns "a fork can publish static HTML" into "a fork can run code
+      # in our Cloudflare account". `_headers` and `_redirects` are not code,
+      # but they let an upload set arbitrary response headers or proxy another
+      # origin, which is enough for convincing phishing.
+      #
+      # mkdocs emits none of these, and it copies unrecognised files from
+      # docs/docs/ straight to the site root -- so `docs/docs/_worker.js` in a
+      # pull request would land as `site/_worker.js` here.
+      #
+      # Fail rather than strip: presence is either an attack or a deliberate
+      # change, and both deserve a human. This check lives in the deploy job on
+      # purpose; in the build job a malicious pull request could simply delete
+      # it.
+      - name: Reject server-side code in the artifact
+        run: |
+          set -euo pipefail
+          found=0
+          for path in _worker.js _worker.js.map functions _routes.json _headers _redirects; do
+            if [ -e "site/${path}" ]; then
+              echo "::error::artifact contains '${path}', which Cloudflare Pages treats as behaviour rather than a static asset"
+              found=1
+            fi
+          done
+          if [ "$found" -ne 0 ]; then
+            echo "::error::refusing to deploy -- see .github/workflows/docs-preview-deploy.yml"
+            exit 1
+          fi
+          echo "artifact contains no Pages Functions or routing overrides"
+
       # The pull request number is derived from the head SHA on the trusted
       # `workflow_run` event, NOT from the build artifact.
       #

--- a/.github/workflows/docs-preview-deploy.yml
+++ b/.github/workflows/docs-preview-deploy.yml
@@ -77,9 +77,45 @@ jobs:
             --project-name=atuin-docs-preview
             --branch=pr-${{ steps.pr.outputs.number }}
 
-      # Upsert a single comment rather than adding one per push. Uses `gh api`
-      # instead of a third-party action to keep the credentialed workflow's
-      # dependency surface small.
+      # A GitHub Deployment renders natively in the pull request timeline as a
+      # "View deployment" button -- the same mechanism Netlify and Vercel use.
+      # Done with `gh api` rather than a third-party action because this
+      # workflow holds the Cloudflare token, and the purpose-built action for
+      # this (AdrianGonz97/refined-cf-pages-action) had no release in the 14
+      # months to July 2026 and 44 stars. Twenty lines of API calls is a better
+      # trade than an unmaintained dependency next to a deploy credential.
+      - name: Record the deployment
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR: ${{ steps.pr.outputs.number }}
+          URL: ${{ steps.deploy.outputs.pages-deployment-alias-url || steps.deploy.outputs.deployment-url }}
+          SHA: ${{ github.event.workflow_run.head_sha }}
+        run: |
+          set -euo pipefail
+
+          # transient_environment marks it as ephemeral, so GitHub greys out
+          # superseded previews instead of leaving a wall of live-looking ones.
+          deployment_id="$(gh api --method POST \
+            "repos/${GITHUB_REPOSITORY}/deployments" \
+            -f ref="${SHA}" \
+            -f environment="docs-preview/pr-${PR}" \
+            -f description="Docs preview for #${PR}" \
+            -F auto_merge=false \
+            -F transient_environment=true \
+            -f 'required_contexts[]' \
+            --jq '.id')"
+
+          gh api --method POST \
+            "repos/${GITHUB_REPOSITORY}/deployments/${deployment_id}/statuses" \
+            -f state="success" \
+            -f environment_url="${URL}" \
+            -f log_url="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}" \
+            -f description="Docs preview ready" >/dev/null
+
+          echo "deployment ${deployment_id} -> ${URL}"
+
+      # The deployment above is the primary signal; this is the visible nudge,
+      # upserted so pushing again edits one comment instead of stacking them.
       - name: Comment the preview link
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -89,13 +125,8 @@ jobs:
         run: |
           set -euo pipefail
           marker="<!-- atuin-docs-preview -->"
-          body="${marker}
-          **Docs preview** — [\`${SHA:0:7}\`](${URL})
-
-          ${URL}
-
-          Built with \`mkdocs build --strict\`, so a broken link or a dead
-          \`#anchor\` fails this check rather than shipping."
+          printf -v body '%s\n### Docs preview\n\n| | |\n|---|---|\n| Preview | %s |\n| Commit | `%s` |\n\nBuilt with `mkdocs build --strict`, so a broken link or a dead `#anchor` fails this check rather than shipping.\n' \
+            "$marker" "$URL" "${SHA:0:7}"
 
           existing="$(gh api "repos/${GITHUB_REPOSITORY}/issues/${PR}/comments" \
             --paginate --jq "map(select(.body | startswith(\"${marker}\"))) | .[0].id // empty")"
@@ -103,9 +134,7 @@ jobs:
           if [ -n "$existing" ]; then
             gh api --method PATCH "repos/${GITHUB_REPOSITORY}/issues/comments/${existing}" \
               -f body="$body" >/dev/null
-            echo "updated comment ${existing}"
           else
             gh api --method POST "repos/${GITHUB_REPOSITORY}/issues/${PR}/comments" \
               -f body="$body" >/dev/null
-            echo "created comment"
           fi

--- a/.github/workflows/docs-preview-deploy.yml
+++ b/.github/workflows/docs-preview-deploy.yml
@@ -62,13 +62,30 @@ jobs:
       # change, and both deserve a human. This check lives in the deploy job on
       # purpose; in the build job a malicious pull request could simply delete
       # it.
+      #
+      # The match is deliberately paranoid, because a miss here is code
+      # execution in the Cloudflare account:
+      #   - case-insensitive: the runner is case-sensitive Linux, but Pages'
+      #     own matching is not documented as case-sensitive, so `_Worker.js`
+      #     must not slip through;
+      #   - symlink-aware (-L): a dangling symlink named `_worker.js` is false
+      #     under `-e`;
+      #   - directory form: `_worker.js/` is caught as well as the file;
+      #   - root only: these files are inert in a subdirectory on Pages, and a
+      #     legitimate page could be named e.g. guide/_redirects.
+      # wrangler config files are added as defence in depth in case a config in
+      # the asset directory could influence the deploy.
       - name: Reject server-side code in the artifact
         run: |
           set -euo pipefail
+          blocked='^(_worker\.js|_worker\.js\.map|functions|_routes\.json|_headers|_redirects|wrangler\.(toml|json|jsonc)|\.dev\.vars)$'
           found=0
-          for path in _worker.js _worker.js.map functions _routes.json _headers _redirects; do
-            if [ -e "site/${path}" ]; then
-              echo "::error::artifact contains '${path}', which Cloudflare Pages treats as behaviour rather than a static asset"
+          for entry in site/* site/.*; do
+            [ -e "$entry" ] || [ -L "$entry" ] || continue
+            base="$(basename "$entry")"
+            low="$(printf '%s' "$base" | tr '[:upper:]' '[:lower:]')"
+            if printf '%s\n' "$low" | grep -Eq "$blocked"; then
+              echo "::error::artifact root contains '${base}', which Cloudflare Pages treats as behaviour rather than a static asset"
               found=1
             fi
           done
@@ -76,7 +93,7 @@ jobs:
             echo "::error::refusing to deploy -- see .github/workflows/docs-preview-deploy.yml"
             exit 1
           fi
-          echo "artifact contains no Pages Functions or routing overrides"
+          echo "artifact root contains no Pages Functions or routing overrides"
 
       # The pull request number is derived from the head SHA on the trusted
       # `workflow_run` event, NOT from the build artifact.

--- a/docs/docs/ai/tools-permissions.md
+++ b/docs/docs/ai/tools-permissions.md
@@ -60,7 +60,7 @@ deny = [
 
 The `AtuinHistory` tool allows Atuin AI to search your Atuin history for relevant commands. This tool is read-only. Atuin AI might ask to use this tool when you ask it to recall a command or information about a command you ran in the past, or when you ask for help with a failing command (e.g. "why did my last command fail?").
 
-![Example of Atuin History tool](../images/tool_atuin_history.png)
+![Example of Atuin History tool](images/tool_atuin_history.png)
 
 **Permission rule and scope:** `AtuinHistory`
 
@@ -94,7 +94,7 @@ allow = ["AtuinOutput"]
 
 The `Read` tool allows Atuin AI to read files on your system. Atuin AI might ask to use this tool when you ask it to analyze the contents of a file, when you ask for edits to the contents of a file, or when you ask a question that is most easily answered by consulting the contents of a file.
 
-![Example of Atuin FS Tools](../images/tool_fs.png)
+![Example of Atuin FS Tools](images/tool_fs.png)
 
 **Permission rule and scope:** `Read(<glob_pattern>)` (e.g. `Read(**/\*.md)`to allow reading all markdown files in the current directory and subdirectories). A missing glob pattern (e.g.`Read`) matches all files.
 
@@ -116,7 +116,7 @@ deny = ["Read(.secret/**)"]
 
 The `Write` tool allows Atuin AI to create and edit files on your system. Atuin AI might ask to use this tool when you ask it to update configuration for a tool or help debug a problem.
 
-![Example of Atuin FS Tools](../images/tool_fs.png)
+![Example of Atuin FS Tools](images/tool_fs.png)
 
 **Permission rule and scope:** `Write(<glob_pattern>)` (e.g. `Write(**/\*.md)`to allow reading all markdown files in the current directory and subdirectories). A missing glob pattern (e.g.`Write`) matches all files.
 
@@ -138,7 +138,7 @@ deny = ["Write(.secret/**)"]
 
 The `Shell` tool allows Atuin AI to execute shell commands on your system. Atuin AI might ask to use this tool when you ask it to perform an action that is most easily accomplished by running a shell command itself, or when you ask for help debugging a failing command, or during a multi-step workflow.
 
-![Example of Atuin Shell Tool](../images/tool_shell.png)
+![Example of Atuin Shell Tool](images/tool_shell.png)
 
 **Permission rule and scope:** `Shell(<command pattern>)` (e.g. `Shell(git *)` to allow any command that starts with `git`). A missing command pattern (e.g. `Shell`) matches all commands.
 

--- a/docs/docs/configuration/config.md
+++ b/docs/docs/configuration/config.md
@@ -1198,4 +1198,4 @@ columns = ["duration", "time", { type = "directory", expand = true }, { type = "
 
 ## ai
 
-The settings for Atuin AI are listed in [a separate section](../../ai/settings/).
+The settings for Atuin AI are listed in [a separate section](../ai/settings.md).

--- a/docs/docs/faq.md
+++ b/docs/docs/faq.md
@@ -35,7 +35,7 @@ EG:
 eval "$(atuin init zsh --disable-up-arrow)"
 ```
 
-See [key binding](../configuration/key-binding.md) for more
+See [key binding](configuration/key-binding.md) for more
 
 ## How do I remove the default question mark binding for Atuin AI?
 


### PR DESCRIPTION
Adds Cloudflare Pages preview deployments for pull requests that touch `docs/**`, plus a strict build gate. Split out of the docs branding branch so it can be reviewed on its own.

Docs currently have **no PR check at all** — `docs-main.yml` and `docs-release.yml` only run `mike deploy` on push-to-main and on tags. Nothing builds the docs before a merge.

## Fork safety

This is deliberately two workflows rather than one.

| | runs | secrets | permissions |
|---|---|---|---|
| `docs-preview-build` | untrusted PR code | **none** | `contents: read` |
| `docs-preview-deploy` | default-branch code | Cloudflare + `GITHUB_TOKEN` | scoped writes |

Most docs PRs here come from forks, and on `pull_request` a fork gets no secrets — so it cannot deploy. The tempting fix is `pull_request_target`, and it would be genuinely dangerous: the PR owns `docs/mkdocs.yml`, and **mkdocs plugins execute arbitrary Python at build time**, so a fork could ship a plugin that exfiltrates the deploy token.

Instead the build half uploads an artifact with no credentials, and `workflow_run` — which executes the copy of the workflow on the default branch, not the one in the PR — downloads it and deploys. Both files carry a comment warning against collapsing them.

The artifact is still attacker-influenced HTML/JS. That is inherent to previews; it is contained by deploying to a dedicated `atuin-docs-preview` project on `*.pages.dev`, never to `docs.atuin.sh`.

## Alternatives considered

Worth recording, because ~200 lines of workflow looks like over-engineering without it.

- **Cloudflare Pages' native Git integration.** Would need no workflows at all, but it [does not create preview URLs for pull requests from forks](https://developers.cloudflare.com/pages/configuration/preview-deployments/) — which is where most docs contributions come from. Rejected on that alone.
- **`AdrianGonz97/refined-cf-pages-action`.** Purpose-built for exactly this, supports the fork-safe `workflow_run` pattern, and creates GitHub Deployments. Rejected on supply chain: last release May 2025, 44 stars, single maintainer — not something to hand a deploy token in a repo this size. Its useful part (the GitHub Deployment) is ~20 lines of `gh api` instead.
- **Netlify's Git integration.** Technically the best fit — it builds fork PRs, posts the comment and status natively, and needs no CI code. Rejected as a product/vendor decision.
- **gh-pages subdirectory previews.** No new secrets, but `mike` owns that branch and its `versions.json`, and it would publish untrusted PR content on `docs.atuin.sh` itself. Not worth saving a secret.

## Strict gate

The build runs `mkdocs build --strict`, so a broken internal link or a dead `#anchor` fails the check instead of shipping.

That is why the first commit is here: **`--strict` fails on `main` today**, with five long-standing link warnings. Verified — the workflow would break every docs PR if merged without it. One of those five was a real 404 (`faq.md` → `../configuration/key-binding.md` resolves to a path that does not exist in the built site); the other four were noisy but rendered correctly, and the fix is byte-identical output that mkdocs can now actually validate.

## Setup required before this works

1. Create a Cloudflare Pages project named `atuin-docs-preview` using **Direct Upload**, not the Git integration.
2. Create an API token with **Cloudflare Pages: Edit**.
3. Add repository secrets `CLOUDFLARE_API_TOKEN` and `CLOUDFLARE_ACCOUNT_ID`.

These are the **first third-party credentials in this repo** — every existing workflow uses only `GITHUB_TOKEN`. Worth a deliberate decision, not just a merge.

## Notes for review

- **The deploy half cannot run until this is on `main`.** `workflow_run` always uses the default-branch copy, so the build will run on this PR but no preview will appear. First real preview lands on the next docs PR.
- **Preview URLs are public.** Anything on `*.pages.dev` is world-readable; Cloudflare Access can gate them if that is not wanted.
- `cloudflare/pages-action` is deprecated in favour of `cloudflare/wrangler-action`, which this uses at `@v3` per Cloudflare's current docs. This repo runs newer majors elsewhere (`checkout@v7`, `download-artifact@v8`), so worth confirming v3 is still current.
- `--branch=pr-N` gives each PR a stable preview alias, so pushing again reuses the URL rather than minting a new one.
- The PR gets a **GitHub Deployment** (the native "View deployment" button, marked transient so superseded previews grey out) plus one upserted comment. Both via `gh api` rather than actions, to keep the credentialed workflow's dependency surface small.

🤖 Generated with [Claude Code](https://claude.com/claude-code)