### PR TITLE
feat(config): add bind_up_arrow / bind_ctrl_r config option

### DIFF
--- a/crates/atuin-client/config.toml
+++ b/crates/atuin-client/config.toml
@@ -258,6 +258,14 @@ enter_accept = true
 # Defaults to false. The backspace key performs the same functionality as Tab and copies the selected line to the command line to be modified when at the start of the line.
 # accept_with_backspace = false
 
+# Defaults to true. When false, `atuin init` does not bind ↑ (native shell history remains).
+# Same effect as: atuin init <shell> --disable-up-arrow
+# bind_up_arrow = true
+
+# Defaults to true. When false, `atuin init` does not bind Ctrl-R.
+# Same effect as: atuin init <shell> --disable-ctrl-r
+# bind_ctrl_r = true
+
 [preview]
 ## which preview strategy to use to calculate the preview height (respects max_preview_height).
 ## possible values: auto, static

--- a/crates/atuin-client/src/settings.rs
+++ b/crates/atuin-client/src/settings.rs
@@ -1936,6 +1936,11 @@ mod tests {
         );
         assert!(!daemon_autostart);
 
+        let bind_up_arrow: bool = config.get("keys.bind_up_arrow")?;
+        let bind_ctrl_r: bool = config.get("keys.bind_ctrl_r")?;
+        assert!(bind_up_arrow);
+        assert!(bind_ctrl_r);
+
         Ok(())
     }
 

--- a/crates/atuin-client/src/settings.rs
+++ b/crates/atuin-client/src/settings.rs
@@ -372,6 +372,10 @@ pub struct Keys {
     pub accept_past_line_start: bool,
     pub accept_with_backspace: bool,
     pub prefix: String,
+    /// CLI `atuin init <shell> --disable-up-arrow` still disables the bind.
+    pub bind_up_arrow: bool,
+    /// CLI `atuin init <shell> --disable-ctrl-r` still disables the bind.
+    pub bind_ctrl_r: bool,
 }
 
 impl Keys {
@@ -385,6 +389,8 @@ impl Keys {
             accept_past_line_start: false,
             accept_with_backspace: false,
             prefix: "a".to_string(),
+            bind_up_arrow: true,
+            bind_ctrl_r: true,
         }
     }
 
@@ -397,6 +403,8 @@ impl Keys {
             || self.accept_past_line_start != d.accept_past_line_start
             || self.accept_with_backspace != d.accept_with_backspace
             || self.prefix != d.prefix
+            || self.bind_up_arrow != d.bind_up_arrow
+            || self.bind_ctrl_r != d.bind_ctrl_r
     }
 }
 
@@ -1438,6 +1446,8 @@ impl Settings {
             .set_default("keys.accept_past_line_start", false)?
             .set_default("keys.accept_with_backspace", false)?
             .set_default("keys.prefix", "a")?
+            .set_default("keys.bind_up_arrow", true)?
+            .set_default("keys.bind_ctrl_r", true)?
             .set_default("keymap_mode", "emacs")?
             .set_default("keymap_mode_shell", "auto")?
             .set_default("keymap_cursor", HashMap::<String, String>::new())?

--- a/crates/atuin/src/command/client/init.rs
+++ b/crates/atuin/src/command/client/init.rs
@@ -19,11 +19,11 @@ pub struct Cmd {
     shell: Shell,
 
     /// Disable the binding of CTRL-R to atuin
-    #[clap(long)]
+    #[clap(long, alias = "no-ctrl-r")]
     disable_ctrl_r: bool,
 
-    /// Disable the binding of the Up Arrow key to atuin
-    #[clap(long)]
+    /// Disable the binding of the ↑ Up Arrow key to atuin
+    #[clap(long, alias = "no-up-arrow")]
     disable_up_arrow: bool,
 
     /// Disable the binding of ? to Atuin AI
@@ -120,9 +120,10 @@ impl Cmd {
     }
 
     fn to_options<'a>(&self, settings: &'a Settings) -> StaticInitOptions<'a> {
+        // CLI --disable-* always wins; config.toml [keys] bind_* defaults true.
         StaticInitOptions {
-            enable_up_arrow: !self.disable_up_arrow,
-            enable_ctrl_r: !self.disable_ctrl_r,
+            enable_up_arrow: !self.disable_up_arrow && settings.keys.bind_up_arrow,
+            enable_ctrl_r: !self.disable_ctrl_r && settings.keys.bind_ctrl_r,
             enable_ai: !self.disable_ai && settings.ai.enabled.unwrap_or(true),
             tmux: &settings.tmux,
         }

--- a/crates/atuin/src/command/client/search/interactive.rs
+++ b/crates/atuin/src/command/client/search/interactive.rs
@@ -2345,6 +2345,8 @@ mod tests {
             accept_past_line_end: true,
             accept_past_line_start: false,
             accept_with_backspace: false,
+            bind_ctrl_r: true,
+            bind_up_arrow: true,
             prefix: "a".to_string(),
         };
 

--- a/docs/docs/configuration/config.md
+++ b/docs/docs/configuration/config.md
@@ -798,6 +798,8 @@ This section of the client config is specifically for configuring key-related se
 [keys]
 scroll_exits = [...]
 prefix = 'a'
+bind_up_arrow = true
+bind_ctrl_r = true
 ```
 
 ### `scroll_exits`
@@ -808,6 +810,32 @@ Configures whether the TUI exits, when scrolled past the last or first entry.
 
 ```toml
 scroll_exits = true
+```
+
+### `bind_up_arrow`
+
+Default: `true`
+
+When `true`, `atuin init` binds the shell up-arrow key to open Atuin search. Set to `false` to keep the shell's native history navigation for ↑ (and still use Atuin via Ctrl-R unless that is also disabled).
+
+Same effect as `atuin init <shell> --disable-up-arrow` when set to `false`.
+
+```toml
+[keys]
+bind_up_arrow = false
+```
+
+### `bind_ctrl_r`
+
+Default: `true`
+
+When `true`, `atuin init` binds Ctrl-R to Atuin search. Set to `false` to leave the shell's default reverse-search (or nothing) alone.
+
+Same effect as `atuin init <shell> --disable-ctrl-r` when set to `false`.
+
+```toml
+[keys]
+bind_ctrl_r = false
 ```
 
 ### `prefix`

--- a/docs/docs/configuration/config.md
+++ b/docs/docs/configuration/config.md
@@ -73,7 +73,7 @@ Configures whether to automatically check for updates. When enabled, Atuin
 checks `https://api.atuin.sh` for the latest release at most once per hour,
 and prints a notice if you're out of date.
 
-Set to `false` to disable. With the update check disabled and sync not set
+Set to `false` to turn it off. With the update check turned off and sync not set
 up, Atuin makes no network requests of its own.
 
 ```toml
@@ -816,7 +816,7 @@ scroll_exits = true
 
 Default: `true`
 
-When `true`, `atuin init` binds the shell up-arrow key to open Atuin search. Set to `false` to keep the shell's native history navigation for ↑ (and still use Atuin via Ctrl-R unless that is also disabled).
+When `true`, `atuin init` binds the shell up-arrow key to open Atuin search. Set to `false` to keep the shell's native history navigation for ↑ (and still use Atuin via Ctrl-R unless that's also turned off).
 
 Same effect as `atuin init <shell> --disable-up-arrow` when set to `false`.
 

--- a/docs/docs/configuration/key-binding.md
+++ b/docs/docs/configuration/key-binding.md
@@ -16,21 +16,48 @@ Our default up-arrow binding can be a bit contentious. Some people love it, some
 
 It becomes much more powerful if you consider binding a different filter mode to the up arrow. For example, on "up" Atuin can default to searching all history for the current directory only, while Ctrl-r searches history globally. See the [config](config.md#filter_mode_shell_up_key_binding) for more.
 
-Otherwise, if you don't like it, you can disable it.
+Otherwise, if you don't like it, you can disable it in either of these ways:
 
-You can also disable either the up-arrow or ++ctrl+r++ bindings individually, by passing
-`--disable-up-arrow` or `--disable-ctrl-r` to the call to `atuin init` in your shell config file:
+### Via config.toml (recommended)
 
-An example for zsh:
+In `~/.config/atuin/config.toml`:
+
+```toml
+[keys]
+bind_up_arrow = false   # keep native ↑ history; Ctrl-R still opens Atuin
+# bind_ctrl_r = false   # optional: also leave Ctrl-R alone
+```
+
+Then keep a normal init line (no extra flags):
+
 ```shell
-# Bind ctrl-r but not up arrow
+# fish
+atuin init fish | source
+
+# zsh / bash
+eval "$(atuin init zsh)"
+```
+
+### Via `atuin init` flags
+
+You can also disable either the up-arrow or ++ctrl+r++ bindings per shell by passing
+`--disable-up-arrow` (alias: `--no-up-arrow`) or `--disable-ctrl-r` (alias: `--no-ctrl-r`)
+to `atuin init`:
+
+```shell
+# fish — Ctrl-R still Atuin; ↑ is plain fish history
+atuin init fish --disable-up-arrow | source
+
+# zsh
 eval "$(atuin init zsh --disable-up-arrow)"
 
-# Bind up-arrow but not ctrl-r
+# leave up-arrow, unbind ctrl-r
 eval "$(atuin init zsh --disable-ctrl-r)"
 ```
 
-If you don't want either key to be bound, either pass both `--disable` arguments, or set the
+CLI flags and config combine with **disable wins**: if either the flag is set or the config is `false`, the key is not bound.
+
+If you don't want either key to be bound, either pass both `--disable` arguments, set both config keys to `false`, or set the
 environment variable `ATUIN_NOBIND` to any value before the call to `atuin init`:
 
 ```shell

--- a/docs/docs/configuration/key-binding.md
+++ b/docs/docs/configuration/key-binding.md
@@ -55,7 +55,7 @@ eval "$(atuin init zsh --disable-up-arrow)"
 eval "$(atuin init zsh --disable-ctrl-r)"
 ```
 
-CLI flags and config combine with **disable wins**: if either the flag is set or the config is `false`, the key is not bound.
+CLI flags and config combine with **disable wins**: if either the flag is set or the config is `false`, the key isn't bound.
 
 If you don't want either key to be bound, either pass both `--disable` arguments, set both config keys to `false`, or set the
 environment variable `ATUIN_NOBIND` to any value before the call to `atuin init`:


### PR DESCRIPTION
`--disable-up-arrow` does works but only for the current session. I'd have to edit my shell init file to add the flag, which kinda defeats the point of having a config file.

 in `~/.config/atuin/config.toml`
```shell
[keys]
bind_up_arrow = true
bind_ctrl_r = true
```

CLI flags still work and override the config if you pass them.

## Checks
- [x] I am happy for maintainers to push small adjustments to this PR, to speed up the review cycle
- [x] I have checked that there are no existing pull requests for the same thing
