### PR TITLE
fix(search): rebalance scorer to prioritize fuzzy match over frecency

### DIFF
--- a/crates/atuin-daemon/src/search/index.rs
+++ b/crates/atuin-daemon/src/search/index.rs
@@ -567,7 +567,9 @@ impl SearchIndex {
         Some(Arc::new(move |cmd: &String, fuzzy_score: u32| {
             // HashMap<Arc<str>, _>::get accepts &str via Borrow trait
             let frecency = map.get(cmd.as_str()).copied().unwrap_or(0);
-            fuzzy_score + frecency
+            fuzzy_score
+                .saturating_mul(1000)
+                .saturating_add(frecency.min(999))
         }))
     }
 }


### PR DESCRIPTION
## Summary

Fixes #3702.

The daemon search scorer combined `fuzzy_score + frecency` with equal weight, allowing frecency (typically 0-200) to dominate the ranking and override fuzzy match quality. This caused queries like "foo bar" to rank scattered character matches (e.g., "foo ...b...a...r...") above genuine contiguous substring matches (e.g., "foo bar something"), even though the latter should be clearly better fuzzy matches.

As the maintainer noted in the issue, this "could be the search engine over-biasing for frecency over the fuzzy match" and suggested setting `search.frecency_score_multiplier = 0` as a workaround.

## Fix

Changed the scorer in `crates/atuin-daemon/src/search/index.rs` to use fuzzy_score as the primary sort key:

```rust
fuzzy_score.saturating_mul(1000).saturating_add(frecency.min(999))
```

This ensures fuzzy match quality is the primary ranking criterion, with frecency serving only as a tiebreaker for results with equal fuzzy relevance.

## Verification

- `cargo fmt` passes
- `cargo test -p atuin-daemon`: 33 tests passed, 0 failed
- `cargo test -p atuin-client`: 9 tests passed, 0 failed
- `cargo test -p atuin-nucleo`: all tests passed

Closes https://github.com/atuinsh/atuin/issues/3702