### PR TITLE
ci: run CodSpeed benchmarks on macro runners in walltime mode

### DIFF
--- a/.github/workflows/codspeed.yml
+++ b/.github/workflows/codspeed.yml
@@ -14,7 +14,7 @@ env:
 jobs:
   benchmarks:
     name: Run benchmarks
-    runs-on: depot-ubuntu-24.04
+    runs-on: codspeed-macro
 
     permissions:
       contents: read # required for actions/checkout
@@ -32,7 +32,7 @@ jobs:
 
       - name: Build the benchmark targets
         run: >
-          cargo codspeed build -m simulation
+          cargo codspeed build -m walltime
           -p atuin-client
           -p atuin-history
           -p atuin-nucleo-matcher
@@ -40,10 +40,6 @@ jobs:
 
       - name: Run the benchmarks
         uses: CodSpeedHQ/action@v4
-        env:
-          # daemon search bench: instrumented execution is much slower than
-          # native, so index build time at 1M+ history lines would dominate
-          BENCH_SCALES: "10000,100000"
         with:
-          mode: simulation
+          mode: walltime
           run: cargo codspeed run


### PR DESCRIPTION
<!-- Thank you for making a PR! Bug fixes are always welcome, but if you're adding a new feature or changing an existing one, we'd really appreciate if you open an issue, post on the forum, or drop in on Discord -->
Gives us a reliable machine to run benchmarks on, with no architecture changes happening randomly and producing noise

## Checks
- [ ] I am happy for maintainers to push small adjustments to this PR, to speed up the review cycle
- [ ] I have checked that there are no existing pull requests for the same thing
