### PR TITLE
feat(search): add Dubeolsik layout fallback

### DIFF
--- a/crates/atuin/src/command/client/search/engines.rs
+++ b/crates/atuin/src/command/client/search/engines.rs
@@ -11,7 +11,11 @@ use super::cursor::Cursor;
 #[cfg(feature = "daemon")]
 pub mod daemon;
 pub mod db;
+mod layout;
 pub mod skim;
+
+#[cfg(test)]
+mod tests;
 
 #[allow(unused)] // settings is only used if daemon feature is enabled
 pub fn engine(search_mode: SearchMode, settings: &Settings) -> Box<dyn SearchEngine> {
@@ -39,6 +43,16 @@ pub struct SearchState {
 }
 
 impl SearchState {
+    fn with_input(&self, input: String) -> Self {
+        Self {
+            input: input.into(),
+            filter_mode: self.filter_mode,
+            context: self.context.clone(),
+            custom_context: self.custom_context.clone(),
+            shells: self.shells.clone(),
+        }
+    }
+
     pub(crate) fn rotate_filter_mode(&mut self, settings: &Settings, offset: isize) {
         let mut i = settings
             .search
@@ -92,9 +106,34 @@ pub trait SearchEngine: Send + Sync + 'static {
                 .into_iter()
                 .collect::<Vec<_>>())
         } else {
-            self.full_query(state, db).await
+            let results = self.full_query(state, db).await?;
+            if !results.is_empty() || !self.corrects_dubeolsik_layout() {
+                return Ok(results);
+            }
+
+            let Some(corrected_input) = layout::dubeolsik_to_qwerty(state.input.as_str()) else {
+                return Ok(results);
+            };
+
+            self.full_query(&state.with_input(corrected_input), db)
+                .await
         }
     }
 
-    fn get_highlight_indices(&self, command: &str, search_input: &str) -> Vec<usize>;
+    fn corrects_dubeolsik_layout(&self) -> bool {
+        false
+    }
+
+    fn get_highlight_indices_for_query(&self, command: &str, search_input: &str) -> Vec<usize>;
+
+    fn get_highlight_indices(&self, command: &str, search_input: &str) -> Vec<usize> {
+        let indices = self.get_highlight_indices_for_query(command, search_input);
+        if !indices.is_empty() || !self.corrects_dubeolsik_layout() {
+            return indices;
+        }
+
+        layout::dubeolsik_to_qwerty(search_input).map_or(indices, |corrected_input| {
+            self.get_highlight_indices_for_query(command, &corrected_input)
+        })
+    }
 }

--- a/crates/atuin/src/command/client/search/engines/daemon.rs
+++ b/crates/atuin/src/command/client/search/engines/daemon.rs
@@ -222,8 +222,12 @@ impl SearchEngine for Search {
         Ok(ordered_results)
     }
 
+    fn corrects_dubeolsik_layout(&self) -> bool {
+        true
+    }
+
     #[instrument(skip_all, level = Level::TRACE, name = "daemon_highlight")]
-    fn get_highlight_indices(&self, command: &str, search_input: &str) -> Vec<usize> {
+    fn get_highlight_indices_for_query(&self, command: &str, search_input: &str) -> Vec<usize> {
         // Use fulltext highlighting for regex queries
         if Self::contains_regex_pattern(search_input) {
             return super::db::get_highlight_indices_fulltext(command, search_input);

--- a/crates/atuin/src/command/client/search/engines/db.rs
+++ b/crates/atuin/src/command/client/search/engines/db.rs
@@ -41,8 +41,12 @@ impl SearchEngine for Search {
         Ok(results)
     }
 
+    fn corrects_dubeolsik_layout(&self) -> bool {
+        self.0 == DbSearchMode::Fuzzy
+    }
+
     #[instrument(skip_all, level = Level::TRACE, name = "db_highlight")]
-    fn get_highlight_indices(&self, command: &str, search_input: &str) -> Vec<usize> {
+    fn get_highlight_indices_for_query(&self, command: &str, search_input: &str) -> Vec<usize> {
         if self.0 == DbSearchMode::Prefix {
             return vec![];
         } else if self.0 == DbSearchMode::FullText {

--- a/crates/atuin/src/command/client/search/engines/layout.rs
+++ b/crates/atuin/src/command/client/search/engines/layout.rs
@@ -1,0 +1,133 @@
+const LEADING_KEYS: [&str; 19] = [
+    "r", "R", "s", "e", "E", "f", "a", "q", "Q", "t", "T", "d", "w", "W", "c", "z", "x", "v", "g",
+];
+
+const VOWEL_KEYS: [&str; 21] = [
+    "k", "o", "i", "O", "j", "p", "u", "P", "h", "hk", "ho", "hl", "y", "n", "nj", "np", "nl", "b",
+    "m", "ml", "l",
+];
+
+const TRAILING_KEYS: [&str; 28] = [
+    "", "r", "R", "rt", "s", "sw", "sg", "e", "f", "fr", "fa", "fq", "ft", "fx", "fv", "fg", "a",
+    "q", "qt", "t", "T", "d", "w", "c", "z", "x", "v", "g",
+];
+
+pub fn dubeolsik_to_qwerty(input: &str) -> Option<String> {
+    let mut output = String::with_capacity(input.len());
+    let mut converted = false;
+
+    for character in input.chars() {
+        if let Some(keys) = jamo_keys(character) {
+            output.push_str(keys);
+            converted = true;
+        } else if let Some(keys) = syllable_keys(character) {
+            output.push_str(&keys);
+            converted = true;
+        } else {
+            output.push(character);
+        }
+    }
+
+    converted.then_some(output)
+}
+
+fn syllable_keys(character: char) -> Option<String> {
+    const FIRST_SYLLABLE: u32 = 0xac00;
+    const LAST_SYLLABLE: u32 = 0xd7a3;
+    const TRAILING_COUNT: u32 = 28;
+    const VOWEL_COUNT: u32 = 21;
+
+    let codepoint = u32::from(character);
+    if !(FIRST_SYLLABLE..=LAST_SYLLABLE).contains(&codepoint) {
+        return None;
+    }
+
+    let offset = codepoint - FIRST_SYLLABLE;
+    let leading = usize::try_from(offset / (VOWEL_COUNT * TRAILING_COUNT)).ok()?;
+    let vowel = usize::try_from((offset / TRAILING_COUNT) % VOWEL_COUNT).ok()?;
+    let trailing = usize::try_from(offset % TRAILING_COUNT).ok()?;
+
+    Some(
+        [
+            LEADING_KEYS[leading],
+            VOWEL_KEYS[vowel],
+            TRAILING_KEYS[trailing],
+        ]
+        .concat(),
+    )
+}
+
+fn jamo_keys(character: char) -> Option<&'static str> {
+    let codepoint = u32::from(character);
+
+    if ('\u{1100}'..='\u{1112}').contains(&character) {
+        return LEADING_KEYS
+            .get(usize::try_from(codepoint - 0x1100).ok()?)
+            .copied();
+    }
+    if ('\u{1161}'..='\u{1175}').contains(&character) {
+        return VOWEL_KEYS
+            .get(usize::try_from(codepoint - 0x1161).ok()?)
+            .copied();
+    }
+    if ('\u{11a8}'..='\u{11c2}').contains(&character) {
+        return TRAILING_KEYS
+            .get(usize::try_from(codepoint - 0x11a7).ok()?)
+            .copied();
+    }
+
+    match character {
+        'ㄱ' => Some("r"),
+        'ㄲ' => Some("R"),
+        'ㄳ' => Some("rt"),
+        'ㄴ' => Some("s"),
+        'ㄵ' => Some("sw"),
+        'ㄶ' => Some("sg"),
+        'ㄷ' => Some("e"),
+        'ㄸ' => Some("E"),
+        'ㄹ' => Some("f"),
+        'ㄺ' => Some("fr"),
+        'ㄻ' => Some("fa"),
+        'ㄼ' => Some("fq"),
+        'ㄽ' => Some("ft"),
+        'ㄾ' => Some("fx"),
+        'ㄿ' => Some("fv"),
+        'ㅀ' => Some("fg"),
+        'ㅁ' => Some("a"),
+        'ㅂ' => Some("q"),
+        'ㅃ' => Some("Q"),
+        'ㅄ' => Some("qt"),
+        'ㅅ' => Some("t"),
+        'ㅆ' => Some("T"),
+        'ㅇ' => Some("d"),
+        'ㅈ' => Some("w"),
+        'ㅉ' => Some("W"),
+        'ㅊ' => Some("c"),
+        'ㅋ' => Some("z"),
+        'ㅌ' => Some("x"),
+        'ㅍ' => Some("v"),
+        'ㅎ' => Some("g"),
+        'ㅏ' => Some("k"),
+        'ㅐ' => Some("o"),
+        'ㅑ' => Some("i"),
+        'ㅒ' => Some("O"),
+        'ㅓ' => Some("j"),
+        'ㅔ' => Some("p"),
+        'ㅕ' => Some("u"),
+        'ㅖ' => Some("P"),
+        'ㅗ' => Some("h"),
+        'ㅘ' => Some("hk"),
+        'ㅙ' => Some("ho"),
+        'ㅚ' => Some("hl"),
+        'ㅛ' => Some("y"),
+        'ㅜ' => Some("n"),
+        'ㅝ' => Some("nj"),
+        'ㅞ' => Some("np"),
+        'ㅟ' => Some("nl"),
+        'ㅠ' => Some("b"),
+        'ㅡ' => Some("m"),
+        'ㅢ' => Some("ml"),
+        'ㅣ' => Some("l"),
+        _ => None,
+    }
+}

--- a/crates/atuin/src/command/client/search/engines/skim.rs
+++ b/crates/atuin/src/command/client/search/engines/skim.rs
@@ -46,8 +46,12 @@ impl SearchEngine for Search {
         Ok(fuzzy_search(&self.engine, state, &self.all_history).await)
     }
 
+    fn corrects_dubeolsik_layout(&self) -> bool {
+        true
+    }
+
     #[instrument(skip_all, level = Level::TRACE, name = "skim_highlight")]
-    fn get_highlight_indices(&self, command: &str, search_input: &str) -> Vec<usize> {
+    fn get_highlight_indices_for_query(&self, command: &str, search_input: &str) -> Vec<usize> {
         let (_, indices) = self
             .engine
             .fuzzy_indices(command, search_input)

--- a/crates/atuin/src/command/client/search/engines/tests.rs
+++ b/crates/atuin/src/command/client/search/engines/tests.rs
@@ -1,0 +1,154 @@
+use async_trait::async_trait;
+use atuin_client::{
+    database::{Context, Database, DbSearchMode, Sqlite},
+    history::History,
+    settings::{FilterMode, Shells},
+};
+use eyre::Result;
+use time::OffsetDateTime;
+
+use super::{SearchEngine, SearchState, db};
+
+fn search_state(input: &str) -> SearchState {
+    SearchState {
+        input: input.to_owned().into(),
+        filter_mode: FilterMode::Global,
+        context: Context {
+            session: "test-session".to_owned(),
+            cwd: "/tmp".to_owned(),
+            hostname: "test-host".to_owned(),
+            host_id: "test-host-id".to_owned(),
+            git_root: None,
+        },
+        custom_context: None,
+        shells: Shells::All,
+    }
+}
+
+async fn database_with(commands: &[&str]) -> Sqlite {
+    let db = Sqlite::new("sqlite::memory:", 2.0).await.unwrap();
+    for command in commands {
+        let history: History = History::capture()
+            .timestamp(OffsetDateTime::now_utc())
+            .command(*command)
+            .cwd("/tmp")
+            .build()
+            .into();
+        db.save(&history).await.unwrap();
+    }
+    db
+}
+
+async fn fuzzy_commands(query: &str, commands: &[&str]) -> Vec<String> {
+    let mut database = database_with(commands).await;
+    let mut engine = db::Search(DbSearchMode::Fuzzy);
+
+    engine
+        .query(&search_state(query), &mut database)
+        .await
+        .unwrap()
+        .into_iter()
+        .map(|history| history.command)
+        .collect()
+}
+
+#[tokio::test]
+async fn native_korean_match_wins_before_layout_fallback() {
+    let mut database = database_with(&["echo 안녕", "dkssud"]).await;
+    let mut engine = db::Search(DbSearchMode::Fuzzy);
+
+    let results = engine
+        .query(&search_state("안녕"), &mut database)
+        .await
+        .unwrap();
+
+    assert_eq!(
+        results
+            .iter()
+            .map(|history| history.command.as_str())
+            .collect::<Vec<_>>(),
+        ["echo 안녕"]
+    );
+}
+
+#[derive(Default)]
+struct CountingSearch {
+    queries: Vec<String>,
+}
+
+#[async_trait]
+impl SearchEngine for CountingSearch {
+    async fn full_query(
+        &mut self,
+        state: &SearchState,
+        _database: &mut dyn Database,
+    ) -> Result<Vec<History>> {
+        self.queries.push(state.input.as_str().to_owned());
+        Ok(Vec::new())
+    }
+
+    fn corrects_dubeolsik_layout(&self) -> bool {
+        true
+    }
+
+    fn get_highlight_indices_for_query(&self, _command: &str, _search_input: &str) -> Vec<usize> {
+        Vec::new()
+    }
+}
+
+#[tokio::test]
+async fn ascii_query_does_not_retry() {
+    let mut database = database_with(&[]).await;
+    let mut engine = CountingSearch::default();
+
+    let results = engine
+        .query(&search_state("git worktree"), &mut database)
+        .await
+        .unwrap();
+
+    assert!(results.is_empty());
+    assert_eq!(engine.queries, ["git worktree"]);
+}
+
+#[tokio::test]
+async fn prefix_search_does_not_use_layout_fallback() {
+    let mut database = database_with(&["et work"]).await;
+    let mut engine = db::Search(DbSearchMode::Prefix);
+
+    let results = engine
+        .query(&search_state("ㄷㅅ 재가"), &mut database)
+        .await
+        .unwrap();
+
+    assert!(results.is_empty());
+}
+
+#[tokio::test]
+async fn search_falls_back_from_reported_dubeolsik_query() {
+    let commands = fuzzy_commands("ㄷㅅ 재가", &["et work"]).await;
+
+    assert_eq!(commands, ["et work"]);
+}
+
+#[tokio::test]
+async fn search_falls_back_for_mixed_ascii_and_dubeolsik() {
+    let commands = fuzzy_commands("git 재가", &["git work"]).await;
+
+    assert_eq!(commands, ["git work"]);
+}
+
+#[tokio::test]
+async fn search_falls_back_for_compound_dubeolsik_jamo() {
+    let commands = fuzzy_commands("ㄳㅘ", &["rthk"]).await;
+
+    assert_eq!(commands, ["rthk"]);
+}
+
+#[test]
+fn fuzzy_highlight_uses_dubeolsik_fallback() {
+    let engine = db::Search(DbSearchMode::Fuzzy);
+
+    let indices = engine.get_highlight_indices("et work", "ㄷㅅ 재가");
+
+    assert!(!indices.is_empty());
+}


### PR DESCRIPTION
Closes #3780.

## Summary

- Retry interactive fuzzy search with the corresponding QWERTY keystrokes only when the original Hangul query has no matches.
- Keep the original query visible and prefer native Korean matches.
- Apply the fallback to database, skim, and daemon fuzzy search and highlighting, while leaving prefix, full-text, and regex queries unchanged.

For example, `ㄷㅅ 재가` can find `et work`.

## Context

This complements #3559 and #3558. That work fixes Enter while CJK text is still being composed by an IME. This change handles text that has already been committed under the wrong keyboard layout. They solve different stages of the input flow and do not depend on each other.

## Testing

- `cargo fmt --check`
- `cargo clippy -p atuin --tests -- -D warnings -D clippy::redundant_clone`
- `cargo test -p atuin --bin atuin` (320 passed)
- `cargo build -p atuin`
- Manual PTY checks for reported, mixed, compound-jamo, and native-Korean queries

## Checks

- [x] I am happy for maintainers to push small adjustments to this PR, to speed up the review cycle
- [x] I have checked that there are no existing pull requests for the same thing