### PR TITLE
chore(release): prepare for release 18.19.0-beta.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,47 @@
 
 All notable changes to this project will be documented in this file.
 
+## [unreleased]
+
+### Bug Fixes
+
+- *(config)* Preserve comments in `atuin config set` ([#3766](https://github.com/atuinsh/atuin/issues/3766))
+- Fix atuin-search-bench/benches/search.rs ([#3788](https://github.com/atuinsh/atuin/issues/3788))
+- Close OSC133 C when launching Atuin AI to prevent content erasure ([#3794](https://github.com/atuinsh/atuin/issues/3794))
+
+
+### Documentation
+
+- Clarify update check network, provide build command ([#3767](https://github.com/atuinsh/atuin/issues/3767))
+- Remove old i18n docs ([#3787](https://github.com/atuinsh/atuin/issues/3787))
+
+
+### Features
+
+- *(config)* Validate new settings in `atuin config set` before writing them to disk ([#3769](https://github.com/atuinsh/atuin/issues/3769))
+- Remove word with ALT-Backspace ALT-D ([#2457](https://github.com/atuinsh/atuin/issues/2457))
+
+
+### Miscellaneous Tasks
+
+- *(ci)* Fix `package` step ([#3770](https://github.com/atuinsh/atuin/issues/3770))
+- Remove Store trait ([#3779](https://github.com/atuinsh/atuin/issues/3779))
+- Daemon search benchmark (divan + CodSpeed) ([#3763](https://github.com/atuinsh/atuin/issues/3763))
+- Run CodSpeed benchmarks on macro runners in walltime mode ([#3786](https://github.com/atuinsh/atuin/issues/3786))
+- Add `OrFilter` as a replacement for `Vec`s as filter lists ([#3768](https://github.com/atuinsh/atuin/issues/3768))
+- Add `atuin-domain` crate for shared domain types ([#3790](https://github.com/atuinsh/atuin/issues/3790))
+- Run CodSpeed walltime benchmarks on depot-macos-26 ([#3791](https://github.com/atuinsh/atuin/issues/3791))
+
+
+### Testing
+
+- Adopt rstest across the workspace test suite ([#3785](https://github.com/atuinsh/atuin/issues/3785))
+
+
+### Daemon
+
+- Replace nucleo with frizbee, rank by match quality with frecency tiebreak ([#3782](https://github.com/atuinsh/atuin/issues/3782))
+
 ## 18.18.1
 
 ### Bug Fixes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -214,7 +214,7 @@ checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "atuin"
-version = "18.18.1"
+version = "18.19.0-beta.1"
 dependencies = [
  "arboard",
  "async-trait",
@@ -281,7 +281,7 @@ dependencies = [
 
 [[package]]
 name = "atuin-ai"
-version = "18.18.1"
+version = "18.19.0-beta.1"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -338,7 +338,7 @@ dependencies = [
 
 [[package]]
 name = "atuin-client"
-version = "18.18.1"
+version = "18.19.0-beta.1"
 dependencies = [
  "async-trait",
  "atuin-common",
@@ -395,7 +395,7 @@ dependencies = [
 
 [[package]]
 name = "atuin-common"
-version = "18.18.1"
+version = "18.19.0-beta.1"
 dependencies = [
  "base64",
  "derive_more",
@@ -424,7 +424,7 @@ dependencies = [
 
 [[package]]
 name = "atuin-daemon"
-version = "18.18.1"
+version = "18.19.0-beta.1"
 dependencies = [
  "atuin-client",
  "atuin-common",
@@ -460,7 +460,7 @@ dependencies = [
 
 [[package]]
 name = "atuin-domain"
-version = "18.18.1"
+version = "18.19.0-beta.1"
 dependencies = [
  "derive_more",
  "eyre",
@@ -476,7 +476,7 @@ dependencies = [
 
 [[package]]
 name = "atuin-dotfiles"
-version = "18.18.1"
+version = "18.19.0-beta.1"
 dependencies = [
  "atuin-client",
  "atuin-common",
@@ -494,7 +494,7 @@ dependencies = [
 
 [[package]]
 name = "atuin-history"
-version = "18.18.1"
+version = "18.19.0-beta.1"
 dependencies = [
  "atuin-client",
  "codspeed-divan-compat",
@@ -508,7 +508,7 @@ dependencies = [
 
 [[package]]
 name = "atuin-kv"
-version = "18.18.1"
+version = "18.19.0-beta.1"
 dependencies = [
  "atuin-client",
  "atuin-common",
@@ -545,7 +545,7 @@ dependencies = [
 
 [[package]]
 name = "atuin-pty-proxy"
-version = "18.18.1"
+version = "18.19.0-beta.1"
 dependencies = [
  "atuin-common",
  "clap",
@@ -559,7 +559,7 @@ dependencies = [
 
 [[package]]
 name = "atuin-scripts"
-version = "18.18.1"
+version = "18.19.0-beta.1"
 dependencies = [
  "atuin-client",
  "atuin-common",
@@ -596,7 +596,7 @@ dependencies = [
 
 [[package]]
 name = "atuin-server"
-version = "18.18.1"
+version = "18.19.0-beta.1"
 dependencies = [
  "argon2",
  "atuin-common",
@@ -624,7 +624,7 @@ dependencies = [
 
 [[package]]
 name = "atuin-server-database"
-version = "18.18.1"
+version = "18.19.0-beta.1"
 dependencies = [
  "async-trait",
  "atuin-common",
@@ -640,7 +640,7 @@ dependencies = [
 
 [[package]]
 name = "atuin-server-postgres"
-version = "18.18.1"
+version = "18.19.0-beta.1"
 dependencies = [
  "async-trait",
  "atuin-common",
@@ -659,7 +659,7 @@ dependencies = [
 
 [[package]]
 name = "atuin-server-sqlite"
-version = "18.18.1"
+version = "18.19.0-beta.1"
 dependencies = [
  "async-trait",
  "atuin-common",
@@ -5330,7 +5330,7 @@ dependencies = [
 
 [[package]]
 name = "tests-database"
-version = "18.18.1"
+version = "18.19.0-beta.1"
 dependencies = [
  "async-trait",
  "atuin-common",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ resolver = "2"
 exclude = ["ui/backend", "crates/atuin-nucleo/matcher/fuzz"]
 
 [workspace.package]
-version = "18.18.1"
+version = "18.19.0-beta.1"
 authors = ["Ellie Huxtable <ellie@atuin.sh>"]
 rust-version = "1.97.0"
 license = "MIT"
@@ -18,18 +18,18 @@ readme = "README.md"
 
 [workspace.dependencies]
 async-trait = "0.1.58"
-atuin-client = { path = "crates/atuin-client", version = "18.18.1" }
-atuin-common = { path = "crates/atuin-common", version = "18.18.1" }
-atuin-daemon = { path = "crates/atuin-daemon", version = "18.18.1" }
-atuin-domain = { path = "crates/atuin-domain", version = "18.18.1" }
-atuin-dotfiles = { path = "crates/atuin-dotfiles", version = "18.18.1" }
-atuin-history = { path = "crates/atuin-history", version = "18.18.1" }
-atuin-kv = { path = "crates/atuin-kv", version = "18.18.1" }
-atuin-scripts = { path = "crates/atuin-scripts", version = "18.18.1" }
-atuin-server = { path = "crates/atuin-server", version = "18.18.1" }
-atuin-server-database = { path = "crates/atuin-server-database", version = "18.18.1" }
-atuin-server-postgres = { path = "crates/atuin-server-postgres", version = "18.18.1" }
-atuin-server-sqlite = { path = "crates/atuin-server-sqlite", version = "18.18.1" }
+atuin-client = { path = "crates/atuin-client", version = "18.19.0-beta.1" }
+atuin-common = { path = "crates/atuin-common", version = "18.19.0-beta.1" }
+atuin-daemon = { path = "crates/atuin-daemon", version = "18.19.0-beta.1" }
+atuin-domain = { path = "crates/atuin-domain", version = "18.19.0-beta.1" }
+atuin-dotfiles = { path = "crates/atuin-dotfiles", version = "18.19.0-beta.1" }
+atuin-history = { path = "crates/atuin-history", version = "18.19.0-beta.1" }
+atuin-kv = { path = "crates/atuin-kv", version = "18.19.0-beta.1" }
+atuin-scripts = { path = "crates/atuin-scripts", version = "18.19.0-beta.1" }
+atuin-server = { path = "crates/atuin-server", version = "18.19.0-beta.1" }
+atuin-server-database = { path = "crates/atuin-server-database", version = "18.19.0-beta.1" }
+atuin-server-postgres = { path = "crates/atuin-server-postgres", version = "18.19.0-beta.1" }
+atuin-server-sqlite = { path = "crates/atuin-server-sqlite", version = "18.19.0-beta.1" }
 atuin-nucleo = { path = "crates/atuin-nucleo", version = "0.6.0" }
 atuin-nucleo-matcher = { path = "crates/atuin-nucleo/matcher", version = "0.3.1" }
 frizbee = "0.11.0"

--- a/crates/atuin-client/Cargo.toml
+++ b/crates/atuin-client/Cargo.toml
@@ -77,11 +77,11 @@ strum = { version = "0.27", features = ["strum_macros"] }
 
 [dependencies.atuin-common]
 path = "../atuin-common"
-version = "18.18.1"
+version = "18.19.0-beta.1"
 
 [dependencies.atuin-domain]
 path = "../atuin-domain"
-version = "18.18.1"
+version = "18.19.0-beta.1"
 
 [dev-dependencies]
 tokio = { version = "1", features = ["full"] }
@@ -94,7 +94,7 @@ toml = "1.1"
 # This crate's tests require the `test-utils` feature in atuin-common.
 [dev-dependencies.atuin-common]
 path = "../atuin-common"
-version = "18.18.1"
+version = "18.19.0-beta.1"
 features = ["test-utils"]
 
 [[bench]]

--- a/crates/atuin-daemon/Cargo.toml
+++ b/crates/atuin-daemon/Cargo.toml
@@ -14,11 +14,11 @@ readme.workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-atuin-client = { path = "../atuin-client", version = "18.18.1" }
-atuin-common = { path = "../atuin-common", version = "18.18.1" }
+atuin-client = { path = "../atuin-client", version = "18.19.0-beta.1" }
+atuin-common = { path = "../atuin-common", version = "18.19.0-beta.1" }
 derive_more = { workspace = true }
-atuin-dotfiles = { path = "../atuin-dotfiles", version = "18.18.1" }
-atuin-history = { path = "../atuin-history", version = "18.18.1" }
+atuin-dotfiles = { path = "../atuin-dotfiles", version = "18.19.0-beta.1" }
+atuin-history = { path = "../atuin-history", version = "18.19.0-beta.1" }
 
 time = { workspace = true }
 uuid = { workspace = true }

--- a/crates/atuin-dotfiles/Cargo.toml
+++ b/crates/atuin-dotfiles/Cargo.toml
@@ -14,9 +14,9 @@ readme.workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-atuin-common = { path = "../atuin-common", version = "18.18.1" }
-atuin-domain = { path = "../atuin-domain", version = "18.18.1" }
-atuin-client = { path = "../atuin-client", version = "18.18.1" }
+atuin-common = { path = "../atuin-common", version = "18.19.0-beta.1" }
+atuin-domain = { path = "../atuin-domain", version = "18.19.0-beta.1" }
+atuin-client = { path = "../atuin-client", version = "18.19.0-beta.1" }
 derive_more = { workspace = true }
 
 eyre = { workspace = true }

--- a/crates/atuin-history/Cargo.toml
+++ b/crates/atuin-history/Cargo.toml
@@ -14,7 +14,7 @@ readme.workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-atuin-client = { path = "../atuin-client", version = "18.18.1" }
+atuin-client = { path = "../atuin-client", version = "18.19.0-beta.1" }
 
 time = { workspace = true }
 serde = { workspace = true }

--- a/crates/atuin-kv/Cargo.toml
+++ b/crates/atuin-kv/Cargo.toml
@@ -14,9 +14,9 @@ readme.workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-atuin-client = { path = "../atuin-client", version = "18.18.1" }
-atuin-common = { path = "../atuin-common", version = "18.18.1" }
-atuin-domain = { path = "../atuin-domain", version = "18.18.1" }
+atuin-client = { path = "../atuin-client", version = "18.19.0-beta.1" }
+atuin-common = { path = "../atuin-common", version = "18.19.0-beta.1" }
+atuin-domain = { path = "../atuin-domain", version = "18.19.0-beta.1" }
 derive_more = { workspace = true }
 
 tracing = { workspace = true }

--- a/crates/atuin-scripts/Cargo.toml
+++ b/crates/atuin-scripts/Cargo.toml
@@ -14,9 +14,9 @@ readme.workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-atuin-client = { path = "../atuin-client", version = "18.18.1" }
-atuin-common = { path = "../atuin-common", version = "18.18.1" }
-atuin-domain = { path = "../atuin-domain", version = "18.18.1" }
+atuin-client = { path = "../atuin-client", version = "18.19.0-beta.1" }
+atuin-common = { path = "../atuin-common", version = "18.19.0-beta.1" }
+atuin-domain = { path = "../atuin-domain", version = "18.19.0-beta.1" }
 derive_more = { workspace = true }
 
 tracing = { workspace = true }

--- a/crates/atuin-server-database/Cargo.toml
+++ b/crates/atuin-server-database/Cargo.toml
@@ -10,8 +10,8 @@ homepage = { workspace = true }
 repository = { workspace = true }
 
 [dependencies]
-atuin-common = { path = "../atuin-common", version = "18.18.1" }
-atuin-domain = { path = "../atuin-domain", version = "18.18.1" }
+atuin-common = { path = "../atuin-common", version = "18.19.0-beta.1" }
+atuin-domain = { path = "../atuin-domain", version = "18.19.0-beta.1" }
 derive_more = { workspace = true }
 
 async-trait = { workspace = true }

--- a/crates/atuin-server-postgres/Cargo.toml
+++ b/crates/atuin-server-postgres/Cargo.toml
@@ -10,9 +10,9 @@ homepage = { workspace = true }
 repository = { workspace = true }
 
 [dependencies]
-atuin-common = { path = "../atuin-common", version = "18.18.1" }
-atuin-domain = { path = "../atuin-domain", version = "18.18.1" }
-atuin-server-database = { path = "../atuin-server-database", version = "18.18.1" }
+atuin-common = { path = "../atuin-common", version = "18.19.0-beta.1" }
+atuin-domain = { path = "../atuin-domain", version = "18.19.0-beta.1" }
+atuin-server-database = { path = "../atuin-server-database", version = "18.19.0-beta.1" }
 derive_more = { workspace = true }
 
 eyre = { workspace = true }

--- a/crates/atuin-server-sqlite/Cargo.toml
+++ b/crates/atuin-server-sqlite/Cargo.toml
@@ -10,9 +10,9 @@ homepage = { workspace = true }
 repository = { workspace = true }
 
 [dependencies]
-atuin-common = { path = "../atuin-common", version = "18.18.1" }
-atuin-domain = { path = "../atuin-domain", version = "18.18.1" }
-atuin-server-database = { path = "../atuin-server-database", version = "18.18.1" }
+atuin-common = { path = "../atuin-common", version = "18.19.0-beta.1" }
+atuin-domain = { path = "../atuin-domain", version = "18.19.0-beta.1" }
+atuin-server-database = { path = "../atuin-server-database", version = "18.19.0-beta.1" }
 derive_more = { workspace = true }
 
 eyre = { workspace = true }

--- a/crates/atuin/Cargo.toml
+++ b/crates/atuin/Cargo.toml
@@ -51,14 +51,14 @@ clipboard = ["arboard"]
 check-update = ["atuin-client/check-update"]
 
 [dependencies]
-atuin-ai = { path = "../atuin-ai", version = "18.18.1", optional = true, default-features = false }
-atuin-client = { path = "../atuin-client", version = "18.18.1", optional = true, default-features = false }
+atuin-ai = { path = "../atuin-ai", version = "18.19.0-beta.1", optional = true, default-features = false }
+atuin-client = { path = "../atuin-client", version = "18.19.0-beta.1", optional = true, default-features = false }
 atuin-common = { workspace = true, features = ["unicode"] }
 atuin-domain = { workspace = true }
 atuin-dotfiles = { workspace = true }
 atuin-history = { workspace = true }
-atuin-daemon = { path = "../atuin-daemon", version = "18.18.1", optional = true, default-features = false }
-atuin-pty-proxy = { path = "../atuin-pty-proxy", version = "18.18.1", optional = true, default-features = false }
+atuin-daemon = { path = "../atuin-daemon", version = "18.19.0-beta.1", optional = true, default-features = false }
+atuin-pty-proxy = { path = "../atuin-pty-proxy", version = "18.19.0-beta.1", optional = true, default-features = false }
 atuin-scripts = { workspace = true }
 atuin-kv = { workspace = true }
 derive_more = { workspace = true }
@@ -119,7 +119,7 @@ daemonize = "0.5.0"
 # compiles cleanly. tree-sitter 0.26's portable/endian.h fails on illumos,
 # Windows cross-compiles, and potentially other exotic targets.
 [target.'cfg(any(target_os = "linux", target_os = "macos"))'.dependencies]
-atuin-ai = { path = "../atuin-ai", version = "18.18.1", optional = true, default-features = false, features = ["tree-sitter"] }
+atuin-ai = { path = "../atuin-ai", version = "18.19.0-beta.1", optional = true, default-features = false, features = ["tree-sitter"] }
 tree-sitter = { workspace = true }
 tree-sitter-bash = { workspace = true }
 tree-sitter-fish = { workspace = true }


### PR DESCRIPTION
### Bug Fixes

- *(config)* Preserve comments in `atuin config set` (#3766)
- Fix atuin-search-bench/benches/search.rs (#3788)
- Close OSC133 C when launching Atuin AI to prevent content erasure (#3794)

### Documentation

- Clarify update check network, provide build command (#3767)
- Remove old i18n docs (#3787)

### Features

- *(config)* Validate new settings in `atuin config set` before writing them to disk (#3769)
- Remove word with ALT-Backspace ALT-D (#2457)

### Miscellaneous Tasks

- *(ci)* Fix `package` step (#3770)
- Remove Store trait (#3779)
- Daemon search benchmark (divan + CodSpeed) (#3763)
- Run CodSpeed benchmarks on macro runners in walltime mode (#3786)
- Add `OrFilter` as a replacement for `Vec`s as filter lists (#3768)
- Add `atuin-domain` crate for shared domain types (#3790)
- Run CodSpeed walltime benchmarks on depot-macos-26 (#3791)

### Testing

- Adopt rstest across the workspace test suite (#3785)

### Daemon

- Replace nucleo with frizbee, rank by match quality with frecency tiebreak (#3782)