### PR TITLE
docs: use shell-agnostic install command in quickstart pages

### DIFF
--- a/docs/docs/guide/getting-started.md
+++ b/docs/docs/guide/getting-started.md
@@ -17,7 +17,7 @@ The install script handles the binary and the shell plugin, and walks you
 through the rest:
 
 ```shell
-bash <(curl --proto '=https' --tlsv1.2 -sSf https://setup.atuin.sh)
+curl --proto '=https' --tlsv1.2 -LsSf https://setup.atuin.sh | sh
 ```
 
 Then restart your shell. Prefer a package manager, or want to install the pieces

--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -12,7 +12,7 @@ entirely and stay local.
 ## Quickstart
 
 ```bash
-bash <(curl --proto '=https' --tlsv1.2 -sSf https://setup.atuin.sh)
+curl --proto '=https' --tlsv1.2 -LsSf https://setup.atuin.sh | sh
 ```
 
 Restart your shell, then press ++ctrl+r++ or the ++up++ arrow to search. Type a


### PR DESCRIPTION
## What

The Quickstart on the docs [home page](https://docs.atuin.sh/latest/) and the [Getting Started guide](https://docs.atuin.sh/latest/guide/getting-started/) still recommended:

```bash
bash <(curl --proto '=https' --tlsv1.2 -sSf https://setup.atuin.sh)
```

This uses process substitution, which fish doesn't support, so fish users hit:

```
fish: Invalid redirection target:
```

Both pages now use the canonical form already used in the README and the [Installation](https://docs.atuin.sh/latest/guide/installation/) page:

```bash
curl --proto '=https' --tlsv1.2 -LsSf https://setup.atuin.sh | sh
```

This works in bash, zsh, and fish.

## Why

The homepage and README were fixed a while ago, but the docs pages were missed — flagged in the last comments of #547.

Fixes #547
