### PR TITLE
ci: switch CodSpeed back to simulation mode

### DIFF
--- a/.github/workflows/codspeed.yml
+++ b/.github/workflows/codspeed.yml
@@ -14,7 +14,11 @@ env:
 jobs:
   benchmarks:
     name: Run benchmarks
-    runs-on: codspeed-macro
+    # Dedicated Depot machine: no queueing for the shared codspeed-macro pool
+    # and no cross-environment comparisons from mixed runner generations.
+    # Walltime mode supports arm64 macOS (the codspeed runner ships
+    # aarch64-apple-darwin builds).
+    runs-on: depot-macos-26
 
     permissions:
       contents: read # required for actions/checkout

--- a/.github/workflows/codspeed.yml
+++ b/.github/workflows/codspeed.yml
@@ -14,11 +14,11 @@ env:
 jobs:
   benchmarks:
     name: Run benchmarks
-    # Dedicated Depot machine: no queueing for the shared codspeed-macro pool
-    # and no cross-environment comparisons from mixed runner generations.
-    # Walltime mode supports arm64 macOS (the codspeed runner ships
-    # aarch64-apple-darwin builds).
-    runs-on: depot-macos-26
+    # Dedicated Depot machine — no queueing for the shared codspeed-macro
+    # pool. Simulation mode is valgrind-based and Linux-only, so this can't
+    # run on the macOS runners; measurements are simulated CPU instruction
+    # counts, so runner generation and machine load don't add noise.
+    runs-on: depot-ubuntu-24.04
 
     permissions:
       contents: read # required for actions/checkout
@@ -36,7 +36,7 @@ jobs:
 
       - name: Build the benchmark targets
         run: >
-          cargo codspeed build -m walltime
+          cargo codspeed build -m simulation
           -p atuin-client
           -p atuin-history
           -p atuin-nucleo-matcher
@@ -45,5 +45,5 @@ jobs:
       - name: Run the benchmarks
         uses: CodSpeedHQ/action@v4
         with:
-          mode: walltime
+          mode: simulation
           run: cargo codspeed run


### PR DESCRIPTION
Follow-up to #3791 (already merged).

Disables walltime mode: walltime measurement has been noisy however it's hosted — the shared macro pool queues 20+ minutes and mixes runner generations (every report on #3782 carries the "different runtime environments" warning), and any real-time measurement is sensitive to machine load and thread-spawn timing. Simulation mode measures simulated CPU instruction counts, so results are deterministic regardless of runner.

One constraint discovered while checking this: **simulation mode is valgrind-based and Linux-only** — the CodSpeed runner's macOS build supports walltime only, and the action's `mode` input is required (no "no mode" option). So disabling walltime necessarily moves the job off `depot-macos-26` and back to `depot-ubuntu-24.04` (still a dedicated Depot machine, not the codspeed pool). Net effect: the original #3784 setup, plus `atuin-search-bench` in the build list.

If the intent was "keep the Mac runner but without walltime" — that combination doesn't exist in CodSpeed today; close this and keep #3791's setup instead.

Note: simulation executes each benchmark once under CPU simulation (~20-50x slowdown on execution, single iteration), so the search bench's index-build setup will dominate the job time; the run on this PR will show whether that's acceptable.