### PR TITLE
ci: build x86_64-apple-darwin on Depot M4 macs; move all macOS CI to Depot

### DIFF
--- a/.github/workflows/installer.yml
+++ b/.github/workflows/installer.yml
@@ -13,7 +13,7 @@ jobs:
   install:
     strategy:
       matrix:
-        os: [depot-ubuntu-24.04, macos-14]
+        os: [depot-ubuntu-24.04, depot-macos-26]
     runs-on: ${{ matrix.os }}
 
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -131,6 +131,10 @@ jobs:
             curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
             echo "$HOME/.cargo/bin" >> $GITHUB_PATH
           fi
+      - uses: swatinem/rust-cache@v2
+        with:
+          key: ${{ join(matrix.targets, '-') }}
+          cache-provider: ${{ matrix.cache_provider }}
       - name: Install dist
         run: ${{ matrix.install_dist.run }}
       # Get the dist-manifest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -131,10 +131,6 @@ jobs:
             curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
             echo "$HOME/.cargo/bin" >> $GITHUB_PATH
           fi
-      - uses: swatinem/rust-cache@v2
-        with:
-          key: ${{ join(matrix.targets, '-') }}
-          cache-provider: ${{ matrix.cache_provider }}
       - name: Install dist
         run: ${{ matrix.install_dist.run }}
       # Get the dist-manifest

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -17,7 +17,7 @@ jobs:
   build:
     strategy:
       matrix:
-        os: [depot-ubuntu-24.04, macos-14, depot-windows-2025-16]
+        os: [depot-ubuntu-24.04, depot-macos-26, depot-windows-2025-16]
     runs-on: ${{ matrix.os }}
 
     steps:
@@ -88,7 +88,7 @@ jobs:
   unit-test:
     strategy:
       matrix:
-        os: [depot-ubuntu-24.04, macos-14, depot-windows-2025-16]
+        os: [depot-ubuntu-24.04, depot-macos-26, depot-windows-2025-16]
     runs-on: ${{ matrix.os }}
 
     steps:
@@ -118,7 +118,7 @@ jobs:
   check:
     strategy:
       matrix:
-        os: [depot-ubuntu-24.04, macos-14, depot-windows-2025-16]
+        os: [depot-ubuntu-24.04, depot-macos-26, depot-windows-2025-16]
     runs-on: ${{ matrix.os }}
 
     steps:

--- a/crates/atuin-nucleo/bench/Cargo.toml
+++ b/crates/atuin-nucleo/bench/Cargo.toml
@@ -2,6 +2,12 @@
 name = "atuin-nucleo-bench"
 version = "0.1.0"
 edition = "2021"
+publish = false
+
+# Not a distributable app; without this dist treats the bench binary as a
+# releasable package and refuses to plan (incoherent versions vs atuin).
+[package.metadata.dist]
+dist = false
 
 [dependencies]
 atuin-nucleo = { version = "*", path = "../" }

--- a/dist-workspace.toml
+++ b/dist-workspace.toml
@@ -14,8 +14,7 @@ installers = ["shell", "powershell"]
 # Target platforms to build apps for (Rust target-triple syntax)
 targets = ["aarch64-apple-darwin", "x86_64-apple-darwin", "aarch64-unknown-linux-gnu", "aarch64-unknown-linux-musl", "riscv64gc-unknown-linux-gnu", "x86_64-unknown-linux-gnu", "x86_64-unknown-linux-musl", "x86_64-pc-windows-msvc"]
 # Which actions to run on pull requests
-# TEMP: "upload" to test the depot-macos-26 builds on this PR; revert to "plan" before merge
-pr-run-mode = "upload"
+pr-run-mode = "plan"
 # Whether to install an updater program
 install-updater = true
 # The archive format to use for non-windows builds (defaults .tar.xz)

--- a/dist-workspace.toml
+++ b/dist-workspace.toml
@@ -12,9 +12,10 @@ ci = "github"
 # The installers to generate for each app
 installers = ["shell", "powershell"]
 # Target platforms to build apps for (Rust target-triple syntax)
-targets = ["aarch64-apple-darwin", "aarch64-unknown-linux-gnu", "aarch64-unknown-linux-musl", "riscv64gc-unknown-linux-gnu", "x86_64-unknown-linux-gnu", "x86_64-unknown-linux-musl", "x86_64-pc-windows-msvc"]
+targets = ["aarch64-apple-darwin", "x86_64-apple-darwin", "aarch64-unknown-linux-gnu", "aarch64-unknown-linux-musl", "riscv64gc-unknown-linux-gnu", "x86_64-unknown-linux-gnu", "x86_64-unknown-linux-musl", "x86_64-pc-windows-msvc"]
 # Which actions to run on pull requests
-pr-run-mode = "plan"
+# TEMP: "upload" to test the depot-macos-26 builds on this PR; revert to "plan" before merge
+pr-run-mode = "upload"
 # Whether to install an updater program
 install-updater = true
 # The archive format to use for non-windows builds (defaults .tar.xz)
@@ -28,6 +29,17 @@ aarch64-unknown-linux-musl = "depot-ubuntu-24.04-arm-8"
 riscv64gc-unknown-linux-gnu = "ubuntu-24.04-riscv"
 x86_64-unknown-linux-gnu = "depot-ubuntu-24.04-8"
 x86_64-unknown-linux-musl = "depot-ubuntu-24.04-8"
+
+# Build both mac targets in one job on a Depot M4 runner: aarch64 natively,
+# x86_64 cross-compiled. Depot runner names don't encode the host arch, so
+# dist needs `host` spelled out to know these are arm64 machines.
+[dist.github-custom-runners.aarch64-apple-darwin]
+runner = "depot-macos-26"
+host = "aarch64-apple-darwin"
+
+[dist.github-custom-runners.x86_64-apple-darwin]
+runner = "depot-macos-26"
+host = "aarch64-apple-darwin"
 
 # Pin the actions dist generates into release.yml. Without these, `dist generate`
 # emits the versions baked into dist 0.31.0 (checkout@v6, upload-artifact@v6,


### PR DESCRIPTION
Adds x86_64 mac back to releases and gets us off GitHub's slow mac runners entirely.

- Add `x86_64-apple-darwin` to the dist release targets, cross-compiled on `depot-macos-26` (M4, 8 CPU) alongside the native aarch64 build. Depot runner names don't encode the host arch, so the config uses dist's `runner`/`host` table form.
- Move the `rust.yml` and `installer.yml` macOS jobs from `macos-14` to `depot-macos-26`.

**TEMP, revert before merge:** `pr-run-mode = "upload"` so this PR runs the full artifact builds to prove the mac cross-compile works.

Verified locally: `cargo check --release --target x86_64-apple-darwin` passes for the whole workspace on an arm64 mac.