### PR TITLE
fix(hook): install agent hooks with absolute atuin path

### DIFF
--- a/crates/atuin/src/command/client/hook.rs
+++ b/crates/atuin/src/command/client/hook.rs
@@ -338,6 +338,11 @@ fn add_hook_entries(hooks: &mut Value, agent: &Agent, hook_command: &str) -> Res
 
         // Rewrite every Atuin-managed entry to the absolute command and drop any
         // duplicates so reinstalling never leaves stale bare `atuin hook ...` lines.
+        //
+        // `seen_managed` is intentionally shared across all wrapper entries for this
+        // event type: we want exactly one Atuin hook to fire per event, so if two
+        // different-matcher wrappers both contain a managed hook, only the first is
+        // kept (and an emptied wrapper is pruned below).
         let mut seen_managed = false;
         for entry in arr.iter_mut() {
             let Some(hooks_arr) = entry.get_mut("hooks").and_then(Value::as_array_mut) else {

--- a/crates/atuin/src/command/client/hook.rs
+++ b/crates/atuin/src/command/client/hook.rs
@@ -265,11 +265,30 @@ fn resolve_hook_command(agent: &Agent) -> Result<String> {
 }
 
 fn format_hook_command(exe: &Path, hook_agent: &str) -> String {
-    let exe = shlex::try_quote(exe.to_string_lossy().as_ref()).map_or_else(
-        |_| format!("\"{}\"", exe.display()),
+    format!("{} hook {hook_agent}", quote_exe(exe))
+}
+
+/// Quote an executable path for the platform shell that will run the hook.
+///
+/// Agent hook commands are executed by the host shell, so quoting must match it:
+/// POSIX (single-quote) rules on Unix and `cmd.exe` (double-quote) rules on Windows.
+#[cfg(windows)]
+fn quote_exe(exe: &Path) -> String {
+    let raw = exe.to_string_lossy();
+    if raw.contains(|c: char| c.is_whitespace()) {
+        // cmd.exe does not understand POSIX single quotes; wrap in double quotes.
+        format!("\"{raw}\"")
+    } else {
+        raw.into_owned()
+    }
+}
+
+#[cfg(not(windows))]
+fn quote_exe(exe: &Path) -> String {
+    shlex::try_quote(exe.to_string_lossy().as_ref()).map_or_else(
+        |_| format!("'{}'", exe.display()),
         std::borrow::Cow::into_owned,
-    );
-    format!("{exe} hook {hook_agent}")
+    )
 }
 
 /// True when `command` is an Atuin-managed hook entry for `hook_agent`
@@ -317,37 +336,46 @@ fn add_hook_entries(hooks: &mut Value, agent: &Agent, hook_command: &str) -> Res
             .as_array_mut()
             .ok_or_else(|| eyre::eyre!("hooks.{event_type} is not an array"))?;
 
-        let mut updated_existing = false;
+        // Rewrite every Atuin-managed entry to the absolute command and drop any
+        // duplicates so reinstalling never leaves stale bare `atuin hook ...` lines.
+        let mut seen_managed = false;
         for entry in arr.iter_mut() {
             let Some(hooks_arr) = entry.get_mut("hooks").and_then(Value::as_array_mut) else {
                 continue;
             };
 
-            for hook in hooks_arr.iter_mut() {
+            hooks_arr.retain_mut(|hook| {
                 let Some(command) = hook.get("command").and_then(Value::as_str) else {
-                    continue;
+                    return true;
                 };
 
                 if !is_managed_hook_command(command, hook_agent) {
-                    continue;
+                    return true;
                 }
 
-                if command == hook_command {
-                    eprintln!("hooks.{event_type}: already installed, skipping");
-                } else {
+                if seen_managed {
+                    // A managed entry already survived; drop this duplicate.
+                    return false;
+                }
+
+                seen_managed = true;
+                if command != hook_command {
                     hook["command"] = Value::String(hook_command.to_string());
-                    eprintln!("hooks.{event_type}: updated hook command to absolute atuin path");
                 }
-                updated_existing = true;
-                break;
-            }
-
-            if updated_existing {
-                break;
-            }
+                true
+            });
         }
 
-        if updated_existing {
+        // Prune wrapper entries whose `hooks` array is now empty.
+        arr.retain(|entry| {
+            entry
+                .get("hooks")
+                .and_then(Value::as_array)
+                .is_none_or(|hooks| !hooks.is_empty())
+        });
+
+        if seen_managed {
+            eprintln!("hooks.{event_type}: ensured absolute atuin hook command");
             continue;
         }
 
@@ -523,5 +551,67 @@ mod tests {
                 desired
             );
         }
+    }
+
+    #[test]
+    fn add_hook_entries_dedups_multiple_managed_commands() {
+        let agent = Agent::from_name("claude-code").unwrap();
+        let desired = "/opt/homebrew/bin/atuin hook claude-code";
+        let mut hooks = serde_json::json!({
+            "PreToolUse": [
+                {
+                    "matcher": "Bash",
+                    "hooks": [{"type": "command", "command": "atuin hook claude-code"}]
+                },
+                {
+                    "matcher": "Bash",
+                    "hooks": [{"type": "command", "command": "/usr/local/bin/atuin hook claude-code"}]
+                }
+            ],
+            "PostToolUse": [{
+                "matcher": "Bash",
+                "hooks": [{"type": "command", "command": "atuin hook claude-code"}]
+            }],
+            "PostToolUseFailure": [{
+                "matcher": "Bash",
+                "hooks": [{"type": "command", "command": "atuin hook claude-code"}]
+            }]
+        });
+
+        add_hook_entries(&mut hooks, &agent, desired).unwrap();
+
+        // Only one managed entry survives, rewritten to the absolute command,
+        // and the now-empty wrapper is pruned.
+        let pre = hooks["PreToolUse"].as_array().unwrap();
+        assert_eq!(pre.len(), 1);
+        assert_eq!(pre[0]["hooks"][0]["command"].as_str().unwrap(), desired);
+    }
+
+    #[test]
+    fn add_hook_entries_preserves_unmanaged_commands() {
+        let agent = Agent::from_name("codex").unwrap();
+        let desired = "/usr/bin/atuin hook codex";
+        let mut hooks = serde_json::json!({
+            "PreToolUse": [{
+                "matcher": "^Bash$",
+                "hooks": [
+                    {"type": "command", "command": "/usr/bin/echo hi"},
+                    {"type": "command", "command": "atuin hook codex"}
+                ]
+            }],
+            "PostToolUse": [],
+            "PostToolUseFailure": []
+        });
+
+        add_hook_entries(&mut hooks, &agent, desired).unwrap();
+
+        let commands: Vec<&str> = hooks["PreToolUse"][0]["hooks"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|h| h["command"].as_str().unwrap())
+            .collect();
+        assert!(commands.contains(&"/usr/bin/echo hi"));
+        assert!(commands.contains(&desired));
     }
 }

--- a/crates/atuin/src/command/client/hook.rs
+++ b/crates/atuin/src/command/client/hook.rs
@@ -1,10 +1,10 @@
 use std::io::Read;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use atuin_client::settings::Settings;
 use atuin_common::utils::home_dir;
 use clap::{Parser, Subcommand};
-use eyre::{Result, bail};
+use eyre::{Context, Result, bail};
 use serde_json::Value;
 
 use super::history;
@@ -20,7 +20,8 @@ const PI_EXTENSION_SOURCE: &str = include_str!("../../../contrib/pi/atuin.ts");
 enum InstallKind {
     JsonHooks {
         config_path: &'static [&'static str],
-        hook_command: &'static str,
+        /// Agent name passed to `atuin hook <agent>`
+        hook_agent: &'static str,
         matcher: &'static str,
     },
     PiExtension {
@@ -39,7 +40,7 @@ const CLAUDE_CODE: AgentSpec = AgentSpec {
     actor_name: "claude-code",
     install_kind: InstallKind::JsonHooks {
         config_path: &[".claude", "settings.json"],
-        hook_command: "atuin hook claude-code",
+        hook_agent: "claude-code",
         matcher: "Bash",
     },
 };
@@ -49,7 +50,7 @@ const CODEX: AgentSpec = AgentSpec {
     actor_name: "codex",
     install_kind: InstallKind::JsonHooks {
         config_path: &[".codex", "hooks.json"],
-        hook_command: "atuin hook codex",
+        hook_agent: "codex",
         matcher: "^Bash$",
     },
 };
@@ -186,7 +187,7 @@ fn install(agent_name: &str) -> Result<()> {
     match agent.install_kind() {
         InstallKind::JsonHooks {
             config_path,
-            hook_command: _,
+            hook_agent: _,
             matcher: _,
         } => {
             let config_path = Agent::path(config_path);
@@ -208,13 +209,14 @@ fn install(agent_name: &str) -> Result<()> {
                 .entry("hooks")
                 .or_insert_with(|| Value::Object(serde_json::Map::new()));
 
-            add_hook_entries(hooks, &agent)?;
+            let hook_command = resolve_hook_command(&agent)?;
+            add_hook_entries(hooks, &agent, &hook_command)?;
 
             let content = serde_json::to_string_pretty(&root)?;
             std::fs::write(&config_path, content)?;
 
             eprintln!(
-                "\nAtuin hooks installed for {}. Config: {}",
+                "\nAtuin hooks installed for {}. Config: {}\nHook command: {hook_command}",
                 agent.actor_name(),
                 config_path.display()
             );
@@ -247,10 +249,57 @@ fn install(agent_name: &str) -> Result<()> {
     Ok(())
 }
 
-fn add_hook_entries(hooks: &mut Value, agent: &Agent) -> Result<()> {
+/// Resolve the absolute path of this `atuin` binary and build the hook command string.
+///
+/// Agent runtimes often spawn hooks with a minimal PATH (and default shells that never ran
+/// `atuin init`), so a bare `atuin ...` command fails with exit 127. Pinning to
+/// `current_exe()` matches how the daemon is spawned.
+fn resolve_hook_command(agent: &Agent) -> Result<String> {
+    let InstallKind::JsonHooks { hook_agent, .. } = agent.install_kind() else {
+        bail!("agent does not use JSON hooks");
+    };
+
+    let exe =
+        std::env::current_exe().wrap_err("could not locate atuin executable for hook install")?;
+    Ok(format_hook_command(&exe, hook_agent))
+}
+
+fn format_hook_command(exe: &Path, hook_agent: &str) -> String {
+    let exe = shlex::try_quote(exe.to_string_lossy().as_ref()).map_or_else(
+        |_| format!("\"{}\"", exe.display()),
+        std::borrow::Cow::into_owned,
+    );
+    format!("{exe} hook {hook_agent}")
+}
+
+/// True when `command` is an Atuin-managed hook entry for `hook_agent`
+/// (`atuin hook <agent>` or an absolute path to an `atuin` binary with the same args).
+fn is_managed_hook_command(command: &str, hook_agent: &str) -> bool {
+    let bare = format!("atuin hook {hook_agent}");
+    if command == bare {
+        return true;
+    }
+
+    let suffix = format!(" hook {hook_agent}");
+    let Some(binary) = command.strip_suffix(&suffix) else {
+        return false;
+    };
+
+    let binary = binary
+        .trim()
+        .trim_matches('\'')
+        .trim_matches('"')
+        .trim_end_matches(['\\', '/']);
+
+    let name = binary.rsplit(['/', '\\']).next().unwrap_or(binary);
+
+    name == "atuin" || name.eq_ignore_ascii_case("atuin.exe")
+}
+
+fn add_hook_entries(hooks: &mut Value, agent: &Agent, hook_command: &str) -> Result<()> {
     let InstallKind::JsonHooks {
         config_path: _,
-        hook_command,
+        hook_agent,
         matcher,
     } = agent.install_kind()
     else {
@@ -268,19 +317,37 @@ fn add_hook_entries(hooks: &mut Value, agent: &Agent) -> Result<()> {
             .as_array_mut()
             .ok_or_else(|| eyre::eyre!("hooks.{event_type} is not an array"))?;
 
-        let already_installed = arr.iter().any(|entry| {
-            entry
-                .get("hooks")
-                .and_then(Value::as_array)
-                .is_some_and(|hooks| {
-                    hooks.iter().any(|hook| {
-                        hook.get("command").and_then(Value::as_str) == Some(hook_command)
-                    })
-                })
-        });
+        let mut updated_existing = false;
+        for entry in arr.iter_mut() {
+            let Some(hooks_arr) = entry.get_mut("hooks").and_then(Value::as_array_mut) else {
+                continue;
+            };
 
-        if already_installed {
-            eprintln!("hooks.{event_type}: already installed, skipping");
+            for hook in hooks_arr.iter_mut() {
+                let Some(command) = hook.get("command").and_then(Value::as_str) else {
+                    continue;
+                };
+
+                if !is_managed_hook_command(command, hook_agent) {
+                    continue;
+                }
+
+                if command == hook_command {
+                    eprintln!("hooks.{event_type}: already installed, skipping");
+                } else {
+                    hook["command"] = Value::String(hook_command.to_string());
+                    eprintln!("hooks.{event_type}: updated hook command to absolute atuin path");
+                }
+                updated_existing = true;
+                break;
+            }
+
+            if updated_existing {
+                break;
+            }
+        }
+
+        if updated_existing {
             continue;
         }
 
@@ -302,6 +369,7 @@ mod tests {
         command::{AtuinCmd, client},
     };
     use clap::Parser;
+    use std::path::PathBuf;
 
     #[test]
     fn parse_hook_agent_command() {
@@ -352,5 +420,108 @@ mod tests {
             AtuinCmd::Client(client::Cmd::Hook(Cmd { action: None, agent: Some(agent) }))
                 if agent == "codex"
         ));
+    }
+
+    #[test]
+    fn format_hook_command_uses_absolute_path() {
+        let path = PathBuf::from("/opt/homebrew/bin/atuin");
+        assert_eq!(
+            format_hook_command(&path, "claude-code"),
+            "/opt/homebrew/bin/atuin hook claude-code"
+        );
+    }
+
+    #[test]
+    fn format_hook_command_quotes_spaces() {
+        let path = PathBuf::from("/Users/Ada Lovelace/bin/atuin");
+        let cmd = format_hook_command(&path, "codex");
+        assert!(cmd.contains("hook codex"), "{cmd}");
+        assert!(
+            cmd.starts_with('\'') || cmd.starts_with('"'),
+            "expected quoted path: {cmd}"
+        );
+    }
+
+    #[test]
+    fn is_managed_hook_command_matches_bare_and_absolute() {
+        assert!(is_managed_hook_command(
+            "atuin hook claude-code",
+            "claude-code"
+        ));
+        assert!(is_managed_hook_command(
+            "/usr/local/bin/atuin hook claude-code",
+            "claude-code"
+        ));
+        assert!(is_managed_hook_command(
+            "'/Users/Ada/bin/atuin' hook claude-code",
+            "claude-code"
+        ));
+        assert!(is_managed_hook_command(
+            r#""C:\Program Files\atuin\atuin.exe" hook claude-code"#,
+            "claude-code"
+        ));
+        assert!(!is_managed_hook_command("atuin hook codex", "claude-code"));
+        assert!(!is_managed_hook_command(
+            "/usr/bin/echo hook claude-code",
+            "claude-code"
+        ));
+    }
+
+    #[test]
+    fn add_hook_entries_upgrades_bare_command_to_absolute() {
+        let agent = Agent::from_name("claude-code").unwrap();
+        let mut hooks = serde_json::json!({
+            "PreToolUse": [{
+                "matcher": "Bash",
+                "hooks": [{"type": "command", "command": "atuin hook claude-code"}]
+            }],
+            "PostToolUse": [{
+                "matcher": "Bash",
+                "hooks": [{"type": "command", "command": "atuin hook claude-code"}]
+            }],
+            "PostToolUseFailure": [{
+                "matcher": "Bash",
+                "hooks": [{"type": "command", "command": "atuin hook claude-code"}]
+            }]
+        });
+
+        let desired = "/opt/homebrew/bin/atuin hook claude-code";
+        add_hook_entries(&mut hooks, &agent, desired).unwrap();
+
+        for event in HOOK_EVENT_TYPES {
+            let command = hooks[event][0]["hooks"][0]["command"].as_str().unwrap();
+            assert_eq!(command, desired);
+            assert_eq!(hooks[event].as_array().unwrap().len(), 1);
+        }
+    }
+
+    #[test]
+    fn add_hook_entries_is_idempotent_for_desired_command() {
+        let agent = Agent::from_name("codex").unwrap();
+        let desired = "/usr/bin/atuin hook codex";
+        let mut hooks = serde_json::json!({
+            "PreToolUse": [{
+                "matcher": "^Bash$",
+                "hooks": [{"type": "command", "command": desired}]
+            }],
+            "PostToolUse": [{
+                "matcher": "^Bash$",
+                "hooks": [{"type": "command", "command": desired}]
+            }],
+            "PostToolUseFailure": [{
+                "matcher": "^Bash$",
+                "hooks": [{"type": "command", "command": desired}]
+            }]
+        });
+
+        add_hook_entries(&mut hooks, &agent, desired).unwrap();
+
+        for event in HOOK_EVENT_TYPES {
+            assert_eq!(hooks[event].as_array().unwrap().len(), 1);
+            assert_eq!(
+                hooks[event][0]["hooks"][0]["command"].as_str().unwrap(),
+                desired
+            );
+        }
     }
 }

--- a/docs/docs/guide/agent-hooks.md
+++ b/docs/docs/guide/agent-hooks.md
@@ -31,7 +31,7 @@ When `atuin hook install` runs, it writes the agent's config file or extension t
 | Codex | `~/.codex/hooks.json` |
 | pi | `~/.pi/agent/extensions/atuin.ts` |
 
-For Claude Code and Codex, the installer writes an **absolute path** to the `atuin` binary (via `current_exe`) so the hook does not depend on `PATH` inside the agent's process. That matters when your default shell never runs `atuin init`, or when the agent spawns hooks with a minimal environment.
+For Claude Code and Codex, the installer writes an **absolute path** to the `atuin` binary (via `current_exe`) so the hook doesn't depend on `PATH` inside the agent's process. That matters when your default shell never runs `atuin init`, or when the agent spawns hooks with a minimal environment.
 
 The hook lifecycle:
 

--- a/docs/docs/guide/agent-hooks.md
+++ b/docs/docs/guide/agent-hooks.md
@@ -31,6 +31,8 @@ When `atuin hook install` runs, it writes the agent's config file or extension t
 | Codex | `~/.codex/hooks.json` |
 | pi | `~/.pi/agent/extensions/atuin.ts` |
 
+For Claude Code and Codex, the installer writes an **absolute path** to the `atuin` binary (via `current_exe`) so the hook does not depend on `PATH` inside the agent's process. That matters when your default shell never runs `atuin init`, or when the agent spawns hooks with a minimal environment.
+
 The hook lifecycle:
 
 1. **PreToolUse** -- the agent is about to run a Bash command. Atuin records the command, working directory, and timestamp (same as `history start`).
@@ -80,7 +82,7 @@ Currently recognized agent names are: `claude-code`, `codex`, `copilot`, `openco
 atuin hook install claude-code
 ```
 
-This adds hook entries to `~/.claude/settings.json`. Claude Code calls `atuin hook claude-code` on each `Bash` tool use, passing the event as JSON on `stdin`.
+This adds hook entries to `~/.claude/settings.json`. Claude Code calls the installed hook command (absolute path to `atuin hook claude-code`) on each `Bash` tool use, passing the event as JSON on `stdin`.
 
 ### Codex
 
@@ -88,7 +90,7 @@ This adds hook entries to `~/.claude/settings.json`. Claude Code calls `atuin ho
 atuin hook install codex
 ```
 
-This adds hook entries to `~/.codex/hooks.json`. Codex calls `atuin hook codex` on each Bash tool use matching `^Bash$`.
+This adds hook entries to `~/.codex/hooks.json`. Codex calls the installed hook command (absolute path to `atuin hook codex`) on each Bash tool use matching `^Bash$`.
 
 ### pi
 
@@ -127,12 +129,14 @@ ls ~/.pi/agent/extensions/atuin.ts
 
 ## Re-installing
 
-Running `atuin hook install` again is safe. If hooks are already installed, the command will skip them and print a message:
+Running `atuin hook install` again is safe. If hooks are already installed with the same absolute path, the command will skip them and print a message:
 
 ```
 hooks.PreToolUse: already installed, skipping
 hooks.PostToolUse: already installed, skipping
 hooks.PostToolUseFailure: already installed, skipping
 ```
+
+If an older install used a bare `atuin hook ...` command (or a different absolute path), reinstalling upgrades the entry to the current binary path.
 
 For pi, reinstalling will also skip if the managed extension already matches the bundled version.


### PR DESCRIPTION
## Summary

- `atuin hook install` now writes an absolute path to the Atuin binary for Claude Code / Codex hooks.
- Re-running install upgrades older bare `atuin hook …` entries without duplicating them.

## Motivation

Closes #3698.

Agent processes often start hooks with a minimal environment. When bash is the default shell (but never got `atuin init`), PATH lacks `atuin` and hooks fail with exit 127 (`command not found`). Pinning the hook command to `current_exe()` matches how the daemon is already spawned.

## Verification

- `cargo test -p atuin hook` — 35 passed
- `cargo clippy -p atuin --bin atuin -- -D warnings` — clean
- `cargo fmt -p atuin -- --check` — clean
- Unit coverage: absolute formatting, space quoting, bare→absolute upgrade, idempotent reinstall

## Checklist

- [x] I am happy for maintainers to push small adjustments to this PR
- [x] I have checked that there are no existing pull requests for the same thing

---
<!-- fleet-pr-claim: agent_id=sera platform=hermes -->
**Agent-Owner:** `sera` · **Platform:** hermes · **Claim:** `sera` · **Claim-TTL:** 48h

