### PR TITLE
fix(install): disable update checks for local-only installs

### DIFF
--- a/docs/docs/configuration/config.md
+++ b/docs/docs/configuration/config.md
@@ -69,11 +69,26 @@ auto_sync = true/false
 
 Default: `true`
 
-Configures whether to automatically check for updates.
+Configures whether to automatically check for updates. When enabled, interactive
+search may contact `https://api.atuin.sh` about once per hour to learn the
+latest release version. This is independent of sync: it still runs when you are
+not logged in.
+
+If you want Atuin fully offline (no outbound network), set:
 
 ```toml
-update_check = true/false
+update_check = false
 ```
+
+Or:
+
+```shell
+atuin config set update_check false
+```
+
+Package-managed installs should usually leave updates to the package manager and
+disable this. The install script also turns it off when you decline a sync
+account so a local-only setup does not surprise network monitors.
 
 ### `sync_address`
 

--- a/docs/docs/configuration/config.md
+++ b/docs/docs/configuration/config.md
@@ -88,7 +88,7 @@ atuin config set update_check false
 
 Package-managed installs should usually leave updates to the package manager and
 disable this. The install script also turns it off when you decline a sync
-account so a local-only setup does not surprise network monitors.
+account so a local-only setup doesn't surprise network monitors.
 
 ### `sync_address`
 

--- a/docs/docs/faq.md
+++ b/docs/docs/faq.md
@@ -74,6 +74,28 @@ If you have a backup of `~/.local/share/atuin`, you can import it by:
 3. reenabling Atuin
 4. setting up sync!
 
+## Why does Atuin contact api.atuin.sh when I am not using sync?
+
+Skipping registration or login keeps your history local, but by default Atuin
+still checks for new releases (`update_check = true`). Interactive search
+(Ctrl-R) may open a brief connection to `https://api.atuin.sh` about once an
+hour. That is separate from history sync.
+
+To run fully offline:
+
+```toml
+# ~/.config/atuin/config.toml
+update_check = false
+```
+
+```shell
+atuin config set update_check false
+```
+
+If you used the install script and declined a sync account, recent installers
+set this for you. Re-enable updates with `atuin config set update_check true` if
+you want the reminder again.
+
 ## Alternative projects
 
 If you don't like Atuin, perhaps one of these works better for you:

--- a/docs/docs/faq.md
+++ b/docs/docs/faq.md
@@ -74,12 +74,12 @@ If you have a backup of `~/.local/share/atuin`, you can import it by:
 3. reenabling Atuin
 4. setting up sync!
 
-## Why does Atuin contact api.atuin.sh when I am not using sync?
+## Why does Atuin contact `api.atuin.sh` when I am not using sync?
 
 Skipping registration or login keeps your history local, but by default Atuin
 still checks for new releases (`update_check = true`). Interactive search
 (Ctrl-R) may open a brief connection to `https://api.atuin.sh` about once an
-hour. That is separate from history sync.
+hour. That's separate from history sync.
 
 To run fully offline:
 

--- a/docs/docs/guide/getting-started.md
+++ b/docs/docs/guide/getting-started.md
@@ -52,7 +52,10 @@ need it to log in on any other machine, and it can't be recovered. See
 [Setting up sync](sync.md) for the details, including logging in elsewhere.
 
 Skipping this step is fine. Your history stays on this machine, not backed up
-and not synchronized.
+and not synchronized. Note that Atuin can still check for application updates
+over the network unless you set
+[`update_check = false`](../configuration/config.md#update_check) (local-only /
+firewall-friendly installs).
 
 ## 4. Make it yours
 

--- a/install.sh
+++ b/install.sh
@@ -159,6 +159,17 @@ EOF
       echo ""
       printf "Already have an account? Log in with 'atuin login'.\n"
       echo "You can also run 'atuin register' any time to create one."
+      # Declining sync is not the same as fully offline: update checks still
+      # hit api.atuin.sh from interactive search. Disable them for local-only installs.
+      # Default update_check remains true for other install paths (#959).
+      if "$ATUIN_BIN" config set update_check false --type boolean >/dev/null 2>&1; then
+        echo ""
+        echo "Local-only install: disabled automatic update checks (no api.atuin.sh)."
+        echo "Re-enable later with: atuin config set update_check true"
+      else
+        echo ""
+        echo "Tip: for fully offline use, set update_check = false in ~/.config/atuin/config.toml"
+      fi
       ;;
   esac
 


### PR DESCRIPTION
Declining sync during install still left `update_check` on, so Ctrl-R contacted api.atuin.sh. Disable update checks for that local-only install path and document how to run fully offline.

Closes #3755

Tested: `bash -n install.sh`; docs review.

---
<!-- fleet-pr-claim: agent_id=sera platform=hermes -->
**Agent-Owner:** `sera` · **Platform:** hermes · **Claim-TTL:** 24h
