### PR TITLE
ci: build riscv64 release artifacts via zigbuild extra-artifacts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -131,10 +131,6 @@ jobs:
             curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
             echo "$HOME/.cargo/bin" >> $GITHUB_PATH
           fi
-      - uses: swatinem/rust-cache@v2
-        with:
-          key: ${{ join(matrix.targets, '-') }}
-          cache-provider: ${{ matrix.cache_provider }}
       - name: Install dist
         run: ${{ matrix.install_dist.run }}
       # Get the dist-manifest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,7 +47,7 @@ on:
 jobs:
   # Run 'dist plan' (or host) to determine what tasks we need to do
   plan:
-    runs-on: "ubuntu-22.04"
+    runs-on: "depot-ubuntu-24.04-8"
     outputs:
       val: ${{ steps.plan.outputs.manifest }}
       tag: ${{ !github.event.pull_request && github.ref_name || '' }}
@@ -131,6 +131,10 @@ jobs:
             curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
             echo "$HOME/.cargo/bin" >> $GITHUB_PATH
           fi
+      - uses: swatinem/rust-cache@v2
+        with:
+          key: ${{ join(matrix.targets, '-') }}
+          cache-provider: ${{ matrix.cache_provider }}
       - name: Install dist
         run: ${{ matrix.install_dist.run }}
       # Get the dist-manifest
@@ -178,7 +182,7 @@ jobs:
     needs:
       - plan
       - build-local-artifacts
-    runs-on: "ubuntu-22.04"
+    runs-on: "depot-ubuntu-24.04-8"
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       BUILD_MANIFEST_NAME: target/distrib/global-dist-manifest.json
@@ -229,7 +233,7 @@ jobs:
     if: ${{ always() && needs.plan.result == 'success' && needs.plan.outputs.publishing == 'true' && (needs.build-global-artifacts.result == 'skipped' || needs.build-global-artifacts.result == 'success') && (needs.build-local-artifacts.result == 'skipped' || needs.build-local-artifacts.result == 'success') }}
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-    runs-on: "ubuntu-22.04"
+    runs-on: "depot-ubuntu-24.04-8"
     outputs:
       val: ${{ steps.host.outputs.manifest }}
     steps:
@@ -294,7 +298,7 @@ jobs:
     # still allowing individual publish jobs to skip themselves (for prereleases).
     # "host" however must run to completion, no skipping allowed!
     if: ${{ always() && needs.host.result == 'success' }}
-    runs-on: "ubuntu-22.04"
+    runs-on: "depot-ubuntu-24.04-8"
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:

--- a/dist-workspace.toml
+++ b/dist-workspace.toml
@@ -14,8 +14,7 @@ installers = ["shell", "powershell"]
 # Target platforms to build apps for (Rust target-triple syntax)
 targets = ["aarch64-apple-darwin", "x86_64-apple-darwin", "aarch64-unknown-linux-gnu", "aarch64-unknown-linux-musl", "x86_64-unknown-linux-gnu", "x86_64-unknown-linux-musl", "x86_64-pc-windows-msvc"]
 # Which actions to run on pull requests
-# TEMP: "upload" to test the riscv extra-artifacts build on this PR; revert to "plan" before merge
-pr-run-mode = "upload"
+pr-run-mode = "plan"
 # Whether to install an updater program
 install-updater = true
 # The archive format to use for non-windows builds (defaults .tar.xz)

--- a/dist-workspace.toml
+++ b/dist-workspace.toml
@@ -12,9 +12,10 @@ ci = "github"
 # The installers to generate for each app
 installers = ["shell", "powershell"]
 # Target platforms to build apps for (Rust target-triple syntax)
-targets = ["aarch64-apple-darwin", "x86_64-apple-darwin", "aarch64-unknown-linux-gnu", "aarch64-unknown-linux-musl", "riscv64gc-unknown-linux-gnu", "x86_64-unknown-linux-gnu", "x86_64-unknown-linux-musl", "x86_64-pc-windows-msvc"]
+targets = ["aarch64-apple-darwin", "x86_64-apple-darwin", "aarch64-unknown-linux-gnu", "aarch64-unknown-linux-musl", "x86_64-unknown-linux-gnu", "x86_64-unknown-linux-musl", "x86_64-pc-windows-msvc"]
 # Which actions to run on pull requests
-pr-run-mode = "plan"
+# TEMP: "upload" to test the riscv extra-artifacts build on this PR; revert to "plan" before merge
+pr-run-mode = "upload"
 # Whether to install an updater program
 install-updater = true
 # The archive format to use for non-windows builds (defaults .tar.xz)
@@ -22,10 +23,24 @@ unix-archive = ".tar.gz"
 # Whether to enable GitHub Attestations
 github-attestations = true
 
+# riscv64 tarballs, cross-compiled with zigbuild in the global-artifacts job.
+# Not a regular target: install-updater = true requires a prebuilt axoupdater
+# for every target, and axoupdater ships none for riscv64. See the script.
+[[dist.extra-artifacts]]
+artifacts = [
+    "atuin-riscv64gc-unknown-linux-gnu.tar.gz",
+    "atuin-riscv64gc-unknown-linux-gnu.tar.gz.sha256",
+    "atuin-server-riscv64gc-unknown-linux-gnu.tar.gz",
+    "atuin-server-riscv64gc-unknown-linux-gnu.tar.gz.sha256",
+]
+build = ["./scripts/build-riscv64-artifacts.sh"]
+
 [dist.github-custom-runners]
+# the global job cross-compiles the riscv64 extra artifacts, so give it a
+# real runner instead of the 2-core default
+global = "depot-ubuntu-24.04-8"
 aarch64-unknown-linux-gnu = "depot-ubuntu-24.04-arm-8"
 aarch64-unknown-linux-musl = "depot-ubuntu-24.04-arm-8"
-riscv64gc-unknown-linux-gnu = "ubuntu-24.04-riscv"
 x86_64-unknown-linux-gnu = "depot-ubuntu-24.04-8"
 x86_64-unknown-linux-musl = "depot-ubuntu-24.04-8"
 

--- a/scripts/build-riscv64-artifacts.sh
+++ b/scripts/build-riscv64-artifacts.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# Builds riscv64 release tarballs as dist "extra artifacts" (see
+# dist-workspace.toml), cross-compiled with cargo-zigbuild.
+#
+# riscv64 can't be a first-class dist target: with install-updater = true,
+# dist requires a prebuilt axoupdater binary for every target, and axoupdater
+# publishes none for riscv64. install-updater is all-or-nothing, and turning
+# it off would break `atuin update` everywhere. Fold this back into
+# [dist].targets once axoupdater ships riscv64 builds.
+set -euo pipefail
+
+TARGET=riscv64gc-unknown-linux-gnu
+
+rustup target add "$TARGET"
+if ! command -v cargo-zigbuild >/dev/null 2>&1; then
+  pip3 install cargo-zigbuild 2>/dev/null || pip3 install --break-system-packages cargo-zigbuild
+  export PATH="$HOME/.local/bin:$PATH"
+fi
+
+cargo zigbuild --profile dist --target "$TARGET" -p atuin -p atuin-server
+
+for bin in atuin atuin-server; do
+  dir="${bin}-${TARGET}"
+  rm -rf "$dir"
+  mkdir "$dir"
+  cp "target/${TARGET}/dist/${bin}" CHANGELOG.md LICENSE README.md "$dir/"
+  tar czf "${dir}.tar.gz" "$dir"
+  rm -rf "$dir"
+  # same format dist emits: "<sha256> *<file>"
+  if command -v sha256sum >/dev/null 2>&1; then
+    sha256sum -b "${dir}.tar.gz" > "${dir}.tar.gz.sha256"
+  else
+    shasum -a 256 -b "${dir}.tar.gz" > "${dir}.tar.gz.sha256"
+  fi
+done


### PR DESCRIPTION
Fixes the riscv64 release job, which was broken two ways and had never actually run (first execution was on #3742's test run):

1. The `dist` installer has no riscv64 host build, so the native `ubuntu-24.04-riscv` job died at "Install dist".
2. Even past that, `install-updater = true` makes dist fetch a prebuilt axoupdater per target — axoupdater publishes no riscv64 builds, and the setting is all-or-nothing. Disabling it globally would break `atuin update` for install-script users (that's how uv/ruff ship riscv64: they embed axoupdater as a library instead of the standalone updater).

So riscv64 moves out of the dist target matrix and is instead cross-compiled with cargo-zigbuild in the global-artifacts job via dist's `extra-artifacts` hook (`scripts/build-riscv64-artifacts.sh`). Tarball layout and `.sha256` format match dist's native artifacts; the global job moves to a depot 8-core runner to absorb the build (~3.5 min). Trade-off: riscv64 gets release tarballs but no shell-installer/self-updater support until axoupdater ships riscv64 binaries, at which point this can fold back into `targets`.

**TEMP, revert before merge:** `pr-run-mode = "upload"` to exercise the global-artifacts job on this PR.

Verified locally: script produces valid RISC-V ELF tarballs with matching checksums.