### PR TITLE
fix: Show server status next to AI progress indicator

### DIFF
--- a/crates/atuin-ai/src/fsm/mod.rs
+++ b/crates/atuin-ai/src/fsm/mod.rs
@@ -74,6 +74,17 @@ impl StreamingStatus {
     }
 }
 
+impl StreamingStatus {
+    pub(crate) fn to_str(&self) -> &str {
+        match &self {
+            StreamingStatus::Processing => "processing",
+            StreamingStatus::Searching => "searching",
+            StreamingStatus::Thinking => "thinking",
+            StreamingStatus::WaitingForTools => "waiting for tools",
+        }
+    }
+}
+
 /// Pending dangerous command confirmation state.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct PendingConfirmation {

--- a/crates/atuin-ai/src/tui/app.rs
+++ b/crates/atuin-ai/src/tui/app.rs
@@ -14,6 +14,7 @@ use ratatui_core::style::{Color, Modifier, Style};
 use tokio::sync::mpsc::UnboundedSender;
 use tui_textarea::TextArea;
 
+use crate::fsm::StreamPhase;
 use crate::fsm::effects::{Effect, ExitAction, PermissionTarget, TimeoutKind};
 use crate::fsm::events::{Event, PermissionChoice, PermissionResponse};
 use crate::fsm::tools::ToolPreviewData;
@@ -795,6 +796,7 @@ impl AiApp {
                 self.pushed_turns == 0 && i == 0,
                 false,
                 false,
+                None,
             ));
             self.pushed_turns += 1;
         }
@@ -1075,6 +1077,17 @@ impl App for AiApp {
                 Some(UiTurnKind::Agent { .. })
             );
 
+        let status_text = if let AgentState::Turn {
+            stream: StreamPhase::Streaming {
+                status: Some(status),
+            },
+        } = &self.fsm.state
+        {
+            Some(capitalize(status.to_str()))
+        } else {
+            None
+        };
+
         col()
             .when_some(
                 (self.pushed_turns == 0)
@@ -1091,15 +1104,23 @@ impl App for AiApp {
                 },
             )
             .children(turns.iter().enumerate().map(|(i, turn)| {
+                let status_text = ((i == last).then_some(status_text.as_deref())).flatten();
+
                 view::turn_view(
                     turn,
                     self.pushed_turns == 0 && i == 0,
                     busy && i == last,
                     asking.is_some(),
+                    status_text,
                 )
             }))
             .when(needs_pending_banner, |c| {
-                c.child(view::agent_turn_view(&[], true, asking.is_some()))
+                c.child(view::agent_turn_view(
+                    &[],
+                    true,
+                    asking.is_some(),
+                    status_text.as_deref(),
+                ))
             })
             .when_some(
                 match &self.fsm.state {
@@ -1219,6 +1240,14 @@ impl App for AiApp {
         }
 
         km
+    }
+}
+
+fn capitalize(s: &str) -> String {
+    let mut c = s.chars();
+    match c.next() {
+        None => String::new(),
+        Some(f) => f.to_uppercase().collect::<String>() + c.as_str(),
     }
 }
 

--- a/crates/atuin-ai/src/tui/view/mod.rs
+++ b/crates/atuin-ai/src/tui/view/mod.rs
@@ -74,10 +74,11 @@ pub(crate) fn turn_view(
     first: bool,
     busy: bool,
     showing_ui: bool,
+    status_text: Option<&str>,
 ) -> AnyElement<'static> {
     match &turn.kind {
         UiTurnKind::User { events } => user_turn_view(events, first),
-        UiTurnKind::Agent { events } => agent_turn_view(events, busy, showing_ui),
+        UiTurnKind::Agent { events } => agent_turn_view(events, busy, showing_ui, status_text),
         UiTurnKind::OutOfBand { events } => out_of_band_turn_view(events),
     }
 }
@@ -102,6 +103,7 @@ pub(crate) fn agent_turn_view(
     events: &[UiEvent],
     busy: bool,
     showing_ui: bool,
+    status_text: Option<&str>,
 ) -> AnyElement<'static> {
     let label_style = Style::default()
         .fg(Color::Yellow)
@@ -117,10 +119,15 @@ pub(crate) fn agent_turn_view(
         }))
         .when(busy && !showing_ui, |c| {
             c.child(
-                spinner("")
+                spinner(status_text.unwrap_or(""))
                     .spinner_style(
                         Style::default()
                             .fg(Color::Yellow)
+                            .add_modifier(Modifier::BOLD),
+                    )
+                    .label_style(
+                        Style::default()
+                            .fg(Color::DarkGray)
                             .add_modifier(Modifier::BOLD),
                     )
                     .pad_left(2)


### PR DESCRIPTION
The server has been sending status strings for a long time, and the client stored it in `StreamPhase::Streaming`, but we didn't show it anywhere. This adds it to the spinner at the bottom of an in-progress agent turn.