### PR TITLE
docs: self-hosting connection tips (curl test, http sync_address, k8s external IP)

### DIFF
--- a/docs/docs/configuration/config.md
+++ b/docs/docs/configuration/config.md
@@ -90,6 +90,17 @@ The address of the server to sync with!
 sync_address = "https://api.atuin.sh"
 ```
 
+If you [self-host](../self-hosting/server-setup.md) without a reverse proxy
+terminating TLS, sync over plain `http://` using the server's address and port
+directly. `https://` will fail to connect unless you've set up your own
+certificate. For example:
+
+```toml
+sync_address = "http://192.168.1.10:8888"
+# or a hostname on your network
+sync_address = "http://atuin.homelab.lan:8888"
+```
+
 ### `sync_frequency`
 
 Default: `1h`

--- a/docs/docs/self-hosting/kubernetes.md
+++ b/docs/docs/self-hosting/kubernetes.md
@@ -229,6 +229,9 @@ You should also change the password string in `ATUIN_DB_PASSWORD` and `ATUIN_DB_
 
 The Atuin service is exposed on port `30530` of the host system. That's configured by the `nodePort` property. Kubernetes has a strict rule that you aren't allowed to expose a port numbered lower than 30000. To make the clients work, set the port in your `config.toml` file, for example `sync_address = "http://192.168.1.10:30530"`.
 
+!!! note
+    If you sync from devices that aren't part of the cluster (laptops, Raspberry Pis, or other machines on your network), point `sync_address` at an IP those devices can actually reach — a node's external IP with the `NodePort` above, or a `LoadBalancer` service if your cluster provides one (for example via [MetalLB](https://metallb.io/) on bare-metal k3s). A `ClusterIP` is only reachable from inside the cluster.
+
 Deploy the Atuin server using `kubectl`:
 
 ```shell

--- a/docs/docs/self-hosting/server-setup.md
+++ b/docs/docs/self-hosting/server-setup.md
@@ -66,6 +66,22 @@ ATUIN_DB_URI="sqlite:///config/atuin.db"
 
 These will create the database in the `/config` directory. Be sure to map a persistent volume to the `/config` directory that's writable by the Atuin server.
 
+### Testing the connection
+
+Once the server is running, check that it's reachable from a client machine with `curl`:
+
+```shell
+curl http://<server-address>:<port>
+```
+
+A healthy server responds with HTTP `200` and a small JSON body:
+
+```json
+{"homage":"\"Through the fathomless deeps of space swims the star turtle Great A'Tuin, bearing on its back the four giant elephants who carry on their shoulders the mass of the Discworld.\" -- Sir Terry Pratchett","version":"18.18.0"}
+```
+
+If that works, use the same address and port for the client's [`sync_address`](../configuration/config.md#sync_address). Use `http://` rather than `https://` unless you've put a reverse proxy with TLS in front of the server.
+
 ### TLS
 
 For TLS/HTTPS support, we recommend using a reverse proxy such as nginx, Caddy, or Traefik in front of the Atuin server. This is the standard approach for containerized applications and provides better flexibility for certificate management.


### PR DESCRIPTION
Closes #2291.