### PR TITLE
feat: allow injecting extra HTTP headers on sync server requests 

### DIFF
--- a/crates/atuin-client/config.toml
+++ b/crates/atuin-client/config.toml
@@ -189,6 +189,12 @@
 # network_connect_timeout = 5
 # network_timeout = 30
 
+## Extra HTTP headers to send on every request to the sync server. Useful when
+## a self-hosted server sits behind a proxy that requires its own auth header,
+## e.g. Cloudflare Access. Headers that Atuin sets itself (e.g. Authorization)
+## cannot be overridden.
+# extra_headers = { "CF-Access-Client-Id" = "...", "CF-Access-Client-Secret" = "..." }
+
 ## Timeout (in seconds) for acquiring a local database connection (sqlite)
 # local_timeout = 5
 

--- a/crates/atuin-client/config.toml
+++ b/crates/atuin-client/config.toml
@@ -192,7 +192,8 @@
 ## Extra HTTP headers to send on every request to the sync server. Useful when
 ## a self-hosted server sits behind a proxy that requires its own auth header,
 ## e.g. Cloudflare Access. Headers that Atuin sets itself (e.g. Authorization)
-## cannot be overridden.
+## cannot be overridden. When set, cross-origin redirects are refused so these
+## headers are never sent to a different origin.
 # extra_headers = { "CF-Access-Client-Id" = "...", "CF-Access-Client-Secret" = "..." }
 
 ## Timeout (in seconds) for acquiring a local database connection (sqlite)

--- a/crates/atuin-client/src/api_client.rs
+++ b/crates/atuin-client/src/api_client.rs
@@ -57,6 +57,39 @@ pub struct Client<'a> {
     client: reqwest::Client,
 }
 
+/// A [`reqwest::ClientBuilder`] appropriate for the given extra headers.
+///
+/// reqwest only strips its own well-known sensitive headers (Authorization,
+/// Cookie, ...) when following a cross-host redirect; user-configured extra
+/// headers would be forwarded as-is. Since those often carry credentials
+/// (e.g. Cloudflare Access secrets), refuse cross-origin redirects entirely
+/// whenever extra headers are configured.
+pub(crate) fn client_builder(extra_headers: &HashMap<String, String>) -> reqwest::ClientBuilder {
+    let builder = reqwest::Client::builder();
+
+    if extra_headers.is_empty() {
+        return builder;
+    }
+
+    builder.redirect(reqwest::redirect::Policy::custom(|attempt| {
+        let same_origin = attempt.previous().last().is_some_and(|prev| {
+            prev.scheme() == attempt.url().scheme()
+                && prev.host_str() == attempt.url().host_str()
+                && prev.port_or_known_default() == attempt.url().port_or_known_default()
+        });
+
+        if !same_origin {
+            attempt.error(
+                "refusing to follow cross-origin redirect: extra_headers are configured and will not be sent to a different origin",
+            )
+        } else if attempt.previous().len() > 10 {
+            attempt.error("too many redirects")
+        } else {
+            attempt.follow()
+        }
+    }))
+}
+
 /// Build a [`HeaderMap`] from user-configured extra headers (the
 /// `extra_headers` setting). Headers Atuin sets itself should be inserted
 /// after these so that Atuin's values win.
@@ -89,7 +122,7 @@ pub async fn register(
     headers.insert(USER_AGENT, APP_USER_AGENT.parse()?);
     headers.insert(ATUIN_HEADER_VERSION, ATUIN_CARGO_VERSION.parse()?);
 
-    let client = reqwest::Client::new();
+    let client = client_builder(extra_headers).build()?;
 
     let url = address.append(["user", username])?;
     let resp = client.get(url).headers(headers.clone()).send().await?;
@@ -117,7 +150,7 @@ pub async fn login(
 ) -> Result<LoginResponse> {
     ensure_crypto_provider();
     let url = address.append(["login"])?;
-    let client = reqwest::Client::new();
+    let client = client_builder(extra_headers).build()?;
 
     let mut headers = extra_headers_map(extra_headers)?;
     headers.insert(USER_AGENT, APP_USER_AGENT.parse()?);
@@ -235,7 +268,7 @@ impl<'a> Client<'a> {
 
         Ok(Client {
             sync_addr,
-            client: reqwest::Client::builder()
+            client: client_builder(extra_headers)
                 .default_headers(headers)
                 .connect_timeout(Duration::new(connect_timeout, 0))
                 .timeout(Duration::new(timeout, 0))
@@ -388,5 +421,84 @@ mod tests {
         let mut extra = HashMap::new();
         extra.insert("bad header".to_string(), "value".to_string());
         assert!(extra_headers_map(&extra).is_err());
+    }
+
+    /// Serve a single connection with a canned HTTP response.
+    async fn serve_one(listener: &tokio::net::TcpListener, response: String) {
+        use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+        let (mut sock, _) = listener.accept().await.unwrap();
+        let mut buf = [0u8; 4096];
+        let _ = sock.read(&mut buf).await;
+        sock.write_all(response.as_bytes()).await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn cross_origin_redirects_refused_with_extra_headers() {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let port = listener.local_addr().unwrap().port();
+
+        // A different port on the same host is a different origin
+        tokio::spawn(async move {
+            serve_one(
+                &listener,
+                format!(
+                    "HTTP/1.1 302 Found\r\nLocation: http://127.0.0.1:{}/\r\nContent-Length: 0\r\nConnection: close\r\n\r\n",
+                    port + 1
+                ),
+            )
+            .await;
+        });
+
+        let mut extra = HashMap::new();
+        extra.insert("X-Auth-Token".to_string(), "secret".to_string());
+
+        ensure_crypto_provider();
+        let client = client_builder(&extra).build().unwrap();
+        let err = client
+            .get(format!("http://127.0.0.1:{port}/"))
+            .send()
+            .await
+            .unwrap_err();
+
+        assert!(
+            err.is_redirect(),
+            "expected a redirect policy error: {err:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn same_origin_redirects_followed_with_extra_headers() {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let port = listener.local_addr().unwrap().port();
+
+        tokio::spawn(async move {
+            serve_one(
+                &listener,
+                format!(
+                    "HTTP/1.1 302 Found\r\nLocation: http://127.0.0.1:{port}/ok\r\nContent-Length: 0\r\nConnection: close\r\n\r\n"
+                ),
+            )
+            .await;
+            serve_one(
+                &listener,
+                "HTTP/1.1 200 OK\r\nContent-Length: 0\r\nConnection: close\r\n\r\n".to_string(),
+            )
+            .await;
+        });
+
+        let mut extra = HashMap::new();
+        extra.insert("X-Auth-Token".to_string(), "secret".to_string());
+
+        ensure_crypto_provider();
+        let client = client_builder(&extra).build().unwrap();
+        let resp = client
+            .get(format!("http://127.0.0.1:{port}/"))
+            .send()
+            .await
+            .unwrap();
+
+        assert_eq!(resp.status(), 200);
+        assert_eq!(resp.url().path(), "/ok");
     }
 }

--- a/crates/atuin-client/src/api_client.rs
+++ b/crates/atuin-client/src/api_client.rs
@@ -5,7 +5,7 @@ use std::time::Duration;
 use eyre::{Result, bail};
 use reqwest::{
     Response, StatusCode, Url,
-    header::{AUTHORIZATION, HeaderMap, USER_AGENT},
+    header::{AUTHORIZATION, HeaderMap, HeaderName, HeaderValue, USER_AGENT},
 };
 
 use atuin_common::{
@@ -57,11 +57,27 @@ pub struct Client<'a> {
     client: reqwest::Client,
 }
 
+/// Build a [`HeaderMap`] from user-configured extra headers (the
+/// `extra_headers` setting). Headers Atuin sets itself should be inserted
+/// after these so that Atuin's values win.
+pub(crate) fn extra_headers_map(extra_headers: &HashMap<String, String>) -> Result<HeaderMap> {
+    let mut headers = HeaderMap::new();
+    for (name, value) in extra_headers {
+        let name = HeaderName::from_bytes(name.as_bytes())
+            .map_err(|e| eyre::eyre!("invalid extra_headers name {name:?}: {e}"))?;
+        let value = HeaderValue::from_str(value)
+            .map_err(|e| eyre::eyre!("invalid extra_headers value for {name:?}: {e}"))?;
+        headers.insert(name, value);
+    }
+    Ok(headers)
+}
+
 pub async fn register(
     address: &Url,
     username: &str,
     email: &str,
     password: &str,
+    extra_headers: &HashMap<String, String>,
 ) -> Result<RegisterResponse> {
     ensure_crypto_provider();
     let mut map = HashMap::new();
@@ -69,22 +85,21 @@ pub async fn register(
     map.insert("email", email);
     map.insert("password", password);
 
+    let mut headers = extra_headers_map(extra_headers)?;
+    headers.insert(USER_AGENT, APP_USER_AGENT.parse()?);
+    headers.insert(ATUIN_HEADER_VERSION, ATUIN_CARGO_VERSION.parse()?);
+
+    let client = reqwest::Client::new();
+
     let url = address.append(["user", username])?;
-    let resp = reqwest::get(url).await?;
+    let resp = client.get(url).headers(headers.clone()).send().await?;
 
     if resp.status().is_success() {
         bail!("username already in use");
     }
 
     let url = address.append(["register"])?;
-    let client = reqwest::Client::new();
-    let resp = client
-        .post(url)
-        .header(USER_AGENT, APP_USER_AGENT)
-        .header(ATUIN_HEADER_VERSION, ATUIN_CARGO_VERSION)
-        .json(&map)
-        .send()
-        .await?;
+    let resp = client.post(url).headers(headers).json(&map).send().await?;
     let resp = handle_resp_error(resp).await?;
 
     if !ensure_version(&resp)? {
@@ -95,17 +110,19 @@ pub async fn register(
     Ok(session)
 }
 
-pub async fn login(address: &Url, req: LoginRequest) -> Result<LoginResponse> {
+pub async fn login(
+    address: &Url,
+    req: LoginRequest,
+    extra_headers: &HashMap<String, String>,
+) -> Result<LoginResponse> {
     ensure_crypto_provider();
     let url = address.append(["login"])?;
     let client = reqwest::Client::new();
 
-    let resp = client
-        .post(url)
-        .header(USER_AGENT, APP_USER_AGENT)
-        .json(&req)
-        .send()
-        .await?;
+    let mut headers = extra_headers_map(extra_headers)?;
+    headers.insert(USER_AGENT, APP_USER_AGENT.parse()?);
+
+    let resp = client.post(url).headers(headers).json(&req).send().await?;
     let resp = handle_resp_error(resp).await?;
 
     if !ensure_version(&resp)? {
@@ -206,10 +223,12 @@ impl<'a> Client<'a> {
         auth: AuthToken,
         connect_timeout: u64,
         timeout: u64,
+        extra_headers: &HashMap<String, String>,
     ) -> Result<Self> {
         ensure_crypto_provider();
-        let mut headers = HeaderMap::new();
+        let mut headers = extra_headers_map(extra_headers)?;
         headers.insert(AUTHORIZATION, auth.to_header_value().parse()?);
+        headers.insert(USER_AGENT, APP_USER_AGENT.parse()?);
 
         // used for semver server check
         headers.insert(ATUIN_HEADER_VERSION, ATUIN_CARGO_VERSION.parse()?);
@@ -217,7 +236,6 @@ impl<'a> Client<'a> {
         Ok(Client {
             sync_addr,
             client: reqwest::Client::builder()
-                .user_agent(APP_USER_AGENT)
                 .default_headers(headers)
                 .connect_timeout(Duration::new(connect_timeout, 0))
                 .timeout(Duration::new(timeout, 0))
@@ -338,5 +356,37 @@ impl<'a> Client<'a> {
         } else {
             bail!("Unknown error");
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn extra_headers_map_parses_headers() {
+        let mut extra = HashMap::new();
+        extra.insert("X-Auth-Token".to_string(), "secret".to_string());
+        let headers = extra_headers_map(&extra).unwrap();
+        assert_eq!(headers.get("x-auth-token").unwrap(), "secret");
+    }
+
+    #[test]
+    fn atuin_headers_override_extra_headers() {
+        let mut extra = HashMap::new();
+        extra.insert("Authorization".to_string(), "Token user-value".to_string());
+
+        let mut headers = extra_headers_map(&extra).unwrap();
+        headers.insert(AUTHORIZATION, "Token atuin-value".parse().unwrap());
+
+        assert_eq!(headers.get(AUTHORIZATION).unwrap(), "Token atuin-value");
+        assert_eq!(headers.get_all(AUTHORIZATION).iter().count(), 1);
+    }
+
+    #[test]
+    fn extra_headers_map_rejects_invalid_names() {
+        let mut extra = HashMap::new();
+        extra.insert("bad header".to_string(), "value".to_string());
+        assert!(extra_headers_map(&extra).is_err());
     }
 }

--- a/crates/atuin-client/src/auth.rs
+++ b/crates/atuin-client/src/auth.rs
@@ -1,3 +1,5 @@
+use std::collections::HashMap;
+
 use async_trait::async_trait;
 use eyre::{Context, Result, bail};
 use reqwest::{StatusCode, Url, header::USER_AGENT};
@@ -87,6 +89,7 @@ pub async fn auth_client(settings: &Settings) -> Box<dyn AuthClient> {
             settings.session_token().await.ok(),
             settings.network_connect_timeout,
             settings.network_timeout,
+            settings.extra_headers.clone(),
         )) as Box<dyn AuthClient>
     }
 }
@@ -100,6 +103,7 @@ pub struct LegacyAuthClient {
     session_token: Option<String>,
     connect_timeout: u64,
     timeout: u64,
+    extra_headers: HashMap<String, String>,
 }
 
 impl LegacyAuthClient {
@@ -108,12 +112,14 @@ impl LegacyAuthClient {
         session_token: Option<String>,
         connect_timeout: u64,
         timeout: u64,
+        extra_headers: HashMap<String, String>,
     ) -> Self {
         Self {
             address: address.clone(),
             session_token,
             connect_timeout,
             timeout,
+            extra_headers,
         }
     }
 
@@ -124,7 +130,7 @@ impl LegacyAuthClient {
             .ok_or_else(|| eyre::eyre!("Not logged in"))?;
 
         ensure_crypto_provider();
-        let mut headers = reqwest::header::HeaderMap::new();
+        let mut headers = crate::api_client::extra_headers_map(&self.extra_headers)?;
         headers.insert(
             reqwest::header::AUTHORIZATION,
             format!("Token {token}").parse()?,
@@ -155,6 +161,7 @@ impl AuthClient for LegacyAuthClient {
                 username: username.to_string(),
                 password: password.to_string(),
             },
+            &self.extra_headers,
         )
         .await?;
 
@@ -165,7 +172,14 @@ impl AuthClient for LegacyAuthClient {
     }
 
     async fn register(&self, username: &str, email: &str, password: &str) -> Result<AuthResponse> {
-        let resp = crate::api_client::register(&self.address, username, email, password).await?;
+        let resp = crate::api_client::register(
+            &self.address,
+            username,
+            email,
+            password,
+            &self.extra_headers,
+        )
+        .await?;
         Ok(AuthResponse::Success {
             session: resp.session,
             auth_type: resp.auth.or(Some("cli".into())),

--- a/crates/atuin-client/src/auth.rs
+++ b/crates/atuin-client/src/auth.rs
@@ -138,7 +138,7 @@ impl LegacyAuthClient {
         headers.insert(USER_AGENT, APP_USER_AGENT.parse()?);
         headers.insert(ATUIN_HEADER_VERSION, ATUIN_CARGO_VERSION.parse()?);
 
-        Ok(reqwest::Client::builder()
+        Ok(crate::api_client::client_builder(&self.extra_headers)
             .default_headers(headers)
             .connect_timeout(std::time::Duration::new(self.connect_timeout, 0))
             .timeout(std::time::Duration::new(self.timeout, 0))

--- a/crates/atuin-client/src/login.rs
+++ b/crates/atuin-client/src/login.rs
@@ -69,8 +69,12 @@ pub async fn login(
         }
     }
 
-    let session =
-        api_client::login(&settings.sync_address, LoginRequest { username, password }).await?;
+    let session = api_client::login(
+        &settings.sync_address,
+        LoginRequest { username, password },
+        &settings.extra_headers,
+    )
+    .await?;
 
     Settings::meta_store()
         .await?

--- a/crates/atuin-client/src/record/sync.rs
+++ b/crates/atuin-client/src/record/sync.rs
@@ -66,6 +66,7 @@ pub async fn build_client(settings: &Settings) -> Result<Client<'_>, SyncError> 
             .map_err(|e| SyncError::RemoteRequestError { msg: e.to_string() })?,
         settings.network_connect_timeout,
         settings.network_timeout,
+        &settings.extra_headers,
     )
     .map_err(|e| SyncError::OperationalError { msg: e.to_string() })
 }

--- a/crates/atuin-client/src/register.rs
+++ b/crates/atuin-client/src/register.rs
@@ -8,8 +8,14 @@ pub async fn register_classic(
     email: String,
     password: String,
 ) -> Result<String> {
-    let session =
-        api_client::register(&settings.sync_address, &username, &email, &password).await?;
+    let session = api_client::register(
+        &settings.sync_address,
+        &username,
+        &email,
+        &password,
+        &settings.extra_headers,
+    )
+    .await?;
 
     let meta = Settings::meta_store().await?;
     meta.save_session(&session.session).await?;

--- a/crates/atuin-client/src/settings.rs
+++ b/crates/atuin-client/src/settings.rs
@@ -1061,6 +1061,14 @@ pub struct Settings {
     pub network_connect_timeout: u64,
     pub network_timeout: u64,
     pub local_timeout: f64,
+
+    /// Extra HTTP headers to send on every request to the sync server, e.g.
+    /// for services like Cloudflare Access that sit in front of a self-hosted
+    /// server. Headers that Atuin sets itself (e.g. Authorization) win over
+    /// values configured here.
+    #[serde(default)]
+    pub extra_headers: HashMap<String, String>,
+
     pub enter_accept: bool,
     pub smart_sort: bool,
     pub command_chaining: bool,
@@ -1455,6 +1463,7 @@ impl Settings {
             .set_default("strip_trailing_whitespace", true)?
             .set_default("network_connect_timeout", 5)?
             .set_default("network_timeout", 30)?
+            .set_default("extra_headers", HashMap::<String, String>::new())?
             .set_default("local_timeout", 2.0)?
             // enter_accept defaults to false here, but true in the default config file. The dissonance is
             // intentional!

--- a/crates/atuin/src/command/client/account/register.rs
+++ b/crates/atuin/src/command/client/account/register.rs
@@ -139,6 +139,7 @@ impl Cmd {
                 &username,
                 &email,
                 &password,
+                &settings.extra_headers,
             )
             .await?;
 

--- a/crates/atuin/src/command/client/store/push.rs
+++ b/crates/atuin/src/command/client/store/push.rs
@@ -48,7 +48,8 @@ impl Push {
                 settings.sync_auth_token().await?,
                 settings.network_connect_timeout,
                 settings.network_timeout * 10, // we may be deleting a lot of data... so up the
-                                               // timeout
+                // timeout
+                &settings.extra_headers,
             )
             .expect("failed to create client");
 

--- a/crates/atuin/src/command/client/sync/status.rs
+++ b/crates/atuin/src/command/client/sync/status.rs
@@ -13,6 +13,7 @@ pub async fn run(settings: &Settings) -> Result<()> {
         settings.sync_auth_token().await?,
         settings.network_connect_timeout,
         settings.network_timeout,
+        &settings.extra_headers,
     )?;
 
     let me = client.me().await?;

--- a/crates/atuin/tests/common/mod.rs
+++ b/crates/atuin/tests/common/mod.rs
@@ -77,15 +77,17 @@ pub async fn register_inner<'a>(
     let email = format!("{}@example.com", uuid_v7().as_simple());
 
     // registration works
-    let registration_response = api_client::register(address, username, &email, password)
-        .await
-        .unwrap();
+    let registration_response =
+        api_client::register(address, username, &email, password, &Default::default())
+            .await
+            .unwrap();
 
     api_client::Client::new(
         address,
         api_client::AuthToken::Token(registration_response.session),
         5,
         30,
+        &Default::default(),
     )
     .unwrap()
 }
@@ -100,6 +102,7 @@ pub async fn login(
     let login_response = api_client::login(
         address,
         atuin_common::api::LoginRequest { username, password },
+        &Default::default(),
     )
     .await
     .unwrap();
@@ -109,6 +112,7 @@ pub async fn login(
         api_client::AuthToken::Token(login_response.session),
         5,
         30,
+        &Default::default(),
     )
     .unwrap()
 }

--- a/docs/docs/configuration/config.md
+++ b/docs/docs/configuration/config.md
@@ -492,6 +492,23 @@ remote sync server. Any longer than this and the request will fail.
 network_connect_timeout = 5
 ```
 
+### `extra_headers`
+
+Atuin version: >= 18.19
+
+Default: `{}`
+
+Extra HTTP headers to send on every request to the sync server. This is useful
+when a self-hosted server sits behind a proxy or access gateway that requires
+its own authentication header — for example Cloudflare Access.
+
+Headers that Atuin sets itself (such as `Authorization`) cannot be overridden;
+Atuin's values always win.
+
+```toml
+extra_headers = { "CF-Access-Client-Id" = "...", "CF-Access-Client-Secret" = "..." }
+```
+
 ### `local_timeout`
 
 Atuin version: >= 18.0

--- a/docs/docs/configuration/config.md
+++ b/docs/docs/configuration/config.md
@@ -503,6 +503,10 @@ its own authentication header — for example Cloudflare Access.
 Headers that Atuin sets itself (such as `Authorization`) cannot be overridden;
 Atuin's values always win.
 
+To avoid leaking credentials, Atuin refuses to follow cross-origin redirects
+when extra headers are configured — they are never sent to an origin other
+than the one you configured.
+
 ```toml
 extra_headers = { "CF-Access-Client-Id" = "...", "CF-Access-Client-Secret" = "..." }
 ```

--- a/docs/docs/configuration/config.md
+++ b/docs/docs/configuration/config.md
@@ -494,8 +494,6 @@ network_connect_timeout = 5
 
 ### `extra_headers`
 
-Atuin version: >= 18.19
-
 Default: `{}`
 
 Extra HTTP headers to send on every request to the sync server. This is useful


### PR DESCRIPTION
Add an extra_headers config option, a map of header name to value sent on
every request to the sync server. Useful when a self-hosted server sits
behind a proxy that requires its own auth header, e.g. Cloudflare Access.

Headers Atuin sets itself (Authorization, User-Agent, the version header)
always win over configured values. Applies to the sync client, login,
register (including the username-availability check), and the legacy auth
client's password-change/account-delete requests.

Closes https://github.com/atuinsh/atuin/issues/3712

## Checks
- [ ] I am happy for maintainers to push small adjustments to this PR, to speed up the review cycle
- [ ] I have checked that there are no existing pull requests for the same thing
