### PR TITLE
fix: also set RPS1 alongside RPROMPT in OSC133 wrapper [fj4WqyCCw3C5ShR1RfB7MoBPTpkRrBFYP1uT35g3MvT]

### DIFF
--- a/crates/atuin/src/shell/atuin.zsh
+++ b/crates/atuin/src/shell/atuin.zsh
@@ -52,7 +52,7 @@ __atuin_osc133_prompt_end=$'%{\033]133;B\a%}'
 
 __atuin_osc133_wrap_prompt() {
     local __atuin_prompt="${PROMPT-}"
-    local __atuin_rprompt="${RPROMPT-}"
+    local __atuin_rprompt="${RPROMPT:-${RPS1-}}"
 
     __atuin_prompt="${__atuin_prompt//$__atuin_osc133_prompt_start/}"
     __atuin_prompt="${__atuin_prompt//$__atuin_osc133_prompt_end/}"
@@ -62,9 +62,11 @@ __atuin_osc133_wrap_prompt() {
     if [[ -n "${ATUIN_PTY_PROXY_ACTIVE:-}" ]]; then
         PROMPT="${__atuin_osc133_prompt_start}${__atuin_prompt}"
         RPROMPT="${__atuin_rprompt}${__atuin_osc133_prompt_end}"
+        RPS1="${__atuin_rprompt}${__atuin_osc133_prompt_end}"
     else
         PROMPT="$__atuin_prompt"
         RPROMPT="$__atuin_rprompt"
+        RPS1="$__atuin_rprompt"
     fi
 }
 


### PR DESCRIPTION
Fixes #3758

## Problem

The `__atuin_osc133_wrap_prompt` function reads `RPROMPT` but not `RPS1`.
In ZSH, `RPS1` and `RPROMPT` are synonyms but are **not automatically mirrored**
(unlike `PS1`/`PROMPT` which are). When a user sets `RPS1` instead of `RPROMPT`,
the OSC133 wrapper clobbers their right prompt.

## Fix

1. Read `RPS1` as a fallback when `RPROMPT` is empty
2. Also set `RPS1` when setting `RPROMPT` so both variables are kept in sync

## Test plan

- `RPS1=" <bar"` in a clean zsh shell should show the right prompt after atuin init
- `RPROMPT=" <bar"` should continue to work as before
- The OSC133 escape sequences should still be properly wrapped