### PR TITLE
fix: bundle CA certificates via reqwest rustls-tls feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -89,7 +89,7 @@ features = ["ansi", "fmt", "registry", "env-filter", "json"]
 
 [workspace.dependencies.reqwest]
 version = "0.13"
-features = ["json", "rustls-no-provider", "stream"]
+features = ["json", "rustls-tls", "stream"]
 default-features = false
 
 [workspace.dependencies.sqlx]


### PR DESCRIPTION
### Fix

reqwest was configured with the `rustls-no-provider` feature, which means no TLS provider or CA certificate bundle is included. On systems where the platform CA store is not available (e.g. certain Linux distributions without openssl-probe, or containers with minimal certificate chains), `reqwest::Client::new()` panics with:

```
Client::new(): reqwest::Error { kind: Builder, source: General("No CA certificates were loaded from the system") }
```

Fix by switching to `rustls-tls`, which bundles Mozilla's root CA certificates (via webpki-roots) and uses ring as the TLS crypto provider, matching the existing `ensure_crypto_provider()` setup.

### Closes

Closes #3369