### PR TITLE
ci: run CodSpeed walltime benchmarks on depot-macos-26

### DIFF
--- a/.github/workflows/codspeed.yml
+++ b/.github/workflows/codspeed.yml
@@ -14,7 +14,11 @@ env:
 jobs:
   benchmarks:
     name: Run benchmarks
-    runs-on: codspeed-macro
+    # Dedicated Depot machine: no queueing for the shared codspeed-macro pool
+    # and no cross-environment comparisons from mixed runner generations.
+    # Walltime mode supports arm64 macOS (the codspeed runner ships
+    # aarch64-apple-darwin builds).
+    runs-on: depot-macos-26
 
     permissions:
       contents: read # required for actions/checkout


### PR DESCRIPTION
The shared `codspeed-macro` pool has been queueing PR benchmark runs for 20+ minutes, and CodSpeed flags its comparisons with "different runtime environments detected" — the base and head runs land on different runner generations, which makes small regressions/improvements hard to trust (see the noise on #3782).

Depot's macOS runners are whole dedicated machines, so walltime numbers should be stable and comparable run to run. CodSpeed's runner ships `aarch64-apple-darwin` builds, so walltime mode is supported there.

Merging this first lets `main` record baseline benchmark data on the new runner; #3782 will then rebase and re-benchmark against a like-for-like base.