### PR TITLE
chore(release): prepare for release 18.18.0-beta.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,14 @@ All notable changes to this project will be documented in this file.
 
 - *(daemon)* Index synced history directly instead of malformed SQL ([#3627](https://github.com/atuinsh/atuin/issues/3627)) ([#3641](https://github.com/atuinsh/atuin/issues/3641))
 - *(deps)* Update unsound/vulnerable dependencies in Cargo.lock ([#3632](https://github.com/atuinsh/atuin/issues/3632))
+- *(docs)* Repair every stale link in the repo ([#3727](https://github.com/atuinsh/atuin/issues/3727))
+- *(docs)* Make the incorrect-decrypt-key error actionable ([#3609](https://github.com/atuinsh/atuin/issues/3609))
 - *(hook)* Drop agent commands containing NUL bytes via NonNulStr ([#3589](https://github.com/atuinsh/atuin/issues/3589)) ([#3660](https://github.com/atuinsh/atuin/issues/3660))
+- *(import)* Survive corrupt entries instead of aborting the import ([#3721](https://github.com/atuinsh/atuin/issues/3721))
 - *(init)* Fix include guard in Bash init script; chore(init): improve inclusion of shell init scripts in Rust ([#3645](https://github.com/atuinsh/atuin/issues/3645))
 - *(install)* Make /dev/tty authoritative for interactivity detection ([#3691](https://github.com/atuinsh/atuin/issues/3691))
+- *(ui)* Calculate preview height based on command display width instead of byte count ([#3678](https://github.com/atuinsh/atuin/issues/3678))
+- *(win32)* Cargo-binstall package metadata ([#3673](https://github.com/atuinsh/atuin/issues/3673))
 - Search functionality to respect character offsets and non-ASCII ([#3659](https://github.com/atuinsh/atuin/issues/3659))
 - Quote argument-hint YAML values so Copilot CLI ≥1.0.65 loads all skills ([#3613](https://github.com/atuinsh/atuin/issues/3613)) ([#3614](https://github.com/atuinsh/atuin/issues/3614))
 - Correct grammar in 'history last' help text ([#3430](https://github.com/atuinsh/atuin/issues/3430))
@@ -18,6 +23,9 @@ All notable changes to this project will be documented in this file.
 - Improve non-interactive TTY detection in install.sh ([#3315](https://github.com/atuinsh/atuin/issues/3315))
 - Add /model hint to status bar ([#3687](https://github.com/atuinsh/atuin/issues/3687))
 - Set correct umask for pty-proxy ([#3700](https://github.com/atuinsh/atuin/issues/3700))
+- Atuin AI not erasing the input box before closing ([#3715](https://github.com/atuinsh/atuin/issues/3715))
+- Show server status next to AI progress indicator ([#3723](https://github.com/atuinsh/atuin/issues/3723))
+- Show full command when using AtuinOutput tool ([#3725](https://github.com/atuinsh/atuin/issues/3725))
 
 ### Documentation
 
@@ -29,12 +37,22 @@ All notable changes to this project will be documented in this file.
 - Version docs.atuin.sh with mike (per-release + main) ([#3688](https://github.com/atuinsh/atuin/issues/3688))
 - Hotfix bad path ([#3690](https://github.com/atuinsh/atuin/issues/3690))
 - Document built-in bash-preexec ([#3651](https://github.com/atuinsh/atuin/issues/3651))
+- Retheme docs.atuin.sh to the Atuin brand ([#3701](https://github.com/atuinsh/atuin/issues/3701))
+- Bundle of improvements ([#3716](https://github.com/atuinsh/atuin/issues/3716))
+- Remove ugly cards on landing page ([#3724](https://github.com/atuinsh/atuin/issues/3724))
+- Fix broken README links ([#3696](https://github.com/atuinsh/atuin/issues/3696))
+- Lint prose with Vale and gate it in CI ([#3726](https://github.com/atuinsh/atuin/issues/3726))
+- Slightly nicer default config.toml order ([#2485](https://github.com/atuinsh/atuin/issues/2485))
+- Kubernetes self-hosting documentation ([#3238](https://github.com/atuinsh/atuin/issues/3238))
+- Add canonical Supported platforms page ([#3736](https://github.com/atuinsh/atuin/issues/3736))
 
 ### Features
 
+- *(ai)* Up/down to scroll through previously sent messages ([#3720](https://github.com/atuinsh/atuin/issues/3720))
 - *(bash)* Bundle bash-preexec with Atuin; automatically load if no other preexec backend is loaded ([#3650](https://github.com/atuinsh/atuin/issues/3650))
 - *(search)* Add `--shell` option to `atuin search` to filter results by shell ([#3658](https://github.com/atuinsh/atuin/issues/3658))
 - *(search)* Syntax highlight commands in interactive search ([#3704](https://github.com/atuinsh/atuin/issues/3704))
+- *(search)* Filter by shell in interactive search ([#3692](https://github.com/atuinsh/atuin/issues/3692))
 - *(string)* EllipsizeExt -- General-purpose utility for adding ellipses to strings ([#3639](https://github.com/atuinsh/atuin/issues/3639))
 - Add 'yolo' setting to Atuin AI options ([#3637](https://github.com/atuinsh/atuin/issues/3637))
 - Add `shell` field to history entries ([#3636](https://github.com/atuinsh/atuin/issues/3636))
@@ -42,6 +60,7 @@ All notable changes to this project will be documented in this file.
 - Add atuin stats --filter-mode ([#1737](https://github.com/atuinsh/atuin/issues/1737))
 - More aggressive optimizations for dist release ([#3683](https://github.com/atuinsh/atuin/issues/3683))
 - Capture zsh comments as history ([#3699](https://github.com/atuinsh/atuin/issues/3699))
+- Allow injecting extra HTTP headers on sync server requests  ([#3718](https://github.com/atuinsh/atuin/issues/3718))
 
 ### Miscellaneous Tasks
 
@@ -62,6 +81,16 @@ All notable changes to this project will be documented in this file.
 - Update Atuin AI to eye-declare v0.6.1 ([#3686](https://github.com/atuinsh/atuin/issues/3686))
 - Remove docs-dispatch ([#3694](https://github.com/atuinsh/atuin/issues/3694))
 - Docker healtcheck ([#2451](https://github.com/atuinsh/atuin/issues/2451))
+- Run windows jobs on depot-windows-2025-16 ([#3711](https://github.com/atuinsh/atuin/issues/3711))
+- Hotfix script ([#3714](https://github.com/atuinsh/atuin/issues/3714))
+- Update flake.nix ([#3509](https://github.com/atuinsh/atuin/issues/3509))
+- Add Timezone and restart policy for postgres backup docker ([#3083](https://github.com/atuinsh/atuin/issues/3083))
+
+### Performance
+
+- Do not block counting history ([#3729](https://github.com/atuinsh/atuin/issues/3729))
+- Actually delete history rows, and index active history ([#3730](https://github.com/atuinsh/atuin/issues/3730))
+- Index filtered history search, record store tags, and cache inspector stats ([#3731](https://github.com/atuinsh/atuin/issues/3731))
 
 ### Refactor
 
@@ -71,9 +100,18 @@ All notable changes to this project will be documented in this file.
 - Use typed Url instead of hand-built string URLs ([#3644](https://github.com/atuinsh/atuin/issues/3644))
 - Extract shared vt100 logic into atuin-common ([#3664](https://github.com/atuinsh/atuin/issues/3664))
 
+### Styling
+
+- Improve Atuin AI TUI styles ([#3710](https://github.com/atuinsh/atuin/issues/3710))
+
 ### Testing
 
 - Parametrize tests with rstest across 8 crates ([#3653](https://github.com/atuinsh/atuin/issues/3653))
+
+### Bug
+
+- Fix enter_accept default ([#3717](https://github.com/atuinsh/atuin/issues/3717))
+- Abort install.sh on cURL fails ([#2911](https://github.com/atuinsh/atuin/issues/2911))
 
 ## 18.17.1
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -214,7 +214,7 @@ checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "atuin"
-version = "18.18.0-beta.2"
+version = "18.18.0-beta.3"
 dependencies = [
  "arboard",
  "async-trait",
@@ -281,7 +281,7 @@ dependencies = [
 
 [[package]]
 name = "atuin-ai"
-version = "18.18.0-beta.2"
+version = "18.18.0-beta.3"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -338,7 +338,7 @@ dependencies = [
 
 [[package]]
 name = "atuin-client"
-version = "18.18.0-beta.2"
+version = "18.18.0-beta.3"
 dependencies = [
  "async-trait",
  "atuin-common",
@@ -394,7 +394,7 @@ dependencies = [
 
 [[package]]
 name = "atuin-common"
-version = "18.18.0-beta.2"
+version = "18.18.0-beta.3"
 dependencies = [
  "base64",
  "derive_more",
@@ -425,7 +425,7 @@ dependencies = [
 
 [[package]]
 name = "atuin-daemon"
-version = "18.18.0-beta.2"
+version = "18.18.0-beta.3"
 dependencies = [
  "atuin-client",
  "atuin-common",
@@ -461,7 +461,7 @@ dependencies = [
 
 [[package]]
 name = "atuin-dotfiles"
-version = "18.18.0-beta.2"
+version = "18.18.0-beta.3"
 dependencies = [
  "atuin-client",
  "atuin-common",
@@ -478,7 +478,7 @@ dependencies = [
 
 [[package]]
 name = "atuin-history"
-version = "18.18.0-beta.2"
+version = "18.18.0-beta.3"
 dependencies = [
  "atuin-client",
  "crossterm",
@@ -492,7 +492,7 @@ dependencies = [
 
 [[package]]
 name = "atuin-kv"
-version = "18.18.0-beta.2"
+version = "18.18.0-beta.3"
 dependencies = [
  "atuin-client",
  "atuin-common",
@@ -536,7 +536,7 @@ dependencies = [
 
 [[package]]
 name = "atuin-pty-proxy"
-version = "18.18.0-beta.2"
+version = "18.18.0-beta.3"
 dependencies = [
  "atuin-common",
  "clap",
@@ -550,7 +550,7 @@ dependencies = [
 
 [[package]]
 name = "atuin-scripts"
-version = "18.18.0-beta.2"
+version = "18.18.0-beta.3"
 dependencies = [
  "atuin-client",
  "atuin-common",
@@ -573,7 +573,7 @@ dependencies = [
 
 [[package]]
 name = "atuin-server"
-version = "18.18.0-beta.2"
+version = "18.18.0-beta.3"
 dependencies = [
  "argon2",
  "atuin-common",
@@ -600,7 +600,7 @@ dependencies = [
 
 [[package]]
 name = "atuin-server-database"
-version = "18.18.0-beta.2"
+version = "18.18.0-beta.3"
 dependencies = [
  "async-trait",
  "atuin-common",
@@ -615,7 +615,7 @@ dependencies = [
 
 [[package]]
 name = "atuin-server-postgres"
-version = "18.18.0-beta.2"
+version = "18.18.0-beta.3"
 dependencies = [
  "async-trait",
  "atuin-common",
@@ -633,7 +633,7 @@ dependencies = [
 
 [[package]]
 name = "atuin-server-sqlite"
-version = "18.18.0-beta.2"
+version = "18.18.0-beta.3"
 dependencies = [
  "async-trait",
  "atuin-common",
@@ -5266,7 +5266,7 @@ dependencies = [
 
 [[package]]
 name = "tests-database"
-version = "18.18.0-beta.2"
+version = "18.18.0-beta.3"
 dependencies = [
  "async-trait",
  "atuin-common",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ resolver = "2"
 exclude = ["ui/backend", "crates/atuin-nucleo/matcher/fuzz"]
 
 [workspace.package]
-version = "18.18.0-beta.2"
+version = "18.18.0-beta.3"
 authors = ["Ellie Huxtable <ellie@atuin.sh>"]
 rust-version = "1.97.0"
 license = "MIT"
@@ -19,17 +19,17 @@ readme = "README.md"
 
 [workspace.dependencies]
 async-trait = "0.1.58"
-atuin-client = { path = "crates/atuin-client", version = "18.18.0-beta.2" }
-atuin-common = { path = "crates/atuin-common", version = "18.18.0-beta.2" }
-atuin-daemon = { path = "crates/atuin-daemon", version = "18.18.0-beta.2" }
-atuin-dotfiles = { path = "crates/atuin-dotfiles", version = "18.18.0-beta.2" }
-atuin-history = { path = "crates/atuin-history", version = "18.18.0-beta.2" }
-atuin-kv = { path = "crates/atuin-kv", version = "18.18.0-beta.2" }
-atuin-scripts = { path = "crates/atuin-scripts", version = "18.18.0-beta.2" }
-atuin-server = { path = "crates/atuin-server", version = "18.18.0-beta.2" }
-atuin-server-database = { path = "crates/atuin-server-database", version = "18.18.0-beta.2" }
-atuin-server-postgres = { path = "crates/atuin-server-postgres", version = "18.18.0-beta.2" }
-atuin-server-sqlite = { path = "crates/atuin-server-sqlite", version = "18.18.0-beta.2" }
+atuin-client = { path = "crates/atuin-client", version = "18.18.0-beta.3" }
+atuin-common = { path = "crates/atuin-common", version = "18.18.0-beta.3" }
+atuin-daemon = { path = "crates/atuin-daemon", version = "18.18.0-beta.3" }
+atuin-dotfiles = { path = "crates/atuin-dotfiles", version = "18.18.0-beta.3" }
+atuin-history = { path = "crates/atuin-history", version = "18.18.0-beta.3" }
+atuin-kv = { path = "crates/atuin-kv", version = "18.18.0-beta.3" }
+atuin-scripts = { path = "crates/atuin-scripts", version = "18.18.0-beta.3" }
+atuin-server = { path = "crates/atuin-server", version = "18.18.0-beta.3" }
+atuin-server-database = { path = "crates/atuin-server-database", version = "18.18.0-beta.3" }
+atuin-server-postgres = { path = "crates/atuin-server-postgres", version = "18.18.0-beta.3" }
+atuin-server-sqlite = { path = "crates/atuin-server-sqlite", version = "18.18.0-beta.3" }
 atuin-nucleo = { path = "crates/atuin-nucleo", version = "0.6.0" }
 atuin-nucleo-matcher = { path = "crates/atuin-nucleo/matcher", version = "0.3.1" }
 base64 = "0.22"

--- a/crates/atuin-client/Cargo.toml
+++ b/crates/atuin-client/Cargo.toml
@@ -77,7 +77,7 @@ strum = { version = "0.27", features = ["strum_macros"] }
 
 [dependencies.atuin-common]
 path = "../atuin-common"
-version = "18.18.0-beta.2"
+version = "18.18.0-beta.3"
 
 [dev-dependencies]
 tokio = { version = "1", features = ["full"] }
@@ -90,7 +90,7 @@ toml = "1.1"
 # This crate's tests require the `test-utils` feature in atuin-common.
 [dev-dependencies.atuin-common]
 path = "../atuin-common"
-version = "18.18.0-beta.2"
+version = "18.18.0-beta.3"
 features = ["test-utils"]
 
 [[bench]]

--- a/crates/atuin-daemon/Cargo.toml
+++ b/crates/atuin-daemon/Cargo.toml
@@ -14,11 +14,11 @@ readme.workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-atuin-client = { path = "../atuin-client", version = "18.18.0-beta.2" }
-atuin-common = { path = "../atuin-common", version = "18.18.0-beta.2" }
+atuin-client = { path = "../atuin-client", version = "18.18.0-beta.3" }
+atuin-common = { path = "../atuin-common", version = "18.18.0-beta.3" }
 derive_more = { workspace = true }
-atuin-dotfiles = { path = "../atuin-dotfiles", version = "18.18.0-beta.2" }
-atuin-history = { path = "../atuin-history", version = "18.18.0-beta.2" }
+atuin-dotfiles = { path = "../atuin-dotfiles", version = "18.18.0-beta.3" }
+atuin-history = { path = "../atuin-history", version = "18.18.0-beta.3" }
 
 time = { workspace = true }
 uuid = { workspace = true }

--- a/crates/atuin-dotfiles/Cargo.toml
+++ b/crates/atuin-dotfiles/Cargo.toml
@@ -14,8 +14,8 @@ readme.workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-atuin-common = { path = "../atuin-common", version = "18.18.0-beta.2" }
-atuin-client = { path = "../atuin-client", version = "18.18.0-beta.2" }
+atuin-common = { path = "../atuin-common", version = "18.18.0-beta.3" }
+atuin-client = { path = "../atuin-client", version = "18.18.0-beta.3" }
 derive_more = { workspace = true }
 
 eyre = { workspace = true }

--- a/crates/atuin-history/Cargo.toml
+++ b/crates/atuin-history/Cargo.toml
@@ -14,7 +14,7 @@ readme.workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-atuin-client = { path = "../atuin-client", version = "18.18.0-beta.2" }
+atuin-client = { path = "../atuin-client", version = "18.18.0-beta.3" }
 
 time = { workspace = true }
 serde = { workspace = true }

--- a/crates/atuin-kv/Cargo.toml
+++ b/crates/atuin-kv/Cargo.toml
@@ -14,8 +14,8 @@ readme.workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-atuin-client = { path = "../atuin-client", version = "18.18.0-beta.2" }
-atuin-common = { path = "../atuin-common", version = "18.18.0-beta.2" }
+atuin-client = { path = "../atuin-client", version = "18.18.0-beta.3" }
+atuin-common = { path = "../atuin-common", version = "18.18.0-beta.3" }
 derive_more = { workspace = true }
 
 tracing = { workspace = true }

--- a/crates/atuin-scripts/Cargo.toml
+++ b/crates/atuin-scripts/Cargo.toml
@@ -14,8 +14,8 @@ readme.workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-atuin-client = { path = "../atuin-client", version = "18.18.0-beta.2" }
-atuin-common = { path = "../atuin-common", version = "18.18.0-beta.2" }
+atuin-client = { path = "../atuin-client", version = "18.18.0-beta.3" }
+atuin-common = { path = "../atuin-common", version = "18.18.0-beta.3" }
 derive_more = { workspace = true }
 
 tracing = { workspace = true }

--- a/crates/atuin-server-database/Cargo.toml
+++ b/crates/atuin-server-database/Cargo.toml
@@ -10,7 +10,7 @@ homepage = { workspace = true }
 repository = { workspace = true }
 
 [dependencies]
-atuin-common = { path = "../atuin-common", version = "18.18.0-beta.2" }
+atuin-common = { path = "../atuin-common", version = "18.18.0-beta.3" }
 derive_more = { workspace = true }
 
 async-trait = { workspace = true }

--- a/crates/atuin-server-postgres/Cargo.toml
+++ b/crates/atuin-server-postgres/Cargo.toml
@@ -10,8 +10,8 @@ homepage = { workspace = true }
 repository = { workspace = true }
 
 [dependencies]
-atuin-common = { path = "../atuin-common", version = "18.18.0-beta.2" }
-atuin-server-database = { path = "../atuin-server-database", version = "18.18.0-beta.2" }
+atuin-common = { path = "../atuin-common", version = "18.18.0-beta.3" }
+atuin-server-database = { path = "../atuin-server-database", version = "18.18.0-beta.3" }
 derive_more = { workspace = true }
 
 eyre = { workspace = true }

--- a/crates/atuin-server-sqlite/Cargo.toml
+++ b/crates/atuin-server-sqlite/Cargo.toml
@@ -10,8 +10,8 @@ homepage = { workspace = true }
 repository = { workspace = true }
 
 [dependencies]
-atuin-common = { path = "../atuin-common", version = "18.18.0-beta.2" }
-atuin-server-database = { path = "../atuin-server-database", version = "18.18.0-beta.2" }
+atuin-common = { path = "../atuin-common", version = "18.18.0-beta.3" }
+atuin-server-database = { path = "../atuin-server-database", version = "18.18.0-beta.3" }
 derive_more = { workspace = true }
 
 eyre = { workspace = true }

--- a/crates/atuin/Cargo.toml
+++ b/crates/atuin/Cargo.toml
@@ -49,13 +49,13 @@ clipboard = ["arboard"]
 check-update = ["atuin-client/check-update"]
 
 [dependencies]
-atuin-ai = { path = "../atuin-ai", version = "18.18.0-beta.2", optional = true, default-features = false }
-atuin-client = { path = "../atuin-client", version = "18.18.0-beta.2", optional = true, default-features = false }
+atuin-ai = { path = "../atuin-ai", version = "18.18.0-beta.3", optional = true, default-features = false }
+atuin-client = { path = "../atuin-client", version = "18.18.0-beta.3", optional = true, default-features = false }
 atuin-common = { workspace = true, features = ["unicode"] }
 atuin-dotfiles = { workspace = true }
 atuin-history = { workspace = true }
-atuin-daemon = { path = "../atuin-daemon", version = "18.18.0-beta.2", optional = true, default-features = false }
-atuin-pty-proxy = { path = "../atuin-pty-proxy", version = "18.18.0-beta.2", optional = true, default-features = false }
+atuin-daemon = { path = "../atuin-daemon", version = "18.18.0-beta.3", optional = true, default-features = false }
+atuin-pty-proxy = { path = "../atuin-pty-proxy", version = "18.18.0-beta.3", optional = true, default-features = false }
 atuin-scripts = { workspace = true }
 atuin-kv = { workspace = true }
 derive_more = { workspace = true }
@@ -117,7 +117,7 @@ daemonize = "0.5.0"
 # compiles cleanly. tree-sitter 0.26's portable/endian.h fails on illumos,
 # Windows cross-compiles, and potentially other exotic targets.
 [target.'cfg(any(target_os = "linux", target_os = "macos"))'.dependencies]
-atuin-ai = { path = "../atuin-ai", version = "18.18.0-beta.2", optional = true, default-features = false, features = ["tree-sitter"] }
+atuin-ai = { path = "../atuin-ai", version = "18.18.0-beta.3", optional = true, default-features = false, features = ["tree-sitter"] }
 tree-sitter = { workspace = true }
 tree-sitter-bash = { workspace = true }
 tree-sitter-fish = { workspace = true }


### PR DESCRIPTION
## [unreleased]

### Bug Fixes

- *(daemon)* Index synced history directly instead of malformed SQL ([#3627](https://github.com/atuinsh/atuin/issues/3627)) ([#3641](https://github.com/atuinsh/atuin/issues/3641))
- *(deps)* Update unsound/vulnerable dependencies in Cargo.lock ([#3632](https://github.com/atuinsh/atuin/issues/3632))
- *(docs)* Repair every stale link in the repo ([#3727](https://github.com/atuinsh/atuin/issues/3727))
- *(docs)* Make the incorrect-decrypt-key error actionable ([#3609](https://github.com/atuinsh/atuin/issues/3609))
- *(hook)* Drop agent commands containing NUL bytes via NonNulStr ([#3589](https://github.com/atuinsh/atuin/issues/3589)) ([#3660](https://github.com/atuinsh/atuin/issues/3660))
- *(import)* Survive corrupt entries instead of aborting the import ([#3721](https://github.com/atuinsh/atuin/issues/3721))
- *(init)* Fix include guard in Bash init script; chore(init): improve inclusion of shell init scripts in Rust ([#3645](https://github.com/atuinsh/atuin/issues/3645))
- *(install)* Make /dev/tty authoritative for interactivity detection ([#3691](https://github.com/atuinsh/atuin/issues/3691))
- *(ui)* Calculate preview height based on command display width instead of byte count ([#3678](https://github.com/atuinsh/atuin/issues/3678))
- *(win32)* Cargo-binstall package metadata ([#3673](https://github.com/atuinsh/atuin/issues/3673))
- Search functionality to respect character offsets and non-ASCII ([#3659](https://github.com/atuinsh/atuin/issues/3659))
- Quote argument-hint YAML values so Copilot CLI ≥1.0.65 loads all skills ([#3613](https://github.com/atuinsh/atuin/issues/3613)) ([#3614](https://github.com/atuinsh/atuin/issues/3614))
- Correct grammar in 'history last' help text ([#3430](https://github.com/atuinsh/atuin/issues/3430))
- Work around rust nightly warning on eyre bail ([#3680](https://github.com/atuinsh/atuin/issues/3680))
- Improve non-interactive TTY detection in install.sh ([#3315](https://github.com/atuinsh/atuin/issues/3315))
- Add /model hint to status bar ([#3687](https://github.com/atuinsh/atuin/issues/3687))
- Set correct umask for pty-proxy ([#3700](https://github.com/atuinsh/atuin/issues/3700))
- Atuin AI not erasing the input box before closing ([#3715](https://github.com/atuinsh/atuin/issues/3715))
- Show server status next to AI progress indicator ([#3723](https://github.com/atuinsh/atuin/issues/3723))
- Show full command when using AtuinOutput tool ([#3725](https://github.com/atuinsh/atuin/issues/3725))