### PR TITLE
fix: copy vendored axoasset into docker builder stage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,9 @@ FROM chef AS builder
 RUN apt update && apt install build-essential libssl-dev pkg-config -y
 
 COPY --from=planner /app/recipe.json recipe.json
+# The recipe references the [patch.crates-io] axoasset path dependency, but
+# cargo-chef does not skeleton patched crates, so the real sources are needed
+COPY vendor vendor
 RUN cargo chef cook --release --recipe-path recipe.json
 
 COPY . .


### PR DESCRIPTION
## Problem

The `build-docker` workflow has been failing on main since #3813 landed:

```
error: failed to load source for dependency `axoasset`
Caused by:
  failed to read `/app/vendor/axoasset/Cargo.toml`
Caused by:
  No such file or directory (os error 2)
thread 'main' panicked at .../cargo-chef-0.1.77/src/recipe.rs:224:27
```

#3813 added `[patch.crates-io] axoasset = { path = "vendor/axoasset" }`. cargo-chef's recipe skeletons workspace members and their path dependencies, but not crates pulled in via a `[patch]` path — so the `cargo chef cook` step in the builder stage tries to read the real `vendor/axoasset/Cargo.toml`, which was never copied into that layer.

## Fix

Copy `vendor/` into the builder stage before `cargo chef cook`. Vendor changes are rare, so this barely affects layer caching.

## Verification

Reproduced and verified outside docker with the exact toolchain from the image (rust 1.97.0, cargo-chef 0.1.77): `cargo chef prepare` + `cook --release` in a bare directory fails with the identical panic; with `vendor/` copied alongside the recipe, cook completes cleanly (451 crates, exit 0).

## Checks
- [x] I am happy for maintainers to push small adjustments to this PR, to speed up the review cycle
- [x] I have checked that there are no existing pull requests for the same thing