### PR TITLE
refactor(server): use Arc<dyn Database> instead of a DB type parameter

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -231,7 +231,6 @@ dependencies = [
  "atuin-scripts",
  "atuin-server",
  "atuin-server-database",
- "atuin-server-postgres",
  "clap",
  "clap_complete",
  "clap_complete_nushell",

--- a/crates/atuin-server-database/src/lib.rs
+++ b/crates/atuin-server-database/src/lib.rs
@@ -84,9 +84,7 @@ impl Debug for DbSettings {
 }
 
 #[async_trait]
-pub trait Database: Sized + Clone + Send + Sync + 'static {
-    async fn new(settings: &DbSettings) -> DbResult<Self>;
-
+pub trait Database: Send + Sync + 'static {
     async fn get_session(&self, token: &str) -> DbResult<Session>;
     async fn get_session_user(&self, token: &str) -> DbResult<User>;
     async fn add_session(&self, session: &NewSession) -> DbResult<()>;

--- a/crates/atuin-server-postgres/src/lib.rs
+++ b/crates/atuin-server-postgres/src/lib.rs
@@ -31,9 +31,8 @@ impl Postgres {
     }
 }
 
-#[async_trait]
-impl Database for Postgres {
-    async fn new(settings: &DbSettings) -> DbResult<Self> {
+impl Postgres {
+    pub async fn new(settings: &DbSettings) -> DbResult<Self> {
         let pool = PgPoolOptions::new()
             .max_connections(100)
             .connect(settings.db_uri.as_str())
@@ -92,7 +91,10 @@ impl Database for Postgres {
 
         Ok(Self { pool, read_pool })
     }
+}
 
+#[async_trait]
+impl Database for Postgres {
     #[instrument(skip_all)]
     async fn get_session(&self, token: &str) -> DbResult<Session> {
         sqlx::query_as("select id, user_id, token from sessions where token = $1")

--- a/crates/atuin-server-sqlite/src/lib.rs
+++ b/crates/atuin-server-sqlite/src/lib.rs
@@ -20,9 +20,8 @@ pub struct Sqlite {
     pool: sqlx::Pool<sqlx::sqlite::Sqlite>,
 }
 
-#[async_trait]
-impl Database for Sqlite {
-    async fn new(settings: &DbSettings) -> DbResult<Self> {
+impl Sqlite {
+    pub async fn new(settings: &DbSettings) -> DbResult<Self> {
         let opts = SqliteConnectOptions::from_str(&settings.db_uri)?
             .journal_mode(SqliteJournalMode::Wal)
             .create_if_missing(true);
@@ -36,7 +35,10 @@ impl Database for Sqlite {
 
         Ok(Self { pool })
     }
+}
 
+#[async_trait]
+impl Database for Sqlite {
     #[instrument(skip_all)]
     async fn get_session(&self, token: &str) -> DbResult<Session> {
         sqlx::query_as("select id, user_id, token from sessions where token = $1")

--- a/crates/atuin-server/src/bin/main.rs
+++ b/crates/atuin-server/src/bin/main.rs
@@ -3,12 +3,9 @@
 use std::net::SocketAddr;
 
 use atuin_server::{Settings, example_config, launch, launch_metrics_server};
-use atuin_server_database::DbType;
-use atuin_server_postgres::Postgres;
-use atuin_server_sqlite::Sqlite;
 
 use clap::Parser;
-use eyre::{Context, Result, eyre};
+use eyre::{Context, Result};
 use tracing_subscriber::{EnvFilter, fmt, prelude::*};
 
 #[derive(Parser, Debug)]
@@ -59,11 +56,7 @@ async fn main() -> Result<()> {
                 ));
             }
 
-            match settings.db_settings.db_type() {
-                DbType::Postgres => launch::<Postgres>(settings, addr).await,
-                DbType::Sqlite => launch::<Sqlite>(settings, addr).await,
-                DbType::Unknown => Err(eyre!("db_uri must start with postgres:// or sqlite://")),
-            }
+            launch(settings, addr).await
         }
         Cmd::DefaultConfig => {
             println!("{}", example_config());

--- a/crates/atuin-server/src/handlers/mod.rs
+++ b/crates/atuin-server/src/handlers/mod.rs
@@ -1,5 +1,4 @@
 use atuin_domain::api::{ErrorResponse, IndexResponse};
-use atuin_server_database::Database;
 use axum::{Json, extract::State, http, response::IntoResponse};
 
 use crate::router::AppState;
@@ -10,7 +9,7 @@ pub mod v0;
 
 const VERSION: &str = env!("CARGO_PKG_VERSION");
 
-pub async fn index<DB: Database>(state: State<AppState<DB>>) -> Json<IndexResponse> {
+pub async fn index(state: State<AppState>) -> Json<IndexResponse> {
     let homage = r#""Through the fathomless deeps of space swims the star turtle Great A'Tuin, bearing on its back the four giant elephants who carry on their shoulders the mass of the Discworld." -- Sir Terry Pratchett"#;
 
     let version = state

--- a/crates/atuin-server/src/handlers/user.rs
+++ b/crates/atuin-server/src/handlers/user.rs
@@ -21,7 +21,7 @@ use atuin_common::tls::ensure_crypto_provider;
 use super::{ErrorResponse, ErrorResponseStatus, RespExt};
 use crate::router::{AppState, UserAuth};
 use atuin_server_database::{
-    Database, DbError,
+    DbError,
     models::{NewSession, NewUser},
 };
 
@@ -64,9 +64,9 @@ async fn send_register_hook(url: &url::Url, username: String, registered: String
 }
 
 #[instrument(skip_all, fields(user.username = username.as_str()))]
-pub async fn get<DB: Database>(
+pub async fn get(
     Path(username): Path<String>,
-    state: State<AppState<DB>>,
+    state: State<AppState>,
 ) -> Result<Json<UserResponse>, ErrorResponseStatus<'static>> {
     let db = &state.0.database;
     let user = match db.get_user(username.as_ref()).await {
@@ -88,8 +88,8 @@ pub async fn get<DB: Database>(
 }
 
 #[instrument(skip_all)]
-pub async fn register<DB: Database>(
-    state: State<AppState<DB>>,
+pub async fn register(
+    state: State<AppState>,
     Json(register): Json<RegisterRequest>,
 ) -> Result<Json<RegisterResponse>, ErrorResponseStatus<'static>> {
     if !state.settings.open_registration {
@@ -164,9 +164,9 @@ pub async fn register<DB: Database>(
 }
 
 #[instrument(skip_all, fields(user.id = user.id))]
-pub async fn delete<DB: Database>(
+pub async fn delete(
     UserAuth(user): UserAuth,
-    state: State<AppState<DB>>,
+    state: State<AppState>,
 ) -> Result<Json<DeleteUserResponse>, ErrorResponseStatus<'static>> {
     debug!("request to delete user {}", user.id);
 
@@ -184,9 +184,9 @@ pub async fn delete<DB: Database>(
 }
 
 #[instrument(skip_all, fields(user.id = user.id, change_password))]
-pub async fn change_password<DB: Database>(
+pub async fn change_password(
     UserAuth(mut user): UserAuth,
-    state: State<AppState<DB>>,
+    state: State<AppState>,
     Json(change_password): Json<ChangePasswordRequest>,
 ) -> Result<Json<ChangePasswordResponse>, ErrorResponseStatus<'static>> {
     let db = &state.0.database;
@@ -214,8 +214,8 @@ pub async fn change_password<DB: Database>(
 }
 
 #[instrument(skip_all, fields(user.username = login.username.as_str()))]
-pub async fn login<DB: Database>(
-    state: State<AppState<DB>>,
+pub async fn login(
+    state: State<AppState>,
     login: Json<LoginRequest>,
 ) -> Result<Json<LoginResponse>, ErrorResponseStatus<'static>> {
     let db = &state.0.database;

--- a/crates/atuin-server/src/handlers/v0/record.rs
+++ b/crates/atuin-server/src/handlers/v0/record.rs
@@ -7,14 +7,12 @@ use crate::{
     handlers::{ErrorResponse, ErrorResponseStatus, RespExt},
     router::{AppState, UserAuth},
 };
-use atuin_server_database::Database;
-
 use atuin_domain::record::{EncryptedData, HostId, Record, RecordIdx, RecordStatus};
 
 #[instrument(skip_all, fields(user.id = user.id))]
-pub async fn post<DB: Database>(
+pub async fn post(
     UserAuth(user): UserAuth,
-    state: State<AppState<DB>>,
+    state: State<AppState>,
     Json(records): Json<Vec<Record<EncryptedData>>>,
 ) -> Result<(), ErrorResponseStatus<'static>> {
     let State(AppState { database, settings }) = state;
@@ -51,9 +49,9 @@ pub async fn post<DB: Database>(
 }
 
 #[instrument(skip_all, fields(user.id = user.id))]
-pub async fn index<DB: Database>(
+pub async fn index(
     UserAuth(user): UserAuth,
-    state: State<AppState<DB>>,
+    state: State<AppState>,
 ) -> Result<Json<RecordStatus>, ErrorResponseStatus<'static>> {
     let State(AppState {
         database,
@@ -84,10 +82,10 @@ pub struct NextParams {
 }
 
 #[instrument(skip_all, fields(user.id = user.id))]
-pub async fn next<DB: Database>(
+pub async fn next(
     params: Query<NextParams>,
     UserAuth(user): UserAuth,
-    state: State<AppState<DB>>,
+    state: State<AppState>,
 ) -> Result<Json<Vec<Record<EncryptedData>>>, ErrorResponseStatus<'static>> {
     let State(AppState {
         database,

--- a/crates/atuin-server/src/handlers/v0/store.rs
+++ b/crates/atuin-server/src/handlers/v0/store.rs
@@ -7,16 +7,14 @@ use crate::{
     handlers::{ErrorResponse, ErrorResponseStatus, RespExt},
     router::{AppState, UserAuth},
 };
-use atuin_server_database::Database;
-
 #[derive(Deserialize)]
 pub struct DeleteParams {}
 
 #[instrument(skip_all, fields(user.id = user.id))]
-pub async fn delete<DB: Database>(
+pub async fn delete(
     _params: Query<DeleteParams>,
     UserAuth(user): UserAuth,
-    state: State<AppState<DB>>,
+    state: State<AppState>,
 ) -> Result<(), ErrorResponseStatus<'static>> {
     let State(AppState {
         database,

--- a/crates/atuin-server/src/lib.rs
+++ b/crates/atuin-server/src/lib.rs
@@ -2,10 +2,13 @@
 
 use std::future::Future;
 use std::net::SocketAddr;
+use std::sync::Arc;
 
-use atuin_server_database::Database;
+use atuin_server_database::{Database, DbSettings, DbType};
+use atuin_server_postgres::Postgres;
+use atuin_server_sqlite::Sqlite;
 use axum::{Router, serve};
-use eyre::{Context, Result};
+use eyre::{Context, Result, eyre};
 
 mod handlers;
 mod metrics;
@@ -42,8 +45,8 @@ async fn shutdown_signal() {
     eprintln!("Shutting down gracefully...");
 }
 
-pub async fn launch<Db: Database>(settings: Settings, addr: SocketAddr) -> Result<()> {
-    launch_with_tcp_listener::<Db>(
+pub async fn launch(settings: Settings, addr: SocketAddr) -> Result<()> {
+    launch_with_tcp_listener(
         settings,
         TcpListener::bind(addr)
             .await
@@ -53,12 +56,12 @@ pub async fn launch<Db: Database>(settings: Settings, addr: SocketAddr) -> Resul
     .await
 }
 
-pub async fn launch_with_tcp_listener<Db: Database>(
+pub async fn launch_with_tcp_listener(
     settings: Settings,
     listener: TcpListener,
     shutdown: impl Future<Output = ()> + Send + 'static,
 ) -> Result<()> {
-    let r = make_router::<Db>(settings).await?;
+    let r = make_router(settings).await?;
 
     serve(listener, r.into_make_service())
         .with_graceful_shutdown(shutdown)
@@ -88,8 +91,20 @@ pub async fn launch_metrics_server(host: String, port: u16) -> Result<()> {
     Ok(())
 }
 
-async fn make_router<Db: Database>(settings: Settings) -> Result<Router, eyre::Error> {
-    let db = Db::new(&settings.db_settings)
+async fn connect(settings: &DbSettings) -> Result<Arc<dyn Database>> {
+    let db: Arc<dyn Database> = match settings.db_type() {
+        DbType::Postgres => Arc::new(Postgres::new(settings).await?),
+        DbType::Sqlite => Arc::new(Sqlite::new(settings).await?),
+        DbType::Unknown => {
+            return Err(eyre!("db_uri must start with postgres:// or sqlite://"));
+        }
+    };
+
+    Ok(db)
+}
+
+async fn make_router(settings: Settings) -> Result<Router, eyre::Error> {
+    let db = connect(&settings.db_settings)
         .await
         .wrap_err_with(|| format!("failed to connect to db: {:?}", settings.db_settings))?;
     let r = router::router(db, settings);

--- a/crates/atuin-server/src/router.rs
+++ b/crates/atuin-server/src/router.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use atuin_domain::api::{ATUIN_CARGO_VERSION, ATUIN_HEADER_VERSION, ErrorResponse};
 use axum::{
     Router,
@@ -21,15 +23,12 @@ use atuin_server_database::{Database, DbError, models::User};
 
 pub struct UserAuth(pub User);
 
-impl<DB: Send + Sync> FromRequestParts<AppState<DB>> for UserAuth
-where
-    DB: Database,
-{
+impl FromRequestParts<AppState> for UserAuth {
     type Rejection = ErrorResponseStatus<'static>;
 
     async fn from_request_parts(
         req: &mut Parts,
-        state: &AppState<DB>,
+        state: &AppState,
     ) -> Result<Self, Self::Rejection> {
         let auth_header = req
             .headers
@@ -101,12 +100,12 @@ async fn semver(request: Request, next: Next) -> Response {
 }
 
 #[derive(Clone)]
-pub struct AppState<DB: Database> {
-    pub database: DB,
+pub struct AppState {
+    pub database: Arc<dyn Database>,
     pub settings: Settings,
 }
 
-pub fn router<DB: Database>(database: DB, settings: Settings) -> Router {
+pub fn router(database: Arc<dyn Database>, settings: Settings) -> Router {
     let routes = Router::new()
         .route("/", get(handlers::index))
         .route("/healthz", get(handlers::health::health_check));

--- a/crates/atuin/Cargo.toml
+++ b/crates/atuin/Cargo.toml
@@ -136,4 +136,3 @@ rstest = { workspace = true }
 # TODO: Consider moving these tests to atuin-server crate instead (client would become a dev dep there)
 atuin-server = { workspace = true }
 atuin-server-database = { workspace = true }
-atuin-server-postgres = { workspace = true }

--- a/crates/atuin/tests/common/mod.rs
+++ b/crates/atuin/tests/common/mod.rs
@@ -4,7 +4,6 @@ use atuin_client::api_client;
 use atuin_common::utils::uuid_v7;
 use atuin_server::{Settings as ServerSettings, launch_with_tcp_listener};
 use atuin_server_database::DbSettings;
-use atuin_server_postgres::Postgres;
 use futures_util::TryFutureExt;
 use tokio::{net::TcpListener, sync::oneshot, task::JoinHandle};
 use tracing::{Dispatch, dispatcher};
@@ -48,7 +47,7 @@ pub async fn start_server(path: &str) -> (url::Url, oneshot::Sender<()>, JoinHan
     let server = tokio::spawn(async move {
         let _tracing_guard = dispatcher::set_default(&dispatch);
 
-        if let Err(e) = launch_with_tcp_listener::<Postgres>(
+        if let Err(e) = launch_with_tcp_listener(
             server_settings,
             listener,
             shutdown_rx.unwrap_or_else(|_| ()),

--- a/crates/tests-database/tests/db_story.rs
+++ b/crates/tests-database/tests/db_story.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use atuin_common::utils::{crypto_random_string, uuid_v7};
 use atuin_domain::record::{EncryptedData, Host, HostId, Record, RecordIdx};
 use atuin_server_database::{
@@ -45,14 +47,13 @@ async fn test_full_db_story() -> eyre::Result<()> {
     let settings = &test_db.settings;
 
     match settings.db_type() {
-        DbType::Postgres => run_the_test::<Postgres>(settings).await,
-        DbType::Sqlite => run_the_test::<Sqlite>(settings).await,
+        DbType::Postgres => run_the_test(Arc::new(Postgres::new(settings).await?)).await,
+        DbType::Sqlite => run_the_test(Arc::new(Sqlite::new(settings).await?)).await,
         DbType::Unknown => todo!(),
     }
 }
 
-async fn run_the_test<DB: Database>(settings: &DbSettings) -> eyre::Result<()> {
-    let db = DB::new(settings).await?;
+async fn run_the_test(db: Arc<dyn Database>) -> eyre::Result<()> {
     // register a user
     let new_user = NewUser {
         username: "foo".to_owned(),


### PR DESCRIPTION
## What

`atuin-server` was generic over the `Database` trait — `AppState<DB>`, `router<DB>`, the `UserAuth` extractor, and every handler carried a `<DB: Database>` parameter, monomorphized twice. But the trait has **two live implementations** (`Postgres`, `Sqlite`) selected at runtime by the `db_uri` scheme, so the generic was never resolved to a single type in practice.

This collapses the compile-time generic into a single `Arc<dyn Database>` behind dynamic dispatch. Both backends are preserved.

## Changes

- **`atuin-server-database`**: make `Database` object-safe — drop the `Sized + Clone` supertraits and the `new()` method.
- **`atuin-server-postgres` / `atuin-server-sqlite`**: move `new()` from the trait impl into an inherent `impl`.
- **`atuin-server`**: `AppState`, `router`, `UserAuth`, all handlers, and `launch`/`launch_with_tcp_listener`/`make_router` lose `<DB>`. `AppState` holds `Arc<dyn Database>` (clones as a refcount bump, matching the shared-pool semantics). Backend selection (`postgres://` vs `sqlite:`) moves out of `main.rs` into a single `connect()` helper.
- Update the two test harnesses; drop the now-unused `atuin-server-postgres` dev-dependency from `atuin`.

No behaviour change: same backends, same runtime selection.

## Verification

- `cargo check --workspace --all-targets` — clean
- `cargo clippy` on affected crates + all targets — clean
- `cargo test -p tests-database --test db_story` — passes via the `Arc<dyn Database>` path on the sqlite backend

Not run locally (needs a live Postgres): the Postgres integration test and the `atuin` sync tests. They compile.