### PR TITLE
docs(faq): show how to use absolute timestamps in search

### DIFF
--- a/docs/docs/faq.md
+++ b/docs/docs/faq.md
@@ -45,6 +45,28 @@ Add `--disable-ai`, e.g.:
 eval "$(atuin init zsh --disable-ai)"
 ```
 
+## How do I show absolute timestamps instead of relative time in search?
+
+Interactive search defaults to a relative `time` column (for example `59m ago`).
+To show wall-clock timestamps instead, replace `time` with `datetime` under
+`[ui]` in `~/.config/atuin/config.toml`:
+
+```toml
+[ui]
+columns = ["duration", "datetime", "command"]
+```
+
+`datetime` renders values like `2025-01-22 14:35` (width 16 by default). You can
+keep both:
+
+```toml
+[ui]
+columns = ["duration", "time", "datetime", "command"]
+```
+
+See the [UI columns](configuration/config.md#columns) config reference for the
+full list of column types and width options.
+
 ## How do I edit a command instead of running it immediately?
 
 Press tab! By default, enter will execute a command, and tab will insert it ready for editing.


### PR DESCRIPTION
## Summary

- FAQ entry for showing absolute timestamps in interactive search.
- Points at existing `[ui].columns` `datetime` support (no code change).

## Motivation

Closes #3477.

Default search columns use relative `time` (`59m ago`). Absolute wall-clock
times are already available via the `datetime` column added with custom UI
columns; this surfaces that at FAQ level so Ctrl+R users can find it.

## Verification

- Matched docs to `UiColumnType::Datetime` / `history_list::datetime` (`YYYY-MM-DD HH:MM`).
- Link target: `configuration/config.md#columns` (column table includes `datetime`).
- Docs-only.

## Checklist

- [x] I am happy for maintainers to push small adjustments to this PR
- [x] I have checked that there are no existing pull requests for the same thing

---
<!-- fleet-pr-claim: agent_id=sera platform=hermes -->
**Agent-Owner:** `sera` · **Platform:** hermes · **Claim-TTL:** 48h