### PR TITLE
fix: streamline key management on login

### DIFF
--- a/crates/atuin/src/command/client.rs
+++ b/crates/atuin/src/command/client.rs
@@ -185,7 +185,7 @@ impl Cmd {
         let theme = theme_manager.load_theme(theme_name.as_str(), settings.theme.max_depth);
 
         match self {
-            Self::Setup => setup::run(&settings).await,
+            Self::Setup => setup::run(&settings, &sqlite_store).await,
             Self::Import(import) => import.run(&db).await,
             Self::Stats(stats) => stats.run(&db, &settings, theme).await,
             Self::Search(search) => search.run(db, &mut settings, sqlite_store, theme).await,

--- a/crates/atuin/src/command/client/account/login.rs
+++ b/crates/atuin/src/command/client/account/login.rs
@@ -1,4 +1,4 @@
-use std::io;
+use std::io::{self, IsTerminal};
 
 use clap::Parser;
 use eyre::{Context, Result, bail};
@@ -68,7 +68,63 @@ impl Cmd {
             self.run_legacy_login(settings, store).await?;
         }
 
-        verify_key_against_remote(settings).await
+        // Verify the key can decrypt the data on the server, prompting for a
+        // new key until it does. Candidates are only held in memory; the
+        // store is re-encrypted once, after a key is confirmed correct.
+        let stored_key: [u8; 32] = load_key(settings)
+            .context("could not load encryption key for verification")?
+            .into();
+        let mut key = stored_key;
+
+        while !verify_key_against_remote(settings, &key).await? {
+            if self.key.is_none() && io::stdin().is_terminal() {
+                println!(
+                    "\nThat encryption key does not match the data on the server.\n\
+                     Find the correct key by running 'atuin key' on a machine that already \
+                     syncs successfully, and try again.\n"
+                );
+                eprint!("Please enter encryption key [blank to log out]: ");
+
+                let mut line = String::new();
+                let eof = io::stdin().read_line(&mut line)? == 0;
+                let input = line.trim_end_matches(['\r', '\n']).to_string();
+
+                if !eof && !input.is_empty() {
+                    match normalize_key(input) {
+                        Ok(encoded) => key = decode_key(encoded)?.into(),
+                        Err(e) => println!("{e}"),
+                    }
+                    continue;
+                }
+            }
+
+            // Give up: roll back the saved session so the user is not left
+            // half-authenticated with a key that can't read the data.
+            if let Ok(meta) = Settings::meta_store().await {
+                let _ = meta.delete_session().await;
+                let _ = meta.delete_hub_session().await;
+            }
+            crate::print_error::print_error(
+                "Wrong encryption key",
+                "The encryption key on this machine does not match the data on the server. \
+                 You have been logged out.\n\n\
+                 To fix this, find your existing key by running `atuin key` on a machine that \
+                 already syncs successfully, then run `atuin login` again here with that key.",
+            );
+            std::process::exit(1);
+        }
+
+        if key != stored_key {
+            println!("\nRe-encrypting local store with the new key");
+            store.re_encrypt(&stored_key, &key).await?;
+
+            println!("Writing new key");
+            let mut file = File::create(&settings.key_path).await?;
+            file.write_all(encode_key(Key::from_slice(&key))?.as_bytes())
+                .await?;
+        }
+
+        Ok(())
     }
 
     /// Hub login: use the browser flow unless the username was provided for headless use.
@@ -181,69 +237,70 @@ impl Cmd {
     async fn prompt_and_store_key(&self, settings: &Settings, store: &SqliteStore) -> Result<()> {
         let key_path = &settings.key_path;
 
-        println!("IMPORTANT");
+        println!("Logging in requires the encryption key for your account.");
         println!(
-            "If you are already logged in on another machine, you must ensure that the key you use here is the same as the key you used there."
+            "To get it, run 'atuin key' on a machine where you are already logged in, and paste it below."
         );
-        println!("You can find your key by running 'atuin key' on the other machine.");
         println!("Do not share this key with anyone.");
         println!(
             "\nRead more here: {} \n",
             atuin_common::docs::url("guide/sync/#login")
         );
 
-        let key = or_user_input(
-            self.key.clone(),
-            "encryption key [blank to use existing key file]",
-        );
-
-        // if provided, the key may be EITHER base64, or a bip mnemonic
-        // try to normalize on base64
-        let key = if key.is_empty() {
-            key
+        let key_prompt = if key_path.exists() {
+            "encryption key [blank to use existing key file]"
         } else {
-            // try parse the key as a mnemonic...
-            match bip39::Mnemonic::from_phrase(&key, bip39::Language::English) {
-                Ok(mnemonic) => encode_key(Key::from_slice(mnemonic.entropy()))?,
-                Err(err) => {
-                    match err {
-                        // assume they copied in the base64 key
-                        bip39::ErrorKind::InvalidWord(_) => key,
-                        bip39::ErrorKind::InvalidChecksum => {
-                            bail!("Key mnemonic is not valid")
-                        }
-                        bip39::ErrorKind::InvalidKeysize(_)
-                        | bip39::ErrorKind::InvalidWordLength(_)
-                        | bip39::ErrorKind::InvalidEntropyLength(_, _) => {
-                            bail!("Key is not the correct length")
-                        }
+            "encryption key"
+        };
+
+        // The key may be entered as base64 or as a bip39 mnemonic; keep
+        // prompting until we get something valid. A key passed via --key
+        // fails fast instead.
+        let key = match self.key.clone() {
+            Some(key) if !key.is_empty() => normalize_key(key)?,
+            Some(key) => key, // empty --key: fall through to the existing key file
+            None => loop {
+                eprint!("Please enter {key_prompt}: ");
+                let mut line = String::new();
+                let eof = io::stdin().read_line(&mut line)? == 0;
+                let input = line.trim_end_matches(['\r', '\n']).to_string();
+                let interactive = !eof && io::stdin().is_terminal();
+
+                if input.is_empty() {
+                    if key_path.exists() {
+                        break input;
                     }
+
+                    let msg = "No encryption key provided, and no existing key was found on this machine.\n\
+                               Run 'atuin key' on a machine that is already logged in to get your key.";
+                    if !interactive {
+                        bail!(msg);
+                    }
+                    println!("{msg}\n");
+                    continue;
                 }
-            }
+
+                match normalize_key(input) {
+                    Ok(encoded) => break encoded,
+                    Err(e) if interactive => println!("{e}\n"),
+                    Err(e) => return Err(e),
+                }
+            },
         };
 
         if key.is_empty() {
-            if key_path.exists() {
-                let bytes = fs_err::read_to_string(key_path).context(format!(
-                    "Existing key file at '{}' could not be read",
+            // key_path is known to exist here
+            let bytes = fs_err::read_to_string(key_path).context(format!(
+                "Existing key file at '{}' could not be read",
+                key_path.to_string_lossy()
+            ))?;
+            if decode_key(bytes).is_err() {
+                bail!(format!(
+                    "The key in existing key file at '{}' is invalid",
                     key_path.to_string_lossy()
-                ))?;
-                if decode_key(bytes).is_err() {
-                    bail!(format!(
-                        "The key in existing key file at '{}' is invalid",
-                        key_path.to_string_lossy()
-                    ));
-                }
-            } else {
-                panic!(
-                    "No key provided and no existing key file found. Please use 'atuin key' on your other machine, or recover your key from a backup"
-                )
+                ));
             }
         } else if !key_path.exists() {
-            if decode_key(key.clone()).is_err() {
-                bail!("The specified key is invalid");
-            }
-
             let mut file = File::create(key_path).await?;
             file.write_all(key.as_bytes()).await?;
         } else {
@@ -274,46 +331,55 @@ impl Cmd {
     }
 }
 
-async fn verify_key_against_remote(settings: &Settings) -> Result<()> {
-    let key: [u8; 32] = load_key(settings)
-        .context("could not load encryption key for verification")?
-        .into();
-
+/// Check that an encryption key can decrypt the data on the server.
+/// Returns `Ok(false)` if the key is wrong; transient errors (e.g. network)
+/// are treated as verified so login still succeeds.
+async fn verify_key_against_remote(settings: &Settings, key: &[u8; 32]) -> Result<bool> {
     let client = sync::build_client(settings).await?;
     let remote_index = match client.record_status().await {
         Ok(idx) => idx,
         Err(e) => {
             tracing::warn!("could not fetch remote status to verify key: {e}");
-            return Ok(());
+            return Ok(true);
         }
     };
 
-    match sync::check_encryption_key(&client, &remote_index, &key).await {
-        Ok(()) => Ok(()),
-        Err(SyncError::WrongKey) => {
-            // Roll back the saved session so the user is not left in a
-            // half-authenticated state with a key that can't read the data.
-            if let Ok(meta) = Settings::meta_store().await {
-                let _ = meta.delete_session().await;
-                let _ = meta.delete_hub_session().await;
-            }
-            crate::print_error::print_error(
-                "Wrong encryption key",
-                "The encryption key on this machine does not match the data on the server. \
-                 You have been logged out.\n\n\
-                 To fix this, find your existing key by running `atuin key` on a machine that \
-                 already syncs successfully, then run `atuin login` again here with that key.",
-            );
-            std::process::exit(1);
-        }
+    match sync::check_encryption_key(&client, &remote_index, key).await {
+        Ok(()) => Ok(true),
+        Err(SyncError::WrongKey) => Ok(false),
         Err(e) => {
-            // Non-key error (e.g. transient network issue). Don't fail the
-            // login — the user is authenticated and can sync later when the
-            // network recovers.
             tracing::warn!("could not verify encryption key against remote: {e}");
-            Ok(())
+            Ok(true)
         }
     }
+}
+
+/// A key may be entered either as base64 or as a bip39 mnemonic; normalize to
+/// the base64 encoding, validating that it decodes to a real key.
+fn normalize_key(key: String) -> Result<String> {
+    let encoded = match bip39::Mnemonic::from_phrase(&key, bip39::Language::English) {
+        Ok(mnemonic) => encode_key(Key::from_slice(mnemonic.entropy()))?,
+        Err(err) => {
+            match err {
+                // assume they copied in the base64 key
+                bip39::ErrorKind::InvalidWord(_) => key,
+                bip39::ErrorKind::InvalidChecksum => {
+                    bail!("Key mnemonic is not valid")
+                }
+                bip39::ErrorKind::InvalidKeysize(_)
+                | bip39::ErrorKind::InvalidWordLength(_)
+                | bip39::ErrorKind::InvalidEntropyLength(_, _) => {
+                    bail!("Key is not the correct length")
+                }
+            }
+        }
+    };
+
+    if decode_key(encoded.clone()).is_err() {
+        bail!("The provided key is invalid - it should be a base64 string or a 24 word mnemonic");
+    }
+
+    Ok(encoded)
 }
 
 pub(super) fn or_user_input(value: Option<String>, name: &'static str) -> String {

--- a/crates/atuin/src/command/client/setup.rs
+++ b/crates/atuin/src/command/client/setup.rs
@@ -1,11 +1,20 @@
+use atuin_client::record::sqlite_store::SqliteStore;
 use atuin_client::settings::Settings;
+#[cfg(feature = "sync")]
+use atuin_client::settings::SyncAuth;
 
 use colored::Colorize;
 use eyre::Result;
 use std::io::{self, Write};
 use toml_edit::{DocumentMut, value};
 
-pub async fn run(_settings: &Settings) -> Result<()> {
+pub async fn run(settings: &Settings, store: &SqliteStore) -> Result<()> {
+    #[cfg(feature = "sync")]
+    setup_sync(settings, store).await?;
+
+    #[cfg(not(feature = "sync"))]
+    let _ = (settings, store);
+
     let enable_ai = prompt(
         "Atuin AI",
         "This will enable command generation and other AI features via the question mark key",
@@ -57,6 +66,87 @@ pub async fn run(_settings: &Settings) -> Result<()> {
         );
     }
 
+    Ok(())
+}
+
+#[cfg(feature = "sync")]
+async fn setup_sync(settings: &Settings, store: &SqliteStore) -> Result<()> {
+    if !matches!(
+        settings.resolve_sync_auth().await,
+        SyncAuth::NotLoggedIn { .. }
+    ) {
+        println!(
+            "{check} Sync is already set up on this machine",
+            check = "✓".bold().bright_green()
+        );
+        return Ok(());
+    }
+
+    println!("> Set up {sync}?", sync = "Sync".bold().bright_blue());
+    println!("  Back up your shell history and sync it across all of your machines.");
+    println!("  Everything is end-to-end encrypted - only you can read your history.");
+    println!();
+    println!("  Do you already have an Atuin account?");
+    println!();
+    println!("  {n}) No - create a new account", n = "1".bold());
+    println!("  {n}) Yes - log in", n = "2".bold());
+    println!("  {n}) Skip sync for now", n = "3".bold());
+    println!();
+
+    let choice = loop {
+        print!("  Enter a number {q} ", q = "[1/2/3]".bold());
+        io::stdout().flush().ok();
+
+        let mut input = String::new();
+        io::stdin().read_line(&mut input)?;
+
+        match input.trim() {
+            "1" => break 1,
+            "2" => break 2,
+            "3" | "" => break 3,
+            _ => println!("  Please enter 1, 2, or 3"),
+        }
+    };
+
+    println!();
+
+    match choice {
+        1 => {
+            super::account::register::Cmd {
+                username: None,
+                password: None,
+                email: None,
+            }
+            .run(settings, store)
+            .await?;
+
+            println!(
+                "\nRun {key} to see your encryption key - store it somewhere safe.",
+                key = "'atuin key'".bold()
+            );
+            println!("You will need it to log in on other machines, and it cannot be recovered.");
+        }
+        2 => {
+            super::account::login::Cmd {
+                username: None,
+                password: None,
+                key: None,
+                totp_code: None,
+                from_registration: false,
+            }
+            .run(settings, store)
+            .await?;
+        }
+        _ => {
+            println!(
+                "  Skipping sync - you can run {register} or {login} at any time",
+                register = "'atuin register'".bold(),
+                login = "'atuin login'".bold()
+            );
+        }
+    }
+
+    println!();
     Ok(())
 }
 


### PR DESCRIPTION
Currently the setup command is a bit confusing if the user already has an account. This gives them the opportunity to provide a key

We also loop on key attempts, so a typo or mis-paste does not break the user out of signing in

- [ ] I am happy for maintainers to push small adjustments to this PR, to speed up the review cycle
- [ ] I have checked that there are no existing pull requests for the same thing
