### PR TITLE
chore(deps): Update to eye-declare 0.6.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1669,9 +1669,9 @@ dependencies = [
 
 [[package]]
 name = "eye_declare"
-version = "0.6.1"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5693ee53b3e59a1f2fbd1cc7eeebe8f843759c7b6730091ea130727536389995"
+checksum = "80dcc9ff67e8474dc551572afc209d96caba03917060e42aea673aa99737b552"
 dependencies = [
  "crossterm",
  "eye_declare_engine",
@@ -1686,9 +1686,9 @@ dependencies = [
 
 [[package]]
 name = "eye_declare_engine"
-version = "0.6.1"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d025cca4225f033a206e4b09b832fd82276547a45baffd98bce9042d5e07ab4"
+checksum = "dd864458085188a89c3f84b86a243d02a64e213b8ceb97b059ba8c941474cc30"
 dependencies = [
  "ratatui-core",
  "ratatui-widgets",

--- a/crates/atuin-ai/Cargo.toml
+++ b/crates/atuin-ai/Cargo.toml
@@ -49,8 +49,8 @@ uuid = { workspace = true }
 tui-textarea-2 = "0.10.2"
 unicode-width = "0.2"
 # Path dependency until eye_declare 0.6.0 publishes; then just a version.
-eye_declare = "0.6.1"
-eye_declare_engine = { version = "0.6.1", features = ["test-util"] }
+eye_declare = "0.6.2"
+eye_declare_engine = { version = "0.6.2", features = ["test-util"] }
 ratatui-core = "0.1"
 ratatui-widgets = "0.3"
 thiserror = { workspace = true }

--- a/crates/atuin-ai/src/tui/view/mod.rs
+++ b/crates/atuin-ai/src/tui/view/mod.rs
@@ -117,7 +117,7 @@ fn out_of_band_output_view(details: &OutOfBandOutputDetails) -> AnyElement<'stat
         .when_some(details.command.clone(), |c, command| {
             c.child(text(command).style(Style::default().fg(Color::Blue)))
         })
-        .child(markdown(details.content.clone()))
+        .child(markdown(details.content.clone()).streaming(true))
         .pad_left(2)
         .any()
 }


### PR DESCRIPTION
This also enables markdown tables with streaming support, added in https://github.com/atuinsh/eye-declare/pull/49