### PR TITLE
chore(ci): fix `package` step

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -276,4 +276,10 @@ jobs:
           key: ${{ runner.os }}-cargo-package-${{ hashFiles('**/Cargo.lock') }}
 
       - name: Build packaged tarballs
-        run: cargo package --workspace
+        run: |
+          rm -rf ~/.cargo/registry/{cache,src}/*/atuin*
+          rm -rf target/package
+          rm -rf target/{debug,release}/libatuin*.rlib
+          rm -rf target/{debug,release}/deps/libatuin*
+          rm -rf target/{debug,release}/.fingerprint/atuin*
+          cargo package --workspace


### PR DESCRIPTION
Right now, the CI `package` step sometimes pulls the `atuin*` crates from crates.io instead of the local tree. This PR fixes that by clearing the relevant cached artifacts. Compared to the approach of reducing the cached paths (removing `target` and `~/.cargo/registry/src`), this approach builds much faster as all of the non-Atuin dependencies don't have to be compiled every time.