### PR TITLE
Revert "ci: add riscv64 to release targets (#3339)"

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -54,7 +54,7 @@ jobs:
         # There was an attempt to make cross-compiles also work on FreeBSD, but that failed with:
         #
         # warning: libelf.so.2, needed by <...>/libkvm.so, not found (try using -rpath or -rpath-link)
-        target: [x86_64-unknown-illumos, riscv64gc-unknown-linux-gnu]
+        target: [x86_64-unknown-illumos]
     runs-on: depot-ubuntu-24.04
     steps:
       - uses: actions/checkout@v7

--- a/dist-workspace.toml
+++ b/dist-workspace.toml
@@ -12,7 +12,7 @@ ci = "github"
 # The installers to generate for each app
 installers = ["shell", "powershell"]
 # Target platforms to build apps for (Rust target-triple syntax)
-targets = ["aarch64-apple-darwin", "x86_64-apple-darwin", "aarch64-unknown-linux-gnu", "aarch64-unknown-linux-musl", "riscv64gc-unknown-linux-gnu", "x86_64-unknown-linux-gnu", "x86_64-unknown-linux-musl", "x86_64-pc-windows-msvc"]
+targets = ["aarch64-apple-darwin", "x86_64-apple-darwin", "aarch64-unknown-linux-gnu", "aarch64-unknown-linux-musl", "x86_64-unknown-linux-gnu", "x86_64-unknown-linux-musl", "x86_64-pc-windows-msvc"]
 # Which actions to run on pull requests
 pr-run-mode = "plan"
 # Whether to install an updater program
@@ -25,7 +25,6 @@ github-attestations = true
 [dist.github-custom-runners]
 aarch64-unknown-linux-gnu = "depot-ubuntu-24.04-arm-8"
 aarch64-unknown-linux-musl = "depot-ubuntu-24.04-arm-8"
-riscv64gc-unknown-linux-gnu = "ubuntu-24.04-riscv"
 x86_64-unknown-linux-gnu = "depot-ubuntu-24.04-8"
 x86_64-unknown-linux-musl = "depot-ubuntu-24.04-8"
 

--- a/docs/docs/support.md
+++ b/docs/docs/support.md
@@ -71,11 +71,7 @@ and how far continuous integration (CI) exercises it.
     </tr>
     <tr><td><code>WSL-2</code></td><td><code>x86_64</code></td><td class="support-yes">✓</td><td>tested</td><td></td></tr>
     <tr>
-      <td rowspan="3" class="tier"><strong>2</strong></td>
-      <td><code>Linux</code></td><td><code>riscv64</code></td><td class="support-yes">✓</td><td>build-only</td>
-      <td>Built on <a href="https://riseproject.dev/">RISE Project</a> runners.</td>
-    </tr>
-    <tr>
+      <td rowspan="2" class="tier"><strong>2</strong></td>
       <td><code>Illumos</code></td><td><code>x86_64</code></td><td class="support-no">✗</td><td>build-only</td>
       <td></td>
     </tr>


### PR DESCRIPTION
This reverts commit b265e31ed53d1b3e98536b0e246ebe17eee48791.

<!-- Thank you for making a PR! Bug fixes are always welcome, but if you're adding a new feature or changing an existing one, we'd really appreciate if you open an issue, post on the forum, or drop in on Discord -->

## Checks
- [ ] I am happy for maintainers to push small adjustments to this PR, to speed up the review cycle
- [ ] I have checked that there are no existing pull requests for the same thing
