### PR TITLE
fix(search): add `DbSearchMode`; correctly fall back to "fuzzy" in non-interactive searches

### DIFF
--- a/crates/atuin-ai/src/tools/mod.rs
+++ b/crates/atuin-ai/src/tools/mod.rs
@@ -1123,8 +1123,7 @@ impl PermissibleToolCall for AtuinHistoryToolCall {
 
 impl AtuinHistoryToolCall {
     pub(crate) async fn execute(&self, db: &atuin_client::database::Sqlite) -> ToolOutcome {
-        use atuin_client::database::{self, Database as _, OptFilters};
-        use atuin_client::settings::SearchMode;
+        use atuin_client::database::{self, Database as _, DbSearchMode, OptFilters};
 
         // query_context rather than current_context: when running outside an
         // atuin-hooked shell (e.g. as an MCP server) there is no ATUIN_SESSION.
@@ -1161,7 +1160,7 @@ impl AtuinHistoryToolCall {
 
         let results = match db
             .search(
-                SearchMode::Fuzzy,
+                DbSearchMode::Fuzzy,
                 filter_mode,
                 &context,
                 &self.query,

--- a/crates/atuin-client/benches/ordering.rs
+++ b/crates/atuin-client/benches/ordering.rs
@@ -1,7 +1,7 @@
 use crate::_util::context::BenchCtx;
 use crate::history::BenchHistory;
+use atuin_client::database::DbSearchMode;
 use atuin_client::ordering::reorder_fuzzy;
-use atuin_client::settings::SearchMode;
 
 /// reorder_fuzzy is invoked on every keystroke during interactive fuzzy search, so keeping the
 /// performance in check is important.
@@ -14,5 +14,5 @@ fn reorder_fuzzy_bench(bencher: divan::Bencher, n: usize) {
             let mut ctx = BenchCtx::new();
             BenchHistory::count(&mut ctx, n)
         })
-        .bench_values(|histories| reorder_fuzzy(SearchMode::Fuzzy, "curl", histories));
+        .bench_values(|histories| reorder_fuzzy(DbSearchMode::Fuzzy, "curl", histories));
 }

--- a/crates/atuin-client/src/database.rs
+++ b/crates/atuin-client/src/database.rs
@@ -185,6 +185,43 @@ fn get_session_start_time(session_id: &str) -> Option<i64> {
     None
 }
 
+/// Controls the type of search [`Database::search`] performs.
+///
+/// This is a narrower set of modes than [`SearchMode`], which also contains modes that apply only
+/// to interactive searches.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum DbSearchMode {
+    Prefix,
+    FullText,
+    Fuzzy,
+}
+
+impl From<DbSearchMode> for SearchMode {
+    fn from(mode: DbSearchMode) -> Self {
+        match mode {
+            DbSearchMode::Prefix => Self::Prefix,
+            DbSearchMode::FullText => Self::FullText,
+            DbSearchMode::Fuzzy => Self::Fuzzy,
+        }
+    }
+}
+
+// This impl is here rather than in settings.rs where `SearchMode` is defined to avoid having
+// modules that cyclicly import each other, which isn't strictly disallowed but could be confusing.
+impl SearchMode {
+    /// Get the [`DbSearchMode`] that most closely matches this [`SearchMode`].
+    ///
+    /// This maps [`SearchMode::Skim`] and [`SearchMode::DaemonFuzzy`], which are interactive-only,
+    /// to [`DbSearchMode::Fuzzy`].
+    pub fn closest_db_mode(self) -> DbSearchMode {
+        match self {
+            SearchMode::Prefix => DbSearchMode::Prefix,
+            SearchMode::FullText => DbSearchMode::FullText,
+            SearchMode::Fuzzy | SearchMode::Skim | SearchMode::DaemonFuzzy => DbSearchMode::Fuzzy,
+        }
+    }
+}
+
 #[async_trait]
 pub trait Database: Send + Sync + 'static {
     async fn save(&self, h: &History) -> Result<()>;
@@ -225,7 +262,7 @@ pub trait Database: Send + Sync + 'static {
     #[allow(clippy::too_many_arguments)]
     async fn search(
         &self,
-        search_mode: SearchMode,
+        search_mode: DbSearchMode,
         filter: FilterMode,
         context: &Context,
         query: &str,
@@ -582,7 +619,7 @@ impl Database for Sqlite {
 
     async fn search(
         &self,
-        search_mode: SearchMode,
+        search_mode: DbSearchMode,
         filter: FilterMode,
         context: &Context,
         query: &str,
@@ -623,8 +660,8 @@ impl Database for Sqlite {
 
         let mut regexes = Vec::new();
         match search_mode {
-            SearchMode::Prefix => sql.and_where_like_left("command", query.replace('*', "%")),
-            _ => {
+            DbSearchMode::Prefix => sql.and_where_like_left("command", query.replace('*', "%")),
+            DbSearchMode::FullText | DbSearchMode::Fuzzy => {
                 let mut is_or = false;
                 for token in QueryTokenizer::new(query) {
                     // TODO smart case mode could be made configurable like in fzf
@@ -656,7 +693,7 @@ impl Database for Sqlite {
                             format!("{glob}{term}{glob}")
                         }
                         QueryToken::Match(term, _) => {
-                            if search_mode == SearchMode::FullText {
+                            if search_mode == DbSearchMode::FullText {
                                 format!("{glob}{term}{glob}")
                             } else {
                                 term.split("").join(glob)
@@ -1196,7 +1233,7 @@ mod test {
 
     async fn assert_search_eq(
         db: &impl Database,
-        mode: SearchMode,
+        mode: DbSearchMode,
         filter_mode: FilterMode,
         query: &str,
         expected: usize,
@@ -1227,7 +1264,7 @@ mod test {
 
     async fn assert_search_commands(
         db: &impl Database,
-        mode: SearchMode,
+        mode: DbSearchMode,
         filter_mode: FilterMode,
         query: &str,
         expected_commands: Vec<&str>,
@@ -1465,7 +1502,7 @@ mod test {
 
         let results = db
             .search(
-                SearchMode::FullText,
+                DbSearchMode::FullText,
                 FilterMode::Global,
                 &context,
                 "",
@@ -1499,7 +1536,7 @@ mod test {
 
         let hits = db
             .search(
-                SearchMode::FullText,
+                DbSearchMode::FullText,
                 FilterMode::Global,
                 &context,
                 "",
@@ -1531,7 +1568,7 @@ mod test {
 
         let result = db
             .search(
-                SearchMode::FullText,
+                DbSearchMode::FullText,
                 FilterMode::Global,
                 &context,
                 "",
@@ -1550,9 +1587,15 @@ mod test {
     async fn test_search_prefix(#[case] query: &str, #[case] expected: usize) {
         let db = db_with(&["ls /home/ellie"]).await;
 
-        assert_search_eq(&db, SearchMode::Prefix, FilterMode::Global, query, expected)
-            .await
-            .unwrap();
+        assert_search_eq(
+            &db,
+            DbSearchMode::Prefix,
+            FilterMode::Global,
+            query,
+            expected,
+        )
+        .await
+        .unwrap();
     }
 
     #[rstest]
@@ -1576,7 +1619,7 @@ mod test {
 
         assert_search_eq(
             &db,
-            SearchMode::FullText,
+            DbSearchMode::FullText,
             FilterMode::Global,
             query,
             expected,
@@ -1619,9 +1662,15 @@ mod test {
         ])
         .await;
 
-        assert_search_eq(&db, SearchMode::Fuzzy, FilterMode::Global, query, expected)
-            .await
-            .unwrap();
+        assert_search_eq(
+            &db,
+            DbSearchMode::Fuzzy,
+            FilterMode::Global,
+            query,
+            expected,
+        )
+        .await
+        .unwrap();
     }
 
     #[tokio::test(flavor = "multi_thread")]
@@ -1637,19 +1686,79 @@ mod test {
         // if fuzzy reordering is on, it should come back in a more sensible order
         assert_search_commands(
             &db,
-            SearchMode::Fuzzy,
+            DbSearchMode::Fuzzy,
             FilterMode::Global,
             "curl",
             vec!["curl", "corburl"],
         )
         .await;
 
-        assert_search_eq(&db, SearchMode::Fuzzy, FilterMode::Global, "xxxx", 0)
+        assert_search_eq(&db, DbSearchMode::Fuzzy, FilterMode::Global, "xxxx", 0)
             .await
             .unwrap();
-        assert_search_eq(&db, SearchMode::Fuzzy, FilterMode::Global, "", 2)
+        assert_search_eq(&db, DbSearchMode::Fuzzy, FilterMode::Global, "", 2)
             .await
             .unwrap();
+    }
+
+    #[rstest]
+    // The three modes the database implements map exactly.
+    #[case::prefix(SearchMode::Prefix, DbSearchMode::Prefix)]
+    #[case::full_text(SearchMode::FullText, DbSearchMode::FullText)]
+    #[case::fuzzy(SearchMode::Fuzzy, DbSearchMode::Fuzzy)]
+    // `Skim` and `DaemonFuzzy` never reach the database in the interactive path:
+    // `engines::engine` routes them to the skim matcher and the daemon index. When they do
+    // arrive via `atuin search --search-mode ...`, the closest database behaviour is a plain
+    // fuzzy query. See issue #3670.
+    #[case::skim_degrades_to_fuzzy(SearchMode::Skim, DbSearchMode::Fuzzy)]
+    #[case::daemon_fuzzy_degrades_to_fuzzy(SearchMode::DaemonFuzzy, DbSearchMode::Fuzzy)]
+    fn closest_db_mode_maps_every_search_mode(
+        #[case] mode: SearchMode,
+        #[case] expected: DbSearchMode,
+    ) {
+        assert_eq!(mode.closest_db_mode(), expected);
+    }
+
+    #[rstest]
+    #[case::prefix(DbSearchMode::Prefix)]
+    #[case::full_text(DbSearchMode::FullText)]
+    #[case::fuzzy(DbSearchMode::Fuzzy)]
+    fn db_search_mode_round_trips_through_search_mode(#[case] mode: DbSearchMode) {
+        assert_eq!(SearchMode::from(mode).closest_db_mode(), mode);
+    }
+
+    /// Issue #3670: `atuin search --search-mode daemon-fuzzy` reached the database as
+    /// an unrecognised mode. It took the fuzzy SQL path but skipped the fuzzy relevance
+    /// reordering, so results came back in raw timestamp order while plain `--search-mode
+    /// fuzzy` ranked them by minimum matching span. Both interactive-only modes must now
+    /// behave exactly like `fuzzy` once they reach the database.
+    #[rstest]
+    #[case::daemon_fuzzy(SearchMode::DaemonFuzzy)]
+    #[case::skim(SearchMode::Skim)]
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_search_interactive_only_modes_rank_like_fuzzy(#[case] mode: SearchMode) {
+        let mut db = Sqlite::new("sqlite::memory:", test_local_timeout())
+            .await
+            .unwrap();
+
+        // "corburl" is strictly newer, so an unranked query would return it first and the assertion
+        // below would fail.
+        let now = OffsetDateTime::now_utc();
+        new_history_item_at(&mut db, "curl", Some(now - time::Duration::seconds(10)))
+            .await
+            .unwrap();
+        new_history_item_at(&mut db, "corburl", Some(now))
+            .await
+            .unwrap();
+
+        assert_search_commands(
+            &db,
+            mode.closest_db_mode(),
+            FilterMode::Global,
+            "curl",
+            vec!["curl", "corburl"],
+        )
+        .await;
     }
 
     #[tokio::test(flavor = "multi_thread")]
@@ -1806,7 +1915,7 @@ mod test {
         let start = Instant::now();
         let _results = db
             .search(
-                SearchMode::Fuzzy,
+                DbSearchMode::Fuzzy,
                 FilterMode::Global,
                 &context,
                 "",
@@ -1872,7 +1981,7 @@ mod test {
 
         let results = db
             .search(
-                SearchMode::FullText,
+                DbSearchMode::FullText,
                 FilterMode::Global,
                 &context,
                 "echo",

--- a/crates/atuin-client/src/ordering.rs
+++ b/crates/atuin-client/src/ordering.rs
@@ -1,11 +1,11 @@
 use minspan::minspan;
 
-use super::{history::History, settings::SearchMode};
+use super::{database::DbSearchMode, history::History};
 
-pub fn reorder_fuzzy(mode: SearchMode, query: &str, res: Vec<History>) -> Vec<History> {
+pub fn reorder_fuzzy(mode: DbSearchMode, query: &str, res: Vec<History>) -> Vec<History> {
     match mode {
-        SearchMode::Fuzzy => reorder(query, |x| &x.command, res),
-        _ => res,
+        DbSearchMode::Fuzzy => reorder(query, |x| &x.command, res),
+        DbSearchMode::Prefix | DbSearchMode::FullText => res,
     }
 }
 

--- a/crates/atuin/src/command/client/search.rs
+++ b/crates/atuin/src/command/client/search.rs
@@ -71,6 +71,8 @@ pub struct Cmd {
     filter_mode: Option<FilterMode>,
 
     /// Allow overriding search mode over config
+    ///
+    /// Note: for non-interactive searches, the "daemon-fuzzy" and "skim" modes behave like "fuzzy".
     #[arg(long)]
     search_mode: Option<SearchMode>,
 
@@ -341,7 +343,7 @@ async fn run_non_interactive(
 
     let results = db
         .search(
-            settings.search_mode,
+            settings.search_mode.closest_db_mode(),
             filter_mode,
             &context,
             query.join(" ").as_str(),

--- a/crates/atuin/src/command/client/search/engines.rs
+++ b/crates/atuin/src/command/client/search/engines.rs
@@ -1,6 +1,6 @@
 use async_trait::async_trait;
 use atuin_client::{
-    database::{Context, Database, OptFilters},
+    database::{Context, Database, DbSearchMode, OptFilters},
     history::{AUTHOR_FILTER_ALL_USER, History, HistoryId},
     settings::{FilterMode, SearchMode, Settings, Shells},
 };
@@ -16,15 +16,17 @@ pub mod skim;
 #[allow(unused)] // settings is only used if daemon feature is enabled
 pub fn engine(search_mode: SearchMode, settings: &Settings) -> Box<dyn SearchEngine> {
     match search_mode {
-        SearchMode::Skim => Box::new(skim::Search::new()) as Box<_>,
+        SearchMode::Skim => Box::new(skim::Search::new()),
         #[cfg(feature = "daemon")]
-        SearchMode::DaemonFuzzy => Box::new(daemon::Search::new(settings)) as Box<_>,
+        SearchMode::DaemonFuzzy => Box::new(daemon::Search::new(settings)),
         #[cfg(not(feature = "daemon"))]
         SearchMode::DaemonFuzzy => {
             // Fall back to fuzzy mode if daemon feature is not enabled
-            Box::new(db::Search(SearchMode::Fuzzy)) as Box<_>
+            Box::new(db::Search(DbSearchMode::Fuzzy))
         }
-        mode => Box::new(db::Search(mode)) as Box<_>,
+        SearchMode::Prefix => Box::new(db::Search(DbSearchMode::Prefix)),
+        SearchMode::FullText => Box::new(db::Search(DbSearchMode::FullText)),
+        SearchMode::Fuzzy => Box::new(db::Search(DbSearchMode::Fuzzy)),
     }
 }
 
@@ -75,7 +77,7 @@ pub trait SearchEngine: Send + Sync + 'static {
         if state.input.as_str().is_empty() {
             Ok(db
                 .search(
-                    SearchMode::FullText,
+                    DbSearchMode::FullText,
                     state.filter_mode,
                     &state.context,
                     "",

--- a/crates/atuin/src/command/client/search/engines/daemon.rs
+++ b/crates/atuin/src/command/client/search/engines/daemon.rs
@@ -1,8 +1,8 @@
 use async_trait::async_trait;
 use atuin_client::{
-    database::{Database, OptFilters},
+    database::{Database, DbSearchMode, OptFilters},
     history::{AUTHOR_FILTER_ALL_USER, History},
-    settings::{SearchMode, Settings},
+    settings::Settings,
 };
 use atuin_daemon::client::{DaemonClientErrorKind, SearchClient, SearchParams, classify_error};
 use atuin_nucleo_matcher::{
@@ -86,7 +86,7 @@ impl Search {
     ) -> Result<Vec<History>> {
         let results = db
             .search(
-                SearchMode::FullText,
+                DbSearchMode::FullText,
                 state.filter_mode,
                 &state.context,
                 state.input.as_str(),

--- a/crates/atuin/src/command/client/search/engines/db.rs
+++ b/crates/atuin/src/command/client/search/engines/db.rs
@@ -3,9 +3,8 @@ use async_trait::async_trait;
 use atuin_client::{
     database::Database,
     database::OptFilters,
-    database::{QueryToken, QueryTokenizer},
+    database::{DbSearchMode, QueryToken, QueryTokenizer},
     history::{AUTHOR_FILTER_ALL_USER, History},
-    settings::SearchMode,
 };
 use eyre::Result;
 use norm::Metric;
@@ -13,7 +12,7 @@ use norm::fzf::{FzfParser, FzfV2};
 use std::ops::Range;
 use tracing::{Level, instrument};
 
-pub struct Search(pub SearchMode);
+pub struct Search(pub DbSearchMode);
 
 #[async_trait]
 impl SearchEngine for Search {
@@ -44,9 +43,9 @@ impl SearchEngine for Search {
 
     #[instrument(skip_all, level = Level::TRACE, name = "db_highlight")]
     fn get_highlight_indices(&self, command: &str, search_input: &str) -> Vec<usize> {
-        if self.0 == SearchMode::Prefix {
+        if self.0 == DbSearchMode::Prefix {
             return vec![];
-        } else if self.0 == SearchMode::FullText {
+        } else if self.0 == DbSearchMode::FullText {
             return get_highlight_indices_fulltext(command, search_input);
         }
         let mut fzf = FzfV2::new();

--- a/docs/docs/configuration/config.md
+++ b/docs/docs/configuration/config.md
@@ -131,6 +131,12 @@ search_mode = "fuzzy"
 
     You can customize the priority given to frequency, recency, and frecency scores in this mode. See [the score multipliers section](#score-multipliers) for more information.
 
+!!! note "Interactive-only modes"
+
+    The `daemon-fuzzy` and `skim` modes take effect only for interactive TUI
+    searches. Non-interactive `atuin search` commands will treat these modes
+    as `fuzzy` instead.
+
 #### `fuzzy` search syntax
 
 The `fuzzy` and `daemon-fuzzy` search syntax is based on the


### PR DESCRIPTION
Add `DbSearchMode`; correctly fall back to "fuzzy" in non-interactive searches when the "daemon-fuzzy" or "skim" modes are specified. Fixes https://github.com/atuinsh/atuin/issues/3670.