### PR TITLE
fix: Show full command when using AtuinOutput tool

### DIFF
--- a/crates/atuin-ai/src/fsm/effects.rs
+++ b/crates/atuin-ai/src/fsm/effects.rs
@@ -45,6 +45,13 @@ pub(crate) enum Effect {
     },
     /// Kill a running tool (send interrupt to shell command).
     AbortTool { tool_id: String },
+    /// Look up the command string behind an atuin_output call's history id
+    /// in the local history db, for display (the model only passes a UUID).
+    /// Resolves via `Event::OutputCommandResolved`.
+    ResolveOutputCommand {
+        tool_id: String,
+        history_id: uuid::Uuid,
+    },
     /// Load a skill's content asynchronously (read + interpolate).
     LoadSkill {
         name: String,

--- a/crates/atuin-ai/src/fsm/events.rs
+++ b/crates/atuin-ai/src/fsm/events.rs
@@ -83,6 +83,12 @@ pub(crate) enum Event {
         lines: Vec<String>,
         exit_code: Option<i32>,
     },
+    /// The command behind an atuin_output call's history id was looked up
+    /// locally (`None` when the id isn't in the local history db).
+    OutputCommandResolved {
+        tool_id: String,
+        command: Option<String>,
+    },
 
     // ─── Timers ─────────────────────────────────────────────────
     /// Confirmation timeout expired.

--- a/crates/atuin-ai/src/fsm/mod.rs
+++ b/crates/atuin-ai/src/fsm/mod.rs
@@ -712,6 +712,17 @@ impl AgentFsm {
                 vec![]
             }
 
+            // Display metadata on a tracked tool; state-independent since
+            // the lookup may land after the turn has moved on.
+            (_, Event::OutputCommandResolved { tool_id, command }) => {
+                if let Some(tracked) = self.ctx.tools.get_mut(&tool_id)
+                    && let crate::tools::ClientToolCall::AtuinOutput(call) = &mut tracked.tool
+                {
+                    call.command = command;
+                }
+                vec![]
+            }
+
             // RequestSkillLoad during non-idle: still emit the effect
             (_, Event::RequestSkillLoad { name, arguments }) => {
                 vec![Effect::LoadSkill { name, arguments }]
@@ -830,6 +841,10 @@ impl AgentFsm {
 
         // Track the tool and push ToolCall event
         let tool_for_effect = tool.clone();
+        let output_history_id = match &tool {
+            crate::tools::ClientToolCall::AtuinOutput(call) => Some(call.history_id),
+            _ => None,
+        };
         self.ctx.tools.insert(id.clone(), tool);
         self.ctx.current_turn_tool_ids.push(id.clone());
         self.ctx.events.push(ConversationEvent::ToolCall {
@@ -848,10 +863,20 @@ impl AgentFsm {
             };
         }
 
-        vec![Effect::CheckPermission {
+        let mut effects = Vec::new();
+        // The permission prompt wants the command behind the UUID; kick the
+        // lookup off alongside the permission check.
+        if let Some(history_id) = output_history_id {
+            effects.push(Effect::ResolveOutputCommand {
+                tool_id: id.clone(),
+                history_id,
+            });
+        }
+        effects.push(Effect::CheckPermission {
             tool_id: id,
             tool: tool_for_effect,
-        }]
+        });
+        effects
     }
 
     /// Handle permission resolver result.

--- a/crates/atuin-ai/src/fsm/tests.rs
+++ b/crates/atuin-ai/src/fsm/tests.rs
@@ -109,6 +109,41 @@ fn stream_tool_call_tracks_tool_and_emits_check_permission() {
 }
 
 #[test]
+fn atuin_output_call_emits_command_lookup_and_stores_result() {
+    let mut fsm = AgentFsm::new(
+        vec!["client_v1_atuin_output".to_string()],
+        "test-inv".to_string(),
+    );
+    fsm.handle(Event::UserSubmit("show output".into()));
+    fsm.handle(Event::StreamStarted);
+
+    let effects = fsm.handle(Event::StreamToolCall {
+        id: "t1".into(),
+        name: "atuin_output".into(),
+        input: json!({"history_id": "018f011c-9a0a-7000-8000-000000000001"}),
+    });
+
+    // The command lookup runs alongside the permission check.
+    assert!(matches!(
+        effects[0],
+        Effect::ResolveOutputCommand { ref tool_id, .. } if tool_id == "t1"
+    ));
+    assert!(matches!(effects[1], Effect::CheckPermission { .. }));
+
+    let effects = fsm.handle(Event::OutputCommandResolved {
+        tool_id: "t1".into(),
+        command: Some("cargo test".into()),
+    });
+
+    assert!(effects.is_empty());
+    let crate::tools::ClientToolCall::AtuinOutput(call) = &fsm.ctx.tools.get("t1").unwrap().tool
+    else {
+        panic!("expected AtuinOutput tool");
+    };
+    assert_eq!(call.command.as_deref(), Some("cargo test"));
+}
+
+#[test]
 fn permission_allowed_transitions_to_executing() {
     let mut fsm = new_fsm();
     fsm.handle(Event::UserSubmit("read".into()));

--- a/crates/atuin-ai/src/tools/mod.rs
+++ b/crates/atuin-ai/src/tools/mod.rs
@@ -1194,6 +1194,10 @@ impl AtuinHistoryToolCall {
 pub(crate) struct AtuinOutputToolCall {
     pub history_id: Uuid,
     pub ranges: Vec<(i64, i64)>,
+    /// The command the history entry ran, resolved from the local history
+    /// db after parsing (`Effect::ResolveOutputCommand`). Display-only:
+    /// `None` until the lookup lands, or when the id isn't known locally.
+    pub command: Option<String>,
 }
 
 impl TryFrom<&serde_json::Value> for AtuinOutputToolCall {
@@ -1231,7 +1235,11 @@ impl TryFrom<&serde_json::Value> for AtuinOutputToolCall {
             })
             .collect::<Result<Vec<(i64, i64)>, eyre::Error>>()?;
 
-        Ok(Self { history_id, ranges })
+        Ok(Self {
+            history_id,
+            ranges,
+            command: None,
+        })
     }
 }
 

--- a/crates/atuin-ai/src/tui/app.rs
+++ b/crates/atuin-ai/src/tui/app.rs
@@ -369,6 +369,29 @@ impl AiApp {
                 Effect::CheckPermission { tool_id, tool } => {
                     self.check_permission(tool_id, tool, ctx)
                 }
+                Effect::ResolveOutputCommand {
+                    tool_id,
+                    history_id,
+                } => {
+                    let Some(io) = &self.io else { continue };
+                    let db = io.app_ctx.history_db.clone();
+                    ctx.perform(async move {
+                        use atuin_client::database::Database as _;
+                        // Ids are stored in simple (no-hyphen) form today,
+                        // but older or imported rows may be hyphenated.
+                        let command = match db.load(&history_id.as_simple().to_string()).await {
+                            Ok(Some(h)) => Some(h.command),
+                            _ => db
+                                .load(&history_id.as_hyphenated().to_string())
+                                .await
+                                .ok()
+                                .flatten()
+                                .map(|h| h.command),
+                        };
+                        Msg::Fsm(Event::OutputCommandResolved { tool_id, command })
+                    })
+                    .detach();
+                }
                 Effect::ExecuteTool { tool_id, tool } => self.execute_tool(tool_id, tool, ctx),
                 Effect::AbortTool { tool_id } => {
                     if let Some(interrupt_tx) = self.tool_interrupts.remove(&tool_id) {

--- a/crates/atuin-ai/src/tui/view/mod.rs
+++ b/crates/atuin-ai/src/tui/view/mod.rs
@@ -18,7 +18,10 @@ use crate::tui::events::PermissionResult;
 use crate::tui::select;
 
 pub(crate) mod input;
+mod trunc;
 pub(crate) mod turn;
+
+use trunc::{command_spinner, truncated_line};
 
 use turn::{
     ConfidenceLevel, DangerLevel, OutOfBandOutputDetails, SuggestedCommandDetails, ToolCallDetails,
@@ -215,17 +218,11 @@ fn shell_tool_view(command: &str, preview: Option<&ToolPreview>) -> AnyElement<'
 
     match preview {
         Some(preview) => col()
-            .child(
-                tool_spinner(
-                    if done {
-                        format!("Ran: {command}")
-                    } else {
-                        format!("Running: {command}")
-                    },
-                    done,
-                )
-                .hide_checkmark(),
-            )
+            .child(command_spinner(
+                if done { "Ran: " } else { "Running: " },
+                command,
+                done,
+            ))
             .child(
                 row()
                     .fixed(2, text("└ ").style(Style::default().fg(Color::DarkGray)))
@@ -238,7 +235,7 @@ fn shell_tool_view(command: &str, preview: Option<&ToolPreview>) -> AnyElement<'
             )
             .child(shell_tool_footer(preview, done))
             .any(),
-        None => tool_spinner(format!("Running: {command}"), false).any(),
+        None => command_spinner("Running: ", command, false).any(),
     }
 }
 
@@ -696,22 +693,33 @@ pub(crate) fn permission_prompt_view(
     cursor: usize,
 ) -> AnyElement<'static> {
     let verb = tool_call.tool.descriptor().display_verb;
-    let tool_desc = match &tool_call.tool {
-        ClientToolCall::Read(tool) => tool.path.display().to_string(),
-        ClientToolCall::Edit(tool) => tool.path.display().to_string(),
-        ClientToolCall::Write(tool) => tool.path.display().to_string(),
-        ClientToolCall::Shell(tool) => tool.command.clone(),
-        ClientToolCall::AtuinHistory(tool) => tool.query.clone(),
-        ClientToolCall::AtuinOutput(tool) => tool.history_id.to_string(),
-        ClientToolCall::LoadSkill(tool) => format!("skill: {}", tool.name),
+    let prefix = format!("Atuin AI would like to {verb}: ");
+    let desc_style = Style::default().fg(Color::Yellow);
+    // Wraps, so the user reviews the full text of what they're approving.
+    let wrapped = |desc: String| text(prefix.clone()).span(desc, desc_style).any();
+    let header: AnyElement<'static> = match &tool_call.tool {
+        ClientToolCall::Read(tool) => wrapped(tool.path.display().to_string()),
+        ClientToolCall::Edit(tool) => wrapped(tool.path.display().to_string()),
+        ClientToolCall::Write(tool) => wrapped(tool.path.display().to_string()),
+        ClientToolCall::Shell(tool) => wrapped(tool.command.clone()),
+        ClientToolCall::AtuinHistory(tool) => wrapped(tool.query.clone()),
+        // The model passes a history UUID, which means nothing to the user —
+        // show the command it refers to once the local lookup resolves. The
+        // command is context here, not the thing being approved, so one
+        // middle-elided line beats wrapping.
+        ClientToolCall::AtuinOutput(tool) => {
+            let desc = tool
+                .command
+                .clone()
+                .unwrap_or_else(|| tool.history_id.to_string());
+            truncated_line(prefix.clone(), Style::default(), desc, desc_style).any()
+        }
+        ClientToolCall::LoadSkill(tool) => wrapped(format!("skill: {}", tool.name)),
     };
     let options = permission_options(&tool_call.tool, in_git_project);
 
     col()
-        .child(
-            text(format!("Atuin AI would like to {verb}: "))
-                .span(tool_desc, Style::default().fg(Color::Yellow)),
-        )
+        .child(header)
         .child(select::select_view(options.iter().map(|(label, _)| *label), cursor).pad_left(2))
         .pad_left(2)
         .pad_top(1)

--- a/crates/atuin-ai/src/tui/view/trunc.rs
+++ b/crates/atuin-ai/src/tui/view/trunc.rs
@@ -1,0 +1,217 @@
+//! Width-aware one-line labels that middle-elide a command instead of
+//! clipping it at the right edge.
+//!
+//! eye-declare's `Spinner` hard-clips its label and `Text` word-wraps;
+//! neither suits a long shell command on a status line, where the tail
+//! (flags, paths) matters as much as the head. These elements measure at
+//! render time and splice an ellipsis into the middle so both ends stay
+//! visible. Truncation is display-only — anywhere the user must review a
+//! command in full (permission prompts for shell, suggested commands)
+//! keeps the wrapping renderers.
+
+use std::time::Duration;
+
+use atuin_common::string::EllipsizeExt as _;
+use atuin_common::string::Measure;
+use atuin_common::string::ellipsis::{Indicator, Pos};
+use eye_declare::{Element, Spinner};
+use ratatui_core::buffer::Buffer;
+use ratatui_core::layout::Rect;
+use ratatui_core::style::Style;
+use unicode_width::UnicodeWidthStr as _;
+
+/// Fit `command` into `cols` display columns on a single line: whitespace
+/// runs (including newlines in multiline commands) collapse to single
+/// spaces, and the middle is elided when it still doesn't fit.
+fn fit_middle(command: &str, cols: usize) -> String {
+    let one_line = command.split_whitespace().collect::<Vec<_>>().join(" ");
+    one_line
+        .ellipsize(Measure::Columns(cols), Pos::Middle, Indicator::UNICODE)
+        .to_string()
+}
+
+/// A tool spinner labeled `prefix` + command, the command middle-elided to
+/// the render width. Styling matches [`super::tool_spinner`]; the done
+/// checkmark is always hidden, as in the shell tool view.
+pub(crate) struct CommandSpinner {
+    prefix: &'static str,
+    command: String,
+    done: bool,
+}
+
+pub(crate) fn command_spinner(
+    prefix: &'static str,
+    command: impl Into<String>,
+    done: bool,
+) -> CommandSpinner {
+    CommandSpinner {
+        prefix,
+        command: command.into(),
+        done,
+    }
+}
+
+impl CommandSpinner {
+    fn spinner_at(&self, width: u16) -> Spinner {
+        // Marker glyph + trailing space while animating; a done spinner
+        // with a hidden checkmark has no marker (see Spinner::render).
+        let marker_cols = if self.done { 0 } else { 2 };
+        let budget = (width as usize)
+            .saturating_sub(marker_cols)
+            .saturating_sub(self.prefix.width());
+        let label = format!("{}{}", self.prefix, fit_middle(&self.command, budget));
+        super::tool_spinner(label, self.done).hide_checkmark()
+    }
+}
+
+impl Element for CommandSpinner {
+    fn height(&self, width: u16) -> u16 {
+        if width == 0 { 0 } else { 1 }
+    }
+
+    fn render(&self, area: Rect, buf: &mut Buffer) {
+        self.spinner_at(area.width).render(area, buf);
+    }
+
+    fn animated(&self) -> Option<Duration> {
+        // Delegate so the frame interval stays in lockstep with Spinner's.
+        self.spinner_at(0).animated()
+    }
+}
+
+/// A one-line `prefix` + value, the value middle-elided to the render
+/// width rather than wrapped.
+pub(crate) struct TruncatedLine {
+    prefix: String,
+    prefix_style: Style,
+    value: String,
+    value_style: Style,
+}
+
+pub(crate) fn truncated_line(
+    prefix: impl Into<String>,
+    prefix_style: Style,
+    value: impl Into<String>,
+    value_style: Style,
+) -> TruncatedLine {
+    TruncatedLine {
+        prefix: prefix.into(),
+        prefix_style,
+        value: value.into(),
+        value_style,
+    }
+}
+
+impl Element for TruncatedLine {
+    fn height(&self, width: u16) -> u16 {
+        if width == 0 { 0 } else { 1 }
+    }
+
+    fn render(&self, area: Rect, buf: &mut Buffer) {
+        if area.width == 0 || area.height == 0 {
+            return;
+        }
+        let width = area.width as usize;
+        buf.set_stringn(area.x, area.y, &self.prefix, width, self.prefix_style);
+        let used = self.prefix.width().min(width);
+        let budget = width - used;
+        if budget == 0 {
+            return;
+        }
+        buf.set_stringn(
+            area.x + used as u16,
+            area.y,
+            fit_middle(&self.value, budget),
+            budget,
+            self.value_style,
+        );
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn render_line(el: &impl Element, width: u16) -> String {
+        let area = Rect::new(0, 0, width, 1);
+        let mut buf = Buffer::empty(area);
+        el.render(area, &mut buf);
+        (0..width)
+            .map(|x| buf[(x, 0)].symbol().to_string())
+            .collect::<String>()
+            .trim_end()
+            .to_string()
+    }
+
+    #[test]
+    fn fit_middle_keeps_short_commands() {
+        assert_eq!(fit_middle("cargo test", 20), "cargo test");
+    }
+
+    #[test]
+    fn fit_middle_elides_the_middle() {
+        let out = fit_middle("cargo test --workspace -- --nocapture history", 20);
+        assert!(out.starts_with("cargo"), "head survives: {out}");
+        assert!(out.ends_with("history"), "tail survives: {out}");
+        assert!(out.contains('…'), "elision marked: {out}");
+        assert!(out.width() <= 20);
+    }
+
+    #[test]
+    fn fit_middle_flattens_multiline_commands() {
+        assert_eq!(
+            fit_middle("for f in *.rs\ndo\n  wc -l \"$f\"\ndone", 80),
+            "for f in *.rs do wc -l \"$f\" done"
+        );
+    }
+
+    #[test]
+    fn done_command_spinner_shows_both_ends() {
+        let el = command_spinner("Ran: ", "git log --oneline --graph --all --decorate", true);
+        let line = render_line(&el, 24);
+        assert!(line.starts_with("Ran: git"), "got: {line}");
+        assert!(line.ends_with("decorate"), "got: {line}");
+        assert!(line.contains('…'), "got: {line}");
+    }
+
+    #[test]
+    fn running_command_spinner_reserves_marker_columns() {
+        let el = command_spinner("Running: ", "cargo build --release --locked", false);
+        // The label budget accounts for the 2-column marker, so the command's
+        // tail lands exactly at the right edge instead of getting clipped.
+        let line = render_line(&el, 24);
+        assert!(line.contains("Running: cargo"), "got: {line}");
+        assert!(line.contains('…'), "got: {line}");
+        assert!(line.ends_with("locked"), "got: {line}");
+        assert_eq!(line.width(), 24, "got: {line}");
+    }
+
+    #[test]
+    fn command_spinner_fits_untruncated_when_room() {
+        let el = command_spinner("Ran: ", "ls -la", true);
+        assert_eq!(render_line(&el, 40), "Ran: ls -la");
+    }
+
+    #[test]
+    fn truncated_line_elides_value_not_prefix() {
+        let el = truncated_line(
+            "would like to view: ",
+            Style::default(),
+            "docker compose up --build --force-recreate",
+            Style::default(),
+        );
+        let line = render_line(&el, 40);
+        assert!(
+            line.starts_with("would like to view: docker"),
+            "got: {line}"
+        );
+        assert!(line.ends_with("recreate"), "got: {line}");
+        assert!(line.contains('…'), "got: {line}");
+    }
+
+    #[test]
+    fn truncated_line_fits_untruncated_when_room() {
+        let el = truncated_line("view: ", Style::default(), "ls -la", Style::default());
+        assert_eq!(render_line(&el, 40), "view: ls -la");
+    }
+}


### PR DESCRIPTION
Previously, the AtuinOutput tool showed the History UUID when asking for permission. This now shows the command itself. Also, long commands and filenames in tool results are now middle-truncated.

<img width="637" height="164" alt="image" src="https://github.com/user-attachments/assets/10f49428-1f0c-4041-b988-031076697936" />
