### PR TITLE
fix: Close OSC133 C when launching Atuin AI to prevent content erasure

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1669,9 +1669,9 @@ dependencies = [
 
 [[package]]
 name = "eye_declare"
-version = "0.6.3"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1cc99af3bcd67a004429420e80ab4b48d9bf0b8e5fc088baf6efe315459f6bd"
+checksum = "b213867877c012beaf72f3e7295510a43efe0c285ff3fa1d99cc4e641879ba99"
 dependencies = [
  "crossterm",
  "eye_declare_engine",
@@ -1686,9 +1686,9 @@ dependencies = [
 
 [[package]]
 name = "eye_declare_engine"
-version = "0.6.3"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b04e565ceb56e538fc2ee52b2907d3a1deda69b22d63f9f21f058ff8d443df36"
+checksum = "c9f766ef1f5a9f08cd0759b3aff638c69cca8d8b99545b390531c7e9cd9a367f"
 dependencies = [
  "ratatui-core",
  "ratatui-widgets",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -102,3 +102,8 @@ inherits = "release"
 lto = "fat"
 strip = "symbols"
 codegen-units = 1
+
+# For local development against a local eye-declare, uncomment below
+#[patch.crates-io]
+#eye_declare = { path = "../eye_declare/crates/eye_declare" }
+#eye_declare_engine = { path = "../eye_declare/crates/eye_declare_engine" }

--- a/crates/atuin-ai/Cargo.toml
+++ b/crates/atuin-ai/Cargo.toml
@@ -49,8 +49,8 @@ uuid = { workspace = true }
 tui-textarea-2 = "0.10.2"
 unicode-width = "0.2"
 # Path dependency until eye_declare 0.6.0 publishes; then just a version.
-eye_declare = "0.6.3"
-eye_declare_engine = { version = "0.6.3", features = ["test-util"] }
+eye_declare = "0.6.4"
+eye_declare_engine = { version = "0.6.4", features = ["test-util"] }
 ratatui-core = "0.1"
 ratatui-widgets = "0.3"
 thiserror = { workspace = true }

--- a/crates/atuin-ai/src/commands/init.rs
+++ b/crates/atuin-ai/src/commands/init.rs
@@ -49,6 +49,13 @@ self-atuin-ai-question-mark() {
     # If buffer is empty or just contains '?', trigger natural language mode
     if [[ -z "$BUFFER" || "$BUFFER" == "?" ]]; then
         BUFFER=""
+        # Close the semantic prompt zone (OSC 133 C, "command output
+        # starts") before handing the terminal to the TUI. Without it,
+        # terminals with shell integration (Ghostty) believe we are
+        # still at the prompt, and their resize-time prompt reflow
+        # erases everything below the prompt mark — including the
+        # conversation the TUI printed.
+        printf '\033]133;C\007' > /dev/tty
         local output
         output=$(atuin ai inline --hook 3>&1 1>&2 2>&3)
 
@@ -98,6 +105,10 @@ _atuin_ai_question_mark() {
         READLINE_LINE=""
         READLINE_POINT=0
 
+        # Close the semantic prompt zone (OSC 133 C) so terminals with
+        # shell integration don't erase the TUI's output during their
+        # resize-time prompt reflow.
+        printf '\033]133;C\007' > /dev/tty
         local output
         output=$(atuin ai inline --hook 3>&1 1>&2 2>&3)
 
@@ -159,6 +170,11 @@ function _atuin_ai_question_mark
     # If buffer is empty or just contains '?', trigger natural language mode
     if test -z "$buf" -o "$buf" = "?"
         commandline -r ""
+
+        # Close the semantic prompt zone (OSC 133 C) so terminals with
+        # shell integration don't erase the TUI's output during their
+        # resize-time prompt reflow.
+        printf '\033]133;C\007' > /dev/tty
 
         # Run atuin ai inline, swapping stdout and stderr
         set -l output (atuin ai inline --hook 3>&1 1>&2 2>&3 | string collect)


### PR DESCRIPTION
Ghostty's shell integration erases and redraws everything below the last OSC 133 prompt-start mark when the window resizes; that's how it reflows wrapped prompts. The `?` widget never accepts a command, so no "command output starts" mark is ever emitted: Ghostty still believes the screen is sitting at the prompt, and on the very first resize it wipes everything below the prompt mark (the entire conversation) leaving only what our own resize handler repaints (the tail).

The fix is in atuin's shell hooks (zsh, bash, fish): emit `\e]133;C\a` ("command output starts") right before launching the TUI.

Also upgrades eye-declare to catch the new resize fixes from https://github.com/atuinsh/eye-declare/pull/54