### PR TITLE
feat(client): show intent in inspector

### DIFF
--- a/crates/atuin/src/command/client/search/inspector.rs
+++ b/crates/atuin/src/command/client/search/inspector.rs
@@ -139,6 +139,10 @@ pub fn draw_stats_table(
         ]),
         Row::new(vec!["Exit".to_string(), history.exit.to_string()]),
         Row::new(vec!["Directory".to_string(), history.cwd.clone()]),
+        Row::new(vec![
+            "Intent".to_string(),
+            history.intent.clone().unwrap_or_default(),
+        ]),
         Row::new(vec!["Session".to_string(), history.session.clone()]),
         Row::new(vec!["Total runs".to_string(), stats.total.to_string()]),
     ];


### PR DESCRIPTION
## What

Add an **Intent** row to the interactive search inspector's "Command stats" table (the Ctrl-O view).

## Why

The `intent` field — the rationale/metadata attached to a history entry via `ATUIN_HISTORY_INTENT` or `atuin history start --intent` — is already captured and stored on `History`, and is exposed by `atuin history list` / `atuin last` through the `{intent}` format key. However, the interactive inspector never surfaced it, so there was no way to see an entry's intent from within the Ctrl+R UI.

This adds a single row to the stats table, rendering `history.intent` (empty when unset), right after Directory. No new config, no behavior change when intent is absent.

## Screenshot (behavior)

```
┌Command stats───────────────────────────────────┐
│Directory /path/to/repo                          │
│Intent    feature/awesome-work                   │
│Session   019fb483f8127981b3355ac7773e24d3       │
│Total runs 1                                     │
└─────────────────────────────────────────────────┘
```

## Notes

One motivating use case: a shell `preexec` hook that sets `ATUIN_HISTORY_INTENT` to the current git branch, making the branch visible per-command in the inspector.