### PR TITLE
chore(deps): bump frizbee to 0.12.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1889,9 +1889,9 @@ dependencies = [
 
 [[package]]
 name = "frizbee"
-version = "0.11.0"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a151c9ed9ab8cefc76a76b7a15292fc83575f70cf2076d238e0a3251f69738ba"
+checksum = "c0633b457eaadb5bcbee26b5b4cad3196ae4b18cfc968a353e19e7c1a944e56a"
 
 [[package]]
 name = "fs-err"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ atuin-server-postgres = { path = "crates/atuin-server-postgres", version = "18.1
 atuin-server-sqlite = { path = "crates/atuin-server-sqlite", version = "18.19.0-beta.1" }
 atuin-nucleo = { path = "crates/atuin-nucleo", version = "0.6.0" }
 atuin-nucleo-matcher = { path = "crates/atuin-nucleo/matcher", version = "0.3.1" }
-frizbee = "0.11.0"
+frizbee = "0.12.0"
 base64 = "0.22"
 crossterm = "0.29.0"
 time = { version = "0.3.47", features = [


### PR DESCRIPTION
Hey folks, this PR bumps frizbee from [v0.11.0 -> v0.12.0](https://github.com/saghen/frizbee/compare/v0.11.0...v0.12.0) which includes fixes for unicode, u8/backend selection, and some remaining arithmetic panics. I've also added a `config.scoring.max_needle_len()` to avoid the scoring panic, but haven't wired that up here since you already have a sane 512 byte limit.

Would you be interested in a follow-up PR adding opt-in support for typo resistance? In blink.cmp, we do this via `max_typos = Some(needle.len() / 4)`

Thanks for adopting the project and for the really generous sponsorship! It's pretty surreal seeing my fuzzy matcher end up in projects I use daily :)