### PR TITLE
feat: hickory-dns resolver for musl target

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -322,6 +322,7 @@ dependencies = [
  "atuin-client",
  "atuin-common",
  "atuin-daemon",
+ "atuin-domain",
  "chrono",
  "chrono-humanize",
  "clap",
@@ -519,6 +520,7 @@ dependencies = [
  "axum",
  "derive_more",
  "eyre",
+ "hickory-resolver",
  "http",
  "parking_lot",
  "pretty_assertions",
@@ -536,6 +538,7 @@ dependencies = [
  "time",
  "tokio",
  "tower",
+ "tracing",
  "typed-builder",
  "url",
  "uuid",
@@ -1292,6 +1295,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "combine"
+version = "4.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
+dependencies = [
+ "bytes",
+ "memchr",
+]
+
+[[package]]
 name = "compact_str"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1361,6 +1374,16 @@ dependencies = [
 
 [[package]]
 name = "core-foundation"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
@@ -1407,6 +1430,12 @@ name = "crc-catalog"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "217698eaf96b4a3f0bc4f3662aaa55bdf913cd54d7204591faa790070c6d0853"
+
+[[package]]
+name = "critical-section"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "790eea4361631c5e7d22598ecd5723ff611904e3344ce8720784c93e3d83d40b"
 
 [[package]]
 name = "crossbeam-channel"
@@ -2428,6 +2457,76 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
+name = "hickory-net"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2295ed2f9c31e471e1428a8f88a3f0e1f4b27c15049592138d1eebe9c35b183"
+dependencies = [
+ "async-trait",
+ "cfg-if",
+ "data-encoding",
+ "futures-channel",
+ "futures-io",
+ "futures-util",
+ "hickory-proto",
+ "idna",
+ "ipnet",
+ "jni",
+ "rand 0.10.1",
+ "thiserror 2.0.19",
+ "tinyvec",
+ "tokio",
+ "tracing",
+ "url",
+]
+
+[[package]]
+name = "hickory-proto"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bab31817bfb44672a252e97fe81cd0c18d1b2cf892108922f6818820df8c643"
+dependencies = [
+ "data-encoding",
+ "idna",
+ "ipnet",
+ "jni",
+ "once_cell",
+ "prefix-trie",
+ "rand 0.10.1",
+ "ring",
+ "thiserror 2.0.19",
+ "tinyvec",
+ "tracing",
+ "url",
+]
+
+[[package]]
+name = "hickory-resolver"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0d58d28879ceecde6607729660c2667a081ccdc082e082675042793960f178c"
+dependencies = [
+ "cfg-if",
+ "futures-util",
+ "hickory-net",
+ "hickory-proto",
+ "ipconfig",
+ "ipnet",
+ "jni",
+ "moka",
+ "ndk-context",
+ "once_cell",
+ "parking_lot",
+ "rand 0.10.1",
+ "resolv-conf",
+ "smallvec",
+ "system-configuration",
+ "thiserror 2.0.19",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
 name = "hkdf"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2859,10 +2958,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "ipconfig"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d40460c0ce33d6ce4b0630ad68ff63d6661961c48b6dba35e5a4d81cfb48222"
+dependencies = [
+ "socket2",
+ "widestring",
+ "windows-registry",
+ "windows-result 0.4.1",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "ipnet"
 version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "is-docker"
@@ -2921,6 +3036,55 @@ name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
+
+[[package]]
+name = "jni"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5efd9a482cf3a427f00d6b35f14332adc7902ce91efb778580e180ff90fa3498"
+dependencies = [
+ "cfg-if",
+ "combine",
+ "jni-macros",
+ "jni-sys",
+ "log",
+ "simd_cesu8",
+ "thiserror 2.0.19",
+ "walkdir",
+ "windows-link 0.2.1",
+]
+
+[[package]]
+name = "jni-macros"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a00109accc170f0bdb141fed3e393c565b6f5e072365c3bd58f5b062591560a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "simd_cesu8",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "jni-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6377a88cb3910bee9b0fa88d4f42e1d2da8e79915598f65fb0c7ee14c878af2"
+dependencies = [
+ "jni-sys-macros",
+]
+
+[[package]]
+name = "jni-sys-macros"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
+dependencies = [
+ "quote",
+ "syn 2.0.119",
+]
 
 [[package]]
 name = "jobserver"
@@ -3283,6 +3447,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "moka"
+version = "0.12.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4293f18e7567a1caf3c584855554377025c65e0aa445344d04171f5ad63d19b9"
+dependencies = [
+ "crossbeam-channel",
+ "crossbeam-epoch",
+ "crossbeam-utils",
+ "equivalent",
+ "parking_lot",
+ "portable-atomic",
+ "smallvec",
+ "tagptr",
+ "uuid",
+]
+
+[[package]]
 name = "moxcms"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3314,6 +3495,12 @@ dependencies = [
  "security-framework-sys",
  "tempfile",
 ]
+
+[[package]]
+name = "ndk-context"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27b02d87554356db9e9a873add8782d4ea6e3e58ea071a9adb9a2e8ddb884a8b"
 
 [[package]]
 name = "nix"
@@ -3569,6 +3756,10 @@ name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+dependencies = [
+ "critical-section",
+ "portable-atomic",
+]
 
 [[package]]
 name = "once_cell_polyfill"
@@ -3984,6 +4175,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
 dependencies = [
  "zerocopy",
+]
+
+[[package]]
+name = "prefix-trie"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cf6e3177f0684016a5c209b00882e15f8bdd3f3bb48f0491df10cd102d0c6e7"
+dependencies = [
+ "either",
+ "ipnet",
+ "num-traits",
 ]
 
 [[package]]
@@ -4563,6 +4765,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "resolv-conf"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e061d1b48cb8d38042de4ae0a7a6401009d6143dc80d2e2d6f31f0bdd6470c7"
+
+[[package]]
 name = "ring"
 version = "0.17.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4847,7 +5055,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
  "bitflags 2.13.0",
- "core-foundation",
+ "core-foundation 0.10.1",
  "core-foundation-sys",
  "libc",
  "security-framework-sys",
@@ -5159,6 +5367,22 @@ checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
  "rand_core 0.6.4",
 ]
+
+[[package]]
+name = "simd_cesu8"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11031e251abf8611c80f460e19dbdeb54a66db918e49c65a7065b46ac7aec520"
+dependencies = [
+ "rustc_version",
+ "simdutf8",
+]
+
+[[package]]
+name = "simdutf8"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
 
 [[package]]
 name = "siphasher"
@@ -5570,6 +5794,33 @@ dependencies = [
  "rayon",
  "windows 0.52.0",
 ]
+
+[[package]]
+name = "system-configuration"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
+dependencies = [
+ "bitflags 2.13.0",
+ "core-foundation 0.9.4",
+ "system-configuration-sys",
+]
+
+[[package]]
+name = "system-configuration-sys"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "tagptr"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b2093cf4c8eb1e67749a6762251bc9cd836b6fc171623bd0a9d324d37af2417"
 
 [[package]]
 name = "tempfile"
@@ -6944,6 +7195,17 @@ checksum = "9150af68066c4c5c07ddc0ce30421554771e528bde427614c61038bc2c92c2b1"
 dependencies = [
  "windows-core 0.61.2",
  "windows-link 0.1.3",
+]
+
+[[package]]
+name = "windows-registry"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02752bf7fbdcce7f2a27a742f798510f3e5ad88dbe84871e5168e2120c3d5720"
+dependencies = [
+ "windows-link 0.2.1",
+ "windows-result 0.4.1",
+ "windows-strings 0.5.1",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1195,6 +1195,16 @@ dependencies = [
 
 [[package]]
 name = "core-foundation"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
@@ -1241,6 +1251,12 @@ name = "crc-catalog"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "217698eaf96b4a3f0bc4f3662aaa55bdf913cd54d7204591faa790070c6d0853"
+
+[[package]]
+name = "critical-section"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "790eea4361631c5e7d22598ecd5723ff611904e3344ce8720784c93e3d83d40b"
 
 [[package]]
 name = "crossbeam-channel"
@@ -1452,6 +1468,12 @@ dependencies = [
  "once_cell",
  "parking_lot_core",
 ]
+
+[[package]]
+name = "data-encoding"
+version = "2.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
 
 [[package]]
 name = "deltae"
@@ -2185,6 +2207,76 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
+name = "hickory-net"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2295ed2f9c31e471e1428a8f88a3f0e1f4b27c15049592138d1eebe9c35b183"
+dependencies = [
+ "async-trait",
+ "cfg-if",
+ "data-encoding",
+ "futures-channel",
+ "futures-io",
+ "futures-util",
+ "hickory-proto",
+ "idna",
+ "ipnet",
+ "jni",
+ "rand 0.10.1",
+ "thiserror 2.0.18",
+ "tinyvec",
+ "tokio",
+ "tracing",
+ "url",
+]
+
+[[package]]
+name = "hickory-proto"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bab31817bfb44672a252e97fe81cd0c18d1b2cf892108922f6818820df8c643"
+dependencies = [
+ "data-encoding",
+ "idna",
+ "ipnet",
+ "jni",
+ "once_cell",
+ "prefix-trie",
+ "rand 0.10.1",
+ "ring",
+ "thiserror 2.0.18",
+ "tinyvec",
+ "tracing",
+ "url",
+]
+
+[[package]]
+name = "hickory-resolver"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0d58d28879ceecde6607729660c2667a081ccdc082e082675042793960f178c"
+dependencies = [
+ "cfg-if",
+ "futures-util",
+ "hickory-net",
+ "hickory-proto",
+ "ipconfig",
+ "ipnet",
+ "jni",
+ "moka",
+ "ndk-context",
+ "once_cell",
+ "parking_lot",
+ "rand 0.10.1",
+ "resolv-conf",
+ "smallvec",
+ "system-configuration",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
 name = "hkdf"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2591,10 +2683,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "ipconfig"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d40460c0ce33d6ce4b0630ad68ff63d6661961c48b6dba35e5a4d81cfb48222"
+dependencies = [
+ "socket2",
+ "widestring",
+ "windows-registry",
+ "windows-result",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "ipnet"
 version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "is-docker"
@@ -3045,10 +3153,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "moka"
+version = "0.12.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "957228ad12042ee839f93c8f257b62b4c0ab5eaae1d4fa60de53b27c9d7c5046"
+dependencies = [
+ "crossbeam-channel",
+ "crossbeam-epoch",
+ "crossbeam-utils",
+ "equivalent",
+ "parking_lot",
+ "portable-atomic",
+ "smallvec",
+ "tagptr",
+ "uuid",
+]
+
+[[package]]
 name = "multimap"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
+
+[[package]]
+name = "ndk-context"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27b02d87554356db9e9a873add8782d4ea6e3e58ea071a9adb9a2e8ddb884a8b"
 
 [[package]]
 name = "nix"
@@ -3282,6 +3413,10 @@ name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+dependencies = [
+ "critical-section",
+ "portable-atomic",
+]
 
 [[package]]
 name = "once_cell_polyfill"
@@ -3638,6 +3773,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
 dependencies = [
  "zerocopy",
+]
+
+[[package]]
+name = "prefix-trie"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cf6e3177f0684016a5c209b00882e15f8bdd3f3bb48f0491df10cd102d0c6e7"
+dependencies = [
+ "either",
+ "ipnet",
+ "num-traits",
 ]
 
 [[package]]
@@ -4167,6 +4313,7 @@ dependencies = [
  "bytes",
  "futures-core",
  "futures-util",
+ "hickory-resolver",
  "http",
  "http-body",
  "http-body-util",
@@ -4175,6 +4322,7 @@ dependencies = [
  "hyper-util",
  "js-sys",
  "log",
+ "once_cell",
  "percent-encoding",
  "pin-project-lite",
  "rustls",
@@ -4195,6 +4343,12 @@ dependencies = [
  "wasm-streams",
  "web-sys",
 ]
+
+[[package]]
+name = "resolv-conf"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e061d1b48cb8d38042de4ae0a7a6401009d6143dc80d2e2d6f31f0bdd6470c7"
 
 [[package]]
 name = "ring"
@@ -4367,7 +4521,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26d1e2536ce4f35f4846aa13bff16bd0ff40157cdb14cc056c7b14ba41233ba0"
 dependencies = [
- "core-foundation",
+ "core-foundation 0.10.1",
  "core-foundation-sys",
  "jni",
  "log",
@@ -4545,7 +4699,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
  "bitflags 2.13.0",
- "core-foundation",
+ "core-foundation 0.10.1",
  "core-foundation-sys",
  "libc",
  "security-framework-sys",
@@ -5241,6 +5395,33 @@ dependencies = [
  "rayon",
  "windows",
 ]
+
+[[package]]
+name = "system-configuration"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
+dependencies = [
+ "bitflags 2.13.0",
+ "core-foundation 0.9.4",
+ "system-configuration-sys",
+]
+
+[[package]]
+name = "system-configuration-sys"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "tagptr"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b2093cf4c8eb1e67749a6762251bc9cd836b6fc171623bd0a9d324d37af2417"
 
 [[package]]
 name = "tempfile"
@@ -6428,6 +6609,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "widestring"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72069c3113ab32ab29e5584db3c6ec55d416895e60715417b5b883a357c3e471"
+
+[[package]]
 name = "winapi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6517,6 +6704,17 @@ name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-registry"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02752bf7fbdcce7f2a27a742f798510f3e5ad88dbe84871e5168e2120c3d5720"
+dependencies = [
+ "windows-link",
+ "windows-result",
+ "windows-strings",
+]
 
 [[package]]
 name = "windows-result"

--- a/crates/atuin-ai/Cargo.toml
+++ b/crates/atuin-ai/Cargo.toml
@@ -24,6 +24,7 @@ atuin-client = { workspace = true }
 derive_more = { workspace = true }
 atuin-common = { workspace = true, features = ["unicode", "ansi"] }
 atuin-daemon = { workspace = true }
+atuin-domain = { workspace = true }
 tokio = { workspace = true }
 eyre = { workspace = true }
 clap = { workspace = true, features = ["derive", "env"] }

--- a/crates/atuin-ai/src/models.rs
+++ b/crates/atuin-ai/src/models.rs
@@ -30,7 +30,7 @@ pub(crate) struct ModelList {
 pub(crate) async fn fetch_models(endpoint: &reqwest::Url, token: &str) -> Result<ModelList> {
     let url = endpoint.append_path("api/cli/models")?;
 
-    let mut request = reqwest::Client::new()
+    let mut request = atuin_domain::http::client()
         .get(url)
         .header(USER_AGENT, crate::stream::APP_USER_AGENT)
         .timeout(Duration::from_secs(10));

--- a/crates/atuin-ai/src/stream.rs
+++ b/crates/atuin-ai/src/stream.rs
@@ -172,7 +172,7 @@ pub(crate) fn create_chat_stream(
             request_body["session_id"] = serde_json::json!(sid);
         }
 
-        let client = reqwest::Client::new();
+        let client = atuin_domain::http::client();
         let mut request_builder = client
             .post(endpoint.clone())
             .header("Accept", "text/event-stream")

--- a/crates/atuin-ai/src/usage.rs
+++ b/crates/atuin-ai/src/usage.rs
@@ -92,7 +92,7 @@ pub(crate) fn cache_key(token: &str) -> String {
 pub(crate) async fn fetch_usage(endpoint: &reqwest::Url, token: &str) -> Result<UsageSnapshot> {
     let url = endpoint.append_path("api/cli/usage")?;
 
-    let response = reqwest::Client::new()
+    let response = atuin_domain::http::client()
         .get(url)
         .header(USER_AGENT, crate::stream::APP_USER_AGENT)
         .bearer_auth(token)

--- a/crates/atuin-client/Cargo.toml
+++ b/crates/atuin-client/Cargo.toml
@@ -75,6 +75,14 @@ palette = { version = "0.7.5", features = ["serializing"] }
 strum_macros = "0.27"
 strum = { version = "0.27", features = ["strum_macros"] }
 
+# musl's built-in resolver queries all resolv.conf nameservers in parallel
+# and takes the first reply so static musl builds fail to resolve names in
+# split-horizon DNS setups where glibc builds work.
+# Use reqwest's hickory-dns resolver on musl for glibc-like behavior.
+# See https://wiki.musl-libc.org/functional-differences-from-glibc.html
+[target.'cfg(target_env = "musl")'.dependencies]
+reqwest = { workspace = true, optional = true, features = ["hickory-dns"] }
+
 [dependencies.atuin-common]
 path = "../atuin-common"
 version = "18.19.0-beta.1"

--- a/crates/atuin-client/src/api_client.rs
+++ b/crates/atuin-client/src/api_client.rs
@@ -67,7 +67,7 @@ pub struct Client {
 /// (e.g. Cloudflare Access secrets), refuse cross-origin redirects entirely
 /// whenever extra headers are configured.
 pub(crate) fn client_builder(extra_headers: &HashMap<String, String>) -> reqwest::ClientBuilder {
-    let builder = reqwest::Client::builder();
+    let builder = atuin_domain::http::client_builder();
 
     if extra_headers.is_empty() {
         return builder;
@@ -171,7 +171,7 @@ pub async fn latest_version() -> Result<Version> {
     use atuin_domain::api::IndexResponse;
 
     let url = crate::settings::DEFAULT_SYNC_URL.clone();
-    let client = reqwest::Client::new();
+    let client = atuin_domain::http::client();
 
     let resp = client
         .get(url)
@@ -297,7 +297,7 @@ impl Client {
         Ok(Client {
             sync_addr,
             client,
-            lfs_client: reqwest::Client::builder()
+            lfs_client: atuin_domain::http::client_builder()
                 .connect_timeout(Duration::from_secs(connect_timeout))
                 .timeout(Duration::from_secs(timeout))
                 .build()?,

--- a/crates/atuin-client/src/auth.rs
+++ b/crates/atuin-client/src/auth.rs
@@ -287,7 +287,7 @@ impl AuthClient for HubAuthClient {
         totp_code: Option<&str>,
     ) -> Result<AuthResponse> {
         let url = self.address.append_path("api/v0/login")?;
-        let client = reqwest::Client::new();
+        let client = atuin_domain::http::client();
 
         let mut body = serde_json::json!({
             "username": username,
@@ -334,7 +334,7 @@ impl AuthClient for HubAuthClient {
 
     async fn register(&self, username: &str, email: &str, password: &str) -> Result<AuthResponse> {
         let url = self.address.append_path("api/v0/register")?;
-        let client = reqwest::Client::new();
+        let client = atuin_domain::http::client();
 
         let resp = client
             .post(url)
@@ -387,7 +387,7 @@ impl AuthClient for HubAuthClient {
         }
 
         let url = self.address.append_path("api/v0/account/password")?;
-        let client = reqwest::Client::new();
+        let client = atuin_domain::http::client();
 
         let mut body = serde_json::json!({
             "current_password": current_password,
@@ -458,7 +458,7 @@ impl AuthClient for HubAuthClient {
         }
 
         let url = self.address.append_path("api/v0/account")?;
-        let client = reqwest::Client::new();
+        let client = atuin_domain::http::client();
 
         let mut body = serde_json::json!({
             "password": password,

--- a/crates/atuin-client/src/hub.rs
+++ b/crates/atuin-client/src/hub.rs
@@ -232,7 +232,7 @@ pub async fn link_account(hub_address: &Url, cli_token: &str) -> Result<()> {
 
     debug!("Linking CLI account to Hub at {}", hub_address);
 
-    let client = reqwest::Client::new();
+    let client = atuin_domain::http::client();
 
     let resp = client
         .post(url)
@@ -277,7 +277,7 @@ async fn handle_resp_error(resp: reqwest::Response) -> Result<reqwest::Response,
 /// Request a CLI auth code from the Atuin Hub
 async fn request_code(address: &Url) -> Result<CliCodeResponse, HubError> {
     let url = address.append_path("auth/cli/code")?;
-    let client = reqwest::Client::new();
+    let client = atuin_domain::http::client();
 
     debug!("Requesting code from Hub at {url}");
 
@@ -296,7 +296,7 @@ async fn request_code(address: &Url) -> Result<CliCodeResponse, HubError> {
 /// Poll to verify the CLI auth code and get the session token
 async fn verify_code(address: &Url, code: &str) -> Result<CliVerifyResponse, HubError> {
     let mut url = address.append_path("auth/cli/verify")?;
-    let client = reqwest::Client::new();
+    let client = atuin_domain::http::client();
 
     // Logged before the code is appended, so the secret stays out of the logs.
     debug!("Verifying code with Hub at {url}");

--- a/crates/atuin-domain/Cargo.toml
+++ b/crates/atuin-domain/Cargo.toml
@@ -35,6 +35,13 @@ tokio = { workspace = true }
 axum = { version = "0.8", optional = true }
 strum = { workspace = true }
 strum_macros = { workspace = true }
+tracing = { workspace = true }
+
+# See `http::musl_dns`: musl's resolver races all of resolv.conf's nameservers
+# and takes the first reply, which breaks split-horizon DNS. We drive
+# hickory-dns ourselves so negative responses don't end a lookup early.
+[target.'cfg(target_env = "musl")'.dependencies]
+hickory-resolver = "0.26"
 
 [features]
 # Feature-gated axum integration for the server-side capability handlers (`caps::axum`).

--- a/crates/atuin-domain/src/http.rs
+++ b/crates/atuin-domain/src/http.rs
@@ -1,0 +1,135 @@
+//! Constructors for Atuin's outbound HTTP clients.
+//!
+//! Anything that talks to a sync server, the hub, or a model provider should
+//! build its client through here, so that platform-specific configuration
+//! lives in one place rather than at each call site.
+
+/// A [`reqwest::ClientBuilder`] with Atuin's platform defaults applied.
+///
+/// Prefer this over [`reqwest::Client::builder`] directly.
+pub fn client_builder() -> reqwest::ClientBuilder {
+    let builder = reqwest::Client::builder();
+
+    #[cfg(target_env = "musl")]
+    let builder = builder.dns_resolver(musl_dns::HickoryResolver);
+
+    builder
+}
+
+/// A [`reqwest::Client`] with Atuin's platform defaults applied.
+///
+/// Drop-in replacement for [`reqwest::Client::new`], and panics under the same
+/// circumstances (a TLS backend that fails to initialise).
+pub fn client() -> reqwest::Client {
+    client_builder()
+        .build()
+        .expect("failed to build HTTP client")
+}
+
+/// DNS resolution for musl targets.
+///
+/// musl's `getaddrinfo` queries every nameserver in `resolv.conf` in parallel
+/// and takes the first definitive reply. On a split-horizon network, a
+/// nameserver that doesn't serve the internal zone can therefore answer
+/// NXDOMAIN before the one that does, and the lookup fails. glibc queries
+/// nameservers in order and never sees the loser's answer, which is why only
+/// the musl release artifacts are affected.
+///
+/// Swapping in hickory-dns fixes the parallel-race half of this, but not the
+/// whole problem: hickory orders nameservers by observed latency
+/// (`ServerOrderingStrategy::QueryStatistics`), so a nameserver that NXDOMAINs
+/// instantly earns the *best* stats and gets promoted to first, and
+/// `NameServerConfig::trust_negative_responses` then makes hickory accept that
+/// answer without consulting the others. Measured on such a network, that
+/// still failed roughly half of all lookups.
+///
+/// So we build the resolver ourselves with negative-response trust disabled: a
+/// bare NXDOMAIN no longer ends the lookup, it falls through to the remaining
+/// nameservers. Note this is deliberately more forgiving than glibc, which
+/// would also fail here if the unhelpful nameserver happened to be listed
+/// first — the goal is to resolve wherever an answer exists, not to reproduce
+/// glibc exactly. Only the empty-NXDOMAIN case is affected; every other
+/// response code is retried regardless of this setting.
+#[cfg(target_env = "musl")]
+mod musl_dns {
+    use std::net::SocketAddr;
+    use std::sync::OnceLock;
+
+    use hickory_resolver::{
+        TokioResolver,
+        config::{GOOGLE, LookupIpStrategy, ResolverConfig},
+        net::{NetError, runtime::TokioRuntimeProvider},
+        system_conf,
+    };
+    use reqwest::dns::{Addrs, Name, Resolve, Resolving};
+
+    /// Built on first use: constructing it needs a Tokio runtime, and
+    /// [`client_builder`](super::client_builder) may be called outside one.
+    static RESOLVER: OnceLock<TokioResolver> = OnceLock::new();
+
+    #[derive(Debug, Clone, Copy)]
+    pub(super) struct HickoryResolver;
+
+    impl Resolve for HickoryResolver {
+        fn resolve(&self, name: Name) -> Resolving {
+            Box::pin(async move {
+                let resolver = match RESOLVER.get() {
+                    Some(resolver) => resolver,
+                    // Two callers racing here both build one; `get_or_init`
+                    // keeps whichever lands first and drops the other.
+                    None => {
+                        let built = build()?;
+                        RESOLVER.get_or_init(|| built)
+                    }
+                };
+
+                let lookup = resolver.lookup_ip(name.as_str()).await?;
+                let addrs: Addrs = Box::new(
+                    lookup
+                        .iter()
+                        .map(|ip| SocketAddr::new(ip, 0))
+                        .collect::<Vec<_>>()
+                        .into_iter(),
+                );
+                Ok(addrs)
+            })
+        }
+    }
+
+    fn build() -> Result<TokioResolver, NetError> {
+        let mut builder = match system_conf::read_system_conf() {
+            Ok((system, options)) => {
+                let mut config = ResolverConfig::from_parts(
+                    system.domain().cloned(),
+                    system.search().to_vec(),
+                    vec![],
+                );
+                for mut name_server in system.name_servers().to_vec() {
+                    name_server.trust_negative_responses = false;
+                    config.add_name_server(name_server);
+                }
+
+                let mut builder =
+                    TokioResolver::builder_with_config(config, TokioRuntimeProvider::default());
+                *builder.options_mut() = options;
+                builder
+            }
+            // Same fallback reqwest's own hickory integration uses when
+            // resolv.conf can't be read.
+            Err(err) => {
+                tracing::debug!(
+                    ?err,
+                    "could not read system DNS configuration; falling back to Google DNS"
+                );
+                TokioResolver::builder_with_config(
+                    ResolverConfig::udp_and_tcp(&GOOGLE),
+                    TokioRuntimeProvider::default(),
+                )
+            }
+        };
+
+        // Match reqwest's own hickory setup so "happy eyeballs" still works.
+        builder.options_mut().ip_strategy = LookupIpStrategy::Ipv4AndIpv6;
+        builder.build()
+    }
+}

--- a/crates/atuin-domain/src/lib.rs
+++ b/crates/atuin-domain/src/lib.rs
@@ -5,7 +5,8 @@
 //! Where `atuin-common` is a grab-bag of utility helpers, this crate holds the
 //! types that make up Atuin's domain: the sync [`record`] types, the HTTP
 //! [`api`] request/response types, and the [`caps`] capability types. These are
-//! shared across the client, the daemon, and the server.
+//! shared across the client, the daemon, and the server. It also owns
+//! [`http`], the constructor for Atuin's outbound HTTP clients.
 
 /// Defines a new UUID type wrapper
 macro_rules! new_uuid {
@@ -66,4 +67,5 @@ macro_rules! new_uuid {
 
 pub mod api;
 pub mod caps;
+pub mod http;
 pub mod record;


### PR DESCRIPTION
Follow up to #3647 and #3652.

Hi again👋

I noticed that reqwest was bumped to 0.13.x and now pulls in a version of hickory-dns that is not vulnerable.

<!-- Thank you for making a PR! Bug fixes are always welcome, but if you're adding a new feature or changing an existing one, we'd really appreciate if you open an issue, post on the forum, or drop in on Discord -->

## Checks

- [x] I am happy for maintainers to push small adjustments to this PR, to speed up the review cycle
- [X] I have checked that there are no existing pull requests for the same thing

Feel free to close this PR if you would prefer enterprise users to use the glibc build instead, but might be worth documenting somewhere in the docs.

## Environment

I work in an enterprise environment with an always on VPN, internal root certs, and HTTP proxy that does SSL incerception. Client is Windows 11 laptop + WSL2 running Ubuntu 26.04. I installed Atuin using mise, which pulls down the musl build by default.

## The problem

I tried to setup a personal sync server internally but couldn't login:

```sh
Error: error sending request for url (https://atuin.company.local/login)

Caused by:
   0: client error (Connect)
   1: dns error
   2: failed to lookup address information: Name does not resolve

Location:
    crates/atuin-client/src/api_client.rs:126:16
```

## Root cause

I let Claude do some digging in the background and it quickly found the issue:

> The musl release binaries fail to resolve hostnames when `resolv.conf` lists nameservers that don't serve the same zones. This is common in enterprise networks with split DNS, and especially on WSL2, which generates `resolv.conf` from all Windows network adapters. A typical result is two corporate nameservers plus a home router as the third.

> musl's resolver sends the query to all nameservers at once and takes the first answer it gets, including NXDOMAIN. A router that answers NXDOMAIN for an internal name in 2 ms always beats the corporate server that answers correctly in 14 ms, so internal hostnames fail with "Name does not resolve" every time. glibc tries nameservers in order, which is why the gnu binary works on the same machine. Pinning the name in `/etc/hosts` doesn't help either: musl matches hosts entries case sensitively, and reqwest lowercases the host, so the mixed-case entries WSL generates never match. Other static musl tools (uv for example) show the same failure.

This is actually documented on the musl wiki: https://wiki.musl-libc.org/functional-differences-from-glibc.html

## The fix

Enable reqwest's hickory-dns feature for musl targets only. Hickory reads `resolv.conf` and `/etc/hosts` like glibc does.

## Testing

When using the hickory-dns build I can now sign in without any issues.