### PR TITLE
docs(search): explain how to search history from another host

### DIFF
--- a/docs/docs/faq.md
+++ b/docs/docs/faq.md
@@ -45,6 +45,33 @@ Add `--disable-ai`, e.g.:
 eval "$(atuin init zsh --disable-ai)"
 ```
 
+## How do I search history from another host?
+
+After [sync](guide/sync.md), the interactive **host** filter mode only includes history recorded on the machine you are currently using. Commands from other machines are still available under the default **global** filter.
+
+To label rows by machine, show the `host` column:
+
+```toml
+[ui]
+columns = ["duration", "time", "host", "command"]
+```
+
+To focus one other host inside the TUI:
+
+1. Stay in **global** filter mode and find any command that ran on that host (the host column helps).
+2. Press **ctrl-a** then **c** to [switch context](guide/advanced-usage.md#context-switch) onto that command (Atuin adopts its host, session, and directory).
+3. Press **ctrl-r** until the filter mode is **host** — search is then limited to that host.
+
+`atuin search` doesn't accept a `--host` flag. From a script you can print the host with `--format` and filter afterward, for example:
+
+```shell
+atuin search --filter-mode global --format '{host}|{command}' | grep '^bucket|'
+```
+
+Because `grep` is line-oriented, this only matches the first line of each entry, so multiline commands are truncated in the output. If you need the full command text, drop the `| grep` and filter with a tool that keeps whole records instead.
+
+See [filter modes](guide/advanced-usage.md#filter-mode) and [UI columns](configuration/config.md#columns).
+
 ## How do I edit a command instead of running it immediately?
 
 Press tab! By default, enter will execute a command, and tab will insert it ready for editing.

--- a/docs/docs/guide/advanced-usage.md
+++ b/docs/docs/guide/advanced-usage.md
@@ -12,7 +12,7 @@ modes by pressing **ctrl-r** inside the TUI.
 | Mode             | Searches                                                                             |
 |------------------|--------------------------------------------------------------------------------------|
 | global (default) | Your full history, from every machine                                                |
-| host             | Only history from this machine                                                       |
+| host             | Only history from the current machine (or the host of a [switched context](#context-switch)) |
 | session          | Only history from the current shell session                                          |
 | directory        | Only history from the current directory                                              |
 | workspace        | Only history from anywhere in the current git repository                             |
@@ -48,6 +48,10 @@ Atuin uses the current context (host, session, directory) to filter the history 
 
 You can switch this context to the one of the currently selected command by pressing **ctrl-a** then **c**.
 
-This will set the filter mode to *session* and clear the search query, which will show you all the commands executed in the same shell session.
+That adopts the selected command's host, session, and directory into the search context, sets the filter mode to *session*, and clears the search query — so you immediately see the other commands from that shell session.
 
-Pressing this key combination again will return to the initial context. You can customize this behavior by setting [custom key bindings](../configuration/advanced-key-binding.md) to the `switch-context` and `clear-context` commands. `switch-context` can be called several times to navigate through multiple command contexts, while `clear-context` will always return to the initial context.
+Because host and directory came along with the session, you can then press **ctrl-r** to move to the *host* or *directory* filter mode and keep searching that remote machine (or path) instead of the one you are typed into right now. This is the interactive way to answer "show me history from host X while I am on host Y" after sync.
+
+Pressing the key combination again (or `clear-context`) returns to the initial context. You can customize this behavior by setting [custom key bindings](../configuration/advanced-key-binding.md) to the `switch-context` and `clear-context` commands. `switch-context` can be called several times to navigate through multiple command contexts, while `clear-context` will always return to the initial context.
+
+To label each row with its machine, add the `host` column under [`[ui]`](../configuration/config.md#columns).


### PR DESCRIPTION
## Summary

- FAQ: how to search history that ran on another synced host.
- Advanced usage: clarify that context switch carries host/directory, so host filter mode can target that machine.

## Motivation

Closes #2442.

`host` filter mode only matches the current machine. Multi-host users need the global view + host column, or switch-context onto a remote entry then cycle to host mode. There is still no `--host` CLI flag; document a `--format` post-filter for scripts.

## Verification

- Matched `Context::from_history` (adopts hostname/session/cwd) and host-mode SQL (`lower(hostname)` vs context hostname).
- Matched default `ctrl-a` then `c` → `switch-context`, and `ctrl-r` → `cycle-filter-mode`.
- Docs-only.

## Checklist

- [x] I am happy for maintainers to push small adjustments to this PR
- [x] I have checked that there are no existing pull requests for the same thing

---
<!-- fleet-pr-claim: agent_id=sera platform=hermes -->
**Agent-Owner:** `sera` · **Platform:** hermes · **Claim:** `sera` · **Claim-TTL:** 48h
