### PR TITLE
fix(crates.io): fix installation from crates.io

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -255,3 +255,25 @@ jobs:
 
       - name: Format
         run: cargo fmt -- --check
+
+  package:
+    runs-on: depot-ubuntu-24.04
+
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Install rust
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: 1.97.0
+
+      - uses: actions/cache@v6
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-package-${{ hashFiles('**/Cargo.lock') }}
+
+      - name: Build packaged tarballs
+        run: cargo package --workspace

--- a/crates/atuin/Cargo.toml
+++ b/crates/atuin/Cargo.toml
@@ -11,6 +11,8 @@ license = { workspace = true }
 homepage = { workspace = true }
 repository = { workspace = true }
 
+exclude = ["vendor/bash-preexec/.github", "vendor/bash-preexec/test"]
+
 [package.metadata.binstall]
 pkg-url = "{ repo }/releases/download/v{ version }/{ name }-{ target }.tar.gz"
 bin-dir = "{ name }-{ target }/{ bin }{ binary-ext }"

--- a/crates/atuin/src/shell.rs
+++ b/crates/atuin/src/shell.rs
@@ -19,7 +19,7 @@ pub struct Bash<'a> {
 pub const BASH: Bash<'_> = Bash {
     include_guard: include_shell!("atuin.bash.d/include-guard.bash"),
     main: include_shell!("atuin.bash"),
-    preexec: include_trimmed!("../../../vendor/bash-preexec/bash-preexec.sh"),
+    preexec: include_trimmed!("../vendor/bash-preexec/bash-preexec.sh"),
 };
 
 pub const FISH: &str = include_shell!("atuin.fish");

--- a/crates/atuin/vendor/bash-preexec
+++ b/crates/atuin/vendor/bash-preexec
@@ -1,0 +1,1 @@
+../../../vendor/bash-preexec

--- a/vendor/.repositories.json
+++ b/vendor/.repositories.json
@@ -1,0 +1,7 @@
+{
+  "/* COMMENT */": "Do not modify this file directly -- use vendor.sh",
+  "bash-preexec": {
+    "commit": "66e913cd9dec25b1399262c8301fb6d637c68e7e",
+    "url": "https://github.com/rcaloras/bash-preexec"
+  }
+}

--- a/vendor/README.md
+++ b/vendor/README.md
@@ -4,13 +4,17 @@ Use [vendor.sh](vendor.sh) to manage vendored repositories:
 
 ```
 Usage:
-  vendor.sh add <repo-url> <ref> [name]
-  vendor.sh list
-  vendor.sh update <name> <ref>
+  vendor/vendor.sh add <repo-url> <ref> [name]
+  vendor/vendor.sh update <name> <ref>
+  vendor/vendor.sh list
 
 <ref> specifies which branch/tag/commit to check out in the vendored
 repository.
 
 <name> is the name of the subdirectory in 'vendor/'. By default, it is
 inferred from the repository URL.
+
+Vendored repositories are recorded in 'vendor/.repositories.json'.
 ```
+
+`add` and `update` stage their changes; review them and commit.

--- a/vendor/vendor.sh
+++ b/vendor/vendor.sh
@@ -1,23 +1,26 @@
 #!/bin/sh
 # This script manages vendored repositories. See `./vendor.sh --help`.
-# shellcheck disable=SC3043
+#
+# shellcheck disable=SC3043  # allow `local` extension
+# shellcheck disable=SC2016  # `$n` is a jq variable
 set -euf
 
 root_dir=$(command git rev-parse --show-toplevel)
 vendor_dir=vendor
+db_path=$vendor_dir/.repositories.json
 script_name=$(basename "$0")
 
 usage() {
     cat << EOF
 Usage:
-  $script_name add <repo-url> <ref> [name]
-  $script_name update <name> <ref>
-  $script_name list
+  $vendor_dir/$script_name add <repo-url> <ref> [name]
+  $vendor_dir/$script_name update <name> <ref>
+  $vendor_dir/$script_name list
 
 <ref> specifies which branch/tag/commit to check out in the vendored
 repository.
 
-<name> is the name of the subdirectory in 'vendor/'. By default, it is
+<name> is the name of the subdirectory in '$vendor_dir/'. By default, it is
 inferred from the repository URL.
 EOF
 }
@@ -25,7 +28,7 @@ EOF
 # args: <message>
 usage_error() {
     printf >&2 '%s\n' "$script_name: $1"
-    printf >&2 '%s\n' "See 'vendor.sh --help' for usage information."
+    printf >&2 '%s\n' "See '$script_name --help' for usage information."
     exit 1
 }
 
@@ -35,68 +38,56 @@ error() {
     exit 1
 }
 
+# Runs `git` in the root directory; forwards all args
 git() {
     command git -C "$root_dir" "$@"
 }
 
-# args: <url> <ref>
-fetch_and_resolve() {
-    git fetch -- "$1" "$2"
-    if ! git rev-parse --verify --quiet 'FETCH_HEAD^{commit}'; then
-        error "could not resolve '$2' in '$1'"
+# Runs `jq` on the database; forwards all args
+jq_db() {
+    if ! command -v jq > /dev/null; then
+        printf >&2 '%s\n' "error: missing jq"
+        exit 1
     fi
+    jq "$@" -- "$root_dir/$db_path"
 }
 
-# args: <verb> <name> <ref> <commit> <url>
-make_commit_msg() {
-    local verb="$1"
-    local name="$2"
+# args: <name>
+validate_name() {
+    case "$1" in
+        ''|*/*|.|..) error "invalid name: '$1'" ;;
+    esac
+}
+
+# args: <name> <url> <ref>
+sync_repo() {
+    local name="$1"
+    local url="$2"
     local ref="$3"
-    local commit="$4"
-    local url="$5"
-    cat << EOF
-vendor.sh: $verb $name at $ref
 
-vendored-repo-name: $name
-vendored-repo-commit: $commit
-vendored-repo-url: $url
-EOF
-}
+    local dir="$vendor_dir/$name"
+    if [ -n "$(git status --porcelain -- "$dir")" ]; then
+        error "'$dir' has uncommitted changes"
+    fi
 
-# For each vendored repository, print `<name>`, `<url>`, and `<commit>`
-# separated by tabs.
-get_repos() {
-    set -- --topo-order --all-match --no-show-signature \
-        --grep='^vendor\.sh: ' \
-        --grep='^vendored-repo-name: ' \
-        --grep='^vendored-repo-commit: ' \
-        --grep='^vendored-repo-url: ' \
-        --format='@start%n%B%n@end'
-    git log "$@" | awk '
-        $1 == "@start" {
-            name = ""
-            commit = ""
-            url = ""
-            next
-        }
-        $1 == "vendored-repo-name:" {
-            name = $2
-            next
-        }
-        $1 == "vendored-repo-commit:" {
-            commit = $2
-            next
-        }
-        $1 == "vendored-repo-url:" {
-            url = $2
-            next
-        }
-        $1 == "@end" && name != "" && commit != "" && url != "" {
-            if (name in seen) next
-            seen[name] = 1
-            print name "\t" url "\t" commit
-        }
-    '
+    git fetch -- "$url" "$ref"
+    local commit
+    if ! commit=$(git rev-parse --verify 'FETCH_HEAD^{commit}'); then
+        error "could not resolve '$ref' in '$url'"
+    fi
+
+    rm -rf -- "${root_dir:?}/$dir"
+    mkdir -p -- "$root_dir/$dir"
+    git archive "$commit" | tar -C "$root_dir/$dir" -x
+
+    local json
+    json=$(jq_db -S --arg name "$name" --arg url "$url" \
+        --arg commit "$commit" '. + {$name: {url: $url, commit: $commit}}')
+
+    printf '%s\n' "$json" > "$root_dir/$db_path"
+    git add -A -- "$dir" "$db_path"
+    printf '%s\n' "$script_name: staged '$dir' at $commit"
+    printf '%s\n' "$script_name: review and commit the changes"
 }
 
 cmd_add() {
@@ -106,33 +97,20 @@ cmd_add() {
 
     local url="$1"
     local ref="$2"
-
     local name
-    if [ $# -eq 3 ]; then
+    if [ -n "${3+x}" ]; then
         name="$3"
     else
         name=${url%/}
         name=${name##*/}
         name=${name%.git}
     fi
+    validate_name "$name"
 
-    if [ -z "$name" ]; then
-        error "could not infer a name from '$url'"
-    fi
-    case $name in
-        */* | . | ..) error "invalid name: '$name'" ;;
-    esac
-    if [ -e "$vendor_dir/$name" ]; then
+    if [ -e "$root_dir/$vendor_dir/$name" ]; then
         error "'$vendor_dir/$name' already exists"
     fi
-
-    local commit
-    commit=$(fetch_and_resolve "$url" "$ref")
-    git subtree add \
-        --squash \
-        --prefix="$vendor_dir/$name" \
-        --message="$(make_commit_msg add "$name" "$ref" "$commit" "$url")" \
-        "$commit"
+    sync_repo "$name" "$url" "$ref"
 }
 
 cmd_update() {
@@ -142,30 +120,25 @@ cmd_update() {
 
     local name="$1"
     local ref="$2"
+    validate_name "$name"
+
     local url
-    url=$(get_repos | awk -F'\t' -v n="$name" '$1 == n { print $2; exit }')
+    url=$(jq_db -r --arg name "$name" '(.[$name] | objects | .url) // empty')
+
     if [ -z "$url" ]; then
         error "no vendored repository named '$name'"
     fi
-
-    local commit
-    commit=$(fetch_and_resolve "$url" "$ref")
-    git subtree merge \
-        --squash \
-        --prefix="$vendor_dir/$name" \
-        --message="$(make_commit_msg update "$name" "$ref" "$commit" "$url")" \
-        "$commit"
+    sync_repo "$name" "$url" "$ref"
 }
 
 cmd_list() {
     if [ "$#" -ne 0 ]; then
         usage_error "unexpected number of arguments to 'list'"
     fi
-    get_repos | awk '{
-        print "name: " $1
-        print "url: " $2
-        print "commit: " $3
-    }'
+    jq_db -r 'to_entries | map(select(.value | type == "object")
+        | ["name: " + .key, "url: " + .value.url, "commit: " + .value.commit]
+        | join("\n")
+    ) | join("\n\n")'
 }
 
 if [ "$#" -lt 1 ]; then
@@ -176,7 +149,7 @@ shift
 
 case "$cmd" in
     add|list|update) ;;
-    -h|--help)
+    -h|--help|help)
         usage
         exit 0
         ;;

--- a/vendor/vendor.sh
+++ b/vendor/vendor.sh
@@ -45,10 +45,6 @@ git() {
 
 # Runs `jq` on the database; forwards all args
 jq_db() {
-    if ! command -v jq > /dev/null; then
-        printf >&2 '%s\n' "error: missing jq"
-        exit 1
-    fi
     jq "$@" -- "$root_dir/$db_path"
 }
 
@@ -157,4 +153,8 @@ case "$cmd" in
         usage_error "unknown command"
         ;;
 esac
+if ! command -v jq > /dev/null; then
+    printf >&2 '%s\n' "error: missing jq"
+    exit 1
+fi
 "cmd_$cmd" "$@"

--- a/vendor/vendor.sh
+++ b/vendor/vendor.sh
@@ -87,7 +87,7 @@ sync_repo() {
     mkdir -p -- "$temp/$name"
 
     # NOTE: `git archive` honors export-ignore and will not fetch submodules.
-    # For mose use cases, this is fine, but we will have to change the strategy
+    # For most use cases, this is fine, but we will have to change the strategy
     # if we need a vendored repository that isn't compatible with these
     # limitations.
     git archive "$commit" | tar -C "$temp/$name" -x

--- a/vendor/vendor.sh
+++ b/vendor/vendor.sh
@@ -70,7 +70,10 @@ sync_repo() {
     local ref="$3"
 
     local dir="$vendor_dir/$name"
-    if [ -n "$(git status --porcelain -- "$dir")" ]; then
+    local status
+    status=$(git status --porcelain -- "$dir")
+    if [ -n "$status" ]; then
+        printf '%s\n' "$status"
         error "'$dir' has uncommitted changes"
     fi
 

--- a/vendor/vendor.sh
+++ b/vendor/vendor.sh
@@ -71,7 +71,7 @@ sync_repo() {
 
     local dir="$vendor_dir/$name"
     local status
-    status=$(git status --porcelain -- "$dir")
+    status=$(git status --porcelain --ignored -- "$dir")
     if [ -n "$status" ]; then
         printf '%s\n' "$status"
         error "'$dir' has uncommitted changes"

--- a/vendor/vendor.sh
+++ b/vendor/vendor.sh
@@ -86,6 +86,10 @@ sync_repo() {
     temp=$(mktemp -d)
     mkdir -p -- "$temp/$name"
 
+    # NOTE: `git archive` honors export-ignore and will not fetch submodules.
+    # For mose use cases, this is fine, but we will have to change the strategy
+    # if we need a vendored repository that isn't compatible with these
+    # limitations.
     git archive "$commit" | tar -C "$temp/$name" -x
     rm -rf -- "${root_dir:?}/$dir"
     mv -- "$temp/$name" "$root_dir/$vendor_dir/"

--- a/vendor/vendor.sh
+++ b/vendor/vendor.sh
@@ -55,6 +55,14 @@ validate_name() {
     esac
 }
 
+temp=
+
+cleanup() {
+    if [ -n "$temp" ]; then
+        rm -rf -- "$temp"
+    fi
+}
+
 # args: <name> <url> <ref>
 sync_repo() {
     local name="$1"
@@ -72,9 +80,12 @@ sync_repo() {
         error "could not resolve '$ref' in '$url'"
     fi
 
+    temp=$(mktemp -d)
+    mkdir -p -- "$temp/$name"
+
+    git archive "$commit" | tar -C "$temp/$name" -x
     rm -rf -- "${root_dir:?}/$dir"
-    mkdir -p -- "$root_dir/$dir"
-    git archive "$commit" | tar -C "$root_dir/$dir" -x
+    mv -- "$temp/$name" "$root_dir/$vendor_dir/"
 
     local json
     json=$(jq_db -S --arg name "$name" --arg url "$url" \
@@ -157,4 +168,5 @@ if ! command -v jq > /dev/null; then
     printf >&2 '%s\n' "error: missing jq"
     exit 1
 fi
+trap cleanup HUP INT QUIT TERM EXIT
 "cmd_$cmd" "$@"


### PR DESCRIPTION
The `atuin` crate relies on a file that lies outside the crate root and thus isn't included in the package uploaded to crates.io. This PR fixes the issue by symlinking the required file into the crate. The symlink will get converted to a regular file when the package is uploaded to crates.io (we're already using symlinks for other files like README.md).

This PR also fixes the way we're managing vendored repositories. Previously, we were relying on special fields in commit messages, but these commit messages get dropped when we squash-merge our PRs. In fact, we can't rely on git-subtree at all, since we drop its messages too. This PR uses `git archive` and stores the metadata in a JSON file.

This PR also modifies CI to catch errors like this in the future.

Will fix https://github.com/atuinsh/atuin/issues/3761 once we publish a new version.