### PR TITLE
fix(search): fuzzy ranking operator coverage

### DIFF
--- a/crates/atuin-client/benches/ordering.rs
+++ b/crates/atuin-client/benches/ordering.rs
@@ -15,5 +15,5 @@ fn reorder_fuzzy_bench(bencher: divan::Bencher, n: usize) {
             let mut ctx = BenchCtx::new();
             BenchHistory::count(&mut ctx, n)
         })
-        .bench_values(|histories| reorder_fuzzy(DbSearchMode::Fuzzy, "curl", histories));
+        .bench_values(|histories| reorder_fuzzy(DbSearchMode::Fuzzy, &["curl"], histories));
 }

--- a/crates/atuin-client/benches/ordering.rs
+++ b/crates/atuin-client/benches/ordering.rs
@@ -14,5 +14,5 @@ fn reorder_fuzzy_bench(bencher: divan::Bencher, n: usize) {
             let mut ctx = BenchCtx::new();
             BenchHistory::count(&mut ctx, n)
         })
-        .bench_values(|histories| reorder_fuzzy(DbSearchMode::Fuzzy, "curl", histories));
+        .bench_values(|histories| reorder_fuzzy(DbSearchMode::Fuzzy, &["curl"], histories));
 }

--- a/crates/atuin-client/src/database.rs
+++ b/crates/atuin-client/src/database.rs
@@ -1921,23 +1921,18 @@ mod test {
     }
 
     // Which signal decides the order of two matched rows, given the tighter match is always the
-    // older of the two. Distinguishes a legitimate tie from ranking not happening at all: both put
-    // the newer row first, but only one of them is correct.
+    // older of the two.
     #[derive(Debug, Clone, Copy)]
     enum RankedBy {
         // The tighter match wins despite being older.
         Span,
-        // Both rows score the same span, so recency correctly breaks the tie.
+        // Both rows score alike, so recency correctly breaks the tie.
         TiedSpan,
-        // No row matches the ranking query, so every key is usize::MAX and the stable sort leaves
-        // SQL's recency order untouched. Ranking is off.
-        NothingScored,
     }
 
-    // Characterises which query shapes the span scorer can actually rank. Each term is ranked
-    // independently, matching how SQL emits one condition per term, so the surviving
-    // `NothingScored` rows are all the same defect: SQL matched by folding case, which the span
-    // scorer does not.
+    // Every query shape the tokenizer can produce, and how it ranks. Each term is scored on its own
+    // against the command, mirroring the one condition per term SQL emits, so a shape ranks
+    // whenever any term discriminates between the rows and ties only when none does.
     #[rstest]
     // A lone term, and terms in the order they appear in the command, rank correctly.
     #[case::plain_term("screen", &["screen"], ("screen", "search green"), RankedBy::Span)]
@@ -1970,10 +1965,10 @@ mod test {
     // Each row matches one branch equally tightly, so there is nothing to choose between them.
     #[case::alternation("foo | bar", &["foo", "bar"], ("foo", "bar"), RankedBy::TiedSpan)]
     #[case::alternation_three_way("foo | bar | qux", &["foo", "bar", "qux"], ("foo", "bar"), RankedBy::TiedSpan)]
-    // SQL matched only by case folding, which LIKE does and the span scorer does not. Unaffected by
-    // an uppercase term elsewhere in the query: each term picks LIKE or GLOB on its own.
-    #[case::lowercase_term_matching_uppercase("ls", &["ls"], ("LS", "L x S"), RankedBy::NothingScored)]
-    #[case::mixed_case_lowercase_term("ls FOO", &["ls", "FOO"], ("LS FOO", "LS x FOO"), RankedBy::NothingScored)]
+    // A lowercase term folds case for ranking exactly as LIKE did for matching. Each term decides
+    // that on its own, so an uppercase term elsewhere in the query does not disturb it.
+    #[case::lowercase_term_matching_uppercase("ls", &["ls"], ("LS", "L x S"), RankedBy::Span)]
+    #[case::mixed_case_lowercase_term("ls FOO", &["ls", "FOO"], ("LS FOO", "LS x FOO"), RankedBy::Span)]
     #[tokio::test(flavor = "multi_thread")]
     async fn test_search_fuzzy_operator_ranking(
         #[case] query: &str,
@@ -1997,7 +1992,7 @@ mod test {
         // Recency puts `looser` first, so only span scoring can surface `tighter`.
         let expected_first = match ranked_by {
             RankedBy::Span => tighter,
-            RankedBy::TiedSpan | RankedBy::NothingScored => looser,
+            RankedBy::TiedSpan => looser,
         };
         assert_eq!(
             results[0].command,

--- a/crates/atuin-client/src/database.rs
+++ b/crates/atuin-client/src/database.rs
@@ -1814,23 +1814,18 @@ mod test {
     }
 
     // Which signal decides the order of two matched rows, given the tighter match is always the
-    // older of the two. Distinguishes a legitimate tie from ranking not happening at all: both put
-    // the newer row first, but only one of them is correct.
+    // older of the two.
     #[derive(Debug, Clone, Copy)]
     enum RankedBy {
         // The tighter match wins despite being older.
         Span,
-        // Both rows score the same span, so recency correctly breaks the tie.
+        // Both rows score alike, so recency correctly breaks the tie.
         TiedSpan,
-        // No row matches the ranking query, so every key is usize::MAX and the stable sort leaves
-        // SQL's recency order untouched. Ranking is off.
-        NothingScored,
     }
 
-    // Characterises which query shapes the span scorer can actually rank. Each term is ranked
-    // independently, matching how SQL emits one condition per term, so the surviving
-    // `NothingScored` rows are all the same defect: SQL matched by folding case, which the span
-    // scorer does not.
+    // Every query shape the tokenizer can produce, and how it ranks. Each term is scored on its own
+    // against the command, mirroring the one condition per term SQL emits, so a shape ranks
+    // whenever any term discriminates between the rows and ties only when none does.
     #[rstest]
     // A lone term, and terms in the order they appear in the command, rank correctly.
     #[case::plain_term("screen", &["screen"], ("screen", "search green"), RankedBy::Span)]
@@ -1863,10 +1858,10 @@ mod test {
     // Each row matches one branch equally tightly, so there is nothing to choose between them.
     #[case::alternation("foo | bar", &["foo", "bar"], ("foo", "bar"), RankedBy::TiedSpan)]
     #[case::alternation_three_way("foo | bar | qux", &["foo", "bar", "qux"], ("foo", "bar"), RankedBy::TiedSpan)]
-    // SQL matched only by case folding, which LIKE does and the span scorer does not. Unaffected by
-    // an uppercase term elsewhere in the query: each term picks LIKE or GLOB on its own.
-    #[case::lowercase_term_matching_uppercase("ls", &["ls"], ("LS", "L x S"), RankedBy::NothingScored)]
-    #[case::mixed_case_lowercase_term("ls FOO", &["ls", "FOO"], ("LS FOO", "LS x FOO"), RankedBy::NothingScored)]
+    // A lowercase term folds case for ranking exactly as LIKE did for matching. Each term decides
+    // that on its own, so an uppercase term elsewhere in the query does not disturb it.
+    #[case::lowercase_term_matching_uppercase("ls", &["ls"], ("LS", "L x S"), RankedBy::Span)]
+    #[case::mixed_case_lowercase_term("ls FOO", &["ls", "FOO"], ("LS FOO", "LS x FOO"), RankedBy::Span)]
     #[tokio::test(flavor = "multi_thread")]
     async fn test_search_fuzzy_operator_ranking(
         #[case] query: &str,
@@ -1890,7 +1885,7 @@ mod test {
         // Recency puts `looser` first, so only span scoring can surface `tighter`.
         let expected_first = match ranked_by {
             RankedBy::Span => tighter,
-            RankedBy::TiedSpan | RankedBy::NothingScored => looser,
+            RankedBy::TiedSpan => looser,
         };
         assert_eq!(
             results[0].command,

--- a/crates/atuin-client/src/database.rs
+++ b/crates/atuin-client/src/database.rs
@@ -806,8 +806,8 @@ impl Database for Sqlite {
             .fetch_all(&self.pool)
             .await?;
 
-        let reorder_query = fuzzy_ranking_query(orig_query);
-        Ok(ordering::reorder_fuzzy(search_mode, &reorder_query, res))
+        let reorder_terms = fuzzy_ranking_terms(orig_query);
+        Ok(ordering::reorder_fuzzy(search_mode, &reorder_terms, res))
     }
 
     async fn query_history(&self, query: &str) -> Result<Vec<History>> {
@@ -1126,10 +1126,10 @@ impl SqlBuilderExt for SqlBuilder {
     }
 }
 
-/// The characters the span scorer ranks on. SQL matches on the tokenizer's plain terms, so the
-/// ranking query must drop everything SQL never matched literally: whitespace, the `| ^ $ ' r/../`
-/// operators, and negated terms, whose characters SQL excluded rather than required.
-fn fuzzy_ranking_query(query: &str) -> String {
+/// The terms the span scorer ranks on. SQL matches on the tokenizer's plain terms, so ranking must
+/// drop everything SQL never matched literally: whitespace, the `| ^ $ ' r/../` operators, and
+/// negated terms, whose characters SQL excluded rather than required.
+fn fuzzy_ranking_terms(query: &str) -> Vec<&str> {
     QueryTokenizer::new(query)
         .filter(|token| !token.is_inverse())
         .filter_map(|token| match token {
@@ -1934,48 +1934,50 @@ mod test {
         NothingScored,
     }
 
-    // Characterises which query shapes the span scorer can actually rank. The ranking query is a
-    // single concatenation of the plain terms, but SQL emits one independent condition per term,
-    // so any shape where the two disagree leaves every row unscored. `NothingScored` rows are
-    // defects, recorded here to pin current behaviour.
+    // Characterises which query shapes the span scorer can actually rank. Each term is ranked
+    // independently, matching how SQL emits one condition per term, so the surviving
+    // `NothingScored` rows are all the same defect: SQL matched by folding case, which the span
+    // scorer does not.
     #[rstest]
     // A lone term, and terms in the order they appear in the command, rank correctly.
-    #[case::plain_term("screen", "screen", ("screen", "search green"), RankedBy::Span)]
-    #[case::terms_in_command_order("foo bar", "foobar", ("foo bar", "foo qux bar"), RankedBy::Span)]
-    #[case::exact_word_terms("'foo 'bar", "foobar", ("foo bar", "foo qux bar"), RankedBy::Span)]
-    // Anchors rank as long as no term sits on the impossible side of them.
-    #[case::start_anchor_then_term("^foo bar", "foobar", ("foo bar", "foo qux bar"), RankedBy::Span)]
-    #[case::term_then_end_anchor("foo screen$", "fooscreen", ("foo screen", "foo x screen"), RankedBy::Span)]
+    #[case::plain_term("screen", &["screen"], ("screen", "search green"), RankedBy::Span)]
+    #[case::terms_in_command_order("foo bar", &["foo", "bar"], ("foo bar", "foo qux bar"), RankedBy::Span)]
+    #[case::exact_word_terms("'foo 'bar", &["foo", "bar"], ("foo bar", "foo qux bar"), RankedBy::Span)]
+    // Terms SQL matches independently rank independently, in whichever order the command has them.
+    #[case::terms_out_of_command_order("bar foo", &["bar", "foo"], ("foo bar", "foo qux bar"), RankedBy::Span)]
+    // Anchors rank from either side: a term is no longer required to follow the anchored one.
+    #[case::start_anchor_then_term("^foo bar", &["foo", "bar"], ("foo bar", "foo qux bar"), RankedBy::Span)]
+    #[case::term_before_start_anchor("bar ^foo", &["bar", "foo"], ("foo bar", "foo qux bar"), RankedBy::Span)]
+    #[case::term_then_end_anchor("foo screen$", &["foo", "screen"], ("foo screen", "foo x screen"), RankedBy::Span)]
+    #[case::term_after_end_anchor("screen$ foo", &["screen", "foo"], ("foo screen", "foo x screen"), RankedBy::Span)]
     // A negated term is a filter, not a ranking signal, so it drops out and the rest still ranks.
-    #[case::negated_term("foo screen !zzz", "fooscreen", ("foo screen", "foo x screen"), RankedBy::Span)]
-    #[case::negated_start_anchor("bar !^foo", "bar", ("bar", "b a r"), RankedBy::Span)]
+    #[case::negated_term("foo screen !zzz", &["foo", "screen"], ("foo screen", "foo x screen"), RankedBy::Span)]
+    #[case::negated_start_anchor("bar !^foo", &["bar"], ("bar", "b a r"), RankedBy::Span)]
     // An uppercase term switches SQL to case-sensitive GLOB, which agrees with the span scorer.
-    #[case::uppercase_term("LS", "LS", ("LS", "L x S"), RankedBy::Span)]
-    #[case::mixed_case_uppercase_term("LS foo", "LSfoo", ("LS foo", "LS x foo"), RankedBy::Span)]
+    #[case::uppercase_term("LS", &["LS"], ("LS", "L x S"), RankedBy::Span)]
+    #[case::mixed_case_uppercase_term("LS foo", &["LS", "foo"], ("LS foo", "LS x foo"), RankedBy::Span)]
     // A regex is a filter too; the plain term alongside it still ranks.
-    #[case::regex_with_term("r/screen/ foo", "foo", ("foo screen", "f o o screen"), RankedBy::Span)]
+    #[case::regex_with_term("r/screen/ foo", &["foo"], ("foo screen", "f o o screen"), RankedBy::Span)]
+    // Only one alternation branch is present per row, so ranking runs on the branch that matched.
+    #[case::alternation_ranks_matched_branch("foo | bar", &["foo", "bar"], ("foo", "f o o"), RankedBy::Span)]
+    // Matching more of the query outranks matching less of it, however tight the lesser match is.
+    #[case::alternation_prefers_matching_both("foo | bar", &["foo", "bar"], ("foo bar", "foo"), RankedBy::Span)]
     // Nothing left to rank on, or nothing to tell the rows apart. Recency is the right answer.
-    #[case::regex_only("r/screen/", "", ("foo screen", "foo x screen"), RankedBy::TiedSpan)]
-    #[case::negated_term_only("!zzz", "", ("foo screen", "foo x screen"), RankedBy::TiedSpan)]
-    #[case::start_anchor_only("^foo", "foo", ("foo bar", "foo qux bar"), RankedBy::TiedSpan)]
-    #[case::end_anchor_only("screen$", "screen", ("foo screen", "foo x screen"), RankedBy::TiedSpan)]
-    // Terms SQL matches independently, but the concatenation demands them in query order.
-    #[case::terms_out_of_command_order("bar foo", "barfoo", ("foo bar", "foo qux bar"), RankedBy::NothingScored)]
-    // SQL requires either branch; the concatenation demands every one of them.
-    #[case::alternation("foo | bar", "foobar", ("foo", "bar"), RankedBy::NothingScored)]
-    #[case::alternation_three_way("foo | bar | qux", "foobarqux", ("foo", "bar"), RankedBy::NothingScored)]
-    // `^foo` pins foo at offset 0, so nothing in the concatenation can precede it.
-    #[case::term_before_start_anchor("bar ^foo", "barfoo", ("foo bar", "foo qux bar"), RankedBy::NothingScored)]
-    // `screen$` pins screen at the end, so nothing in the concatenation can follow it.
-    #[case::term_after_end_anchor("screen$ foo", "screenfoo", ("foo screen", "foo x screen"), RankedBy::NothingScored)]
+    #[case::regex_only("r/screen/", &[], ("foo screen", "foo x screen"), RankedBy::TiedSpan)]
+    #[case::negated_term_only("!zzz", &[], ("foo screen", "foo x screen"), RankedBy::TiedSpan)]
+    #[case::start_anchor_only("^foo", &["foo"], ("foo bar", "foo qux bar"), RankedBy::TiedSpan)]
+    #[case::end_anchor_only("screen$", &["screen"], ("foo screen", "foo x screen"), RankedBy::TiedSpan)]
+    // Each row matches one branch equally tightly, so there is nothing to choose between them.
+    #[case::alternation("foo | bar", &["foo", "bar"], ("foo", "bar"), RankedBy::TiedSpan)]
+    #[case::alternation_three_way("foo | bar | qux", &["foo", "bar", "qux"], ("foo", "bar"), RankedBy::TiedSpan)]
     // SQL matched only by case folding, which LIKE does and the span scorer does not. Unaffected by
     // an uppercase term elsewhere in the query: each term picks LIKE or GLOB on its own.
-    #[case::lowercase_term_matching_uppercase("ls", "ls", ("LS", "L x S"), RankedBy::NothingScored)]
-    #[case::mixed_case_lowercase_term("ls FOO", "lsFOO", ("LS FOO", "LS x FOO"), RankedBy::NothingScored)]
+    #[case::lowercase_term_matching_uppercase("ls", &["ls"], ("LS", "L x S"), RankedBy::NothingScored)]
+    #[case::mixed_case_lowercase_term("ls FOO", &["ls", "FOO"], ("LS FOO", "LS x FOO"), RankedBy::NothingScored)]
     #[tokio::test(flavor = "multi_thread")]
     async fn test_search_fuzzy_operator_ranking(
         #[case] query: &str,
-        #[case] expected_ranking_query: &str,
+        #[case] expected_terms: &[&str],
         #[case] rows: (&str, &str),
         #[case] ranked_by: RankedBy,
     ) {
@@ -1983,9 +1985,9 @@ mod test {
         let db = db_with_ages(&[tighter, looser]).await;
 
         assert_eq!(
-            fuzzy_ranking_query(query),
-            expected_ranking_query,
-            "ranking query for {query:?}"
+            fuzzy_ranking_terms(query),
+            expected_terms,
+            "ranking terms for {query:?}"
         );
 
         let results = assert_search_eq(&db, DbSearchMode::Fuzzy, FilterMode::Global, query, 2)

--- a/crates/atuin-client/src/database.rs
+++ b/crates/atuin-client/src/database.rs
@@ -811,17 +811,7 @@ impl Sqlite {
         let res =
             sqlx::query_as::<_, History>(sqlx::AssertSqlSafe(query)).fetch_all(&self.pool).await?;
 
-        // Rank against the same characters SQL matched: drop spaces, operators and negated terms.
-        let reorder_query: String = QueryTokenizer::new(orig_query)
-            .filter(|token| !token.is_inverse())
-            .filter_map(|token| match token {
-                QueryToken::Match(term, _)
-                | QueryToken::MatchStart(term, _)
-                | QueryToken::MatchEnd(term, _)
-                | QueryToken::MatchFull(term, _) => Some(term),
-                QueryToken::Or | QueryToken::Regex(_) => None,
-            })
-            .collect();
+        let reorder_query = fuzzy_ranking_query(orig_query);
         Ok(ordering::reorder_fuzzy(search_mode, &reorder_query, res))
     }
 
@@ -1119,6 +1109,22 @@ impl SqlBuilderExt for SqlBuilder {
             self.and_where(cond)
         }
     }
+}
+
+/// The characters the span scorer ranks on. SQL matches on the tokenizer's plain terms, so the
+/// ranking query must drop everything SQL never matched literally: whitespace, the `| ^ $ ' r/../`
+/// operators, and negated terms, whose characters SQL excluded rather than required.
+fn fuzzy_ranking_query(query: &str) -> String {
+    QueryTokenizer::new(query)
+        .filter(|token| !token.is_inverse())
+        .filter_map(|token| match token {
+            QueryToken::Match(term, _)
+            | QueryToken::MatchStart(term, _)
+            | QueryToken::MatchEnd(term, _)
+            | QueryToken::MatchFull(term, _) => Some(term),
+            QueryToken::Or | QueryToken::Regex(_) => None,
+        })
+        .collect()
 }
 
 pub struct QueryTokenizer<'a> {

--- a/crates/atuin-client/src/database.rs
+++ b/crates/atuin-client/src/database.rs
@@ -1489,6 +1489,24 @@ mod test {
         assert_eq!(loaded.len(), 1200);
     }
 
+    // Inserts oldest-first with well-separated timestamps, so recency order is the reverse of the
+    // argument order rather than a product of clock resolution.
+    async fn db_with_ages(commands: &[&str]) -> Sqlite {
+        let mut db = Sqlite::new("sqlite::memory:", test_local_timeout())
+            .await
+            .unwrap();
+
+        let now = OffsetDateTime::now_utc();
+        for (i, command) in commands.iter().enumerate() {
+            let age = time::Duration::hours((commands.len() - i) as i64);
+            new_history_item_at(&mut db, command, Some(now - age))
+                .await
+                .unwrap();
+        }
+
+        db
+    }
+
     async fn db_with(commands: &[&str]) -> Sqlite {
         let mut db = Sqlite::new("sqlite::memory:", test_local_timeout())
             .await
@@ -1900,6 +1918,91 @@ mod test {
             vec!["use screen"],
         )
         .await;
+    }
+
+    // Which signal decides the order of two matched rows, given the tighter match is always the
+    // older of the two. Distinguishes a legitimate tie from ranking not happening at all: both put
+    // the newer row first, but only one of them is correct.
+    #[derive(Debug, Clone, Copy)]
+    enum RankedBy {
+        // The tighter match wins despite being older.
+        Span,
+        // Both rows score the same span, so recency correctly breaks the tie.
+        TiedSpan,
+        // No row matches the ranking query, so every key is usize::MAX and the stable sort leaves
+        // SQL's recency order untouched. Ranking is off.
+        NothingScored,
+    }
+
+    // Characterises which query shapes the span scorer can actually rank. The ranking query is a
+    // single concatenation of the plain terms, but SQL emits one independent condition per term,
+    // so any shape where the two disagree leaves every row unscored. `NothingScored` rows are
+    // defects, recorded here to pin current behaviour.
+    #[rstest]
+    // A lone term, and terms in the order they appear in the command, rank correctly.
+    #[case::plain_term("screen", "screen", ("screen", "search green"), RankedBy::Span)]
+    #[case::terms_in_command_order("foo bar", "foobar", ("foo bar", "foo qux bar"), RankedBy::Span)]
+    #[case::exact_word_terms("'foo 'bar", "foobar", ("foo bar", "foo qux bar"), RankedBy::Span)]
+    // Anchors rank as long as no term sits on the impossible side of them.
+    #[case::start_anchor_then_term("^foo bar", "foobar", ("foo bar", "foo qux bar"), RankedBy::Span)]
+    #[case::term_then_end_anchor("foo screen$", "fooscreen", ("foo screen", "foo x screen"), RankedBy::Span)]
+    // A negated term is a filter, not a ranking signal, so it drops out and the rest still ranks.
+    #[case::negated_term("foo screen !zzz", "fooscreen", ("foo screen", "foo x screen"), RankedBy::Span)]
+    #[case::negated_start_anchor("bar !^foo", "bar", ("bar", "b a r"), RankedBy::Span)]
+    // An uppercase term switches SQL to case-sensitive GLOB, which agrees with the span scorer.
+    #[case::uppercase_term("LS", "LS", ("LS", "L x S"), RankedBy::Span)]
+    #[case::mixed_case_uppercase_term("LS foo", "LSfoo", ("LS foo", "LS x foo"), RankedBy::Span)]
+    // A regex is a filter too; the plain term alongside it still ranks.
+    #[case::regex_with_term("r/screen/ foo", "foo", ("foo screen", "f o o screen"), RankedBy::Span)]
+    // Nothing left to rank on, or nothing to tell the rows apart. Recency is the right answer.
+    #[case::regex_only("r/screen/", "", ("foo screen", "foo x screen"), RankedBy::TiedSpan)]
+    #[case::negated_term_only("!zzz", "", ("foo screen", "foo x screen"), RankedBy::TiedSpan)]
+    #[case::start_anchor_only("^foo", "foo", ("foo bar", "foo qux bar"), RankedBy::TiedSpan)]
+    #[case::end_anchor_only("screen$", "screen", ("foo screen", "foo x screen"), RankedBy::TiedSpan)]
+    // Terms SQL matches independently, but the concatenation demands them in query order.
+    #[case::terms_out_of_command_order("bar foo", "barfoo", ("foo bar", "foo qux bar"), RankedBy::NothingScored)]
+    // SQL requires either branch; the concatenation demands every one of them.
+    #[case::alternation("foo | bar", "foobar", ("foo", "bar"), RankedBy::NothingScored)]
+    #[case::alternation_three_way("foo | bar | qux", "foobarqux", ("foo", "bar"), RankedBy::NothingScored)]
+    // `^foo` pins foo at offset 0, so nothing in the concatenation can precede it.
+    #[case::term_before_start_anchor("bar ^foo", "barfoo", ("foo bar", "foo qux bar"), RankedBy::NothingScored)]
+    // `screen$` pins screen at the end, so nothing in the concatenation can follow it.
+    #[case::term_after_end_anchor("screen$ foo", "screenfoo", ("foo screen", "foo x screen"), RankedBy::NothingScored)]
+    // SQL matched only by case folding, which LIKE does and the span scorer does not. Unaffected by
+    // an uppercase term elsewhere in the query: each term picks LIKE or GLOB on its own.
+    #[case::lowercase_term_matching_uppercase("ls", "ls", ("LS", "L x S"), RankedBy::NothingScored)]
+    #[case::mixed_case_lowercase_term("ls FOO", "lsFOO", ("LS FOO", "LS x FOO"), RankedBy::NothingScored)]
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_search_fuzzy_operator_ranking(
+        #[case] query: &str,
+        #[case] expected_ranking_query: &str,
+        #[case] rows: (&str, &str),
+        #[case] ranked_by: RankedBy,
+    ) {
+        let (tighter, looser) = rows;
+        let db = db_with_ages(&[tighter, looser]).await;
+
+        assert_eq!(
+            fuzzy_ranking_query(query),
+            expected_ranking_query,
+            "ranking query for {query:?}"
+        );
+
+        let results = assert_search_eq(&db, DbSearchMode::Fuzzy, FilterMode::Global, query, 2)
+            .await
+            .unwrap();
+
+        // Recency puts `looser` first, so only span scoring can surface `tighter`.
+        let expected_first = match ranked_by {
+            RankedBy::Span => tighter,
+            RankedBy::TiedSpan | RankedBy::NothingScored => looser,
+        };
+        assert_eq!(
+            results[0].command,
+            expected_first,
+            "{query:?} should rank by {ranked_by:?}, got: {:?}",
+            results.iter().map(|h| &h.command).collect::<Vec<_>>()
+        );
     }
 
     #[rstest]

--- a/crates/atuin-client/src/database.rs
+++ b/crates/atuin-client/src/database.rs
@@ -811,8 +811,8 @@ impl Sqlite {
         let res =
             sqlx::query_as::<_, History>(sqlx::AssertSqlSafe(query)).fetch_all(&self.pool).await?;
 
-        let reorder_query = fuzzy_ranking_query(orig_query);
-        Ok(ordering::reorder_fuzzy(search_mode, &reorder_query, res))
+        let reorder_terms = fuzzy_ranking_terms(orig_query);
+        Ok(ordering::reorder_fuzzy(search_mode, &reorder_terms, res))
     }
 
     #[instrument(level = "trace", skip_all, err)]
@@ -1111,10 +1111,10 @@ impl SqlBuilderExt for SqlBuilder {
     }
 }
 
-/// The characters the span scorer ranks on. SQL matches on the tokenizer's plain terms, so the
-/// ranking query must drop everything SQL never matched literally: whitespace, the `| ^ $ ' r/../`
-/// operators, and negated terms, whose characters SQL excluded rather than required.
-fn fuzzy_ranking_query(query: &str) -> String {
+/// The terms the span scorer ranks on. SQL matches on the tokenizer's plain terms, so ranking must
+/// drop everything SQL never matched literally: whitespace, the `| ^ $ ' r/../` operators, and
+/// negated terms, whose characters SQL excluded rather than required.
+fn fuzzy_ranking_terms(query: &str) -> Vec<&str> {
     QueryTokenizer::new(query)
         .filter(|token| !token.is_inverse())
         .filter_map(|token| match token {
@@ -1827,48 +1827,50 @@ mod test {
         NothingScored,
     }
 
-    // Characterises which query shapes the span scorer can actually rank. The ranking query is a
-    // single concatenation of the plain terms, but SQL emits one independent condition per term,
-    // so any shape where the two disagree leaves every row unscored. `NothingScored` rows are
-    // defects, recorded here to pin current behaviour.
+    // Characterises which query shapes the span scorer can actually rank. Each term is ranked
+    // independently, matching how SQL emits one condition per term, so the surviving
+    // `NothingScored` rows are all the same defect: SQL matched by folding case, which the span
+    // scorer does not.
     #[rstest]
     // A lone term, and terms in the order they appear in the command, rank correctly.
-    #[case::plain_term("screen", "screen", ("screen", "search green"), RankedBy::Span)]
-    #[case::terms_in_command_order("foo bar", "foobar", ("foo bar", "foo qux bar"), RankedBy::Span)]
-    #[case::exact_word_terms("'foo 'bar", "foobar", ("foo bar", "foo qux bar"), RankedBy::Span)]
-    // Anchors rank as long as no term sits on the impossible side of them.
-    #[case::start_anchor_then_term("^foo bar", "foobar", ("foo bar", "foo qux bar"), RankedBy::Span)]
-    #[case::term_then_end_anchor("foo screen$", "fooscreen", ("foo screen", "foo x screen"), RankedBy::Span)]
+    #[case::plain_term("screen", &["screen"], ("screen", "search green"), RankedBy::Span)]
+    #[case::terms_in_command_order("foo bar", &["foo", "bar"], ("foo bar", "foo qux bar"), RankedBy::Span)]
+    #[case::exact_word_terms("'foo 'bar", &["foo", "bar"], ("foo bar", "foo qux bar"), RankedBy::Span)]
+    // Terms SQL matches independently rank independently, in whichever order the command has them.
+    #[case::terms_out_of_command_order("bar foo", &["bar", "foo"], ("foo bar", "foo qux bar"), RankedBy::Span)]
+    // Anchors rank from either side: a term is no longer required to follow the anchored one.
+    #[case::start_anchor_then_term("^foo bar", &["foo", "bar"], ("foo bar", "foo qux bar"), RankedBy::Span)]
+    #[case::term_before_start_anchor("bar ^foo", &["bar", "foo"], ("foo bar", "foo qux bar"), RankedBy::Span)]
+    #[case::term_then_end_anchor("foo screen$", &["foo", "screen"], ("foo screen", "foo x screen"), RankedBy::Span)]
+    #[case::term_after_end_anchor("screen$ foo", &["screen", "foo"], ("foo screen", "foo x screen"), RankedBy::Span)]
     // A negated term is a filter, not a ranking signal, so it drops out and the rest still ranks.
-    #[case::negated_term("foo screen !zzz", "fooscreen", ("foo screen", "foo x screen"), RankedBy::Span)]
-    #[case::negated_start_anchor("bar !^foo", "bar", ("bar", "b a r"), RankedBy::Span)]
+    #[case::negated_term("foo screen !zzz", &["foo", "screen"], ("foo screen", "foo x screen"), RankedBy::Span)]
+    #[case::negated_start_anchor("bar !^foo", &["bar"], ("bar", "b a r"), RankedBy::Span)]
     // An uppercase term switches SQL to case-sensitive GLOB, which agrees with the span scorer.
-    #[case::uppercase_term("LS", "LS", ("LS", "L x S"), RankedBy::Span)]
-    #[case::mixed_case_uppercase_term("LS foo", "LSfoo", ("LS foo", "LS x foo"), RankedBy::Span)]
+    #[case::uppercase_term("LS", &["LS"], ("LS", "L x S"), RankedBy::Span)]
+    #[case::mixed_case_uppercase_term("LS foo", &["LS", "foo"], ("LS foo", "LS x foo"), RankedBy::Span)]
     // A regex is a filter too; the plain term alongside it still ranks.
-    #[case::regex_with_term("r/screen/ foo", "foo", ("foo screen", "f o o screen"), RankedBy::Span)]
+    #[case::regex_with_term("r/screen/ foo", &["foo"], ("foo screen", "f o o screen"), RankedBy::Span)]
+    // Only one alternation branch is present per row, so ranking runs on the branch that matched.
+    #[case::alternation_ranks_matched_branch("foo | bar", &["foo", "bar"], ("foo", "f o o"), RankedBy::Span)]
+    // Matching more of the query outranks matching less of it, however tight the lesser match is.
+    #[case::alternation_prefers_matching_both("foo | bar", &["foo", "bar"], ("foo bar", "foo"), RankedBy::Span)]
     // Nothing left to rank on, or nothing to tell the rows apart. Recency is the right answer.
-    #[case::regex_only("r/screen/", "", ("foo screen", "foo x screen"), RankedBy::TiedSpan)]
-    #[case::negated_term_only("!zzz", "", ("foo screen", "foo x screen"), RankedBy::TiedSpan)]
-    #[case::start_anchor_only("^foo", "foo", ("foo bar", "foo qux bar"), RankedBy::TiedSpan)]
-    #[case::end_anchor_only("screen$", "screen", ("foo screen", "foo x screen"), RankedBy::TiedSpan)]
-    // Terms SQL matches independently, but the concatenation demands them in query order.
-    #[case::terms_out_of_command_order("bar foo", "barfoo", ("foo bar", "foo qux bar"), RankedBy::NothingScored)]
-    // SQL requires either branch; the concatenation demands every one of them.
-    #[case::alternation("foo | bar", "foobar", ("foo", "bar"), RankedBy::NothingScored)]
-    #[case::alternation_three_way("foo | bar | qux", "foobarqux", ("foo", "bar"), RankedBy::NothingScored)]
-    // `^foo` pins foo at offset 0, so nothing in the concatenation can precede it.
-    #[case::term_before_start_anchor("bar ^foo", "barfoo", ("foo bar", "foo qux bar"), RankedBy::NothingScored)]
-    // `screen$` pins screen at the end, so nothing in the concatenation can follow it.
-    #[case::term_after_end_anchor("screen$ foo", "screenfoo", ("foo screen", "foo x screen"), RankedBy::NothingScored)]
+    #[case::regex_only("r/screen/", &[], ("foo screen", "foo x screen"), RankedBy::TiedSpan)]
+    #[case::negated_term_only("!zzz", &[], ("foo screen", "foo x screen"), RankedBy::TiedSpan)]
+    #[case::start_anchor_only("^foo", &["foo"], ("foo bar", "foo qux bar"), RankedBy::TiedSpan)]
+    #[case::end_anchor_only("screen$", &["screen"], ("foo screen", "foo x screen"), RankedBy::TiedSpan)]
+    // Each row matches one branch equally tightly, so there is nothing to choose between them.
+    #[case::alternation("foo | bar", &["foo", "bar"], ("foo", "bar"), RankedBy::TiedSpan)]
+    #[case::alternation_three_way("foo | bar | qux", &["foo", "bar", "qux"], ("foo", "bar"), RankedBy::TiedSpan)]
     // SQL matched only by case folding, which LIKE does and the span scorer does not. Unaffected by
     // an uppercase term elsewhere in the query: each term picks LIKE or GLOB on its own.
-    #[case::lowercase_term_matching_uppercase("ls", "ls", ("LS", "L x S"), RankedBy::NothingScored)]
-    #[case::mixed_case_lowercase_term("ls FOO", "lsFOO", ("LS FOO", "LS x FOO"), RankedBy::NothingScored)]
+    #[case::lowercase_term_matching_uppercase("ls", &["ls"], ("LS", "L x S"), RankedBy::NothingScored)]
+    #[case::mixed_case_lowercase_term("ls FOO", &["ls", "FOO"], ("LS FOO", "LS x FOO"), RankedBy::NothingScored)]
     #[tokio::test(flavor = "multi_thread")]
     async fn test_search_fuzzy_operator_ranking(
         #[case] query: &str,
-        #[case] expected_ranking_query: &str,
+        #[case] expected_terms: &[&str],
         #[case] rows: (&str, &str),
         #[case] ranked_by: RankedBy,
     ) {
@@ -1876,9 +1878,9 @@ mod test {
         let db = db_with_ages(&[tighter, looser]).await;
 
         assert_eq!(
-            fuzzy_ranking_query(query),
-            expected_ranking_query,
-            "ranking query for {query:?}"
+            fuzzy_ranking_terms(query),
+            expected_terms,
+            "ranking terms for {query:?}"
         );
 
         let results = assert_search_eq(&db, DbSearchMode::Fuzzy, FilterMode::Global, query, 2)

--- a/crates/atuin-client/src/database.rs
+++ b/crates/atuin-client/src/database.rs
@@ -806,17 +806,7 @@ impl Database for Sqlite {
             .fetch_all(&self.pool)
             .await?;
 
-        // Rank against the same characters SQL matched: drop spaces, operators and negated terms.
-        let reorder_query: String = QueryTokenizer::new(orig_query)
-            .filter(|token| !token.is_inverse())
-            .filter_map(|token| match token {
-                QueryToken::Match(term, _)
-                | QueryToken::MatchStart(term, _)
-                | QueryToken::MatchEnd(term, _)
-                | QueryToken::MatchFull(term, _) => Some(term),
-                QueryToken::Or | QueryToken::Regex(_) => None,
-            })
-            .collect();
+        let reorder_query = fuzzy_ranking_query(orig_query);
         Ok(ordering::reorder_fuzzy(search_mode, &reorder_query, res))
     }
 
@@ -1134,6 +1124,22 @@ impl SqlBuilderExt for SqlBuilder {
             self.and_where(cond)
         }
     }
+}
+
+/// The characters the span scorer ranks on. SQL matches on the tokenizer's plain terms, so the
+/// ranking query must drop everything SQL never matched literally: whitespace, the `| ^ $ ' r/../`
+/// operators, and negated terms, whose characters SQL excluded rather than required.
+fn fuzzy_ranking_query(query: &str) -> String {
+    QueryTokenizer::new(query)
+        .filter(|token| !token.is_inverse())
+        .filter_map(|token| match token {
+            QueryToken::Match(term, _)
+            | QueryToken::MatchStart(term, _)
+            | QueryToken::MatchEnd(term, _)
+            | QueryToken::MatchFull(term, _) => Some(term),
+            QueryToken::Or | QueryToken::Regex(_) => None,
+        })
+        .collect()
 }
 
 pub struct QueryTokenizer<'a> {

--- a/crates/atuin-client/src/database.rs
+++ b/crates/atuin-client/src/database.rs
@@ -1476,6 +1476,24 @@ mod test {
         assert_eq!(loaded.len(), 1200);
     }
 
+    // Inserts oldest-first with well-separated timestamps, so recency order is the reverse of the
+    // argument order rather than a product of clock resolution.
+    async fn db_with_ages(commands: &[&str]) -> Sqlite {
+        let mut db = Sqlite::new("sqlite::memory:", test_local_timeout())
+            .await
+            .unwrap();
+
+        let now = OffsetDateTime::now_utc();
+        for (i, command) in commands.iter().enumerate() {
+            let age = time::Duration::hours((commands.len() - i) as i64);
+            new_history_item_at(&mut db, command, Some(now - age))
+                .await
+                .unwrap();
+        }
+
+        db
+    }
+
     async fn db_with(commands: &[&str]) -> Sqlite {
         let db = Sqlite::new("sqlite::memory:", test_local_timeout()).await.unwrap();
 
@@ -1793,6 +1811,91 @@ mod test {
             "use screen",
         ])
         .await;
+    }
+
+    // Which signal decides the order of two matched rows, given the tighter match is always the
+    // older of the two. Distinguishes a legitimate tie from ranking not happening at all: both put
+    // the newer row first, but only one of them is correct.
+    #[derive(Debug, Clone, Copy)]
+    enum RankedBy {
+        // The tighter match wins despite being older.
+        Span,
+        // Both rows score the same span, so recency correctly breaks the tie.
+        TiedSpan,
+        // No row matches the ranking query, so every key is usize::MAX and the stable sort leaves
+        // SQL's recency order untouched. Ranking is off.
+        NothingScored,
+    }
+
+    // Characterises which query shapes the span scorer can actually rank. The ranking query is a
+    // single concatenation of the plain terms, but SQL emits one independent condition per term,
+    // so any shape where the two disagree leaves every row unscored. `NothingScored` rows are
+    // defects, recorded here to pin current behaviour.
+    #[rstest]
+    // A lone term, and terms in the order they appear in the command, rank correctly.
+    #[case::plain_term("screen", "screen", ("screen", "search green"), RankedBy::Span)]
+    #[case::terms_in_command_order("foo bar", "foobar", ("foo bar", "foo qux bar"), RankedBy::Span)]
+    #[case::exact_word_terms("'foo 'bar", "foobar", ("foo bar", "foo qux bar"), RankedBy::Span)]
+    // Anchors rank as long as no term sits on the impossible side of them.
+    #[case::start_anchor_then_term("^foo bar", "foobar", ("foo bar", "foo qux bar"), RankedBy::Span)]
+    #[case::term_then_end_anchor("foo screen$", "fooscreen", ("foo screen", "foo x screen"), RankedBy::Span)]
+    // A negated term is a filter, not a ranking signal, so it drops out and the rest still ranks.
+    #[case::negated_term("foo screen !zzz", "fooscreen", ("foo screen", "foo x screen"), RankedBy::Span)]
+    #[case::negated_start_anchor("bar !^foo", "bar", ("bar", "b a r"), RankedBy::Span)]
+    // An uppercase term switches SQL to case-sensitive GLOB, which agrees with the span scorer.
+    #[case::uppercase_term("LS", "LS", ("LS", "L x S"), RankedBy::Span)]
+    #[case::mixed_case_uppercase_term("LS foo", "LSfoo", ("LS foo", "LS x foo"), RankedBy::Span)]
+    // A regex is a filter too; the plain term alongside it still ranks.
+    #[case::regex_with_term("r/screen/ foo", "foo", ("foo screen", "f o o screen"), RankedBy::Span)]
+    // Nothing left to rank on, or nothing to tell the rows apart. Recency is the right answer.
+    #[case::regex_only("r/screen/", "", ("foo screen", "foo x screen"), RankedBy::TiedSpan)]
+    #[case::negated_term_only("!zzz", "", ("foo screen", "foo x screen"), RankedBy::TiedSpan)]
+    #[case::start_anchor_only("^foo", "foo", ("foo bar", "foo qux bar"), RankedBy::TiedSpan)]
+    #[case::end_anchor_only("screen$", "screen", ("foo screen", "foo x screen"), RankedBy::TiedSpan)]
+    // Terms SQL matches independently, but the concatenation demands them in query order.
+    #[case::terms_out_of_command_order("bar foo", "barfoo", ("foo bar", "foo qux bar"), RankedBy::NothingScored)]
+    // SQL requires either branch; the concatenation demands every one of them.
+    #[case::alternation("foo | bar", "foobar", ("foo", "bar"), RankedBy::NothingScored)]
+    #[case::alternation_three_way("foo | bar | qux", "foobarqux", ("foo", "bar"), RankedBy::NothingScored)]
+    // `^foo` pins foo at offset 0, so nothing in the concatenation can precede it.
+    #[case::term_before_start_anchor("bar ^foo", "barfoo", ("foo bar", "foo qux bar"), RankedBy::NothingScored)]
+    // `screen$` pins screen at the end, so nothing in the concatenation can follow it.
+    #[case::term_after_end_anchor("screen$ foo", "screenfoo", ("foo screen", "foo x screen"), RankedBy::NothingScored)]
+    // SQL matched only by case folding, which LIKE does and the span scorer does not. Unaffected by
+    // an uppercase term elsewhere in the query: each term picks LIKE or GLOB on its own.
+    #[case::lowercase_term_matching_uppercase("ls", "ls", ("LS", "L x S"), RankedBy::NothingScored)]
+    #[case::mixed_case_lowercase_term("ls FOO", "lsFOO", ("LS FOO", "LS x FOO"), RankedBy::NothingScored)]
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_search_fuzzy_operator_ranking(
+        #[case] query: &str,
+        #[case] expected_ranking_query: &str,
+        #[case] rows: (&str, &str),
+        #[case] ranked_by: RankedBy,
+    ) {
+        let (tighter, looser) = rows;
+        let db = db_with_ages(&[tighter, looser]).await;
+
+        assert_eq!(
+            fuzzy_ranking_query(query),
+            expected_ranking_query,
+            "ranking query for {query:?}"
+        );
+
+        let results = assert_search_eq(&db, DbSearchMode::Fuzzy, FilterMode::Global, query, 2)
+            .await
+            .unwrap();
+
+        // Recency puts `looser` first, so only span scoring can surface `tighter`.
+        let expected_first = match ranked_by {
+            RankedBy::Span => tighter,
+            RankedBy::TiedSpan | RankedBy::NothingScored => looser,
+        };
+        assert_eq!(
+            results[0].command,
+            expected_first,
+            "{query:?} should rank by {ranked_by:?}, got: {:?}",
+            results.iter().map(|h| &h.command).collect::<Vec<_>>()
+        );
     }
 
     #[rstest]

--- a/crates/atuin-client/src/ordering.rs
+++ b/crates/atuin-client/src/ordering.rs
@@ -17,20 +17,40 @@ pub fn reorder_fuzzy(mode: DbSearchMode, terms: &[&str], res: Vec<History>) -> V
 ///
 /// Terms are ordered by how many went unfound before width, so a row matching more of the query
 /// always outranks one matching less, and a row matching nothing at all sorts last.
+///
+/// Each term folds case exactly where SQL did. Smart case sends an uppercase term to GLOB, which
+/// is case-sensitive, and a lowercase one to LIKE, which folds ASCII case; ranking a lowercase
+/// term without folding would score a row SQL matched only by folding as a non-match.
 fn reorder<F, A>(terms: &[&str], f: F, res: Vec<A>) -> Vec<A>
 where
     F: Fn(&A) -> &String,
 {
-    let terms: Vec<Vec<char>> = terms.iter().map(|term| term.chars().collect()).collect();
+    // Paired with whether SQL matched the term case-sensitively.
+    let terms: Vec<(Vec<char>, bool)> = terms
+        .iter()
+        .map(|term| (term.chars().collect(), term.contains(char::is_uppercase)))
+        .collect();
+
+    let needs_folded = terms.iter().any(|(_, exact)| !*exact);
 
     let mut r = res;
     r.sort_by_cached_key(|h| {
         let command: Vec<char> = f(h).chars().collect();
+        // Folding per character keeps offsets aligned with `command`, over the same ASCII-only range
+        // LIKE folds. A command carrying no ASCII case folds to itself, so it needs no copy.
+        let folded: Option<Vec<char>> = (needs_folded
+            && command.iter().any(char::is_ascii_uppercase))
+        .then(|| command.iter().map(char::to_ascii_lowercase).collect());
 
         let mut unfound = 0usize;
         let (mut lo, mut hi) = (usize::MAX, 0usize);
-        for term in &terms {
-            match minspan::span(term, &command) {
+        for (term, exact_term) in &terms {
+            let command = if *exact_term {
+                &command
+            } else {
+                folded.as_ref().unwrap_or(&command)
+            };
+            match minspan::span(term, command) {
                 Some((from, to)) => {
                     lo = lo.min(from);
                     hi = hi.max(to);

--- a/crates/atuin-client/src/ordering.rs
+++ b/crates/atuin-client/src/ordering.rs
@@ -26,32 +26,47 @@ fn reorder<F, A>(terms: &[&str], f: F, res: Vec<A>) -> Vec<A>
 where
     F: Fn(&A) -> &String,
 {
+    let mut r = res;
+
+    // With nothing to rank on every key is equal, and the stable sort would return the input.
+    if terms.is_empty() || r.len() < 2 {
+        return r;
+    }
+
     // Paired with whether SQL matched the term case-sensitively.
     let terms: Vec<(Vec<char>, bool)> = terms
         .iter()
         .map(|term| (term.chars().collect(), term.contains(char::is_uppercase)))
         .collect();
 
-    let needs_folded = terms.iter().any(|(_, exact)| !*exact);
+    let any_folded = terms.iter().any(|(_, exact)| !*exact);
 
-    let mut r = res;
+    // Refilled per row rather than reallocated: this runs over every result on every keystroke.
+    let mut command: Vec<char> = Vec::new();
+    let mut folded: Vec<char> = Vec::new();
+
     r.sort_by_cached_key(|h| {
-        let command: Vec<char> = f(h).chars().collect();
+        // Whether the command carries case is known by the time it has been walked once.
+        command.clear();
+        let mut has_ascii_case = false;
+        for c in f(h).chars() {
+            has_ascii_case |= c.is_ascii_uppercase();
+            command.push(c);
+        }
+
         // Folding per character keeps offsets aligned with `command`, over the same ASCII-only range
         // LIKE folds. A command carrying no ASCII case folds to itself, so it needs no copy.
-        let folded: Option<Vec<char>> = (needs_folded
-            && command.iter().any(char::is_ascii_uppercase))
-        .then(|| command.iter().map(char::to_ascii_lowercase).collect());
+        let fold = any_folded && has_ascii_case;
+        if fold {
+            folded.clear();
+            folded.extend(command.iter().map(char::to_ascii_lowercase));
+        }
 
         let mut unfound = 0usize;
         let (mut lo, mut hi) = (usize::MAX, 0usize);
-        for (term, exact_term) in &terms {
-            let command = if *exact_term {
-                &command
-            } else {
-                folded.as_ref().unwrap_or(&command)
-            };
-            match minspan::span(term, command) {
+        for (term, exact) in &terms {
+            let haystack = if fold && !*exact { &folded } else { &command };
+            match minspan::span(term, haystack) {
                 Some((from, to)) => {
                     lo = lo.min(from);
                     hi = hi.max(to);

--- a/crates/atuin-client/src/ordering.rs
+++ b/crates/atuin-client/src/ordering.rs
@@ -2,24 +2,45 @@ use minspan::minspan;
 
 use super::{database::DbSearchMode, history::History};
 
-pub fn reorder_fuzzy(mode: DbSearchMode, query: &str, res: Vec<History>) -> Vec<History> {
+pub fn reorder_fuzzy(mode: DbSearchMode, terms: &[&str], res: Vec<History>) -> Vec<History> {
     match mode {
-        DbSearchMode::Fuzzy => reorder(query, |x| &x.command, res),
+        DbSearchMode::Fuzzy => reorder(terms, |x| &x.command, res),
         DbSearchMode::Prefix | DbSearchMode::FullText => res,
     }
 }
 
-fn reorder<F, A>(query: &str, f: F, res: Vec<A>) -> Vec<A>
+/// Ranks each term against the command on its own, then scores by the smallest window covering
+/// every term it found. SQL emits one independent condition per term and imposes no order between
+/// them, so a single concatenated query cannot represent what it matched: terms in the reverse
+/// order to the command, alternation branches, and terms on the far side of a `^`/`$` anchor all
+/// fail the subsequence check even though SQL matched them.
+///
+/// Terms are ordered by how many went unfound before width, so a row matching more of the query
+/// always outranks one matching less, and a row matching nothing at all sorts last.
+fn reorder<F, A>(terms: &[&str], f: F, res: Vec<A>) -> Vec<A>
 where
     F: Fn(&A) -> &String,
 {
+    let terms: Vec<Vec<char>> = terms.iter().map(|term| term.chars().collect()).collect();
+
     let mut r = res;
-    let qvec = &query.chars().collect();
     r.sort_by_cached_key(|h| {
-        // TODO for fzf search we should sum up scores for each matched term
-        // A non-matching row sorts last rather than by a sentinel that can undercut a real match.
-        minspan::span(qvec, &(f(h).chars().collect()))
-            .map_or(usize::MAX, |(from, to)| 1 + to - from)
+        let command: Vec<char> = f(h).chars().collect();
+
+        let mut unfound = 0usize;
+        let (mut lo, mut hi) = (usize::MAX, 0usize);
+        for term in &terms {
+            match minspan::span(term, &command) {
+                Some((from, to)) => {
+                    lo = lo.min(from);
+                    hi = hi.max(to);
+                }
+                None => unfound += 1,
+            }
+        }
+
+        let width = if lo > hi { 0 } else { 1 + hi - lo };
+        (unfound, width)
     });
     r
 }
@@ -46,12 +67,22 @@ mod tests {
 
     #[rstest]
     // A non-matching row must sort last, not ahead of a genuine match.
-    #[case::nonmatch_sorts_last("screen", vec!["screen", "hello"], vec!["screen", "hello"])]
-    // The unchanged match path: a tight match outranks a loose one.
-    #[case::matches_by_span("curl", vec!["central urllib", "curl"], vec!["curl", "central urllib"])]
-    fn reorder_ranks(#[case] query: &str, #[case] input: Vec<&str>, #[case] expected: Vec<&str>) {
+    #[case::nonmatch_sorts_last(vec!["screen"], vec!["screen", "hello"], vec!["screen", "hello"])]
+    // A tight match outranks a loose one.
+    #[case::matches_by_span(vec!["curl"], vec!["central urllib", "curl"], vec!["curl", "central urllib"])]
+    // Several terms score by the window covering them all, so the tightly clustered row wins.
+    #[case::clustered_terms_win(vec!["foo", "bar"], vec!["foo qux bar", "foo bar"], vec!["foo bar", "foo qux bar"])]
+    // That window does not depend on the order the terms were given in.
+    #[case::term_order_is_irrelevant(vec!["bar", "foo"], vec!["foo qux bar", "foo bar"], vec!["foo bar", "foo qux bar"])]
+    // A row matching both terms beats a tighter row matching only one.
+    #[case::more_terms_beats_tighter(vec!["foo", "bar"], vec!["foo", "foo bar"], vec!["foo bar", "foo"])]
+    fn reorder_ranks(
+        #[case] terms: Vec<&str>,
+        #[case] input: Vec<&str>,
+        #[case] expected: Vec<&str>,
+    ) {
         let res = input.into_iter().map(hist).collect();
-        let out = reorder_fuzzy(DbSearchMode::Fuzzy, query, res);
+        let out = reorder_fuzzy(DbSearchMode::Fuzzy, &terms, res);
         assert_eq!(commands(out), expected);
     }
 }

--- a/crates/atuin-client/src/ordering.rs
+++ b/crates/atuin-client/src/ordering.rs
@@ -25,32 +25,47 @@ fn reorder<F, A>(terms: &[&str], f: F, res: Vec<A>) -> Vec<A>
 where
     F: Fn(&A) -> &String,
 {
+    let mut r = res;
+
+    // With nothing to rank on every key is equal, and the stable sort would return the input.
+    if terms.is_empty() || r.len() < 2 {
+        return r;
+    }
+
     // Paired with whether SQL matched the term case-sensitively.
     let terms: Vec<(Vec<char>, bool)> = terms
         .iter()
         .map(|term| (term.chars().collect(), term.contains(char::is_uppercase)))
         .collect();
 
-    let needs_folded = terms.iter().any(|(_, exact)| !*exact);
+    let any_folded = terms.iter().any(|(_, exact)| !*exact);
 
-    let mut r = res;
+    // Refilled per row rather than reallocated: this runs over every result on every keystroke.
+    let mut command: Vec<char> = Vec::new();
+    let mut folded: Vec<char> = Vec::new();
+
     r.sort_by_cached_key(|h| {
-        let command: Vec<char> = f(h).chars().collect();
+        // Whether the command carries case is known by the time it has been walked once.
+        command.clear();
+        let mut has_ascii_case = false;
+        for c in f(h).chars() {
+            has_ascii_case |= c.is_ascii_uppercase();
+            command.push(c);
+        }
+
         // Folding per character keeps offsets aligned with `command`, over the same ASCII-only range
         // LIKE folds. A command carrying no ASCII case folds to itself, so it needs no copy.
-        let folded: Option<Vec<char>> = (needs_folded
-            && command.iter().any(char::is_ascii_uppercase))
-        .then(|| command.iter().map(char::to_ascii_lowercase).collect());
+        let fold = any_folded && has_ascii_case;
+        if fold {
+            folded.clear();
+            folded.extend(command.iter().map(char::to_ascii_lowercase));
+        }
 
         let mut unfound = 0usize;
         let (mut lo, mut hi) = (usize::MAX, 0usize);
-        for (term, exact_term) in &terms {
-            let command = if *exact_term {
-                &command
-            } else {
-                folded.as_ref().unwrap_or(&command)
-            };
-            match minspan::span(term, command) {
+        for (term, exact) in &terms {
+            let haystack = if fold && !*exact { &folded } else { &command };
+            match minspan::span(term, haystack) {
                 Some((from, to)) => {
                     lo = lo.min(from);
                     hi = hi.max(to);

--- a/crates/atuin-client/src/ordering.rs
+++ b/crates/atuin-client/src/ordering.rs
@@ -18,20 +18,40 @@ pub fn reorder_fuzzy(mode: DbSearchMode, terms: &[&str], res: Vec<History>) -> V
 ///
 /// Terms are ordered by how many went unfound before width, so a row matching more of the query
 /// always outranks one matching less, and a row matching nothing at all sorts last.
+///
+/// Each term folds case exactly where SQL did. Smart case sends an uppercase term to GLOB, which
+/// is case-sensitive, and a lowercase one to LIKE, which folds ASCII case; ranking a lowercase
+/// term without folding would score a row SQL matched only by folding as a non-match.
 fn reorder<F, A>(terms: &[&str], f: F, res: Vec<A>) -> Vec<A>
 where
     F: Fn(&A) -> &String,
 {
-    let terms: Vec<Vec<char>> = terms.iter().map(|term| term.chars().collect()).collect();
+    // Paired with whether SQL matched the term case-sensitively.
+    let terms: Vec<(Vec<char>, bool)> = terms
+        .iter()
+        .map(|term| (term.chars().collect(), term.contains(char::is_uppercase)))
+        .collect();
+
+    let needs_folded = terms.iter().any(|(_, exact)| !*exact);
 
     let mut r = res;
     r.sort_by_cached_key(|h| {
         let command: Vec<char> = f(h).chars().collect();
+        // Folding per character keeps offsets aligned with `command`, over the same ASCII-only range
+        // LIKE folds. A command carrying no ASCII case folds to itself, so it needs no copy.
+        let folded: Option<Vec<char>> = (needs_folded
+            && command.iter().any(char::is_ascii_uppercase))
+        .then(|| command.iter().map(char::to_ascii_lowercase).collect());
 
         let mut unfound = 0usize;
         let (mut lo, mut hi) = (usize::MAX, 0usize);
-        for term in &terms {
-            match minspan::span(term, &command) {
+        for (term, exact_term) in &terms {
+            let command = if *exact_term {
+                &command
+            } else {
+                folded.as_ref().unwrap_or(&command)
+            };
+            match minspan::span(term, command) {
                 Some((from, to)) => {
                     lo = lo.min(from);
                     hi = hi.max(to);

--- a/crates/atuin-client/src/ordering.rs
+++ b/crates/atuin-client/src/ordering.rs
@@ -3,24 +3,45 @@ use minspan::minspan;
 use super::database::DbSearchMode;
 use super::history::History;
 
-pub fn reorder_fuzzy(mode: DbSearchMode, query: &str, res: Vec<History>) -> Vec<History> {
+pub fn reorder_fuzzy(mode: DbSearchMode, terms: &[&str], res: Vec<History>) -> Vec<History> {
     match mode {
-        DbSearchMode::Fuzzy => reorder(query, |x| &x.command, res),
+        DbSearchMode::Fuzzy => reorder(terms, |x| &x.command, res),
         DbSearchMode::Prefix | DbSearchMode::FullText => res,
     }
 }
 
-fn reorder<F, A>(query: &str, f: F, res: Vec<A>) -> Vec<A>
+/// Ranks each term against the command on its own, then scores by the smallest window covering
+/// every term it found. SQL emits one independent condition per term and imposes no order between
+/// them, so a single concatenated query cannot represent what it matched: terms in the reverse
+/// order to the command, alternation branches, and terms on the far side of a `^`/`$` anchor all
+/// fail the subsequence check even though SQL matched them.
+///
+/// Terms are ordered by how many went unfound before width, so a row matching more of the query
+/// always outranks one matching less, and a row matching nothing at all sorts last.
+fn reorder<F, A>(terms: &[&str], f: F, res: Vec<A>) -> Vec<A>
 where
     F: Fn(&A) -> &String,
 {
+    let terms: Vec<Vec<char>> = terms.iter().map(|term| term.chars().collect()).collect();
+
     let mut r = res;
-    let qvec = &query.chars().collect();
     r.sort_by_cached_key(|h| {
-        // TODO for fzf search we should sum up scores for each matched term
-        // A non-matching row sorts last rather than by a sentinel that can undercut a real match.
-        minspan::span(qvec, &(f(h).chars().collect()))
-            .map_or(usize::MAX, |(from, to)| 1 + to - from)
+        let command: Vec<char> = f(h).chars().collect();
+
+        let mut unfound = 0usize;
+        let (mut lo, mut hi) = (usize::MAX, 0usize);
+        for term in &terms {
+            match minspan::span(term, &command) {
+                Some((from, to)) => {
+                    lo = lo.min(from);
+                    hi = hi.max(to);
+                }
+                None => unfound += 1,
+            }
+        }
+
+        let width = if lo > hi { 0 } else { 1 + hi - lo };
+        (unfound, width)
     });
     r
 }
@@ -48,12 +69,22 @@ mod tests {
 
     #[rstest]
     // A non-matching row must sort last, not ahead of a genuine match.
-    #[case::nonmatch_sorts_last("screen", vec!["screen", "hello"], vec!["screen", "hello"])]
-    // The unchanged match path: a tight match outranks a loose one.
-    #[case::matches_by_span("curl", vec!["central urllib", "curl"], vec!["curl", "central urllib"])]
-    fn reorder_ranks(#[case] query: &str, #[case] input: Vec<&str>, #[case] expected: Vec<&str>) {
+    #[case::nonmatch_sorts_last(vec!["screen"], vec!["screen", "hello"], vec!["screen", "hello"])]
+    // A tight match outranks a loose one.
+    #[case::matches_by_span(vec!["curl"], vec!["central urllib", "curl"], vec!["curl", "central urllib"])]
+    // Several terms score by the window covering them all, so the tightly clustered row wins.
+    #[case::clustered_terms_win(vec!["foo", "bar"], vec!["foo qux bar", "foo bar"], vec!["foo bar", "foo qux bar"])]
+    // That window does not depend on the order the terms were given in.
+    #[case::term_order_is_irrelevant(vec!["bar", "foo"], vec!["foo qux bar", "foo bar"], vec!["foo bar", "foo qux bar"])]
+    // A row matching both terms beats a tighter row matching only one.
+    #[case::more_terms_beats_tighter(vec!["foo", "bar"], vec!["foo", "foo bar"], vec!["foo bar", "foo"])]
+    fn reorder_ranks(
+        #[case] terms: Vec<&str>,
+        #[case] input: Vec<&str>,
+        #[case] expected: Vec<&str>,
+    ) {
         let res = input.into_iter().map(hist).collect();
-        let out = reorder_fuzzy(DbSearchMode::Fuzzy, query, res);
+        let out = reorder_fuzzy(DbSearchMode::Fuzzy, &terms, res);
         assert_eq!(commands(out), expected);
     }
 }


### PR DESCRIPTION
Relates to:
- #3603
- #3624

After rabbit-holing on fuzzy search, and getting some feedback on properly handling `!` inverse matches, I found that there's almost no test coverage of fuzzy ranking. This PR adds test coverage and fixes some corner cases where fuzzy matching is accidentally disabled.

These fixes brought an unfortunate 71.9µs - 59.6µs = 12.3µs of increased compute per keystroke, median over 200 rows. I chased some low-hanging fruit to bring this down to 47.9µs, i.e. -11.7µs by avoiding a hot loop `Vec<char>` allocation.

Supersedes #3624 with:
- Non-matches sorting last: replaced by a `(terms unfound, window width)` key, so the sentinel goes.
- Whitespace stripped from the ranking query: tokenizer terms never contain whitespace.
- Operators stripped from the ranking query: the tokenizer already yields plain terms.
- Inverse tokens dropped; kept verbatim, now inside `fuzzy_ranking_terms`.

## Checks
- [x] I am happy for maintainers to push small adjustments to this PR, to speed up the review cycle
- [x] I have checked that there are no existing pull requests for the same thing

## Note

This PR stacks on top of #3624 and should be rebased when it merges.

AI review agents may confuse the two sets of changes and review both. 🤷🏻‍♂️