### PR TITLE
AI WIP | Convert daemon locks to parking_lot

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -302,6 +302,7 @@ dependencies = [
  "futures",
  "glob-match",
  "imara-diff",
+ "parking_lot",
  "pretty_assertions",
  "pulldown-cmark",
  "ratatui",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -438,6 +438,7 @@ dependencies = [
  "hyper-util",
  "lasso",
  "listenfd",
+ "parking_lot",
  "prost",
  "prost-types",
  "protox",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,6 +56,7 @@ tokio = { version = "1", features = ["full"] }
 uuid = { version = "1.9", features = ["v4", "v7", "serde"] }
 whoami = "2.1.0"
 typed-builder = "0.23.2"
+parking_lot = "0.12.1"
 pretty_assertions = "1.3.0"
 proptest = "1.11.0"
 rstest = "0.26.1"

--- a/crates/atuin-ai/Cargo.toml
+++ b/crates/atuin-ai/Cargo.toml
@@ -25,6 +25,7 @@ atuin-common = { workspace = true, features = ["unicode", "ansi"] }
 atuin-daemon = { workspace = true }
 tokio = { workspace = true }
 eyre = { workspace = true }
+parking_lot = { workspace = true }
 clap = { workspace = true, features = ["derive", "env"] }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true, features = [

--- a/crates/atuin-ai/src/user_context/mod.rs
+++ b/crates/atuin-ai/src/user_context/mod.rs
@@ -11,7 +11,9 @@ pub(crate) mod interpolate;
 mod walker;
 
 use std::path::Path;
-use std::sync::{Arc, Mutex};
+use std::sync::Arc;
+
+use parking_lot::Mutex;
 
 pub(crate) use walker::global_context_path;
 
@@ -53,7 +55,7 @@ impl UserContextCache {
         // The lock is not held across the gather; streams run one at a time
         // so duplicate gathers aren't a concern.
         let epoch = {
-            let slot = self.lock();
+            let slot = self.inner.lock();
             if let Some(contexts) = slot.contexts.clone() {
                 return contexts;
             }
@@ -66,7 +68,7 @@ impl UserContextCache {
         // it for the in-flight request but leave the cache empty so the
         // next request re-gathers. Likewise, never overwrite a result a
         // concurrent gather stored first — ours may be the older read.
-        let mut slot = self.lock();
+        let mut slot = self.inner.lock();
         if slot.epoch == epoch && slot.contexts.is_none() {
             slot.contexts = Some(contexts.clone());
         }
@@ -75,18 +77,9 @@ impl UserContextCache {
 
     /// Drop the cached contexts so the next request re-gathers them.
     pub fn invalidate(&self) {
-        let mut slot = self.lock();
+        let mut slot = self.inner.lock();
         slot.epoch += 1;
         slot.contexts = None;
-    }
-
-    /// A poisoned lock means another thread panicked while holding it, but
-    /// the cached value is only ever replaced wholesale — it can't be torn.
-    /// Recover with the inner value rather than propagating the panic.
-    fn lock(&self) -> std::sync::MutexGuard<'_, CacheSlot> {
-        self.inner
-            .lock()
-            .unwrap_or_else(std::sync::PoisonError::into_inner)
     }
 }
 

--- a/crates/atuin-daemon/Cargo.toml
+++ b/crates/atuin-daemon/Cargo.toml
@@ -27,6 +27,7 @@ tower = { workspace = true }
 eyre = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
+parking_lot = { workspace = true }
 
 dashmap = "6.1.0"
 lasso = { version = "0.7", features = ["multi-threaded"] }

--- a/crates/atuin-daemon/src/components/history.rs
+++ b/crates/atuin-daemon/src/components/history.rs
@@ -45,10 +45,10 @@ struct HistoryComponentInner {
     running: DashMap<HistoryId, History>,
 
     /// Handle to the daemon (set during start).
-    handle: tokio::sync::RwLock<Option<DaemonHandle>>,
+    handle: parking_lot::RwLock<Option<DaemonHandle>>,
 
     /// History store for pushing records (set during start).
-    history_store: tokio::sync::RwLock<Option<HistoryStore>>,
+    history_store: parking_lot::RwLock<Option<HistoryStore>>,
 }
 
 impl HistoryComponent {
@@ -57,8 +57,8 @@ impl HistoryComponent {
         Self {
             inner: Arc::new(HistoryComponentInner {
                 running: DashMap::new(),
-                handle: tokio::sync::RwLock::new(None),
-                history_store: tokio::sync::RwLock::new(None),
+                handle: parking_lot::RwLock::new(None),
+                history_store: parking_lot::RwLock::new(None),
             }),
         }
     }
@@ -91,8 +91,8 @@ impl Component for HistoryComponent {
         let history_store =
             HistoryStore::new(handle.store().clone(), host_id, *handle.encryption_key());
 
-        *self.inner.history_store.write().await = Some(history_store);
-        *self.inner.handle.write().await = Some(handle);
+        *self.inner.history_store.write() = Some(history_store);
+        *self.inner.handle.write() = Some(handle);
 
         tracing::info!("history component started");
         Ok(())
@@ -166,7 +166,7 @@ impl HistorySvc for HistoryGrpcService {
             .into();
 
         // Emit the event
-        if let Some(handle) = self.inner.handle.read().await.as_ref() {
+        if let Some(handle) = self.inner.handle.read().as_ref() {
             handle.emit(DaemonEvent::HistoryStarted(h.clone()));
         }
 
@@ -201,15 +201,20 @@ impl HistorySvc for HistoryGrpcService {
                 value => i64::try_from(value).expect("failed to get i64 duration"),
             };
 
-            // Get the handle and store to save the history
-            let handle_guard = self.inner.handle.read().await;
-            let handle = handle_guard
-                .as_ref()
+            // Clone the handle and store out so no lock guard is held across
+            // the DB writes below (both are cheap, Arc-backed clones).
+            let handle = self
+                .inner
+                .handle
+                .read()
+                .clone()
                 .ok_or_else(|| Status::internal("component not initialized"))?;
 
-            let store_guard = self.inner.history_store.read().await;
-            let history_store = store_guard
-                .as_ref()
+            let history_store = self
+                .inner
+                .history_store
+                .read()
+                .clone()
                 .ok_or_else(|| Status::internal("component not initialized"))?;
 
             // Save to database
@@ -273,10 +278,11 @@ impl HistorySvc for HistoryGrpcService {
         &self,
         _request: Request<TailHistoryRequest>,
     ) -> Result<Response<Self::TailHistoryStream>, Status> {
-        let handle_guard = self.inner.handle.read().await;
-        let handle = handle_guard
-            .as_ref()
-            .cloned()
+        let handle = self
+            .inner
+            .handle
+            .read()
+            .clone()
             .ok_or_else(|| Status::internal("component not initialized"))?;
 
         let mut rx = handle.subscribe();
@@ -340,7 +346,7 @@ impl HistorySvc for HistoryGrpcService {
         _request: Request<ShutdownRequest>,
     ) -> Result<Response<ShutdownReply>, Status> {
         // Use the daemon handle to request shutdown
-        if let Some(handle) = self.inner.handle.read().await.as_ref() {
+        if let Some(handle) = self.inner.handle.read().as_ref() {
             handle.shutdown();
         }
         Ok(Response::new(ShutdownReply { accepted: true }))

--- a/crates/atuin-daemon/src/components/search.rs
+++ b/crates/atuin-daemon/src/components/search.rs
@@ -216,10 +216,11 @@ impl Component for SearchComponent {
             }
             DaemonEvent::SettingsReloaded => {
                 info!("Settings reloaded, rebuilding frecency map with new multipliers");
-                if let Some(handle) = self.handle.read().as_ref() {
-                    let settings = handle.settings();
-                    self.index.read().rebuild_frecency(&settings.search);
-                }
+                let Some(handle) = self.handle.read().clone() else {
+                    return Ok(());
+                };
+                let settings = handle.settings();
+                self.index.read().rebuild_frecency(&settings.search);
             }
             // Events we don't care about
             DaemonEvent::SyncCompleted { .. }

--- a/crates/atuin-daemon/src/components/search.rs
+++ b/crates/atuin-daemon/src/components/search.rs
@@ -145,7 +145,7 @@ impl Component for SearchComponent {
                         );
                         // Build initial frecency map with current settings
                         let settings = handle_for_loader.settings();
-                        index.read().await.rebuild_frecency(&settings.search).await;
+                        index.read().await.rebuild_frecency(&settings.search);
                         info!("Initial frecency map built");
                         break;
                     }
@@ -171,8 +171,7 @@ impl Component for SearchComponent {
                 index_for_frecency
                     .read()
                     .await
-                    .rebuild_frecency(&settings.search)
-                    .await;
+                    .rebuild_frecency(&settings.search);
             }
         }));
 
@@ -228,8 +227,7 @@ impl Component for SearchComponent {
                     self.index
                         .read()
                         .await
-                        .rebuild_frecency(&settings.search)
-                        .await;
+                        .rebuild_frecency(&settings.search);
                 }
             }
             // Events we don't care about
@@ -314,9 +312,7 @@ impl SearchSvc for SearchGrpcService {
                             span!(Level::TRACE, "daemon_search_query", %query, query_id)
                                 .in_scope(|| async {
                                     let index = index.read().await;
-                                    index
-                                        .search(&query, index_filter, &query_context, RESULTS_LIMIT)
-                                        .await
+                                    index.search(&query, index_filter, &query_context, RESULTS_LIMIT)
                                 })
                                 .await;
 

--- a/crates/atuin-daemon/src/components/search.rs
+++ b/crates/atuin-daemon/src/components/search.rs
@@ -144,7 +144,7 @@ impl Component for SearchComponent {
                             index.read().await.command_count()
                         );
                         // Build initial frecency map with current settings
-                        let settings = handle_for_loader.settings().await;
+                        let settings = handle_for_loader.settings();
                         index.read().await.rebuild_frecency(&settings.search).await;
                         info!("Initial frecency map built");
                         break;
@@ -167,7 +167,7 @@ impl Component for SearchComponent {
             loop {
                 interval.tick().await;
                 trace!("Refreshing frecency map");
-                let settings = handle_for_frecency.settings().await;
+                let settings = handle_for_frecency.settings();
                 index_for_frecency
                     .read()
                     .await
@@ -224,7 +224,7 @@ impl Component for SearchComponent {
                 info!("Settings reloaded, rebuilding frecency map with new multipliers");
                 let handle_guard = self.handle.read().await;
                 if let Some(handle) = handle_guard.as_ref() {
-                    let settings = handle.settings().await;
+                    let settings = handle.settings();
                     self.index
                         .read()
                         .await

--- a/crates/atuin-daemon/src/components/search.rs
+++ b/crates/atuin-daemon/src/components/search.rs
@@ -8,7 +8,7 @@ use std::{pin::Pin, sync::Arc};
 use atuin_client::database::Database;
 use atuin_common::path::DisplayRichExt;
 use eyre::Result;
-use tokio::sync::RwLock;
+use parking_lot::RwLock;
 use tokio_stream::Stream;
 use tonic::{Request, Response, Status, Streaming};
 use tracing::{Level, debug, info, instrument, span, trace};
@@ -37,7 +37,7 @@ const FRECENCY_REFRESH_INTERVAL_SECS: u64 = 60;
 /// - Provides the Search gRPC service
 pub struct SearchComponent {
     index: Arc<RwLock<SearchIndex>>,
-    handle: tokio::sync::RwLock<Option<DaemonHandle>>,
+    handle: RwLock<Option<DaemonHandle>>,
     loader_handle: Option<tokio::task::JoinHandle<()>>,
     frecency_handle: Option<tokio::task::JoinHandle<()>>,
 }
@@ -47,7 +47,7 @@ impl SearchComponent {
     pub fn new() -> Self {
         Self {
             index: Arc::new(RwLock::new(SearchIndex::new())),
-            handle: tokio::sync::RwLock::new(None),
+            handle: RwLock::new(None),
             loader_handle: None,
             frecency_handle: None,
         }
@@ -62,9 +62,10 @@ impl SearchComponent {
 
     /// Rebuild the entire search index from the database.
     async fn rebuild_index(&self) -> Result<()> {
-        let handle_guard = self.handle.read().await;
-        let handle = handle_guard
-            .as_ref()
+        let handle = self
+            .handle
+            .read()
+            .clone()
             .ok_or_else(|| eyre::eyre!("component not initialized"))?;
 
         info!("Rebuilding search index from database");
@@ -98,7 +99,7 @@ impl SearchComponent {
         );
 
         // Replace the old index with the new one
-        *self.index.write().await = new_index;
+        *self.index.write() = new_index;
         Ok(())
     }
 }
@@ -116,7 +117,7 @@ impl Component for SearchComponent {
     }
 
     async fn start(&mut self, handle: DaemonHandle) -> Result<()> {
-        *self.handle.write().await = Some(handle.clone());
+        *self.handle.write() = Some(handle.clone());
 
         // Spawn background task to load history into index
         let index = self.index.clone();
@@ -136,16 +137,16 @@ impl Component for SearchComponent {
                             "Loading {} history entries into search index",
                             histories.len()
                         );
-                        index.read().await.add_histories(&histories);
+                        index.read().add_histories(&histories);
                     }
                     Ok(None) => {
                         info!(
                             "Initial history load complete; {} unique commands indexed",
-                            index.read().await.command_count()
+                            index.read().command_count()
                         );
                         // Build initial frecency map with current settings
                         let settings = handle_for_loader.settings();
-                        index.read().await.rebuild_frecency(&settings.search);
+                        index.read().rebuild_frecency(&settings.search);
                         info!("Initial frecency map built");
                         break;
                     }
@@ -168,10 +169,7 @@ impl Component for SearchComponent {
                 interval.tick().await;
                 trace!("Refreshing frecency map");
                 let settings = handle_for_frecency.settings();
-                index_for_frecency
-                    .read()
-                    .await
-                    .rebuild_frecency(&settings.search);
+                index_for_frecency.read().rebuild_frecency(&settings.search);
             }
         }));
 
@@ -184,23 +182,20 @@ impl Component for SearchComponent {
             DaemonEvent::HistorySynced(ids) => {
                 debug!(count = ids.len(), "Indexing synced history entries");
 
-                let handle_guard = self.handle.read().await;
-                let Some(handle) = handle_guard.as_ref() else {
+                let Some(handle) = self.handle.read().clone() else {
                     return Ok(());
                 };
 
                 let histories = handle.history_db().load_active(ids).await?;
-                self.index.read().await.add_histories(&histories);
+                self.index.read().add_histories(&histories);
             }
             DaemonEvent::HistoryStarted(history) => {
                 debug!(id = %history.id, command = %history.command, "History started (no index action)");
             }
             DaemonEvent::HistoryEnded(history) => {
-                span!(Level::TRACE, "inject_history_ended")
-                    .in_scope(async || {
-                        self.index.read().await.add_history(history);
-                    })
-                    .await;
+                span!(Level::TRACE, "inject_history_ended").in_scope(|| {
+                    self.index.read().add_history(history);
+                });
             }
             DaemonEvent::HistoryPruned | DaemonEvent::HistoryRebuilt => {
                 info!("History store pruned or rebuilt, rebuilding search index");
@@ -221,13 +216,9 @@ impl Component for SearchComponent {
             }
             DaemonEvent::SettingsReloaded => {
                 info!("Settings reloaded, rebuilding frecency map with new multipliers");
-                let handle_guard = self.handle.read().await;
-                if let Some(handle) = handle_guard.as_ref() {
+                if let Some(handle) = self.handle.read().as_ref() {
                     let settings = handle.settings();
-                    self.index
-                        .read()
-                        .await
-                        .rebuild_frecency(&settings.search);
+                    self.index.read().rebuild_frecency(&settings.search);
                 }
             }
             // Events we don't care about
@@ -309,12 +300,16 @@ impl SearchSvc for SearchGrpcService {
 
                         // Perform the search
                         let history_ids =
-                            span!(Level::TRACE, "daemon_search_query", %query, query_id)
-                                .in_scope(|| async {
-                                    let index = index.read().await;
-                                    index.search(&query, index_filter, &query_context, RESULTS_LIMIT)
-                                })
-                                .await;
+                            span!(Level::TRACE, "daemon_search_query", %query, query_id).in_scope(
+                                || {
+                                    index.read().search(
+                                        &query,
+                                        index_filter,
+                                        &query_context,
+                                        RESULTS_LIMIT,
+                                    )
+                                },
+                            );
 
                         // Convert history IDs to bytes
                         let ids: Vec<Vec<u8>> = history_ids

--- a/crates/atuin-daemon/src/components/semantic.rs
+++ b/crates/atuin-daemon/src/components/semantic.rs
@@ -9,7 +9,7 @@ use std::sync::Arc;
 
 use atuin_client::history::{History, HistoryId};
 use eyre::Result;
-use tokio::sync::Mutex;
+use parking_lot::Mutex;
 use tonic::{Request, Response, Status, Streaming};
 use tracing::{Level, instrument};
 
@@ -118,14 +118,14 @@ impl Component for SemanticComponent {
 
     async fn handle_event(&mut self, event: &DaemonEvent) -> Result<()> {
         if let DaemonEvent::HistoryEnded(history) = event {
-            self.inner.record_history(history.clone()).await;
+            self.inner.record_history(history.clone());
         }
 
         Ok(())
     }
 
     async fn stop(&mut self) -> Result<()> {
-        let state = self.inner.state.lock().await;
+        let state = self.inner.state.lock();
         tracing::info!(
             sessions = state.sessions.len(),
             records = state.record_count(),
@@ -138,19 +138,16 @@ impl Component for SemanticComponent {
 }
 
 impl SemanticComponentInner {
-    async fn record_capture(&self, capture: CommandCapture) -> bool {
-        let mut state = self.state.lock().await;
-        state.record_capture(capture)
+    fn record_capture(&self, capture: CommandCapture) -> bool {
+        self.state.lock().record_capture(capture)
     }
 
-    async fn record_history(&self, history: History) {
-        let mut state = self.state.lock().await;
-        state.record_history(history);
+    fn record_history(&self, history: History) {
+        self.state.lock().record_history(history);
     }
 
-    async fn command_output(&self, request: &CommandOutputRequest) -> CommandOutputReply {
-        let mut state = self.state.lock().await;
-        state.command_output(request)
+    fn command_output(&self, request: &CommandOutputRequest) -> CommandOutputReply {
+        self.state.lock().command_output(request)
     }
 }
 
@@ -456,7 +453,7 @@ impl SemanticSvc for SemanticGrpcService {
         let mut accepted = 0_u64;
 
         while let Some(capture) = stream.message().await? {
-            if self.inner.record_capture(capture).await {
+            if self.inner.record_capture(capture) {
                 accepted += 1;
             }
         }
@@ -474,7 +471,7 @@ impl SemanticSvc for SemanticGrpcService {
             return Err(Status::invalid_argument("history_id is required"));
         }
 
-        Ok(Response::new(self.inner.command_output(&request).await))
+        Ok(Response::new(self.inner.command_output(&request)))
     }
 }
 

--- a/crates/atuin-daemon/src/components/sync.rs
+++ b/crates/atuin-daemon/src/components/sync.rs
@@ -115,8 +115,8 @@ impl Component for SyncComponent {
 async fn sync_loop(handle: DaemonHandle, mut cmd_rx: mpsc::Receiver<SyncCommand>) {
     tracing::info!("sync loop starting");
 
-    // Clone settings since we need them across await points
-    let settings = handle.settings().await.clone();
+    // Arc snapshot of the settings; safe to hold across await points
+    let settings = handle.settings();
     let host_id = match Settings::host_id().await {
         Ok(id) => id,
         Err(e) => {
@@ -145,7 +145,7 @@ async fn sync_loop(handle: DaemonHandle, mut cmd_rx: mpsc::Receiver<SyncCommand>
     loop {
         tokio::select! {
             _ = ticker.tick() => {
-                let settings = handle.settings().await;
+                let settings = handle.settings();
 
                 // Skip periodic ticks if auto_sync is disabled AND we're not retrying
                 // a previous failure. Retries must continue regardless of auto_sync.
@@ -168,7 +168,7 @@ async fn sync_loop(handle: DaemonHandle, mut cmd_rx: mpsc::Receiver<SyncCommand>
                 match cmd {
                     Some(SyncCommand::ForceSync) => {
                         tracing::info!("executing force sync");
-                        let settings = handle.settings().await;
+                        let settings = handle.settings();
                         sync_state = do_sync_tick(
                             &handle,
                             &history_store,

--- a/crates/atuin-daemon/src/daemon.rs
+++ b/crates/atuin-daemon/src/daemon.rs
@@ -15,7 +15,8 @@ use atuin_client::{
     settings::Settings,
 };
 use eyre::{Context, Result};
-use tokio::sync::{RwLock, broadcast};
+use parking_lot::RwLock;
+use tokio::sync::broadcast;
 
 use crate::events::DaemonEvent;
 
@@ -31,8 +32,8 @@ pub struct DaemonState {
     // Event bus
     event_tx: broadcast::Sender<DaemonEvent>,
 
-    // Configuration (mutable - can be reloaded)
-    settings: RwLock<Settings>,
+    // Configuration (mutable - can be reloaded; readers take an Arc snapshot)
+    settings: RwLock<Arc<Settings>>,
 
     // Encryption key (immutable - derived at startup)
     encryption_key: [u8; 32],
@@ -65,7 +66,7 @@ pub struct DaemonState {
 /// handle.emit(DaemonEvent::HistoryPruned);
 ///
 /// // Access settings
-/// let settings = handle.settings().await;
+/// let settings = handle.settings();
 /// let sync_freq = settings.daemon.sync_frequency;
 ///
 /// // Access database
@@ -105,21 +106,21 @@ impl DaemonHandle {
 
     // ---- Configuration ----
 
-    /// Get the current settings.
+    /// Get a snapshot of the current settings.
     ///
-    /// This acquires a read lock on the settings. For most use cases, clone
-    /// the settings if you need to hold onto them.
-    pub async fn settings(&self) -> tokio::sync::RwLockReadGuard<'_, Settings> {
-        self.state.settings.read().await
+    /// Returns a cheap `Arc` clone. The snapshot is immutable; a settings
+    /// reload swaps in a new `Arc`, so hold the snapshot as long as needed.
+    pub fn settings(&self) -> Arc<Settings> {
+        self.state.settings.read().clone()
     }
 
     /// Reload settings from disk and emit a SettingsReloaded event.
     ///
     /// Components listening for `SettingsReloaded` can then re-read settings
     /// via `handle.settings()` to pick up the changes.
-    pub async fn reload_settings(&self) -> Result<()> {
+    pub fn reload_settings(&self) -> Result<()> {
         let new_settings = Settings::new()?;
-        self.apply_settings(new_settings).await;
+        self.apply_settings(Arc::new(new_settings));
         Ok(())
     }
 
@@ -127,8 +128,8 @@ impl DaemonHandle {
     ///
     /// Use this when settings have already been loaded (e.g., from a file watcher)
     /// to avoid parsing the config file twice.
-    pub async fn apply_settings(&self, settings: Settings) {
-        *self.state.settings.write().await = settings;
+    pub fn apply_settings(&self, settings: Arc<Settings>) {
+        *self.state.settings.write() = settings;
         self.emit(DaemonEvent::SettingsReloaded);
         tracing::info!("settings applied");
     }
@@ -441,7 +442,7 @@ impl DaemonBuilder {
         // Create the shared state
         let state = Arc::new(DaemonState {
             event_tx,
-            settings: RwLock::new(self.settings),
+            settings: RwLock::new(Arc::new(self.settings)),
             encryption_key,
             history_db,
             store,

--- a/crates/atuin-daemon/src/lib.rs
+++ b/crates/atuin-daemon/src/lib.rs
@@ -74,7 +74,7 @@ pub async fn boot(
                 // Use the already-loaded settings from the watcher
                 // (avoids parsing the config file twice)
                 let new_settings = (*settings_rx.borrow()).clone();
-                watcher_handle.apply_settings((*new_settings).clone()).await;
+                watcher_handle.apply_settings(new_settings);
             }
             tracing::debug!("config file watcher stopped");
         });

--- a/crates/atuin-daemon/src/search/index.rs
+++ b/crates/atuin-daemon/src/search/index.rs
@@ -18,8 +18,8 @@ use atuin_common::path::DisplayRichExt;
 use atuin_nucleo::{Injector, Nucleo, pattern};
 use dashmap::DashMap;
 use lasso::{Spur, ThreadedRodeo};
-use time::OffsetDateTime;
 use parking_lot::RwLock;
+use time::OffsetDateTime;
 use tracing::{Level, instrument};
 use uuid::Uuid;
 
@@ -691,8 +691,7 @@ mod tests {
         assert_eq!(index.command_count(), 3);
 
         // Search for "git" - should match 2 commands
-        let results =
-            index.search("git", IndexFilterMode::Global, &QueryContext::default(), 10);
+        let results = index.search("git", IndexFilterMode::Global, &QueryContext::default(), 10);
         assert_eq!(results.len(), 2);
 
         // Search with directory filter

--- a/crates/atuin-daemon/src/search/index.rs
+++ b/crates/atuin-daemon/src/search/index.rs
@@ -19,7 +19,7 @@ use atuin_nucleo::{Injector, Nucleo, pattern};
 use dashmap::DashMap;
 use lasso::{Spur, ThreadedRodeo};
 use time::OffsetDateTime;
-use tokio::sync::RwLock;
+use parking_lot::RwLock;
 use tracing::{Level, instrument};
 use uuid::Uuid;
 
@@ -329,8 +329,8 @@ impl SearchIndex {
     }
 
     /// Get the number of items in Nucleo (should match command_count).
-    pub async fn nucleo_item_count(&self) -> u32 {
-        self.nucleo.read().await.snapshot().item_count()
+    pub fn nucleo_item_count(&self) -> u32 {
+        self.nucleo.read().snapshot().item_count()
     }
 
     /// Search for commands matching a query.
@@ -338,17 +338,17 @@ impl SearchIndex {
     /// Returns a list of history IDs (most recent invocation per command).
     /// Uses precomputed global frecency for scoring if available.
     #[instrument(skip_all, level = tracing::Level::TRACE, name = "index_search", fields(query = %query))]
-    pub async fn search(
+    pub fn search(
         &self,
         query: &str,
         filter_mode: IndexFilterMode,
         _context: &QueryContext,
         limit: u32,
     ) -> Vec<String> {
-        let mut nucleo = self.nucleo.write().await;
+        let mut nucleo = self.nucleo.write();
 
         // Get precomputed frecency map (may be None if not yet computed)
-        let frecency_map = self.frecency_map.read().await.clone();
+        let frecency_map = self.frecency_map.read().clone();
 
         // Build filter based on mode
         let filter = self.build_filter(&filter_mode);
@@ -400,7 +400,7 @@ impl SearchIndex {
     /// - `frequency_score_multiplier`: Weight for frequency component
     /// - `frecency_score_multiplier`: Overall multiplier for final score
     #[instrument(skip_all, level = tracing::Level::DEBUG, name = "rebuild_frecency")]
-    pub async fn rebuild_frecency(&self, search_settings: &Search) {
+    pub fn rebuild_frecency(&self, search_settings: &Search) {
         let now = OffsetDateTime::now_utc().unix_timestamp();
         let mut frecency_map: HashMap<Arc<str>, u32> = HashMap::new();
 
@@ -420,7 +420,7 @@ impl SearchIndex {
             frecency_map.insert(Arc::clone(entry.key()), frecency);
         }
 
-        *self.frecency_map.write().await = Some(Arc::new(frecency_map));
+        *self.frecency_map.write() = Some(Arc::new(frecency_map));
     }
 
     /// Build filter predicate for the given mode.
@@ -664,8 +664,8 @@ mod tests {
         assert!(!data.has_invocation_in_workspace(&check3, &interner));
     }
 
-    #[tokio::test]
-    async fn search_index_add_and_search() {
+    #[test]
+    fn search_index_add_and_search() {
         let index = SearchIndex::new();
 
         let h1 = make_history(
@@ -691,25 +691,22 @@ mod tests {
         assert_eq!(index.command_count(), 3);
 
         // Search for "git" - should match 2 commands
-        let results = index
-            .search("git", IndexFilterMode::Global, &QueryContext::default(), 10)
-            .await;
+        let results =
+            index.search("git", IndexFilterMode::Global, &QueryContext::default(), 10);
         assert_eq!(results.len(), 2);
 
         // Search with directory filter
-        let results = index
-            .search(
-                "",
-                IndexFilterMode::Directory(
-                    "/home/user/project"
-                        .display_rich()
-                        .trailing_slash(true)
-                        .to_string(),
-                ),
-                &QueryContext::default(),
-                10,
-            )
-            .await;
+        let results = index.search(
+            "",
+            IndexFilterMode::Directory(
+                "/home/user/project"
+                    .display_rich()
+                    .trailing_slash(true)
+                    .to_string(),
+            ),
+            &QueryContext::default(),
+            10,
+        );
         assert_eq!(results.len(), 2); // git status and git commit
     }
 }

--- a/crates/atuin-nucleo/Cargo.toml
+++ b/crates/atuin-nucleo/Cargo.toml
@@ -13,5 +13,5 @@ exclude = ["/typos.toml", "/tarpaulin.toml"]
 
 [dependencies]
 atuin-nucleo-matcher = { version = "0.3.1", path = "matcher" }
-parking_lot = { version = "0.12.1", features = ["send_guard", "arc_lock"] }
+parking_lot = { workspace = true, features = ["send_guard", "arc_lock"] }
 rayon = "1.7.0"


### PR DESCRIPTION
## Summary

Converts `std::sync`/`tokio::sync` locks to `parking_lot` wherever no guard needs to cross an `.await`, removing async lock machinery from the daemon's hot paths:

- **Search path** (runs per keystroke): `SearchIndex::search`/`rebuild_frecency`/`nucleo_item_count` are now fully synchronous; both the inner index locks and the outer `Arc<RwLock<SearchIndex>>` are parking_lot.
- **Settings**: `parking_lot::RwLock<Arc<Settings>>` snapshot pattern — `settings()` is now sync and returns a cheap `Arc<Settings>`; the config watcher no longer deep-clones `Settings` per reload.
- **History component** (per command completion): parking_lot with a clone-out pattern so no guard is held across the DB writes in `end_history`.
- **Semantic component** and **atuin-ai user-context cache**: direct Mutex conversions; std poison-recovery handling removed (parking_lot has no poisoning).

Intentionally untouched: tokio channels (`broadcast`/`mpsc`/`watch`), `DashMap`s, `std::sync::Once`/`OnceLock`, and the test-only mutex in `atuin-common` (rationale table in `docs/superpowers/plans/2026-07-22-parking-lot-conversion.md`).

## Safety notes

`atuin-nucleo` enables parking_lot's `send_guard` feature, and cargo feature-unification makes guards `Send` workspace-wide — so the compiler cannot catch a guard held across an `.await`. Every conversion was manually audited for this, and a final whole-branch review independently re-derived the guard lifetime at every lock site plus a lock-ordering analysis (no cycles; deepest nesting was flattened in the last commit).

## Behavior deltas (benign, for the record)

- Settings reloads no longer wait for an in-flight sync tick: previously the tokio read guard held across `do_sync_tick` blocked `apply_settings` until the tick finished. Now the reload applies immediately and the in-flight tick completes on its stale snapshot; the next tick sees the new settings.
- Concurrent interactive searches block an OS worker thread on the nucleo write lock instead of yielding to tokio. Millisecond-scale, and the old code already blocked a runtime thread on the same CPU-bound work while holding the tokio lock.

## Testing

- `cargo test` green on `atuin-daemon` (23), `atuin-ai` (270), `atuin-nucleo` (12), plus `atuin`/`atuin-client` suites; the only workspace failures are the pre-existing Postgres-dependent `tests/users.rs` (environmental, untouched by this branch).
- `cargo clippy --workspace` zero warnings; `cargo fmt --all -- --check` clean; `cargo tree` confirms a single `parking_lot v0.12.5`.