### PR TITLE
perf: index filtered history search, record store tags, and cache inspector stats

### DIFF
--- a/crates/atuin-client/migrations/20260723000001_filtered_history_indexes.sql
+++ b/crates/atuin-client/migrations/20260723000001_filtered_history_indexes.sql
@@ -1,0 +1,10 @@
+-- The session, directory and workspace filters (`session = ?`, `cwd = ?`,
+-- `cwd like 'x%'`) had no index, so the timestamp-ordered dedup scan in
+-- search() and list() read the whole table per keystroke when matches were
+-- sparse. Partial indexes over live history keep that a range scan, at a
+-- fraction of the size of a full index.
+create index if not exists idx_history_session_timestamp on history(session, timestamp)
+where deleted_at is null;
+
+create index if not exists idx_history_cwd_timestamp on history(cwd, timestamp)
+where deleted_at is null;

--- a/crates/atuin-client/migrations/20260723000002_hostname_index.sql
+++ b/crates/atuin-client/migrations/20260723000002_hostname_index.sql
@@ -1,0 +1,5 @@
+-- The host filter compares lower(hostname), because the reported casing of
+-- the same machine changes over time (e.g. "Ellies-MBP" vs "ellies-mbp").
+-- Index the same expression so the filter is sargable rather than a scan.
+create index if not exists idx_history_hostname_timestamp on history(lower(hostname), timestamp)
+where deleted_at is null;

--- a/crates/atuin-client/migrations/20260723000003_drop_command_index.sql
+++ b/crates/atuin-client/migrations/20260723000003_drop_command_index.sql
@@ -1,0 +1,6 @@
+-- idx_history_command (from the original 2021 schema) has been redundant
+-- since idx_history_command_timestamp was added: it shares the leading
+-- column, so every query that could use it plans identically onto the
+-- (command, timestamp) index. Dropping it saves ~9MB on a 100MB database
+-- and removes an index from the per-command insert path.
+drop index if exists idx_history_command;

--- a/crates/atuin-client/record-migrations/20260723000000_store_tag_index.sql
+++ b/crates/atuin-client/record-migrations/20260723000000_store_tag_index.sql
@@ -1,0 +1,4 @@
+-- all_tagged and len_tag select by tag ordered by timestamp; without an
+-- index they scan and sort the entire store - over a second on a large,
+-- cold store - on every kv/scripts/dotfiles load and store rebuild.
+create index if not exists idx_store_tag_timestamp on store(tag, timestamp);

--- a/crates/atuin-client/src/database.rs
+++ b/crates/atuin-client/src/database.rs
@@ -833,11 +833,14 @@ impl Database for Sqlite {
     }
 
     async fn stats(&self, h: &History) -> Result<HistoryStats> {
-        // We select the previous in the session by time
+        // We select the previous in the session by time. Excluding deleted
+        // history matches every other read path, and lets the query use the
+        // partial (session, timestamp) index.
         let mut prev = SqlBuilder::select_from("history");
         prev.field("*")
             .and_where("timestamp < ?1")
             .and_where("session = ?2")
+            .and_where_is_null("deleted_at")
             .order_by("timestamp", true)
             .limit(1);
 
@@ -845,6 +848,7 @@ impl Database for Sqlite {
         next.field("*")
             .and_where("timestamp > ?1")
             .and_where("session = ?2")
+            .and_where_is_null("deleted_at")
             .order_by("timestamp", false)
             .limit(1);
 

--- a/crates/atuin-client/src/database.rs
+++ b/crates/atuin-client/src/database.rs
@@ -476,7 +476,12 @@ impl Database for Sqlite {
         for filter in filters {
             match filter {
                 FilterMode::Global => &mut query,
-                FilterMode::Host => query.and_where_eq("hostname", quote(&context.hostname)),
+                FilterMode::Host => query.and_where_eq(
+                    // Case-insensitive, matching `search()` - the reported casing of a
+                    // hostname changes over time. lower() is indexed as an expression.
+                    "lower(hostname)",
+                    quote(context.hostname.to_lowercase()),
+                ),
                 FilterMode::Session => query.and_where_eq("session", quote(&context.session)),
                 FilterMode::SessionPreload => {
                     query.and_where_eq("session", quote(&context.session));

--- a/crates/atuin-client/src/database.rs
+++ b/crates/atuin-client/src/database.rs
@@ -903,45 +903,42 @@ impl Database for Sqlite {
             .sql()
             .expect("issue in stats duration over time query");
 
-        let prev = sqlx::query(sqlx::AssertSqlSafe(prev))
-            .bind(h.timestamp.unix_timestamp_nanos() as i64)
-            .bind(&h.session)
-            .map(Self::query_history)
-            .fetch_optional(&self.pool)
-            .await?;
-
-        let next = sqlx::query(sqlx::AssertSqlSafe(next))
-            .bind(h.timestamp.unix_timestamp_nanos() as i64)
-            .bind(&h.session)
-            .map(Self::query_history)
-            .fetch_optional(&self.pool)
-            .await?;
-
-        let total: (i64,) = sqlx::query_as(sqlx::AssertSqlSafe(total))
-            .bind(&h.command)
-            .fetch_one(&self.pool)
-            .await?;
-
-        let average: (f64,) = sqlx::query_as(sqlx::AssertSqlSafe(average))
-            .bind(&h.command)
-            .fetch_one(&self.pool)
-            .await?;
-
-        let exits: Vec<(i64, i64)> = sqlx::query_as(sqlx::AssertSqlSafe(exits))
-            .bind(&h.command)
-            .fetch_all(&self.pool)
-            .await?;
-
-        let day_of_week: Vec<(String, i64)> = sqlx::query_as(sqlx::AssertSqlSafe(day_of_week))
-            .bind(&h.command)
-            .fetch_all(&self.pool)
-            .await?;
-
-        let duration_over_time: Vec<(String, f64)> =
+        // The queries are all independent, so run them concurrently on the pool.
+        let (prev, next, total, average, exits, day_of_week, duration_over_time): (
+            _,
+            _,
+            (i64,),
+            (f64,),
+            Vec<(i64, i64)>,
+            Vec<(String, i64)>,
+            Vec<(String, f64)>,
+        ) = tokio::try_join!(
+            sqlx::query(sqlx::AssertSqlSafe(prev))
+                .bind(h.timestamp.unix_timestamp_nanos() as i64)
+                .bind(&h.session)
+                .map(Self::query_history)
+                .fetch_optional(&self.pool),
+            sqlx::query(sqlx::AssertSqlSafe(next))
+                .bind(h.timestamp.unix_timestamp_nanos() as i64)
+                .bind(&h.session)
+                .map(Self::query_history)
+                .fetch_optional(&self.pool),
+            sqlx::query_as(sqlx::AssertSqlSafe(total))
+                .bind(&h.command)
+                .fetch_one(&self.pool),
+            sqlx::query_as(sqlx::AssertSqlSafe(average))
+                .bind(&h.command)
+                .fetch_one(&self.pool),
+            sqlx::query_as(sqlx::AssertSqlSafe(exits))
+                .bind(&h.command)
+                .fetch_all(&self.pool),
+            sqlx::query_as(sqlx::AssertSqlSafe(day_of_week))
+                .bind(&h.command)
+                .fetch_all(&self.pool),
             sqlx::query_as(sqlx::AssertSqlSafe(duration_over_time))
                 .bind(&h.command)
-                .fetch_all(&self.pool)
-                .await?;
+                .fetch_all(&self.pool),
+        )?;
 
         let duration_over_time = duration_over_time
             .iter()

--- a/crates/atuin/src/command/client/search/interactive.rs
+++ b/crates/atuin/src/command/client/search/interactive.rs
@@ -1832,6 +1832,9 @@ pub async fn history(
     let mut results = app.query_results(&mut db, settings.smart_sort).await?;
 
     let mut stats: Option<HistoryStats> = None;
+    // The id of the history entry `stats` was computed for, so the render loop
+    // only hits the database when the inspected entry actually changes.
+    let mut stats_for: Option<HistoryId> = None;
     let mut inspecting: Option<History> = None;
     let accept;
     let result = 'render: loop {
@@ -1980,6 +1983,7 @@ pub async fn history(
         }
 
         stats = if app.tab_index == 0 {
+            stats_for = None;
             None
         } else if !results.is_empty() {
             // If we have stats, then we can indicate next available IDs. This avoids passing
@@ -1988,18 +1992,26 @@ pub async fn history(
                 Some(insp) => insp,
                 None => results[app.results_state.selected()].clone(),
             };
-            let stats = db.stats(&selected).await?;
-            app.inspecting_state.current = Some(selected.id);
-            app.inspecting_state.previous = match stats.previous.clone() {
-                Some(p) => Some(p.id),
-                _ => None,
-            };
-            app.inspecting_state.next = match stats.next.clone() {
-                Some(p) => Some(p.id),
-                _ => None,
-            };
-            Some(stats)
+            if stats_for.as_ref() == Some(&selected.id) {
+                // Already computed for this entry - the render loop iterates on every
+                // input event and poll timeout, and stats() is several queries.
+                stats
+            } else {
+                let stats = db.stats(&selected).await?;
+                stats_for = Some(selected.id.clone());
+                app.inspecting_state.current = Some(selected.id);
+                app.inspecting_state.previous = match stats.previous.clone() {
+                    Some(p) => Some(p.id),
+                    _ => None,
+                };
+                app.inspecting_state.next = match stats.next.clone() {
+                    Some(p) => Some(p.id),
+                    _ => None,
+                };
+                Some(stats)
+            }
         } else {
+            stats_for = None;
             None
         };
     };


### PR DESCRIPTION
Follow-up to #3729/#3730: an audit found more queries doing full-table work on every keystroke or store load. All numbers below are measured against clones of a real 96MB/167k-row history.db and 156MB/168k-row records.db, with cold-cache numbers taken on fresh APFS clonefile copies.

## Changes

1. **Partial indexes for session/cwd filtered search** — `search()` and `list()` apply FilterMode::Session/Directory as `session = ?` / `cwd = ?` with no index, so the timestamp-ordered dedup scan read the whole table per keystroke when matches were sparse. New partial indexes `(session, timestamp)` and `(cwd, timestamp)` where `deleted_at is null`. The `stats()` previous/next-in-session queries now also exclude deleted history (matching every other read path) so they can use the session index.
2. **Sargable host filter** — `search()` compares `lower(hostname) = lower(?)`, which no plain column index can serve. The lowercasing is load-bearing: in the sampled db 29k of 167k rows differ from their lowercased form, with the same machine stored under several casings over time (`Ellies-MBP:ellie` vs `ellies-mbp:ellie`), so a plain `hostname = ?` would silently drop rows. Instead, index the `lower(hostname)` expression (partial, with timestamp). `list()` compared hostname case-sensitively, disagreeing with `search()`; it now uses the same `lower()` comparison so both are consistent and indexed.
3. **Record store tag index** — `all_tagged` / `len_tag` are `tag = ? order by timestamp`, previously a full scan + temp b-tree sort of the whole store on every kv/scripts/dotfiles load and store rebuild. New index `store(tag, timestamp)`; `len_tag` gets a covering index.
4. **Inspector stats caching** — while the inspector tab is open, `db.stats()` (7 queries) ran on every render-loop iteration, including every 250ms idle poll, even with the selection unchanged. Now cached keyed by the inspected entry id and only recomputed when it changes. The 7 stats queries also run concurrently on the pool instead of sequentially.
5. **Drop redundant `idx_history_command`** — from the original 2021 schema, fully subsumed by `idx_history_command_timestamp` (same leading column). Offsets most of the disk and insert cost of the new indexes; see below.

## Verification

### EXPLAIN QUERY PLAN (real 167k-row db)

Every filtered shape flips SCAN → SEARCH:

| query | before | after |
|---|---|---|
| search, session filter | `SCAN history USING INDEX idx_history_active_timestamp` | `SEARCH history USING INDEX idx_history_session_timestamp (session=?)` |
| search, directory filter | `SCAN history USING INDEX idx_history_active_timestamp` | `SEARCH history USING INDEX idx_history_cwd_timestamp (cwd=?)` |
| search, host filter | `SCAN history USING INDEX idx_history_active_timestamp` | `SEARCH history USING INDEX idx_history_hostname_timestamp (<expr>=?)` |
| stats prev/next in session | `SEARCH idx_history_timestamp (timestamp<?)` (walks time until session hit) | `SEARCH idx_history_session_timestamp (session=? AND timestamp<?)` |
| store all_tagged | `SCAN store` + `USE TEMP B-TREE FOR ORDER BY` | `SEARCH store USING INDEX idx_store_tag_timestamp (tag=?)` |
| store len_tag | `SCAN store` | `SEARCH store USING COVERING INDEX idx_store_tag_timestamp (tag=?)` |

### Query timings (cold clonefile copy / warm)

| query | before | after |
|---|---|---|
| session keystroke, sparse session, fuzzy `cargo` | 535ms / 24.6ms | 2.1ms / <0.1ms |
| session keystroke, sparse session, empty query | 605ms / 39.5ms | 397ms / 16.8ms † |
| directory keystroke, `cwd = ~/tmp` | 555ms / 26.0ms | 2.4ms / <0.1ms |
| host keystroke, sparse host (3 rows) | 569ms / 43.7ms | 5.9ms / <0.1ms |
| host keystroke, dense host (14k rows) | 566ms / 63.9ms | 496ms / 26.1ms ‡ |
| stats previous-in-session | 293ms / 10.8ms | 1.2ms / <0.1ms |
| store all_tagged, `alias`/`kv`/`script` tags | 363–408ms / ~40ms | 1.1–2.8ms / <0.1ms |
| store len_tag | 9.4ms | 0.4ms |

† the filter itself uses the new index; the remaining cost is the dedup NOT EXISTS probing very common commands (`fg`, `ls`) on a cold cache, same as before.
‡ limit-bound: with 14k matching rows the scan terminates after ~200 distinct commands either way; warm still 2.4x.

### End-to-end (release binaries, isolated data dir, cold clones)

| | main | this branch |
|---|---|---|
| `atuin search --filter-mode session --limit 200 cargo` (sparse session) cold | 581ms | 21ms |
| same, warm | 41ms | 18ms (≈ process startup) |
| `atuin kv list` (kv cache rebuild via all_tagged) cold | 542ms | 15ms |

Results are byte-identical between the main and branch binaries for global, host, session, directory and workspace filter modes (up to 1029 rows compared per mode).

Interactive smoke test under a pty (typed query → ctrl-o inspector → esc): inspector renders (previous/next command, duration, exit), no panics.

### Dropping `idx_history_command`: no-regression validation

Every query shape touching the `command` column was checked on the real db with and without the legacy index (stats total/avg/exits/day-of-week/duration-over-time, fuzzy-search dedup, prefix search, `list --unique` GROUP BY, `all_with_count`, `get_dups`, paged unique listing):

- **Plans**: all identical modulo the index swap — every shape that scanned or probed `idx_history_command` uses `idx_history_command_timestamp` instead, still covering where it was covering. Prefix `LIKE` never used either index (case-insensitive LIKE, BINARY collation).
- **Timings**: warm identical; cold identical within run-to-run variance (e.g. `all_with_count` ~1.06–1.11s both ways across repeated cold runs).
- **Results**: byte-identical everywhere except SQLite's documented *arbitrary representative row* in the two bare-column multi-`GROUP BY` shapes (`all_with_count`, paged unique listing): 949 of 57k groups return a different (equally valid) representative `id`, and some `group_concat` orderings shift. All commands, counts, max timestamps, groups — the meaningful output — identical; these picks were already scan-order-dependent and could change with any ANALYZE/SQLite version bump.
- **End-to-end**: pre-drop vs post-drop release binaries on a frozen snapshot produce byte-identical `atuin search` output for global/session/directory/host modes (up to 1254 rows).

### Disk cost (measured via dbstat on the real dbs)

- New: `idx_history_cwd_timestamp` 9.1MB, `idx_history_session_timestamp` 8.1MB, `idx_history_hostname_timestamp` 6.3MB, `idx_store_tag_timestamp` 4.0MB
- Removed: `idx_history_command` 8.7MB
- Net: history.db +14.8MB (~+16%), records.db +4.0MB (~+2.6%)

### Insert cost (the history hook path)

500 single-row autocommitted inserts, steady state, main vs this branch:

- history: ~0.60ms → ~0.68ms per insert (net +0.07ms: three indexes added, one dropped)
- store: no measurable regression (0.47ms → 0.28ms, i.e. within noise)

### One-time migration cost

- history.db (96MB): 1.16s to build the three indexes, file grows net ~15MB
- records.db (156MB): 0.56s

Migrations are `create index if not exists` and run at every db open, so they stay idempotent for shell hooks.

## Notes

- **Workspace filter is unchanged**: `cwd LIKE 'prefix%'` cannot use a BINARY-collated index because LIKE is case-insensitive by default; fixing it needs either `case_sensitive_like` (changes fuzzy-match semantics elsewhere on the connection) or a `COLLATE NOCASE` index plus a query change (which would un-index the Directory `cwd = ?` equality). It keeps exactly the previous plan — no regression, just not improved.
- **Two deliberate semantic alignments**, both making outliers consistent with the rest of the codebase: `stats()` prev/next now skip deleted history (tombstones from old versions have scrambled commands and are excluded everywhere else), and `list()`'s host filter is now case-insensitive like `search()`'s always was.
- As with any migration, a db touched by this version errors under older binaries (sqlx `VersionMissing` on downgrade) — pre-existing behavior, not new to this PR.
- Requires the `build.rs` from #3730 so the new migration files get embedded on incremental builds (already on main).

`cargo fmt` clean, `cargo clippy` clean, full test suites for atuin + atuin-client pass (except the 3 pre-existing `users` server integration tests, which need a running postgres and fail identically on main).
