### PR TITLE
feat(install): don't install bash-preexec in install.sh

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -63,12 +63,6 @@ fi
 # Use of single quotes around $() is intentional here
 # shellcheck disable=SC2016
 
-if ! grep -q "atuin init bash" ~/.bashrc; then
-  curl --proto '=https' --tlsv1.2 -LsSf https://raw.githubusercontent.com/rcaloras/bash-preexec/master/bash-preexec.sh -o ~/.bash-preexec.sh
-  printf '\n[[ -f ~/.bash-preexec.sh ]] && source ~/.bash-preexec.sh\n' >> ~/.bashrc
-  echo 'eval "$(atuin init bash)"' >> ~/.bashrc
-fi
-
 if [ -f "$HOME/.config/fish/config.fish" ]; then
   if ! grep -q "atuin init fish" "$HOME/.config/fish/config.fish"; then
     printf '\nif status is-interactive\n    atuin init fish | source\nend\n' >> "$HOME/.config/fish/config.fish"


### PR DESCRIPTION
bash-preexec is now bundled with Atuin (#3650), so it is no longer necessary to install it in install.sh.

Changes to install.sh get deployed immediately, so **wait to merge this until immediately after the next release**.