### PR TITLE
fix: Atuin AI not erasing the input box before closing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1669,9 +1669,9 @@ dependencies = [
 
 [[package]]
 name = "eye_declare"
-version = "0.6.2"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80dcc9ff67e8474dc551572afc209d96caba03917060e42aea673aa99737b552"
+checksum = "c1cc99af3bcd67a004429420e80ab4b48d9bf0b8e5fc088baf6efe315459f6bd"
 dependencies = [
  "crossterm",
  "eye_declare_engine",
@@ -1686,9 +1686,9 @@ dependencies = [
 
 [[package]]
 name = "eye_declare_engine"
-version = "0.6.2"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd864458085188a89c3f84b86a243d02a64e213b8ceb97b059ba8c941474cc30"
+checksum = "b04e565ceb56e538fc2ee52b2907d3a1deda69b22d63f9f21f058ff8d443df36"
 dependencies = [
  "ratatui-core",
  "ratatui-widgets",

--- a/crates/atuin-ai/Cargo.toml
+++ b/crates/atuin-ai/Cargo.toml
@@ -49,8 +49,8 @@ uuid = { workspace = true }
 tui-textarea-2 = "0.10.2"
 unicode-width = "0.2"
 # Path dependency until eye_declare 0.6.0 publishes; then just a version.
-eye_declare = "0.6.2"
-eye_declare_engine = { version = "0.6.2", features = ["test-util"] }
+eye_declare = "0.6.3"
+eye_declare_engine = { version = "0.6.3", features = ["test-util"] }
 ratatui-core = "0.1"
 ratatui-widgets = "0.3"
 thiserror = { workspace = true }

--- a/crates/atuin-ai/src/commands/init.rs
+++ b/crates/atuin-ai/src/commands/init.rs
@@ -27,9 +27,19 @@ fn generate_auto_integration() -> eyre::Result<&'static str> {
 /// Generate the zsh integration function - pure function for easy testing
 pub fn generate_zsh_integration() -> &'static str {
     r#"
-# TUI uses an alternate screen, so no explicit cleanup is needed.
 _atuin_ai_cleanup() {
     true
+}
+
+# zle reset-prompt anchors the repaint at the cursor row: a multi-line
+# prompt grows *upward*, overwriting whatever the inline TUI left on the
+# rows above. Pad with prompt-height - 1 newlines first so the repaint
+# lands on blank rows below the conversation instead.
+_atuin_ai_reset_prompt() {
+    local -a _prompt_lines=("${(@f)${(%%)PROMPT}}")
+    local -i _pad=$(( ${#_prompt_lines} - 1 ))
+    (( _pad > 0 )) && printf '\n%.0s' {1..$_pad} >/dev/tty
+    zle reset-prompt
 }
 
 # Question mark at start of line - natural language mode.
@@ -46,25 +56,25 @@ self-atuin-ai-question-mark() {
         _atuin_ai_cleanup
 
         if [[ $output == __atuin_ai_print__:* ]]; then
-            zle -I
             echo "${output#__atuin_ai_print__:}"
+            _atuin_ai_reset_prompt
         elif [[ $output == __atuin_ai_cancel__ ]]; then
-            zle reset-prompt
+            _atuin_ai_reset_prompt
         elif [[ $output == __atuin_ai_execute__:* ]]; then
             RBUFFER=""
             LBUFFER=${output#__atuin_ai_execute__:}
-            zle reset-prompt
+            _atuin_ai_reset_prompt
             zle accept-line
         elif [[ $output == __atuin_ai_insert__:* ]]; then
             RBUFFER=""
             LBUFFER=${output#__atuin_ai_insert__:}
-            zle reset-prompt
+            _atuin_ai_reset_prompt
         elif [[ -n $output ]]; then
             RBUFFER=""
             LBUFFER=$output
-            zle reset-prompt
+            _atuin_ai_reset_prompt
         else
-            zle reset-prompt
+            _atuin_ai_reset_prompt
         fi
     else
         zle self-insert

--- a/crates/atuin-ai/src/commands/inline.rs
+++ b/crates/atuin-ai/src/commands/inline.rs
@@ -346,9 +346,6 @@ async fn run_inline_tui(
     // session snapshot is on disk before the process can exit.
     let _ = persist_worker.await;
 
-    // v1 emitted one extra newline at exit; keep the shell handoff spacing.
-    println!();
-
     Ok(outcome)
 }
 

--- a/crates/atuin-ai/src/tui/app.rs
+++ b/crates/atuin-ai/src/tui/app.rs
@@ -79,7 +79,7 @@ pub(crate) enum Msg {
     /// Retry after an error (Enter / r).
     Retry,
     /// Leave the TUI without a command.
-    Quit,
+    Quit(ExitOutcome),
     /// Move the model-picker cursor (Up/Down while picking).
     ModelSelect(SelectMsg),
     /// Choose the highlighted model (Enter while picking).
@@ -133,6 +133,7 @@ pub(crate) struct AiApp {
     /// Turns already committed — 0 means the next turn is the first (no
     /// leading blank row).
     pushed_turns: usize,
+    exiting: bool,
 }
 
 impl AiApp {
@@ -188,6 +189,7 @@ impl AiApp {
             slash_results: Vec::new(),
             pushed_events: 0,
             pushed_turns: 0,
+            exiting: false,
         }
     }
 
@@ -313,11 +315,15 @@ impl AiApp {
         }
         for effect in effects {
             match effect {
-                Effect::ExitApp(action) => ctx.exit(match action {
-                    ExitAction::Execute(cmd) => ExitOutcome::Execute(cmd),
-                    ExitAction::Insert(cmd) => ExitOutcome::Insert(cmd),
-                    ExitAction::Cancel => ExitOutcome::Cancel,
-                }),
+                Effect::ExitApp(action) => {
+                    let exit = match action {
+                        ExitAction::Execute(cmd) => ExitOutcome::Execute(cmd),
+                        ExitAction::Insert(cmd) => ExitOutcome::Insert(cmd),
+                        ExitAction::Cancel => ExitOutcome::Cancel,
+                    };
+                    self.exiting = true;
+                    ctx.perform(async move { Msg::Quit(exit) }).detach();
+                }
                 Effect::StartStream {
                     messages,
                     session_id,
@@ -954,7 +960,7 @@ impl App for AiApp {
             Msg::Cancel => self.handle_fsm(Event::Cancel, ctx),
             Msg::Interrupt => self.handle_fsm(Event::InterruptTools, ctx),
             Msg::Retry => self.handle_fsm(Event::Retry, ctx),
-            Msg::Quit => ctx.exit(ExitOutcome::Cancel),
+            Msg::Quit(outcome) => ctx.exit(outcome),
             Msg::ModelSelect(sel) => {
                 let len = match &self.fsm.ctx.model_picker {
                     Some(crate::fsm::ModelPicker::Ready(list)) => list.models.len(),
@@ -999,7 +1005,7 @@ impl App for AiApp {
             self.fsm.ctx.model_picker,
             Some(crate::fsm::ModelPicker::Loading)
         );
-        let show_input = asking.is_none() && ready_picker.is_none();
+        let show_input = asking.is_none() && ready_picker.is_none() && !self.exiting;
         let needs_pending_banner = busy
             && !matches!(
                 turns.last().map(|t| &t.kind),
@@ -1092,7 +1098,7 @@ impl App for AiApp {
             if self.shell_executing() {
                 Msg::Interrupt
             } else {
-                Msg::Quit
+                Msg::Quit(ExitOutcome::Cancel)
             },
         );
 

--- a/crates/atuin-ai/src/tui/app.rs
+++ b/crates/atuin-ai/src/tui/app.rs
@@ -321,8 +321,12 @@ impl AiApp {
                         ExitAction::Insert(cmd) => ExitOutcome::Insert(cmd),
                         ExitAction::Cancel => ExitOutcome::Cancel,
                     };
+                    // The runtime presents once more after an exit-requesting
+                    // update, and finalize reclaims the rows the tail vacated —
+                    // so hiding the input and exiting in the same update leaves
+                    // the screen without it. No deferred render needed.
                     self.exiting = true;
-                    ctx.perform(async move { Msg::Quit(exit) }).detach();
+                    ctx.exit(exit);
                 }
                 Effect::StartStream {
                     messages,
@@ -960,7 +964,10 @@ impl App for AiApp {
             Msg::Cancel => self.handle_fsm(Event::Cancel, ctx),
             Msg::Interrupt => self.handle_fsm(Event::InterruptTools, ctx),
             Msg::Retry => self.handle_fsm(Event::Retry, ctx),
-            Msg::Quit(outcome) => ctx.exit(outcome),
+            Msg::Quit(outcome) => {
+                self.exiting = true;
+                ctx.exit(outcome);
+            }
             Msg::ModelSelect(sel) => {
                 let len = match &self.fsm.ctx.model_picker {
                     Some(crate::fsm::ModelPicker::Ready(list)) => list.models.len(),
@@ -1277,6 +1284,24 @@ mod tests {
     fn esc_exits_with_cancel() {
         let mut h = Harness::new(fixture_app());
         assert_eq!(h.press(KeyCode::Esc), Some(ExitOutcome::Cancel));
+    }
+
+    #[test]
+    fn exit_erases_the_input_box() {
+        let mut h = Harness::new(fixture_app());
+        assert!(
+            h.screen().contains("Generate a command or ask a question"),
+            "input box missing before exit:\n{}",
+            h.screen()
+        );
+
+        h.press(KeyCode::Esc);
+        assert!(
+            !h.all_lines()
+                .contains("Generate a command or ask a question"),
+            "input box still on screen after exit:\n{}",
+            h.all_lines()
+        );
     }
 
     #[test]


### PR DESCRIPTION
Before the latest eye-declare update, Atuin AI would render a single frame without the input box showing, in order to make the final output as clean as possible. This PR updates the zsh integration for Atuin AI to ensure the proper lines are removed.