### PR TITLE
chore: fix deny.toml and get it to run in CI

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -262,25 +262,9 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
-      - name: Install rust
-        uses: dtolnay/rust-toolchain@master
+      - uses: EmbarkStudios/cargo-deny-action@v2
         with:
-          toolchain: 1.97.0
-
-      - uses: taiki-e/install-action@v2
-        name: Install cargo-deny
-        with:
-          tool: cargo-deny
-
-      - uses: actions/cache@v6
-        with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-          key: ${{ runner.os }}-cargo-deny-${{ hashFiles('**/Cargo.lock') }}
-
-      - name: Run cargo deny
-        run: cargo deny check
+          command: check
 
   package:
     runs-on: depot-ubuntu-24.04

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -256,6 +256,32 @@ jobs:
       - name: Format
         run: cargo fmt -- --check
 
+  deny:
+    runs-on: depot-ubuntu-24.04
+
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Install rust
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: 1.97.0
+
+      - uses: taiki-e/install-action@v2
+        name: Install cargo-deny
+        with:
+          tool: cargo-deny
+
+      - uses: actions/cache@v6
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+          key: ${{ runner.os }}-cargo-deny-${{ hashFiles('**/Cargo.lock') }}
+
+      - name: Run cargo deny
+        run: cargo deny check
+
   package:
     runs-on: depot-ubuntu-24.04
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1156,14 +1156,14 @@ checksum = "baf0a07a401f374238ab8e2f11a104d2851bf9ce711ec69804834de8af45c7af"
 
 [[package]]
 name = "config"
-version = "0.15.21"
+version = "0.15.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fe5feec195269515c4722937cd7ffcfe7b4205d18d2e6577b7223ecb159ab00"
+checksum = "b85f248a4de22d204ceabc6299d89d2c70fbd7f09fea53c06c852369652d8139"
 dependencies = [
  "pathdiff",
  "serde_core",
  "toml",
- "winnow 0.7.15",
+ "winnow",
 ]
 
 [[package]]
@@ -5551,7 +5551,7 @@ dependencies = [
  "toml_datetime",
  "toml_parser",
  "toml_writer",
- "winnow 1.0.3",
+ "winnow",
 ]
 
 [[package]]
@@ -5573,7 +5573,7 @@ dependencies = [
  "toml_datetime",
  "toml_parser",
  "toml_writer",
- "winnow 1.0.3",
+ "winnow",
 ]
 
 [[package]]
@@ -5582,7 +5582,7 @@ version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
 dependencies = [
- "winnow 1.0.3",
+ "winnow",
 ]
 
 [[package]]
@@ -6700,15 +6700,6 @@ name = "windows_x86_64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
-
-[[package]]
-name = "winnow"
-version = "0.7.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
-dependencies = [
- "memchr",
-]
 
 [[package]]
 name = "winnow"

--- a/crates/atuin-search-bench/Cargo.toml
+++ b/crates/atuin-search-bench/Cargo.toml
@@ -2,6 +2,7 @@
 name = "atuin-search-bench"
 version = "0.1.0"
 edition = "2021"
+license = { workspace = true }
 publish = false
 
 # Not a distributable app; without this dist treats the bench binary as a

--- a/deny.toml
+++ b/deny.toml
@@ -53,29 +53,15 @@ db-urls = ["https://github.com/rustsec/advisory-db"]
 unmaintained = "none"
 yanked = "warn"
 ignore = [
-    # potential to misuse ed25519-dalek 1.0
-    # used by rusty-paseto. not in a vulnerable way
-    # and we don't even use paseto public key crypto so we don't use this
-    "RUSTSEC-2022-0093",
-    # DoS with untrusted input. Only runs on the client so not a concern
-    "RUSTSEC-2021-0041",
-    # quadratic-time duplicate-attribute check in quick-xml 0.39.4, pulled in
-    # transitively via arboard -> wl-clipboard-rs -> wayland-client ->
-    # wayland-scanner (Linux Wayland clipboard support). wayland-scanner
-    # 0.31.9 hard-pins `quick-xml = "^0.39"`; the patched release is 0.41.0,
-    # a semver-incompatible major bump `cargo update -p quick-xml` cannot
-    # reach (confirmed: no 0.39.x patched release exists upstream). Risk is
-    # effectively nil: wayland-scanner is a proc-macro crate, so quick-xml
-    # only ever runs during `cargo build` (proc-macro expansion) parsing
-    # static, trusted `.xml` protocol spec files bundled in the
-    # wayland-protocols(-wlr) crate sources to codegen Rust bindings — it is
-    # not linked into the shipped atuin binary and never parses
-    # attacker-supplied/runtime input. Re-evaluate when
-    # wayland-scanner/wl-clipboard-rs bumps its quick-xml requirement.
+    # Pulled in through
+    #   arboard ->
+    #     wl-clipboard-rs ->
+    #       wayland-client ->
+    #         wayland-scanner ->
+    #           quick-xml 0.39.4 <-- problematic
+    #
+    # No upstream patch. Runs only on client, no severe concern.
     "RUSTSEC-2026-0194",
-    # Unbounded namespace-declaration allocation in quick-xml 0.39.4. Same
-    # dependency chain, same blocker, and same low-risk rationale as
-    # RUSTSEC-2026-0194 above.
     "RUSTSEC-2026-0195",
 ]
 
@@ -89,28 +75,16 @@ ignore = [
 # `default = "deny"` / `unlicensed = "deny"` intent.
 allow = [
     "Apache-2.0",
-    # Boost Software License 1.0 (permissive; NOT the Business Source License,
-    # which is "BUSL-1.1"). Needed by clipboard-win, error-code (both via
-    # arboard's Windows clipboard backend) and xxhash-rust.
     "BSL-1.0",
     "BSD-3-Clause",
-    # CC0-1.0 (public-domain dedication). Needed by notify (file watching).
     "CC0-1.0",
-    # CDLA-Permissive-2.0 (permissive). Needed by webpki-roots / webpki-root-certs,
-    # part of the rustls trust-root stack currently on main.
     "CDLA-Permissive-2.0",
     "ISC",
     "MIT",
     "MPL-2.0",
     "OpenSSL",
-    # SPDX identifier used by the icu4x crate family (icu_collections,
-    # icu_locale_core, icu_normalizer(_data), icu_properties(_data),
-    # icu_provider, litemap, potential_utf, tinystr, writeable, yoke(-derive),
-    # zerofrom(-derive), zerotrie, zerovec(-derive)) pulled in transitively via
-    # idna/url, and by unicode-ident (via proc-macro2).
     "Unicode-3.0",
     "Unicode-DFS-2016",
-    # Zlib license. Needed by foldhash (via hashbrown).
     "Zlib",
 ]
 confidence-threshold = 0.8

--- a/deny.toml
+++ b/deny.toml
@@ -6,8 +6,8 @@ no-default-features = false
 [advisories]
 db-path = "~/.cargo/advisory-db"
 db-urls = ["https://github.com/rustsec/advisory-db"]
-unmaintained = "none"
-yanked = "warn"
+unmaintained = "workspace"
+yanked = "deny"
 ignore = [
     # Pulled in through
     #   arboard ->
@@ -19,6 +19,8 @@ ignore = [
     # No upstream patch. Runs only on client, no severe concern.
     "RUSTSEC-2026-0194",
     "RUSTSEC-2026-0195",
+    # daemonize (RUSTSEC-2025-0069): unmaintained, no maintained replacement.
+    "RUSTSEC-2025-0069",
 ]
 
 [licenses]
@@ -40,8 +42,8 @@ exceptions = [
 ]
 
 [bans]
-multiple-versions = "allow"
-wildcards = "warn"
+multiple-versions = "warn"
+wildcards = "deny"
 highlight = "all"
 workspace-default-features = "allow"
 external-default-features = "allow"
@@ -51,4 +53,6 @@ skip = []
 skip-tree = []
 
 [sources]
-unknown-registry = "warn"
+unknown-registry = "deny"
+unknown-git = "deny"
+allow-registry = ["https://github.com/rust-lang/crates.io-index"]

--- a/deny.toml
+++ b/deny.toml
@@ -11,6 +11,13 @@
 
 # Root options
 
+# NOTE(2026-07-30, native-tls migration Task 6): cargo-deny 0.16+ moved these
+# root-level fields into a [graph] table (see
+# https://github.com/EmbarkStudios/cargo-deny/pull/611). This repo's deny.toml
+# hadn't been exercised against a current cargo-deny release; migrated the
+# schema minimally here (values unchanged) purely so `cargo deny check` can run
+# at all. Unrelated to the TLS migration itself.
+[graph]
 targets = []
 all-features = true
 no-default-features = false
@@ -21,10 +28,30 @@ no-default-features = false
 [advisories]
 db-path = "~/.cargo/advisory-db"
 db-urls = ["https://github.com/rustsec/advisory-db"]
-vulnerability = "deny"
-unmaintained = "warn"
+# `vulnerability` and `notice` lint-level fields were removed in cargo-deny 0.16.
+# For `vulnerability` this is a no-op: it's now always denied unless
+# individually listed in `ignore` below, matching the old `vulnerability =
+# "deny"`. For `notice` this is a STRICTER default: the old config used
+# `notice = "warn"` (checked, non-fatal); notice advisories are now always
+# denied unless individually `ignore`d, same as vulnerabilities.
+#
+# `unmaintained` changed from a lint level to a Scope (all/workspace/
+# transitive/none). The original config used `warn` (checked, non-fatal),
+# which has no direct equivalent under the new scheme: any scope other than
+# `none` makes an in-scope unmaintained crate a hard `deny`, there is no
+# "checked but non-fatal" option anymore.
+#
+# Tried `workspace` (checks direct deps of workspace crates) per a 2026-07-30
+# review request: it correctly flags `daemonize` v0.5.0 (RUSTSEC-2025-0069,
+# a direct dependency of `atuin`, unmaintained since 2023, no safe upgrade
+# available) as a genuine, new failure. Tried `transitive` too: it comes back
+# green, but only because of its scope semantics (Scope::Transitive skips
+# any unmaintained crate that IS a direct dependency of a workspace member,
+# which is the exact opposite of what we want visibility into) -- not a real
+# fix, so not adopted. Kept `none` rather than force green with a blanket
+# ignore for `daemonize`.
+unmaintained = "none"
 yanked = "warn"
-notice = "warn"
 ignore = [
     # potential to misuse ed25519-dalek 1.0
     # used by rusty-paseto. not in a vulnerable way
@@ -32,26 +59,60 @@ ignore = [
     "RUSTSEC-2022-0093",
     # DoS with untrusted input. Only runs on the client so not a concern
     "RUSTSEC-2021-0041",
+    # quadratic-time duplicate-attribute check in quick-xml 0.39.4, pulled in
+    # transitively via arboard -> wl-clipboard-rs -> wayland-client ->
+    # wayland-scanner (Linux Wayland clipboard support). wayland-scanner
+    # 0.31.9 hard-pins `quick-xml = "^0.39"`; the patched release is 0.41.0,
+    # a semver-incompatible major bump `cargo update -p quick-xml` cannot
+    # reach (confirmed: no 0.39.x patched release exists upstream). Risk is
+    # effectively nil: wayland-scanner is a proc-macro crate, so quick-xml
+    # only ever runs during `cargo build` (proc-macro expansion) parsing
+    # static, trusted `.xml` protocol spec files bundled in the
+    # wayland-protocols(-wlr) crate sources to codegen Rust bindings — it is
+    # not linked into the shipped atuin binary and never parses
+    # attacker-supplied/runtime input. Re-evaluate when
+    # wayland-scanner/wl-clipboard-rs bumps its quick-xml requirement.
+    "RUSTSEC-2026-0194",
+    # Unbounded namespace-declaration allocation in quick-xml 0.39.4. Same
+    # dependency chain, same blocker, and same low-risk rationale as
+    # RUSTSEC-2026-0194 above.
+    "RUSTSEC-2026-0195",
 ]
 
 # This section is considered when running `cargo deny check licenses`
 # More documentation for the licenses section can be found here:
 # https://embarkstudios.github.io/cargo-deny/checks/licenses/cfg.html
 [licenses]
-unlicensed = "deny"
+# `unlicensed`, `deny`, `copyleft`, `allow-osi-fsf-free`, and `default` fields
+# were removed in cargo-deny 0.16: everything not explicitly allowed via `allow`
+# or `exceptions` below is now denied, which matches this repo's prior
+# `default = "deny"` / `unlicensed = "deny"` intent.
 allow = [
     "Apache-2.0",
+    # Boost Software License 1.0 (permissive; NOT the Business Source License,
+    # which is "BUSL-1.1"). Needed by clipboard-win, error-code (both via
+    # arboard's Windows clipboard backend) and xxhash-rust.
+    "BSL-1.0",
     "BSD-3-Clause",
+    # CC0-1.0 (public-domain dedication). Needed by notify (file watching).
+    "CC0-1.0",
+    # CDLA-Permissive-2.0 (permissive). Needed by webpki-roots / webpki-root-certs,
+    # part of the rustls trust-root stack currently on main.
+    "CDLA-Permissive-2.0",
     "ISC",
     "MIT",
     "MPL-2.0",
     "OpenSSL",
+    # SPDX identifier used by the icu4x crate family (icu_collections,
+    # icu_locale_core, icu_normalizer(_data), icu_properties(_data),
+    # icu_provider, litemap, potential_utf, tinystr, writeable, yoke(-derive),
+    # zerofrom(-derive), zerotrie, zerovec(-derive)) pulled in transitively via
+    # idna/url, and by unicode-ident (via proc-macro2).
+    "Unicode-3.0",
     "Unicode-DFS-2016",
+    # Zlib license. Needed by foldhash (via hashbrown).
+    "Zlib",
 ]
-deny = []
-copyleft = "warn"
-allow-osi-fsf-free = "neither"
-default = "deny"
 confidence-threshold = 0.8
 exceptions = []
 

--- a/deny.toml
+++ b/deny.toml
@@ -1,55 +1,11 @@
-# This template contains all of the possible sections and their default values
-
-# Note that all fields that take a lint level have these possible values:
-# * deny - An error will be produced and the check will fail
-# * warn - A warning will be produced, but the check will not fail
-# * allow - No warning or error will be produced, though in some cases a note
-# will be
-
-# The values provided in this template are the default values that will be used
-# when any section or field is not specified in your own configuration
-
-# Root options
-
-# NOTE(2026-07-30, native-tls migration Task 6): cargo-deny 0.16+ moved these
-# root-level fields into a [graph] table (see
-# https://github.com/EmbarkStudios/cargo-deny/pull/611). This repo's deny.toml
-# hadn't been exercised against a current cargo-deny release; migrated the
-# schema minimally here (values unchanged) purely so `cargo deny check` can run
-# at all. Unrelated to the TLS migration itself.
 [graph]
 targets = []
 all-features = true
 no-default-features = false
 
-# This section is considered when running `cargo deny check advisories`
-# More documentation for the advisories section can be found here:
-# https://embarkstudios.github.io/cargo-deny/checks/advisories/cfg.html
 [advisories]
 db-path = "~/.cargo/advisory-db"
 db-urls = ["https://github.com/rustsec/advisory-db"]
-# `vulnerability` and `notice` lint-level fields were removed in cargo-deny 0.16.
-# For `vulnerability` this is a no-op: it's now always denied unless
-# individually listed in `ignore` below, matching the old `vulnerability =
-# "deny"`. For `notice` this is a STRICTER default: the old config used
-# `notice = "warn"` (checked, non-fatal); notice advisories are now always
-# denied unless individually `ignore`d, same as vulnerabilities.
-#
-# `unmaintained` changed from a lint level to a Scope (all/workspace/
-# transitive/none). The original config used `warn` (checked, non-fatal),
-# which has no direct equivalent under the new scheme: any scope other than
-# `none` makes an in-scope unmaintained crate a hard `deny`, there is no
-# "checked but non-fatal" option anymore.
-#
-# Tried `workspace` (checks direct deps of workspace crates) per a 2026-07-30
-# review request: it correctly flags `daemonize` v0.5.0 (RUSTSEC-2025-0069,
-# a direct dependency of `atuin`, unmaintained since 2023, no safe upgrade
-# available) as a genuine, new failure. Tried `transitive` too: it comes back
-# green, but only because of its scope semantics (Scope::Transitive skips
-# any unmaintained crate that IS a direct dependency of a workspace member,
-# which is the exact opposite of what we want visibility into) -- not a real
-# fix, so not adopted. Kept `none` rather than force green with a blanket
-# ignore for `daemonize`.
 unmaintained = "none"
 yanked = "warn"
 ignore = [
@@ -65,14 +21,7 @@ ignore = [
     "RUSTSEC-2026-0195",
 ]
 
-# This section is considered when running `cargo deny check licenses`
-# More documentation for the licenses section can be found here:
-# https://embarkstudios.github.io/cargo-deny/checks/licenses/cfg.html
 [licenses]
-# `unlicensed`, `deny`, `copyleft`, `allow-osi-fsf-free`, and `default` fields
-# were removed in cargo-deny 0.16: everything not explicitly allowed via `allow`
-# or `exceptions` below is now denied, which matches this repo's prior
-# `default = "deny"` / `unlicensed = "deny"` intent.
 allow = [
     "Apache-2.0",
     "BSL-1.0",
@@ -82,26 +31,12 @@ allow = [
     "ISC",
     "MIT",
     "MPL-2.0",
-    "OpenSSL",
     "Unicode-3.0",
-    "Unicode-DFS-2016",
     "Zlib",
 ]
 confidence-threshold = 0.8
 exceptions = []
 
-# Some crates don't have (easily) machine readable licensing information,
-# adding a clarification entry for it allows you to manually specify the
-# licensing information
-[[licenses.clarify]]
-name = "ring"
-version = "*"
-expression = "MIT AND ISC AND OpenSSL"
-license-files = [{ path = "LICENSE", hash = 0xbd0eed23 }]
-
-# This section is considered when running `cargo deny check bans`.
-# More documentation about the 'bans' section can be found here:
-# https://embarkstudios.github.io/cargo-deny/checks/bans/cfg.html
 [bans]
 multiple-versions = "allow"
 wildcards = "warn"
@@ -113,26 +48,5 @@ deny = []
 skip = []
 skip-tree = []
 
-# This section is considered when running `cargo deny check sources`.
-# More documentation about the 'sources' section can be found here:
-# https://embarkstudios.github.io/cargo-deny/checks/sources/cfg.html
 [sources]
-# Lint level for what to happen when a crate from a crate registry that is not
-# in the allow list is encountered
 unknown-registry = "warn"
-# Lint level for what to happen when a crate from a git repository that is not
-# in the allow list is encountered
-unknown-git = "warn"
-# List of URLs for allowed crate registries. Defaults to the crates.io index
-# if not specified. If it is specified but empty, no registries are allowed.
-allow-registry = ["https://github.com/rust-lang/crates.io-index"]
-# List of URLs for allowed Git repositories
-allow-git = []
-
-[sources.allow-org]
-# 1 or more github.com organizations to allow git sources for
-github = []
-# 1 or more gitlab.com organizations to allow git sources for
-gitlab = []
-# 1 or more bitbucket.org organizations to allow git sources for
-bitbucket = []

--- a/deny.toml
+++ b/deny.toml
@@ -26,7 +26,6 @@ allow = [
     "Apache-2.0",
     "BSL-1.0",
     "BSD-3-Clause",
-    "CC0-1.0",
     "CDLA-Permissive-2.0",
     "ISC",
     "MIT",
@@ -35,7 +34,10 @@ allow = [
     "Zlib",
 ]
 confidence-threshold = 0.8
-exceptions = []
+exceptions = [
+    # CC0-1.0 waives copyright but not patents; allow it only for notify.
+    { crate = "notify", allow = ["CC0-1.0"] },
+]
 
 [bans]
 multiple-versions = "allow"


### PR DESCRIPTION
- `deny.toml` was malformed. [`0.16`](https://github.com/EmbarkStudios/cargo-deny/blob/main/CHANGELOG.md#0160---2024-08-02) changed the schema, so we needed to fix that.
- added some licenses that we were lacking
- added ci for `cargo-deny`