### PR TITLE
perf: actually delete history rows, and index active history

### DIFF
--- a/crates/atuin-client/build.rs
+++ b/crates/atuin-client/build.rs
@@ -1,0 +1,9 @@
+fn main() {
+    // sqlx::migrate!() embeds these directories at compile time, but cargo only
+    // reruns the macro when a tracked file changes - without this, adding a new
+    // migration file does not trigger a recompile and silently ships a binary
+    // missing the migration.
+    println!("cargo:rerun-if-changed=migrations");
+    println!("cargo:rerun-if-changed=meta-migrations");
+    println!("cargo:rerun-if-changed=record-migrations");
+}

--- a/crates/atuin-client/migrations/20260723000000_active_history_index.sql
+++ b/crates/atuin-client/migrations/20260723000000_active_history_index.sql
@@ -1,0 +1,6 @@
+-- Most queries only consider live history (deleted_at is null), and counting
+-- it previously required a full table scan - slow on a large, cold database.
+-- A partial index on timestamp covers both the count and timestamp-ordered
+-- listings of live history, at a fraction of the table's size.
+create index if not exists idx_history_active_timestamp on history(timestamp)
+where deleted_at is null;

--- a/crates/atuin-client/src/database.rs
+++ b/crates/atuin-client/src/database.rs
@@ -10,7 +10,6 @@ use async_trait::async_trait;
 use atuin_common::utils;
 use fs_err as fs;
 use itertools::Itertools;
-use rand::{Rng, distributions::Alphanumeric};
 use sql_builder::{SqlBuilder, SqlName, bind::Bind, esc, quote};
 use sqlx::{
     Result, Row,
@@ -812,20 +811,13 @@ impl Database for Sqlite {
         Paged::new(Box::new(self.clone()), page_size, include_deleted, unique)
     }
 
-    // deleted_at doesn't mean the actual time that the user deleted it,
-    // but the time that the system marks it as deleted
-    async fn delete(&self, mut h: History) -> Result<()> {
-        let now = OffsetDateTime::now_utc();
-        h.command = rand::thread_rng()
-            .sample_iter(&Alphanumeric)
-            .take(32)
-            .map(char::from)
-            .collect(); // overwrite with random string
-        h.deleted_at = Some(now); // delete it
-
-        self.update(&h).await?; // save it
-
-        Ok(())
+    // This used to scramble the command and set deleted_at, so that sync v1 could
+    // propagate the deletion. Sync v2 propagates deletions through the record store
+    // instead (HistoryRecord::Delete), and the only remaining caller deletes entries
+    // that were never pushed to the store - so just delete the row.
+    // deleted_at is still read to keep tombstones from older versions working.
+    async fn delete(&self, h: History) -> Result<()> {
+        self.delete_rows(&[h.id]).await
     }
 
     async fn delete_rows(&self, ids: &[HistoryId]) -> Result<()> {
@@ -1761,15 +1753,27 @@ mod test {
             .clone();
         db.delete(to_delete).await.unwrap();
 
-        // Without include_deleted - should get 2
+        // Deletes remove the row outright, so both views should get 2
         let mut paged = db.all_paged(10, false, false);
         let page = paged.next().await.unwrap().unwrap();
         assert_eq!(page.len(), 2);
 
-        // With include_deleted - should get 3
         let mut paged_deleted = db.all_paged(10, true, false);
         let page_deleted = paged_deleted.next().await.unwrap().unwrap();
-        assert_eq!(page_deleted.len(), 3);
+        assert_eq!(page_deleted.len(), 2);
+
+        // Tombstones written by older versions are still filtered by include_deleted
+        let mut legacy = all.iter().find(|h| h.command == "keep1").unwrap().clone();
+        legacy.deleted_at = Some(OffsetDateTime::now_utc());
+        db.update(&legacy).await.unwrap();
+
+        let mut paged = db.all_paged(10, false, false);
+        let page = paged.next().await.unwrap().unwrap();
+        assert_eq!(page.len(), 1);
+
+        let mut paged_deleted = db.all_paged(10, true, false);
+        let page_deleted = paged_deleted.next().await.unwrap().unwrap();
+        assert_eq!(page_deleted.len(), 2);
     }
 
     #[tokio::test(flavor = "multi_thread")]


### PR DESCRIPTION
## What

Three related changes to history deletion and the cost of the `deleted_at` filter:

1. **`Sqlite::delete` now deletes the row** instead of scrambling the command and setting `deleted_at`. The tombstone dance existed so sync v1 could propagate deletions without leaking command text - v1 is gone (#3634), and sync v2 propagates deletions through the record store (`HistoryRecord::Delete`), which already hard-deletes via `delete_rows` when applied. The only remaining caller is the `store_failed = false` cleanup in `handle_end`, which runs before the entry is ever pushed to the record store, so no other host can know about it.

   `deleted_at` is still **read** everywhere: old databases contain tombstones, which query filters keep hiding, and `init_store` still converts them to deletion records when building a store from a legacy DB. The column and record wire format are unchanged.

2. **Partial index over active history**: `create index ... on history(timestamp) where deleted_at is null`. Counting live history was a full table scan - measured ~430ms cold on a 96MB / 167k-row database, ~975ms at 1M rows. With the index: ~8ms and ~30ms respectively. The planner also uses it for timestamp-ordered listings of live history. No measurable insert overhead (241µs vs 253µs per committed insert - the fsync dominates, and the entry is tiny next to the existing command-text indexes). Complements #3729, which moved the count off the TUI critical path.

3. **`build.rs` for atuin-client**: `sqlx::migrate!()` embeds migration directories at compile time, but without `rerun-if-changed` an incremental build does not recompile when a new migration file is added - producing a binary silently missing the migration. This bit me while testing (2).

## Checks
- [x] I am happy for maintainers to push small adjustments to this PR, to speed up the review cycle
- [x] I have checked that there are no existing pull requests for the same thing