### PR TITLE
perf: store the record store in a compact encoding

### DIFF
--- a/crates/atuin-client/migrations/20260723000001_filtered_history_indexes.sql
+++ b/crates/atuin-client/migrations/20260723000001_filtered_history_indexes.sql
@@ -1,0 +1,10 @@
+-- The session, directory and workspace filters (`session = ?`, `cwd = ?`,
+-- `cwd like 'x%'`) had no index, so the timestamp-ordered dedup scan in
+-- search() and list() read the whole table per keystroke when matches were
+-- sparse. Partial indexes over live history keep that a range scan, at a
+-- fraction of the size of a full index.
+create index if not exists idx_history_session_timestamp on history(session, timestamp)
+where deleted_at is null;
+
+create index if not exists idx_history_cwd_timestamp on history(cwd, timestamp)
+where deleted_at is null;

--- a/crates/atuin-client/migrations/20260723000002_hostname_index.sql
+++ b/crates/atuin-client/migrations/20260723000002_hostname_index.sql
@@ -1,0 +1,5 @@
+-- The host filter compares lower(hostname), because the reported casing of
+-- the same machine changes over time (e.g. "Ellies-MBP" vs "ellies-mbp").
+-- Index the same expression so the filter is sargable rather than a scan.
+create index if not exists idx_history_hostname_timestamp on history(lower(hostname), timestamp)
+where deleted_at is null;

--- a/crates/atuin-client/migrations/20260723000003_drop_command_index.sql
+++ b/crates/atuin-client/migrations/20260723000003_drop_command_index.sql
@@ -1,0 +1,6 @@
+-- idx_history_command (from the original 2021 schema) has been redundant
+-- since idx_history_command_timestamp was added: it shares the leading
+-- column, so every query that could use it plans identically onto the
+-- (command, timestamp) index. Dropping it saves ~9MB on a 100MB database
+-- and removes an index from the per-command insert path.
+drop index if exists idx_history_command;

--- a/crates/atuin-client/record-migrations/20260723000000_store_tag_index.sql
+++ b/crates/atuin-client/record-migrations/20260723000000_store_tag_index.sql
@@ -1,0 +1,4 @@
+-- all_tagged and len_tag select by tag ordered by timestamp; without an
+-- index they scan and sort the entire store - over a second on a large,
+-- cold store - on every kv/scripts/dotfiles load and store rebuild.
+create index if not exists idx_store_tag_timestamp on store(tag, timestamp);

--- a/crates/atuin-client/record-migrations/20260724000000_compact_store_ids.sql
+++ b/crates/atuin-client/record-migrations/20260724000000_compact_store_ids.sql
@@ -1,0 +1,8 @@
+-- Store record and host uuids as 16-byte blobs rather than 36-char hyphenated
+-- text; on a large store the two columns and their indexes are tens of MB.
+-- coalesce guards anything unexpectedly non-uuid, leaving it untouched.
+-- unhex() needs the bundled SQLite >= 3.41.
+update store set
+    id = coalesce(unhex(replace(id, '-', '')), id),
+    host = coalesce(unhex(replace(host, '-', '')), host)
+where typeof(id) = 'text' or typeof(host) = 'text';

--- a/crates/atuin-client/src/database.rs
+++ b/crates/atuin-client/src/database.rs
@@ -833,11 +833,14 @@ impl Database for Sqlite {
     }
 
     async fn stats(&self, h: &History) -> Result<HistoryStats> {
-        // We select the previous in the session by time
+        // We select the previous in the session by time. Excluding deleted
+        // history matches every other read path, and lets the query use the
+        // partial (session, timestamp) index.
         let mut prev = SqlBuilder::select_from("history");
         prev.field("*")
             .and_where("timestamp < ?1")
             .and_where("session = ?2")
+            .and_where_is_null("deleted_at")
             .order_by("timestamp", true)
             .limit(1);
 
@@ -845,6 +848,7 @@ impl Database for Sqlite {
         next.field("*")
             .and_where("timestamp > ?1")
             .and_where("session = ?2")
+            .and_where_is_null("deleted_at")
             .order_by("timestamp", false)
             .limit(1);
 

--- a/crates/atuin-client/src/database.rs
+++ b/crates/atuin-client/src/database.rs
@@ -476,7 +476,12 @@ impl Database for Sqlite {
         for filter in filters {
             match filter {
                 FilterMode::Global => &mut query,
-                FilterMode::Host => query.and_where_eq("hostname", quote(&context.hostname)),
+                FilterMode::Host => query.and_where_eq(
+                    // Case-insensitive, matching `search()` - the reported casing of a
+                    // hostname changes over time. lower() is indexed as an expression.
+                    "lower(hostname)",
+                    quote(context.hostname.to_lowercase()),
+                ),
                 FilterMode::Session => query.and_where_eq("session", quote(&context.session)),
                 FilterMode::SessionPreload => {
                     query.and_where_eq("session", quote(&context.session));

--- a/crates/atuin-client/src/database.rs
+++ b/crates/atuin-client/src/database.rs
@@ -903,45 +903,42 @@ impl Database for Sqlite {
             .sql()
             .expect("issue in stats duration over time query");
 
-        let prev = sqlx::query(sqlx::AssertSqlSafe(prev))
-            .bind(h.timestamp.unix_timestamp_nanos() as i64)
-            .bind(&h.session)
-            .map(Self::query_history)
-            .fetch_optional(&self.pool)
-            .await?;
-
-        let next = sqlx::query(sqlx::AssertSqlSafe(next))
-            .bind(h.timestamp.unix_timestamp_nanos() as i64)
-            .bind(&h.session)
-            .map(Self::query_history)
-            .fetch_optional(&self.pool)
-            .await?;
-
-        let total: (i64,) = sqlx::query_as(sqlx::AssertSqlSafe(total))
-            .bind(&h.command)
-            .fetch_one(&self.pool)
-            .await?;
-
-        let average: (f64,) = sqlx::query_as(sqlx::AssertSqlSafe(average))
-            .bind(&h.command)
-            .fetch_one(&self.pool)
-            .await?;
-
-        let exits: Vec<(i64, i64)> = sqlx::query_as(sqlx::AssertSqlSafe(exits))
-            .bind(&h.command)
-            .fetch_all(&self.pool)
-            .await?;
-
-        let day_of_week: Vec<(String, i64)> = sqlx::query_as(sqlx::AssertSqlSafe(day_of_week))
-            .bind(&h.command)
-            .fetch_all(&self.pool)
-            .await?;
-
-        let duration_over_time: Vec<(String, f64)> =
+        // The queries are all independent, so run them concurrently on the pool.
+        let (prev, next, total, average, exits, day_of_week, duration_over_time): (
+            _,
+            _,
+            (i64,),
+            (f64,),
+            Vec<(i64, i64)>,
+            Vec<(String, i64)>,
+            Vec<(String, f64)>,
+        ) = tokio::try_join!(
+            sqlx::query(sqlx::AssertSqlSafe(prev))
+                .bind(h.timestamp.unix_timestamp_nanos() as i64)
+                .bind(&h.session)
+                .map(Self::query_history)
+                .fetch_optional(&self.pool),
+            sqlx::query(sqlx::AssertSqlSafe(next))
+                .bind(h.timestamp.unix_timestamp_nanos() as i64)
+                .bind(&h.session)
+                .map(Self::query_history)
+                .fetch_optional(&self.pool),
+            sqlx::query_as(sqlx::AssertSqlSafe(total))
+                .bind(&h.command)
+                .fetch_one(&self.pool),
+            sqlx::query_as(sqlx::AssertSqlSafe(average))
+                .bind(&h.command)
+                .fetch_one(&self.pool),
+            sqlx::query_as(sqlx::AssertSqlSafe(exits))
+                .bind(&h.command)
+                .fetch_all(&self.pool),
+            sqlx::query_as(sqlx::AssertSqlSafe(day_of_week))
+                .bind(&h.command)
+                .fetch_all(&self.pool),
             sqlx::query_as(sqlx::AssertSqlSafe(duration_over_time))
                 .bind(&h.command)
-                .fetch_all(&self.pool)
-                .await?;
+                .fetch_all(&self.pool),
+        )?;
 
         let duration_over_time = duration_over_time
             .iter()

--- a/crates/atuin-client/src/record/sqlite_store.rs
+++ b/crates/atuin-client/src/record/sqlite_store.rs
@@ -9,8 +9,9 @@ use async_trait::async_trait;
 use eyre::{Result, eyre};
 use fs_err as fs;
 
+use base64::{Engine, engine::general_purpose::URL_SAFE_NO_PAD};
 use sqlx::{
-    Row,
+    Row, TypeInfo, ValueRef,
     sqlite::{
         SqliteConnectOptions, SqliteJournalMode, SqlitePool, SqlitePoolOptions, SqliteRow,
         SqliteSynchronous,
@@ -25,6 +26,84 @@ use uuid::Uuid;
 
 use super::encryption::PASETO_V4;
 use super::store::Store;
+
+// Storage codec: encrypted payloads reach us as base64 text (a PASETO token
+// and a JSON-wrapped PASERK key), which costs ~35% over the raw bytes - tens
+// of MB on a large store. Payloads matching these exact shapes are stored
+// with the base64 decoded to a blob; anything else is stored as text
+// verbatim, and the column's storage type says which form a row is in. The
+// sync wire format is unchanged: reads rebuild the original string, and
+// compaction is only applied when re-expansion reproduces it byte for byte.
+const DATA_PREFIX: &str = "v4.local.";
+const CEK_PREFIX: &str = "{\"wpk\":\"k4.local-wrap.pie.";
+const CEK_INFIX: &str = "\",\"kid\":\"k4.lid.";
+const CEK_SUFFIX: &str = "\"}";
+
+fn compact_data(data: &str) -> Option<Vec<u8>> {
+    let payload = data.strip_prefix(DATA_PREFIX)?;
+    // a '.' would mean the token carries a footer, which expand_data can't rebuild
+    if payload.contains('.') {
+        return None;
+    }
+    let blob = URL_SAFE_NO_PAD.decode(payload).ok()?;
+    (expand_data(&blob) == data).then_some(blob)
+}
+
+fn expand_data(blob: &[u8]) -> String {
+    format!("{DATA_PREFIX}{}", URL_SAFE_NO_PAD.encode(blob))
+}
+
+fn compact_cek(cek: &str) -> Option<Vec<u8>> {
+    let (wpk, kid) = cek
+        .strip_prefix(CEK_PREFIX)?
+        .strip_suffix(CEK_SUFFIX)?
+        .split_once(CEK_INFIX)?;
+    let wpk = URL_SAFE_NO_PAD.decode(wpk).ok()?;
+    let kid = URL_SAFE_NO_PAD.decode(kid).ok()?;
+
+    let mut blob = Vec::with_capacity(1 + wpk.len() + kid.len());
+    blob.push(u8::try_from(wpk.len()).ok()?);
+    blob.extend_from_slice(&wpk);
+    blob.extend_from_slice(&kid);
+    (expand_cek(&blob).as_deref() == Some(cek)).then_some(blob)
+}
+
+fn expand_cek(blob: &[u8]) -> Option<String> {
+    let (&wpk_len, rest) = blob.split_first()?;
+    let (wpk, kid) = rest.split_at_checked(wpk_len as usize)?;
+    Some(format!(
+        "{CEK_PREFIX}{}{CEK_INFIX}{}{CEK_SUFFIX}",
+        URL_SAFE_NO_PAD.encode(wpk),
+        URL_SAFE_NO_PAD.encode(kid)
+    ))
+}
+
+fn column_is_blob(row: &SqliteRow, col: &str) -> bool {
+    row.try_get_raw(col)
+        .expect("missing column in store row")
+        .type_info()
+        .name()
+        == "BLOB"
+}
+
+/// Read a payload column, re-expanding the compact blob form to its original text.
+fn column_payload(row: &SqliteRow, col: &str, expand: impl Fn(&[u8]) -> Option<String>) -> String {
+    if column_is_blob(row, col) {
+        expand(&row.get::<Vec<u8>, _>(col)).expect("invalid compact payload in sqlite DB")
+    } else {
+        row.get(col)
+    }
+}
+
+/// Read a uuid column: a 16-byte blob, or hyphenated text from before the
+/// compact-ids migration (which converts everything, but be lenient).
+fn column_uuid(row: &SqliteRow, col: &str) -> Uuid {
+    if column_is_blob(row, col) {
+        Uuid::from_slice(&row.get::<Vec<u8>, _>(col)).expect("invalid uuid blob in sqlite DB")
+    } else {
+        Uuid::from_str(row.get(col)).expect("invalid uuid format in sqlite DB")
+    }
+}
 
 #[derive(Debug, Clone)]
 pub struct SqliteStore {
@@ -80,20 +159,27 @@ impl SqliteStore {
         r: &Record<EncryptedData>,
     ) -> Result<()> {
         // In sqlite, we are "limited" to i64. But that is still fine, until 2262.
-        sqlx::query(
+        let query = sqlx::query(
             "insert or ignore into store(id, idx, host, tag, timestamp, version, data, cek)
                 values(?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)",
         )
-        .bind(r.id.0.as_hyphenated().to_string())
+        .bind(r.id.0.as_bytes().as_slice())
         .bind(r.idx as i64)
-        .bind(r.host.id.0.as_hyphenated().to_string())
+        .bind(r.host.id.0.as_bytes().as_slice())
         .bind(r.tag.as_str())
         .bind(r.timestamp as i64)
-        .bind(r.version.as_str())
-        .bind(r.data.data.as_str())
-        .bind(r.data.content_encryption_key.as_str())
-        .execute(&mut **tx)
-        .await?;
+        .bind(r.version.as_str());
+
+        let query = match compact_data(&r.data.data) {
+            Some(blob) => query.bind(blob),
+            None => query.bind(r.data.data.as_str()),
+        };
+        let query = match compact_cek(&r.data.content_encryption_key) {
+            Some(blob) => query.bind(blob),
+            None => query.bind(r.data.content_encryption_key.as_str()),
+        };
+
+        query.execute(&mut **tx).await?;
 
         Ok(())
     }
@@ -103,8 +189,8 @@ impl SqliteStore {
         let timestamp: i64 = row.get("timestamp");
 
         // tbh at this point things are pretty fucked so just panic
-        let id = Uuid::from_str(row.get("id")).expect("invalid id UUID format in sqlite DB");
-        let host = Uuid::from_str(row.get("host")).expect("invalid host UUID format in sqlite DB");
+        let id = column_uuid(&row, "id");
+        let host = column_uuid(&row, "host");
 
         Record {
             id: RecordId(id),
@@ -114,8 +200,8 @@ impl SqliteStore {
             tag: row.get("tag"),
             version: row.get("version"),
             data: EncryptedData {
-                data: row.get("data"),
-                content_encryption_key: row.get("cek"),
+                data: column_payload(&row, "data", |blob| Some(expand_data(blob))),
+                content_encryption_key: column_payload(&row, "cek", expand_cek),
             },
         }
     }
@@ -127,6 +213,59 @@ impl SqliteStore {
             .await?;
 
         Ok(res)
+    }
+
+    /// Rewrite rows saved before the compact encoding existed (base64 text
+    /// payloads) into the blob form, then vacuum to give the space back to the
+    /// filesystem. Returns the number of rows rewritten. One-off maintenance:
+    /// new rows are always written compact.
+    pub async fn compact(&self) -> Result<u64> {
+        let mut rewritten = 0u64;
+        let mut cursor = 0i64;
+
+        loop {
+            let rows = sqlx::query(
+                "select rowid, data, cek from store
+                    where rowid > ?1 and (typeof(data) = 'text' or typeof(cek) = 'text')
+                    order by rowid asc limit 1000",
+            )
+            .bind(cursor)
+            .fetch_all(&self.pool)
+            .await?;
+
+            let Some(last) = rows.last() else { break };
+            cursor = last.get("rowid");
+
+            let mut tx = self.pool.begin().await?;
+            for row in &rows {
+                let rowid: i64 = row.get("rowid");
+                let data = compact_data(&column_payload(row, "data", |b| Some(expand_data(b))));
+                let cek = compact_cek(&column_payload(row, "cek", expand_cek));
+                if data.is_none() && cek.is_none() {
+                    // not in a shape we can compact - leave it as text
+                    continue;
+                }
+
+                sqlx::query(
+                    "update store set data = coalesce(?2, data), cek = coalesce(?3, cek)
+                        where rowid = ?1",
+                )
+                .bind(rowid)
+                .bind(data)
+                .bind(cek)
+                .execute(&mut *tx)
+                .await?;
+                rewritten += 1;
+            }
+            tx.commit().await?;
+        }
+
+        sqlx::query("vacuum").execute(&self.pool).await?;
+        sqlx::query("pragma wal_checkpoint(truncate)")
+            .execute(&self.pool)
+            .await?;
+
+        Ok(rewritten)
     }
 }
 
@@ -149,7 +288,7 @@ impl Store for SqliteStore {
 
     async fn get(&self, id: RecordId) -> Result<Record<EncryptedData>> {
         let res = sqlx::query("select * from store where store.id = ?1")
-            .bind(id.0.as_hyphenated().to_string())
+            .bind(id.0.as_bytes().as_slice())
             .map(Self::query_row)
             .fetch_one(&self.pool)
             .await?;
@@ -159,7 +298,7 @@ impl Store for SqliteStore {
 
     async fn delete(&self, id: RecordId) -> Result<()> {
         sqlx::query("delete from store where id = ?1")
-            .bind(id.0.as_hyphenated().to_string())
+            .bind(id.0.as_bytes().as_slice())
             .execute(&self.pool)
             .await?;
 
@@ -175,7 +314,7 @@ impl Store for SqliteStore {
     async fn last(&self, host: HostId, tag: &str) -> Result<Option<Record<EncryptedData>>> {
         let res =
             sqlx::query("select * from store where host=?1 and tag=?2 order by idx desc limit 1")
-                .bind(host.0.as_hyphenated().to_string())
+                .bind(host.0.as_bytes().as_slice())
                 .bind(tag)
                 .map(Self::query_row)
                 .fetch_one(&self.pool)
@@ -235,7 +374,7 @@ impl Store for SqliteStore {
             "select * from store where idx >= ?1 and host = ?2 and tag = ?3 order by idx asc limit ?4",
         )
         .bind(idx as i64)
-        .bind(host.0.as_hyphenated().to_string())
+        .bind(host.0.as_bytes().as_slice())
         .bind(tag)
         .bind(limit as i64)
         .map(Self::query_row)
@@ -253,7 +392,7 @@ impl Store for SqliteStore {
     ) -> Result<Option<Record<EncryptedData>>> {
         let res = sqlx::query("select * from store where idx = ?1 and host = ?2 and tag = ?3")
             .bind(idx as i64)
-            .bind(host.0.as_hyphenated().to_string())
+            .bind(host.0.as_bytes().as_slice())
             .bind(tag)
             .map(Self::query_row)
             .fetch_one(&self.pool)
@@ -269,22 +408,21 @@ impl Store for SqliteStore {
     async fn status(&self) -> Result<RecordStatus> {
         let mut status = RecordStatus::new();
 
-        let res: Result<Vec<(String, String, i64)>, sqlx::Error> =
-            sqlx::query_as("select host, tag, max(idx) from store group by host, tag")
-                .fetch_all(&self.pool)
-                .await;
+        let res = sqlx::query("select host, tag, max(idx) as idx from store group by host, tag")
+            .fetch_all(&self.pool)
+            .await;
 
         let res = match res {
             Err(e) => return Err(eyre!("failed to fetch local store status: {}", e)),
             Ok(v) => v,
         };
 
-        for i in res {
-            let host = HostId(
-                Uuid::from_str(i.0.as_str()).expect("failed to parse uuid for local store status"),
-            );
+        for row in res {
+            let host = HostId(column_uuid(&row, "host"));
+            let tag: String = row.get("tag");
+            let idx: i64 = row.get("idx");
 
-            status.set_raw(host, i.1, i.2 as u64);
+            status.set_raw(host, tag, idx as u64);
         }
 
         Ok(status)
@@ -400,6 +538,88 @@ mod tests {
             })
             .idx(0)
             .build()
+    }
+
+    #[test]
+    fn codec_round_trips_real_encrypted_record() {
+        let record = Record::builder()
+            .host(Host::new(HostId(uuid_v7())))
+            .version("v0".into())
+            .tag("history".into())
+            .idx(0)
+            .data(DecryptedData(vec![1, 2, 3, 4]))
+            .build()
+            .encrypt::<PASETO_V4>(&[7; 32]);
+
+        let data_blob = super::compact_data(&record.data.data).expect("real token should compact");
+        assert_eq!(super::expand_data(&data_blob), record.data.data);
+        assert!(data_blob.len() < record.data.data.len());
+
+        let cek_blob = super::compact_cek(&record.data.content_encryption_key)
+            .expect("real cek should compact");
+        assert_eq!(
+            super::expand_cek(&cek_blob).as_deref(),
+            Some(record.data.content_encryption_key.as_str())
+        );
+        assert!(cek_blob.len() < record.data.content_encryption_key.len());
+    }
+
+    #[test]
+    fn codec_leaves_unknown_shapes_alone() {
+        // not a token at all, a token with a footer, invalid base64
+        assert_eq!(super::compact_data("1234"), None);
+        assert_eq!(super::compact_data("v4.local.abc.Zm9vdGVy"), None);
+        assert_eq!(super::compact_data("v4.local.!!!"), None);
+        // base64 that would not round-trip byte for byte (padding)
+        assert_eq!(super::compact_data("v4.local.YQ=="), None);
+        assert_eq!(super::compact_cek("1234"), None);
+        assert_eq!(super::compact_cek("{\"wpk\":\"nope\"}"), None);
+    }
+
+    #[tokio::test]
+    async fn legacy_text_rows_read_back_and_compact() {
+        let db = SqliteStore::new(":memory:", test_local_timeout())
+            .await
+            .unwrap();
+
+        // a realistic encrypted record, inserted the way pre-codec atuin
+        // stored it: uuids and payloads all as text
+        let record = Record::builder()
+            .host(Host::new(HostId(uuid_v7())))
+            .version("v0".into())
+            .tag("history".into())
+            .idx(0)
+            .data(DecryptedData(vec![1, 2, 3, 4]))
+            .build()
+            .encrypt::<PASETO_V4>(&[7; 32]);
+
+        sqlx::query(
+            "insert into store(id, idx, host, tag, timestamp, version, data, cek)
+                values(?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)",
+        )
+        .bind(record.id.0.as_hyphenated().to_string())
+        .bind(record.idx as i64)
+        .bind(record.host.id.0.as_hyphenated().to_string())
+        .bind(record.tag.as_str())
+        .bind(record.timestamp as i64)
+        .bind(record.version.as_str())
+        .bind(record.data.data.as_str())
+        .bind(record.data.content_encryption_key.as_str())
+        .execute(&db.pool)
+        .await
+        .unwrap();
+
+        let read = db.load_all().await.unwrap();
+        assert_eq!(read, vec![record.clone()], "text row should read unchanged");
+
+        let rewritten = db.compact().await.unwrap();
+        assert_eq!(rewritten, 1);
+
+        let read = db.load_all().await.unwrap();
+        assert_eq!(read, vec![record], "compacted row should read unchanged");
+
+        // compact again: nothing left to rewrite
+        assert_eq!(db.compact().await.unwrap(), 0);
     }
 
     #[tokio::test]

--- a/crates/atuin/src/command/client/search/interactive.rs
+++ b/crates/atuin/src/command/client/search/interactive.rs
@@ -1832,6 +1832,9 @@ pub async fn history(
     let mut results = app.query_results(&mut db, settings.smart_sort).await?;
 
     let mut stats: Option<HistoryStats> = None;
+    // The id of the history entry `stats` was computed for, so the render loop
+    // only hits the database when the inspected entry actually changes.
+    let mut stats_for: Option<HistoryId> = None;
     let mut inspecting: Option<History> = None;
     let accept;
     let result = 'render: loop {
@@ -1980,6 +1983,7 @@ pub async fn history(
         }
 
         stats = if app.tab_index == 0 {
+            stats_for = None;
             None
         } else if !results.is_empty() {
             // If we have stats, then we can indicate next available IDs. This avoids passing
@@ -1988,18 +1992,26 @@ pub async fn history(
                 Some(insp) => insp,
                 None => results[app.results_state.selected()].clone(),
             };
-            let stats = db.stats(&selected).await?;
-            app.inspecting_state.current = Some(selected.id);
-            app.inspecting_state.previous = match stats.previous.clone() {
-                Some(p) => Some(p.id),
-                _ => None,
-            };
-            app.inspecting_state.next = match stats.next.clone() {
-                Some(p) => Some(p.id),
-                _ => None,
-            };
-            Some(stats)
+            if stats_for.as_ref() == Some(&selected.id) {
+                // Already computed for this entry - the render loop iterates on every
+                // input event and poll timeout, and stats() is several queries.
+                stats
+            } else {
+                let stats = db.stats(&selected).await?;
+                stats_for = Some(selected.id.clone());
+                app.inspecting_state.current = Some(selected.id);
+                app.inspecting_state.previous = match stats.previous.clone() {
+                    Some(p) => Some(p.id),
+                    _ => None,
+                };
+                app.inspecting_state.next = match stats.next.clone() {
+                    Some(p) => Some(p.id),
+                    _ => None,
+                };
+                Some(stats)
+            }
         } else {
+            stats_for = None;
             None
         };
     };

--- a/crates/atuin/src/command/client/store.rs
+++ b/crates/atuin/src/command/client/store.rs
@@ -38,6 +38,9 @@ pub enum Cmd {
     /// Verify that all records in the store can be decrypted with the current key
     Verify(verify::Verify),
 
+    /// Rewrite the store in a compact encoding and reclaim free space
+    Compact,
+
     /// Push all records to the remote sync server (one way sync)
     #[cfg(feature = "sync")]
     Push(push::Push),
@@ -56,6 +59,7 @@ impl Cmd {
     ) -> Result<()> {
         match self {
             Self::Status => self.status(store).await,
+            Self::Compact => self.compact(settings, store).await,
             Self::Rebuild(rebuild) => rebuild.run(settings, store, database).await,
             Self::Rekey(rekey) => rekey.run(settings, store).await,
             Self::Verify(verify) => verify.run(settings, store).await,
@@ -67,6 +71,24 @@ impl Cmd {
             #[cfg(feature = "sync")]
             Self::Pull(pull) => pull.run(settings, store, database).await,
         }
+    }
+
+    #[allow(clippy::cast_precision_loss)]
+    async fn compact(&self, settings: &Settings, store: SqliteStore) -> Result<()> {
+        let store_mb = || {
+            std::fs::metadata(&settings.record_store_path)
+                .map_or(0.0, |m| m.len() as f64 / 1_048_576.0)
+        };
+        let before = store_mb();
+
+        let rewritten = store.compact().await?;
+
+        println!(
+            "compacted {rewritten} records: {before:.1}MB -> {:.1}MB",
+            store_mb()
+        );
+
+        Ok(())
     }
 
     pub async fn status(&self, store: SqliteStore) -> Result<()> {


### PR DESCRIPTION
Stacked on #3731 (base branch is `ellie/sqlite-perf-indexes`; retarget to main once that merges).

records.db stores every record exactly as it travels over sync: uuids as 36-char hyphenated text, the PASETO token as base64 text (`v4.local.…`), and the wrapped content key as JSON-wrapped base64 (`{"wpk":"k4.local-wrap.pie.…","kid":"k4.lid.…"}`). On a real 160MB / 168k-record store that representational overhead is ~50MB — base64 alone is +33% over the raw ciphertext.

## Changes

- **uuid columns → 16-byte blobs.** A migration converts `id`/`host` with `unhex()` (bundled SQLite ≥ 3.41; `coalesce` leaves anything unexpectedly non-uuid untouched). One-time cost: 2.4s at first open for 168k rows.
- **Payload columns → decoded blobs.** `save_raw` decodes the base64 out of the token and the wrapped key when they match the known shapes *exactly* — guarded by re-encoding at write time and only storing compact if the reconstruction is byte-identical. Anything else (other versions, footers, unknown formats) is stored as text verbatim; the column's storage type (`typeof`) records which form each row is in, so the two coexist safely.
- **Reads rebuild the original strings**, so the sync wire format, encryption, and every consumer above the storage layer are completely unchanged.
- **`atuin store compact`** rewrites rows written before the codec existed and vacuums to return the space to the filesystem. Opt-in, one-off; new records are always written compact.

## Verification (real 168,333-record store, clone of a 160MB records.db)

- **Byte identity, independently checked**: a Python reimplementation of the expansion compared every one of the 168,333 rows (id, idx, host, tag, timestamp, version, data, cek) after migration+compaction against the original database: **0 mismatches**.
- **Cryptographic proof**: `atuin store verify` (decrypts every record; PASETO is authenticated, so any byte difference in token or cek fails) passes before and after compaction.
- **Size**: `atuin store compact` → `compacted 168333 records: 160.7MB -> 106.5MB` (**−34%**) in 3.1s. Note the migration alone doesn't shrink the file (SQLite retains freed pages); the full result needs the opt-in compact, but new stores/rows get the small encoding from day one.
- **Functional**: `store status`, `kv set`/`kv get` (fresh record written through the codec lands fully blob and verifies), `kv list` output identical to a main-era binary on the same data, second open is a no-op (28ms).
- Unit tests: codec round-trip on a real encrypted record, fallback for non-token/footer/padded-base64 shapes, and a legacy text row reading back unchanged before and after `compact()`.
- fmt/clippy clean; full `atuin` + `atuin-client` suites pass (including the postgres `users` integration tests).

## Notes

- As with any migration, a store touched by this version can't be opened by older binaries (sqlx refuses unknown applied migrations) — standard behavior, worth the usual release-notes line.
- The write-path cost of the codec is one base64 decode+encode per record (~µs), invisible next to the encryption itself.
- Remaining store size is ~55MB ciphertext + ~24MB per-record wrapped keys + ids/indexes; going lower needs the bigger levers (shared/derived keys, compress-before-encrypt, segment compaction) discussed separately.
