### PR TITLE
feat(config): validate new settings in `atuin config set` before writing them to disk

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -276,10 +276,10 @@ jobs:
           key: ${{ runner.os }}-cargo-package-${{ hashFiles('**/Cargo.lock') }}
 
       - name: Diagnose
-      run: |
-        cargo package --workspace --no-verify
-        tar -xzOf target/package/atuin-client-18.18.1.crate \
-          atuin-client-18.18.1/src/settings.rs | grep -c 'fn validate_str'
-        grep -A 3 'name = "atuin-client"' target/package/atuin-18.18.1/Cargo.lock
-        cat ~/.cargo/config.toml 2>/dev/null || echo "no user cargo config"
-        cargo --version -v
+        run: |
+          cargo package --workspace --no-verify
+          tar -xzOf target/package/atuin-client-18.18.1.crate \
+            atuin-client-18.18.1/src/settings.rs | grep -c 'fn validate_str'
+          grep -A 3 'name = "atuin-client"' target/package/atuin-18.18.1/Cargo.lock
+          cat ~/.cargo/config.toml 2>/dev/null || echo "no user cargo config"
+          cargo --version -v

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -282,4 +282,4 @@ jobs:
           rm -rf target/{debug,release}/libatuin*.rlib
           rm -rf target/{debug,release}/deps/libatuin*
           rm -rf target/{debug,release}/.fingerprint/atuin*
-          cargo package --workspace
+          cargo package -p atuin -p atuin-server

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -277,5 +277,5 @@ jobs:
 
       - name: Build packaged tarballs
         run: |
-          rm -rf target/package ~/.cargo/registry/src/-*
+          rm -rf target/package ~/.cargo/registry/src/*/atuin* ~/.cargo/registry/cache/*/atuin*
           cargo package --workspace

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -270,10 +270,16 @@ jobs:
       - uses: actions/cache@v6
         with:
           path: |
-            ~/.cargo/registry/index
-            ~/.cargo/registry/cache
+            ~/.cargo/registry
             ~/.cargo/git
+            target
           key: ${{ runner.os }}-cargo-package-${{ hashFiles('**/Cargo.lock') }}
 
       - name: Build packaged tarballs
-        run: cargo package --workspace
+        run: |
+          rm -rf ~/.cargo/registry/{cache,src}/*/atuin*
+          rm -rf target/package
+          rm -rf target/{debug,release}/libatuin*.rlib
+          rm -rf target/{debug,release}/deps/libatuin*
+          rm -rf target/{debug,release}/.fingerprint/atuin*
+          cargo package --workspace

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -270,16 +270,10 @@ jobs:
       - uses: actions/cache@v6
         with:
           path: |
-            ~/.cargo/registry
+            ~/.cargo/registry/index
+            ~/.cargo/registry/cache
             ~/.cargo/git
-            target
           key: ${{ runner.os }}-cargo-package-${{ hashFiles('**/Cargo.lock') }}
 
-      - name: Diagnose
-        run: |
-          cargo package --workspace --no-verify
-          tar -xzOf target/package/atuin-client-18.18.1.crate \
-            atuin-client-18.18.1/src/settings.rs | grep -c 'fn validate_str'
-          grep -A 3 'name = "atuin-client"' target/package/atuin-18.18.1/Cargo.lock
-          cat ~/.cargo/config.toml 2>/dev/null || echo "no user cargo config"
-          cargo --version -v
+      - name: Build packaged tarballs
+        run: cargo package --workspace --no-verify

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -276,4 +276,7 @@ jobs:
           key: ${{ runner.os }}-cargo-package-${{ hashFiles('**/Cargo.lock') }}
 
       - name: Build packaged tarballs
-        run: cargo package --workspace
+        run: |
+          # Remove cached local packages (not crates.io)
+          rm -rf ~/.cargo/registry/src/-*
+          cargo package --workspace

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -276,4 +276,4 @@ jobs:
           key: ${{ runner.os }}-cargo-package-${{ hashFiles('**/Cargo.lock') }}
 
       - name: Build packaged tarballs
-        run: cargo package --workspace --no-verify
+        run: cargo package --workspace

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -282,4 +282,4 @@ jobs:
           rm -rf target/{debug,release}/libatuin*.rlib
           rm -rf target/{debug,release}/deps/libatuin*
           rm -rf target/{debug,release}/.fingerprint/atuin*
-          cargo package -p atuin -p atuin-server
+          cargo package --workspace

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -275,7 +275,11 @@ jobs:
             target
           key: ${{ runner.os }}-cargo-package-${{ hashFiles('**/Cargo.lock') }}
 
-      - name: Build packaged tarballs
-        run: |
-          rm -rf target/package ~/.cargo/registry/src/*/atuin* ~/.cargo/registry/cache/*/atuin*
-          cargo package --workspace
+      - name: Diagnose
+      run: |
+        cargo package --workspace --no-verify
+        tar -xzOf target/package/atuin-client-18.18.1.crate \
+          atuin-client-18.18.1/src/settings.rs | grep -c 'fn validate_str'
+        grep -A 3 'name = "atuin-client"' target/package/atuin-18.18.1/Cargo.lock
+        cat ~/.cargo/config.toml 2>/dev/null || echo "no user cargo config"
+        cargo --version -v

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -277,6 +277,5 @@ jobs:
 
       - name: Build packaged tarballs
         run: |
-          # Remove cached local packages (not crates.io)
-          rm -rf ~/.cargo/registry/src/-*
+          rm -rf target/package ~/.cargo/registry/src/-*
           cargo package --workspace

--- a/crates/atuin-client/src/settings.rs
+++ b/crates/atuin-client/src/settings.rs
@@ -5,7 +5,7 @@ use clap::ValueEnum;
 use config::{
     Config, ConfigBuilder, Environment, File as ConfigFile, FileFormat, builder::DefaultState,
 };
-use eyre::{Context, Result, bail, eyre};
+use eyre::{Context, Result, eyre};
 use fs_err::{File, create_dir_all};
 use humantime::parse_duration;
 use regex::RegexSet;
@@ -17,6 +17,7 @@ use std::{
     path::{Path, PathBuf},
     sync::{LazyLock, OnceLock},
 };
+use thiserror::Error;
 use time::OffsetDateTime;
 use tokio::sync::OnceCell;
 use url::Url;
@@ -26,6 +27,18 @@ static EXAMPLE_CONFIG: &str = include_str!("../config.toml");
 static DATA_DIR: OnceLock<PathBuf> = OnceLock::new();
 static META_CONFIG: OnceLock<(String, f64)> = OnceLock::new();
 static META_STORE: OnceCell<crate::meta::MetaStore> = OnceCell::const_new();
+
+/// Keys that need to be shell-expanded before use.
+const EXPANDED_PATH_KEYS: &[&str] = &[
+    "db_path",
+    "record_store_path",
+    "key_path",
+    "daemon.socket_path",
+    "daemon.pidfile_path",
+    "logs.dir",
+    "logs.search.file",
+    "logs.daemon.file",
+];
 
 mod dotfiles;
 mod kv;
@@ -939,16 +952,20 @@ impl Ui {
 
     /// Validate the UI configuration.
     /// Returns an error if more than one column has expand = true.
-    pub fn validate(&self) -> Result<()> {
+    pub fn validate(&self) -> Result<(), UiValidationError> {
         let expand_count = self.columns.iter().filter(|c| c.expand).count();
         if expand_count > 1 {
-            bail!(
-                "Only one column can have expand = true, but {} columns are set to expand",
-                expand_count
-            );
+            return Err(UiValidationError::MultipleExpandingColumns(expand_count));
         }
         Ok(())
     }
+}
+
+/// A [`Ui`] configuration that cannot be used as written.
+#[derive(Debug, Error)]
+pub enum UiValidationError {
+    #[error("Only one column can have expand = true, but {0} columns are set to expand")]
+    MultipleExpandingColumns(usize),
 }
 
 impl Default for Ui {
@@ -1371,10 +1388,14 @@ impl Settings {
     }
 
     pub fn builder() -> Result<ConfigBuilder<DefaultState>> {
-        Self::builder_with_data_dir(&atuin_common::utils::data_dir())
+        Ok(Self::builder_with_data_dir(
+            &atuin_common::utils::data_dir(),
+        )?)
     }
 
-    fn builder_with_data_dir(data_dir: &std::path::Path) -> Result<ConfigBuilder<DefaultState>> {
+    fn builder_with_data_dir(
+        data_dir: &std::path::Path,
+    ) -> Result<ConfigBuilder<DefaultState>, config::ConfigError> {
         let db_path = data_dir.join("history.db");
         let record_store_path = data_dir.join("records.db");
         let kv_path = data_dir.join("kv.db");
@@ -1587,30 +1608,19 @@ impl Settings {
 
         // all paths should be expanded
         let built = config_builder.build_cloned()?;
-        config_builder = [
-            "db_path",
-            "record_store_path",
-            "key_path",
-            "daemon.socket_path",
-            "daemon.pidfile_path",
-            "logs.dir",
-            "logs.search.file",
-            "logs.daemon.file",
-        ]
-        .iter()
-        .map(|key| (key, built.get_string(key).unwrap_or_default()))
-        .filter_map(|(key, value)| match Self::expand_path(value) {
-            Ok(expanded) => Some((key, expanded)),
-            Err(e) => {
-                tracing::warn!("failed to expand path for {key}: {e}");
-                None
-            }
-        })
-        .fold(config_builder, |builder, (key, value)| {
-            builder
-                .set_override(key, value)
-                .unwrap_or_else(|_| panic!("failed to set absolute path override for {key}"))
-        });
+        config_builder = Self::expanded_path_keys(&built)
+            .filter_map(|(key, expanded)| match expanded {
+                Ok(expanded) => Some((key, expanded)),
+                Err(e) => {
+                    tracing::warn!("failed to expand path for {key}: {e}");
+                    None
+                }
+            })
+            .fold(config_builder, |builder, (key, value)| {
+                builder
+                    .set_override(key, value)
+                    .unwrap_or_else(|_| panic!("failed to set absolute path override for {key}"))
+            });
 
         config_builder.build().map_err(Into::into)
     }
@@ -1696,12 +1706,6 @@ impl Settings {
         Ok(settings)
     }
 
-    fn expand_path(path: String) -> Result<String> {
-        shellexpand::full(&path)
-            .map(|p| p.to_string())
-            .map_err(|e| eyre!("failed to expand path: {}", e))
-    }
-
     pub fn example_config() -> &'static str {
         EXAMPLE_CONFIG
     }
@@ -1714,6 +1718,45 @@ impl Settings {
             Path::new(&self.meta.db_path),
         ];
         paths.iter().all(|p| !utils::broken_symlink(*p))
+    }
+
+    /// Check that a TOML string can be successfully deserialized into a [`Settings`] object.
+    pub fn validate_str(toml: &str) -> Result<(), ValidationError> {
+        let config = Self::builder_with_data_dir(&atuin_common::utils::data_dir())?
+            .add_source(ConfigFile::from_str(toml, FileFormat::Toml))
+            .build()?;
+
+        for (key, expanded) in Self::expanded_path_keys(&config) {
+            expanded.map_err(|source| ValidationError::Path { key, source })?;
+        }
+
+        let settings: Settings = config.try_deserialize()?;
+        if let Some(dir) = &settings.data_dir {
+            shellexpand::full(dir).map_err(|source| ValidationError::Path {
+                key: "data_dir",
+                source,
+            })?;
+        }
+
+        settings.ui.validate()?;
+        Ok(())
+    }
+
+    /// Shell-expand every path in [`EXPANDED_PATH_KEYS`].
+    ///
+    /// Returns an iterator that yields `(key, expanded_path)` tuples.
+    fn expanded_path_keys(
+        config: &Config,
+    ) -> impl Iterator<
+        Item = (
+            &'static str,
+            Result<String, shellexpand::LookupError<std::env::VarError>>,
+        ),
+    > + use<'_> {
+        EXPANDED_PATH_KEYS.iter().map(|key| {
+            let raw = config.get_string(key).unwrap_or_default();
+            (*key, shellexpand::full(&raw).map(|p| p.to_string()))
+        })
     }
 }
 
@@ -1728,6 +1771,23 @@ impl Default for Settings {
             .try_deserialize()
             .expect("Could not deserialize config")
     }
+}
+
+/// Error returned by [`Settings::validate_str`] when validation fails.
+#[derive(Debug, Error)]
+pub enum ValidationError {
+    #[error(transparent)]
+    Config(#[from] config::ConfigError),
+
+    #[error(transparent)]
+    Ui(#[from] UiValidationError),
+
+    #[error("failed to expand path for {key}: {source}")]
+    Path {
+        key: &'static str,
+        #[source]
+        source: shellexpand::LookupError<std::env::VarError>,
+    },
 }
 
 /// Initialize the meta store configuration for testing.
@@ -1927,6 +1987,113 @@ mod tests {
         assert!(!daemon_autostart);
 
         Ok(())
+    }
+
+    #[test]
+    fn validate_accepts_a_valid_config() {
+        assert!(Settings::validate_str("search_mode = \"fuzzy\"\n").is_ok());
+    }
+
+    #[test]
+    fn validate_accepts_an_empty_config() {
+        assert!(Settings::validate_str("").is_ok());
+    }
+
+    #[test]
+    fn validate_rejects_an_invalid_enum_variant() {
+        let err = Settings::validate_str("search_mode = \"invalid\"\n")
+            .expect_err("an unknown search_mode variant should not validate")
+            .to_string();
+
+        assert!(
+            err.contains("search_mode"),
+            "error should name the offending key, got: {err}"
+        );
+    }
+
+    #[test]
+    fn validate_rejects_a_value_of_the_wrong_type() {
+        let err = Settings::validate_str("auto_sync = \"banana\"\n")
+            .expect_err("a string is not a valid bool")
+            .to_string();
+
+        assert!(
+            err.contains("auto_sync"),
+            "error should name the offending key, got: {err}"
+        );
+    }
+
+    #[test]
+    fn validate_rejects_an_invalid_nested_value() {
+        let err = Settings::validate_str("[search]\nfilters = [\"nope\"]\n")
+            .expect_err("an unknown filter mode should not validate")
+            .to_string();
+
+        assert!(
+            err.contains("search.filters"),
+            "error should name the offending key, got: {err}"
+        );
+    }
+
+    #[test]
+    fn validate_accepts_a_plain_data_dir() {
+        assert!(Settings::validate_str("data_dir = \"/tmp/atuin-test\"\n").is_ok());
+    }
+
+    #[test]
+    fn validate_rejects_a_data_dir_with_an_unexpandable_variable() {
+        let err = Settings::validate_str("data_dir = \"${DEFINITELY_UNSET_VAR_XYZ}/atuin\"\n")
+            .expect_err("a data_dir referencing an unset env var should not validate")
+            .to_string();
+
+        assert!(
+            err.contains("data_dir"),
+            "error should name data_dir, got: {err}"
+        );
+    }
+
+    #[test]
+    fn validate_accepts_a_plain_path_key() {
+        assert!(Settings::validate_str("db_path = \"/tmp/atuin-test/history.db\"\n").is_ok());
+    }
+
+    #[test]
+    fn validate_rejects_an_unexpandable_path_key() {
+        let err = Settings::validate_str("db_path = \"${DEFINITELY_UNSET_VAR_XYZ}/history.db\"\n")
+            .expect_err("a db_path referencing an unset env var should not validate")
+            .to_string();
+
+        assert!(
+            err.contains("db_path"),
+            "error should name the offending key, got: {err}"
+        );
+    }
+
+    #[test]
+    fn validate_rejects_an_unexpandable_nested_path_key() {
+        let err =
+            Settings::validate_str("[logs]\ndir = \"${DEFINITELY_UNSET_VAR_XYZ}/atuin-logs\"\n")
+                .expect_err("a logs.dir referencing an unset env var should not validate")
+                .to_string();
+
+        assert!(
+            err.contains("logs.dir"),
+            "error should name the offending key, got: {err}"
+        );
+    }
+
+    #[test]
+    fn validate_rejects_more_than_one_expanding_column() {
+        let err = Settings::validate_str(
+            "[ui]\ncolumns = [{ type = \"duration\", expand = true }, { type = \"command\", expand = true }]\n",
+        )
+        .expect_err("two expanding columns should not validate")
+        .to_string();
+
+        assert!(
+            err.contains("expand"),
+            "error should explain the expand conflict, got: {err}"
+        );
     }
 
     #[test]

--- a/crates/atuin-client/src/settings.rs
+++ b/crates/atuin-client/src/settings.rs
@@ -2031,36 +2031,6 @@ mod tests {
     }
 
     #[test]
-    fn validate_accepts_a_plain_path_key() {
-        assert!(Settings::validate_str("db_path = \"/tmp/atuin-test/history.db\"\n").is_ok());
-    }
-
-    #[test]
-    fn validate_rejects_an_unexpandable_path_key() {
-        let err = Settings::validate_str("db_path = \"${DEFINITELY_UNSET_VAR_XYZ}/history.db\"\n")
-            .expect_err("a db_path referencing an unset env var should not validate")
-            .to_string();
-
-        assert!(
-            err.contains("db_path"),
-            "error should name the offending key, got: {err}"
-        );
-    }
-
-    #[test]
-    fn validate_rejects_an_unexpandable_nested_path_key() {
-        let err =
-            Settings::validate_str("[logs]\ndir = \"${DEFINITELY_UNSET_VAR_XYZ}/atuin-logs\"\n")
-                .expect_err("a logs.dir referencing an unset env var should not validate")
-                .to_string();
-
-        assert!(
-            err.contains("logs.dir"),
-            "error should name the offending key, got: {err}"
-        );
-    }
-
-    #[test]
     fn validate_rejects_more_than_one_expanding_column() {
         let err = Settings::validate_str(
             "[ui]\ncolumns = [{ type = \"duration\", expand = true }, { type = \"command\", expand = true }]\n",

--- a/crates/atuin-client/src/settings.rs
+++ b/crates/atuin-client/src/settings.rs
@@ -28,18 +28,6 @@ static DATA_DIR: OnceLock<PathBuf> = OnceLock::new();
 static META_CONFIG: OnceLock<(String, f64)> = OnceLock::new();
 static META_STORE: OnceCell<crate::meta::MetaStore> = OnceCell::const_new();
 
-/// Keys that need to be shell-expanded before use.
-const EXPANDED_PATH_KEYS: &[&str] = &[
-    "db_path",
-    "record_store_path",
-    "key_path",
-    "daemon.socket_path",
-    "daemon.pidfile_path",
-    "logs.dir",
-    "logs.search.file",
-    "logs.daemon.file",
-];
-
 mod dotfiles;
 mod kv;
 pub(crate) mod meta;
@@ -1608,19 +1596,31 @@ impl Settings {
 
         // all paths should be expanded
         let built = config_builder.build_cloned()?;
-        config_builder = Self::expanded_path_keys(&built)
-            .filter_map(|(key, expanded)| match expanded {
-                Ok(expanded) => Some((key, expanded)),
-                Err(e) => {
-                    tracing::warn!("failed to expand path for {key}: {e}");
-                    None
-                }
-            })
-            .fold(config_builder, |builder, (key, value)| {
-                builder
-                    .set_override(key, value)
-                    .unwrap_or_else(|_| panic!("failed to set absolute path override for {key}"))
-            });
+
+        config_builder = [
+            "db_path",
+            "record_store_path",
+            "key_path",
+            "daemon.socket_path",
+            "daemon.pidfile_path",
+            "logs.dir",
+            "logs.search.file",
+            "logs.daemon.file",
+        ]
+        .iter()
+        .map(|key| (key, built.get_string(key).unwrap_or_default()))
+        .filter_map(|(key, value)| match Self::expand_path(value) {
+            Ok(expanded) => Some((key, expanded)),
+            Err(e) => {
+                tracing::warn!("failed to expand path for {key}: {e}");
+                None
+            }
+        })
+        .fold(config_builder, |builder, (key, value)| {
+            builder
+                .set_override(key, value)
+                .unwrap_or_else(|_| panic!("failed to set absolute path override for {key}"))
+        });
 
         config_builder.build().map_err(Into::into)
     }
@@ -1706,6 +1706,12 @@ impl Settings {
         Ok(settings)
     }
 
+    fn expand_path(path: String) -> Result<String> {
+        shellexpand::full(&path)
+            .map(|p| p.to_string())
+            .map_err(|e| eyre!("failed to expand path: {}", e))
+    }
+
     pub fn example_config() -> &'static str {
         EXAMPLE_CONFIG
     }
@@ -1726,37 +1732,13 @@ impl Settings {
             .add_source(ConfigFile::from_str(toml, FileFormat::Toml))
             .build()?;
 
-        for (key, expanded) in Self::expanded_path_keys(&config) {
-            expanded.map_err(|source| ValidationError::Path { key, source })?;
-        }
-
         let settings: Settings = config.try_deserialize()?;
         if let Some(dir) = &settings.data_dir {
-            shellexpand::full(dir).map_err(|source| ValidationError::Path {
-                key: "data_dir",
-                source,
-            })?;
+            shellexpand::full(dir).map_err(ValidationError::DataDir)?;
         }
 
         settings.ui.validate()?;
         Ok(())
-    }
-
-    /// Shell-expand every path in [`EXPANDED_PATH_KEYS`].
-    ///
-    /// Returns an iterator that yields `(key, expanded_path)` tuples.
-    fn expanded_path_keys(
-        config: &Config,
-    ) -> impl Iterator<
-        Item = (
-            &'static str,
-            Result<String, shellexpand::LookupError<std::env::VarError>>,
-        ),
-    > + use<'_> {
-        EXPANDED_PATH_KEYS.iter().map(|key| {
-            let raw = config.get_string(key).unwrap_or_default();
-            (*key, shellexpand::full(&raw).map(|p| p.to_string()))
-        })
     }
 }
 
@@ -1782,12 +1764,8 @@ pub enum ValidationError {
     #[error(transparent)]
     Ui(#[from] UiValidationError),
 
-    #[error("failed to expand path for {key}: {source}")]
-    Path {
-        key: &'static str,
-        #[source]
-        source: shellexpand::LookupError<std::env::VarError>,
-    },
+    #[error("failed to expand `data_dir`: {0}")]
+    DataDir(shellexpand::LookupError<std::env::VarError>),
 }
 
 /// Initialize the meta store configuration for testing.

--- a/crates/atuin-client/src/settings.rs
+++ b/crates/atuin-client/src/settings.rs
@@ -1967,80 +1967,35 @@ mod tests {
         Ok(())
     }
 
-    #[test]
-    fn validate_accepts_a_valid_config() {
-        assert!(Settings::validate_str("search_mode = \"fuzzy\"\n").is_ok());
+    #[rstest]
+    #[case::valid_config("search_mode = \"fuzzy\"\n")]
+    #[case::empty_config("")]
+    #[case::plain_data_dir("data_dir = \"/tmp/atuin-test\"\n")]
+    fn validate_accepts(#[case] toml: &str) {
+        assert!(Settings::validate_str(toml).is_ok());
     }
 
-    #[test]
-    fn validate_accepts_an_empty_config() {
-        assert!(Settings::validate_str("").is_ok());
-    }
-
-    #[test]
-    fn validate_rejects_an_invalid_enum_variant() {
-        let err = Settings::validate_str("search_mode = \"invalid\"\n")
-            .expect_err("an unknown search_mode variant should not validate")
+    /// The error should always name the offending key.
+    #[rstest]
+    #[case::invalid_enum_variant("search_mode = \"invalid\"\n", "search_mode")]
+    #[case::value_of_the_wrong_type("auto_sync = \"banana\"\n", "auto_sync")]
+    #[case::invalid_nested_value("[search]\nfilters = [\"nope\"]\n", "search.filters")]
+    #[case::data_dir_with_an_unexpandable_variable(
+        "data_dir = \"${DEFINITELY_UNSET_VAR_XYZ}/atuin\"\n",
+        "data_dir"
+    )]
+    #[case::more_than_one_expanding_column(
+        "[ui]\ncolumns = [{ type = \"duration\", expand = true }, { type = \"command\", expand = true }]\n",
+        "expand"
+    )]
+    fn validate_rejects(#[case] toml: &str, #[case] expected_err: &str) {
+        let err = Settings::validate_str(toml)
+            .expect_err("config should not validate")
             .to_string();
 
         assert!(
-            err.contains("search_mode"),
-            "error should name the offending key, got: {err}"
-        );
-    }
-
-    #[test]
-    fn validate_rejects_a_value_of_the_wrong_type() {
-        let err = Settings::validate_str("auto_sync = \"banana\"\n")
-            .expect_err("a string is not a valid bool")
-            .to_string();
-
-        assert!(
-            err.contains("auto_sync"),
-            "error should name the offending key, got: {err}"
-        );
-    }
-
-    #[test]
-    fn validate_rejects_an_invalid_nested_value() {
-        let err = Settings::validate_str("[search]\nfilters = [\"nope\"]\n")
-            .expect_err("an unknown filter mode should not validate")
-            .to_string();
-
-        assert!(
-            err.contains("search.filters"),
-            "error should name the offending key, got: {err}"
-        );
-    }
-
-    #[test]
-    fn validate_accepts_a_plain_data_dir() {
-        assert!(Settings::validate_str("data_dir = \"/tmp/atuin-test\"\n").is_ok());
-    }
-
-    #[test]
-    fn validate_rejects_a_data_dir_with_an_unexpandable_variable() {
-        let err = Settings::validate_str("data_dir = \"${DEFINITELY_UNSET_VAR_XYZ}/atuin\"\n")
-            .expect_err("a data_dir referencing an unset env var should not validate")
-            .to_string();
-
-        assert!(
-            err.contains("data_dir"),
-            "error should name data_dir, got: {err}"
-        );
-    }
-
-    #[test]
-    fn validate_rejects_more_than_one_expanding_column() {
-        let err = Settings::validate_str(
-            "[ui]\ncolumns = [{ type = \"duration\", expand = true }, { type = \"command\", expand = true }]\n",
-        )
-        .expect_err("two expanding columns should not validate")
-        .to_string();
-
-        assert!(
-            err.contains("expand"),
-            "error should explain the expand conflict, got: {err}"
+            err.contains(expected_err),
+            "error should mention `{expected_err}`, got: {err}"
         );
     }
 

--- a/crates/atuin/src/command/client/config.rs
+++ b/crates/atuin/src/command/client/config.rs
@@ -144,13 +144,20 @@ pub enum ValueType {
 
 impl SetCmd {
     pub async fn run(self, _settings: &Settings) -> Result<()> {
+        let config_file = Settings::get_config_path()?;
+        let config_str = tokio::fs::read_to_string(&config_file).await?;
+
+        let updated = self.get_updated_config(&config_str)?;
+        tokio::fs::write(&config_file, &updated).await?;
+        Ok(())
+    }
+
+    fn get_updated_config(&self, config_str: &str) -> Result<String> {
         let key = self.key.trim();
         if key.is_empty() || key.contains(char::is_whitespace) {
             eyre::bail!("Config key must be non-empty and must not contain whitespace");
         }
 
-        let config_file = Settings::get_config_path()?;
-        let config_str = tokio::fs::read_to_string(&config_file).await?;
         let mut doc: DocumentMut = config_str.parse()?;
 
         // When using auto type detection, try to match the existing value's type
@@ -159,9 +166,15 @@ impl SetCmd {
         let value = self.parse_value(existing_type.as_ref())?;
         set_deep_key(&mut doc, key, value)?;
 
-        tokio::fs::write(&config_file, doc.to_string()).await?;
-
-        Ok(())
+        let updated = doc.to_string();
+        Settings::validate_str(&updated).map_err(|e| {
+            eyre::eyre!(
+                "cannot update config: setting '{key}' to '{}' would make your configuration \
+                invalid\n\n{e}",
+                self.value,
+            )
+        })?;
+        Ok(updated)
     }
 
     fn parse_value(&self, existing_type: Option<&ValueType>) -> Result<Value> {
@@ -470,5 +483,93 @@ mod tests {
             twice,
             "[sync]\n# how often to sync\nfrequency = \"30m\" # unit is flexible\n"
         );
+    }
+
+    /// Helper for building a [`SetCmd`].
+    fn set_cmd(key: &str, value: &str) -> SetCmd {
+        SetCmd {
+            key: key.to_string(),
+            value: value.to_string(),
+            the_type: ValueType::Auto,
+        }
+    }
+
+    #[test]
+    fn writes_a_valid_value() {
+        let updated = set_cmd("search_mode", "skim")
+            .get_updated_config("search_mode = \"fuzzy\"\n")
+            .expect("skim is a valid search mode");
+
+        assert_eq!(updated, "search_mode = \"skim\"\n");
+    }
+
+    #[test]
+    fn rejects_an_invalid_value() {
+        let err = set_cmd("search_mode", "invalid")
+            .get_updated_config("search_mode = \"fuzzy\"\n")
+            .expect_err("invalid is not a valid search mode")
+            .to_string();
+
+        assert!(
+            err.contains("search_mode") && err.contains("invalid"),
+            "error should name the key and value, got: {err}"
+        );
+    }
+
+    #[test]
+    fn rejects_a_value_of_the_wrong_type_for_a_new_key() {
+        // auto_sync is absent, so type detection falls back to string
+        let err = set_cmd("auto_sync", "banana")
+            .get_updated_config("")
+            .expect_err("banana is not a bool")
+            .to_string();
+
+        assert!(
+            err.contains("auto_sync"),
+            "error should name the key, got: {err}"
+        );
+    }
+
+    #[test]
+    fn rejects_when_another_key_in_the_file_is_invalid() {
+        let err = set_cmd("auto_sync", "false")
+            .get_updated_config("style = \"nope\"\n")
+            .expect_err("style = nope is not loadable")
+            .to_string();
+
+        assert!(err.contains("style"), "error should name style, got: {err}");
+    }
+
+    #[test]
+    fn allows_replacing_an_invalid_value_with_a_valid_one() {
+        let updated = set_cmd("search_mode", "fuzzy")
+            .get_updated_config("search_mode = \"invalid\"\n")
+            .expect("fixing a broken value should be allowed");
+
+        assert_eq!(updated, "search_mode = \"fuzzy\"\n");
+    }
+
+    #[test]
+    fn preserves_comments_and_unrelated_keys() {
+        let original = "# my config\nauto_sync = true\n\n[daemon]\nenabled = false\n";
+
+        let updated = set_cmd("daemon.enabled", "true")
+            .get_updated_config(original)
+            .expect("daemon.enabled = true is valid");
+
+        assert_eq!(
+            updated,
+            "# my config\nauto_sync = true\n\n[daemon]\nenabled = true\n"
+        );
+    }
+
+    #[test]
+    fn rejects_an_empty_key() {
+        let err = set_cmd("  ", "fuzzy")
+            .get_updated_config("")
+            .expect_err("an empty key is not settable")
+            .to_string();
+
+        assert!(err.contains("non-empty"), "unexpected error: {err}");
     }
 }

--- a/crates/atuin/src/command/client/config.rs
+++ b/crates/atuin/src/command/client/config.rs
@@ -494,82 +494,71 @@ mod tests {
         }
     }
 
-    #[test]
-    fn writes_a_valid_value() {
-        let updated = set_cmd("search_mode", "skim")
-            .get_updated_config("search_mode = \"fuzzy\"\n")
-            .expect("skim is a valid search mode");
+    #[rstest]
+    #[case::a_valid_value(
+        "search_mode = \"fuzzy\"\n",
+        "search_mode",
+        "skim",
+        "search_mode = \"skim\"\n"
+    )]
+    #[case::replacing_an_invalid_value_with_a_valid_one(
+        "search_mode = \"invalid\"\n",
+        "search_mode",
+        "fuzzy",
+        "search_mode = \"fuzzy\"\n"
+    )]
+    #[case::preserving_comments_and_unrelated_keys(
+        "# my config\nauto_sync = true\n\n[daemon]\nenabled = false\n",
+        "daemon.enabled",
+        "true",
+        "# my config\nauto_sync = true\n\n[daemon]\nenabled = true\n"
+    )]
+    fn set_writes(
+        #[case] input: &str,
+        #[case] key: &str,
+        #[case] value: &str,
+        #[case] expected: &str,
+    ) {
+        let updated = set_cmd(key, value)
+            .get_updated_config(input)
+            .expect("the update should be accepted");
 
-        assert_eq!(updated, "search_mode = \"skim\"\n");
+        assert_eq!(updated, expected);
     }
 
-    #[test]
-    fn rejects_an_invalid_value() {
-        let err = set_cmd("search_mode", "invalid")
-            .get_updated_config("search_mode = \"fuzzy\"\n")
-            .expect_err("invalid is not a valid search mode")
+    /// The error should always mention every listed fragment.
+    #[rstest]
+    #[case::an_invalid_value(
+        "search_mode = \"fuzzy\"\n",
+        "search_mode",
+        "invalid",
+        &["search_mode", "invalid"]
+    )]
+    // auto_sync is absent, so type detection falls back to string
+    #[case::a_value_of_the_wrong_type_for_a_new_key("", "auto_sync", "banana", &["auto_sync"])]
+    #[case::another_key_in_the_file_being_invalid(
+        "style = \"nope\"\n",
+        "auto_sync",
+        "false",
+        &["style"]
+    )]
+    #[case::an_empty_key("", "  ", "fuzzy", &["non-empty"])]
+    fn set_rejects(
+        #[case] input: &str,
+        #[case] key: &str,
+        #[case] value: &str,
+        #[case] expected_err: &[&str],
+    ) {
+        let err = set_cmd(key, value)
+            .get_updated_config(input)
+            .expect_err("the update should be rejected")
             .to_string();
 
-        assert!(
-            err.contains("search_mode") && err.contains("invalid"),
-            "error should name the key and value, got: {err}"
-        );
-    }
-
-    #[test]
-    fn rejects_a_value_of_the_wrong_type_for_a_new_key() {
-        // auto_sync is absent, so type detection falls back to string
-        let err = set_cmd("auto_sync", "banana")
-            .get_updated_config("")
-            .expect_err("banana is not a bool")
-            .to_string();
-
-        assert!(
-            err.contains("auto_sync"),
-            "error should name the key, got: {err}"
-        );
-    }
-
-    #[test]
-    fn rejects_when_another_key_in_the_file_is_invalid() {
-        let err = set_cmd("auto_sync", "false")
-            .get_updated_config("style = \"nope\"\n")
-            .expect_err("style = nope is not loadable")
-            .to_string();
-
-        assert!(err.contains("style"), "error should name style, got: {err}");
-    }
-
-    #[test]
-    fn allows_replacing_an_invalid_value_with_a_valid_one() {
-        let updated = set_cmd("search_mode", "fuzzy")
-            .get_updated_config("search_mode = \"invalid\"\n")
-            .expect("fixing a broken value should be allowed");
-
-        assert_eq!(updated, "search_mode = \"fuzzy\"\n");
-    }
-
-    #[test]
-    fn preserves_comments_and_unrelated_keys() {
-        let original = "# my config\nauto_sync = true\n\n[daemon]\nenabled = false\n";
-
-        let updated = set_cmd("daemon.enabled", "true")
-            .get_updated_config(original)
-            .expect("daemon.enabled = true is valid");
-
-        assert_eq!(
-            updated,
-            "# my config\nauto_sync = true\n\n[daemon]\nenabled = true\n"
-        );
-    }
-
-    #[test]
-    fn rejects_an_empty_key() {
-        let err = set_cmd("  ", "fuzzy")
-            .get_updated_config("")
-            .expect_err("an empty key is not settable")
-            .to_string();
-
-        assert!(err.contains("non-empty"), "unexpected error: {err}");
+        for fragment in expected_err {
+            assert!(
+                err.contains(fragment),
+                "error should mention `{fragment}`, got: {err}"
+            );
+        }
     }
 }


### PR DESCRIPTION
Currently, `atuin config set` doesn't verify that the new settings can actually be deserialized, which means you can easily break your configuration in a way that `atuin config set` can't fix, because all `atuin` subcommands require a valid config.

This PR validates the new settings before actually writing them to disk.