### PR TITLE
docs: state minimum supported Rust version in install guide

### DIFF
--- a/docs/docs/guide/installation.md
+++ b/docs/docs/guide/installation.md
@@ -52,7 +52,11 @@ If you don't wish to use the installer, the manual installation steps are as fol
 
 === "Cargo"
 
-    It's best to use [rustup](https://rustup.rs/) to set up a Rust
+    Atuin requires a recent Rust toolchain. The minimum supported version is
+    set by `rust-version` in the workspace
+    [`Cargo.toml`](https://github.com/atuinsh/atuin/blob/main/Cargo.toml)
+    (currently {{ msrv }}). Distribution package managers often ship an older Rust,
+    so it's best to use [rustup](https://rustup.rs/) to set up an up-to-date
     toolchain, then you can run:
 
     ```shell
@@ -144,7 +148,10 @@ If you don't wish to use the installer, the manual installation steps are as fol
 === "Source"
 
     Atuin builds on the latest stable version of Rust, and we make no
-    promises regarding older versions. We recommend using [rustup](https://rustup.rs/).
+    promises regarding older versions. The minimum supported version is set by
+    `rust-version` in the workspace
+    [`Cargo.toml`](https://github.com/atuinsh/atuin/blob/main/Cargo.toml)
+    (currently {{ msrv }}). We recommend using [rustup](https://rustup.rs/).
 
     ```shell
     git clone https://github.com/atuinsh/atuin.git

--- a/docs/main.py
+++ b/docs/main.py
@@ -1,0 +1,22 @@
+"""mkdocs-macros hooks exposing repo facts to the docs.
+
+Keeps version numbers quoted in the docs in sync with their source of truth in
+the repo, so they can't drift. Currently exposes `{{ msrv }}`, read from the
+`channel` pinned in `rust-toolchain.toml`.
+"""
+
+import tomllib
+from pathlib import Path
+
+# The docs project lives in `docs/`; the repo root is its parent.
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+_RUST_TOOLCHAIN = _REPO_ROOT / "rust-toolchain.toml"
+
+
+def _read_msrv() -> str:
+    with _RUST_TOOLCHAIN.open("rb") as f:
+        return tomllib.load(f)["toolchain"]["channel"]
+
+
+def define_env(env):
+    env.variables["msrv"] = _read_msrv()

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -60,6 +60,7 @@ theme:
 
 plugins:
   - search
+  - macros # Read repo facts (e.g. the MSRV) into pages; see main.py
   - privacy # Download external assets at compile time for user privacy
   - git-revision-date-localized:
       enable_creation_date: true

--- a/docs/pyproject.toml
+++ b/docs/pyproject.toml
@@ -12,6 +12,7 @@ dependencies = [
   "mkdocs-minify-plugin>=0.8",
   "mkdocs-git-committers-plugin-2>=2.5",
   "mike>=2.1",
+  "mkdocs-macros-plugin>=1.0",
 ]
 
 [tool.uv]

--- a/docs/uv.lock
+++ b/docs/uv.lock
@@ -15,6 +15,7 @@ dependencies = [
     { name = "mkdocs-git-revision-date-localized-plugin" },
     { name = "mkdocs-glightbox" },
     { name = "mkdocs-llmstxt" },
+    { name = "mkdocs-macros-plugin" },
     { name = "mkdocs-material" },
     { name = "mkdocs-minify-plugin" },
     { name = "mkdocs-redirects" },
@@ -27,6 +28,7 @@ requires-dist = [
     { name = "mkdocs-git-revision-date-localized-plugin", specifier = ">=1.2" },
     { name = "mkdocs-glightbox", specifier = ">=0.4" },
     { name = "mkdocs-llmstxt", specifier = ">=0.5" },
+    { name = "mkdocs-macros-plugin", specifier = ">=1.0" },
     { name = "mkdocs-material", specifier = ">=9.5" },
     { name = "mkdocs-minify-plugin", specifier = ">=0.8" },
     { name = "mkdocs-redirects", specifier = ">=1.2.2" },
@@ -214,6 +216,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/5e/d5/3da0b92033887033f4c27f2dd109a303c4ca62813c7b3bb2511edb4777de/gitpython-3.1.54.tar.gz", hash = "sha256:53f2085e24a2cda300eed7c3fc5f1559ae289634b725e98acaf4791940247aa0", size = 225076, upload-time = "2026-07-22T04:08:51.403Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d1/b9/876f442a28df5c068ca69b0122d5c35e65fd2d2fa9992ea5cb5944ea00a6/gitpython-3.1.54-py3-none-any.whl", hash = "sha256:b90d7b3d9bc0238681d24369130826f0dcdb0ceaa45db67cf1d4ffa4c302dedf", size = 216575, upload-time = "2026-07-22T04:08:50.05Z" },
+]
+
+[[package]]
+name = "hjson"
+version = "3.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/82/e5/0b56d723a76ca67abadbf7fb71609fb0ea7e6926e94fcca6c65a85b36a0e/hjson-3.1.0.tar.gz", hash = "sha256:55af475a27cf83a7969c808399d7bccdec8fb836a07ddbd574587593b9cdcf75", size = 40541, upload-time = "2022-08-13T02:53:01.919Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1f/7f/13cd798d180af4bf4c0ceddeefba2b864a63c71645abc0308b768d67bb81/hjson-3.1.0-py3-none-any.whl", hash = "sha256:65713cdcf13214fb554eb8b4ef803419733f4f5e551047c9b711098ab7186b89", size = 54018, upload-time = "2022-08-13T02:52:59.899Z" },
 ]
 
 [[package]]
@@ -514,6 +525,27 @@ wheels = [
 ]
 
 [[package]]
+name = "mkdocs-macros-plugin"
+version = "1.5.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "hjson" },
+    { name = "jinja2" },
+    { name = "mkdocs" },
+    { name = "packaging" },
+    { name = "pathspec" },
+    { name = "python-dateutil" },
+    { name = "pyyaml" },
+    { name = "requests" },
+    { name = "super-collections" },
+    { name = "termcolor" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/92/15/e6a44839841ebc9c5872fa0e6fad1c3757424e4fe026093b68e9f386d136/mkdocs_macros_plugin-1.5.0.tar.gz", hash = "sha256:12aa45ce7ecb7a445c66b9f649f3dd05e9b92e8af6bc65e4acd91d26f878c01f", size = 37730, upload-time = "2025-11-13T08:08:55.545Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/51/62/9fffba5bb9ed3d31a932ad35038ba9483d59850256ee0fea7f1187173983/mkdocs_macros_plugin-1.5.0-py3-none-any.whl", hash = "sha256:c10fabd812bf50f9170609d0ed518e54f1f0e12c334ac29141723a83c881dd6f", size = 44626, upload-time = "2025-11-13T08:08:53.878Z" },
+]
+
+[[package]]
 name = "mkdocs-material"
 version = "9.7.0"
 source = { registry = "https://pypi.org/simple" }
@@ -810,6 +842,27 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/47/2c/0a5f6f8ee0d5589e48c7640213ed5175d52cf540a06725b628cc1a45d6ce/soupsieve-2.8.4.tar.gz", hash = "sha256:e121fd02e975c695e4e9e8774a5ee35d74714b59307868dcc5319ad2d9e3328e", size = 121110, upload-time = "2026-05-24T13:55:57.154Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/5e/f5/0c41cb68dcae6b7de4fac4188a3a9589e21fb31df21ea3a2e888db95e6c9/soupsieve-2.8.4-py3-none-any.whl", hash = "sha256:e7e6b0769c8f51ed59acab6e994b00621096cfb1c640a7509295987388fbaf65", size = 37304, upload-time = "2026-05-24T13:55:55.406Z" },
+]
+
+[[package]]
+name = "super-collections"
+version = "0.6.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "hjson" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e0/de/a0c3d1244912c260638f0f925e190e493ccea37ecaea9bbad7c14413b803/super_collections-0.6.2.tar.gz", hash = "sha256:0c8d8abacd9fad2c7c1c715f036c29f5db213f8cac65f24d45ecba12b4da187a", size = 31315, upload-time = "2025-09-30T00:37:08.067Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/17/43/47c7cf84b3bd74a8631b02d47db356656bb8dff6f2e61a4c749963814d0d/super_collections-0.6.2-py3-none-any.whl", hash = "sha256:291b74d26299e9051d69ad9d89e61b07b6646f86a57a2f5ab3063d206eee9c56", size = 16173, upload-time = "2025-09-30T00:37:07.104Z" },
+]
+
+[[package]]
+name = "termcolor"
+version = "3.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/46/79/cf31d7a93a8fdc6aa0fbb665be84426a8c5a557d9240b6239e9e11e35fc5/termcolor-3.3.0.tar.gz", hash = "sha256:348871ca648ec6a9a983a13ab626c0acce02f515b9e1983332b17af7979521c5", size = 14434, upload-time = "2025-12-29T12:55:21.882Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/33/d1/8bb87d21e9aeb323cc03034f5eaf2c8f69841e40e4853c2627edf8111ed3/termcolor-3.3.0-py3-none-any.whl", hash = "sha256:cf642efadaf0a8ebbbf4bc7a31cec2f9b5f21a9f726f4ccbb08192c9c26f43a5", size = 7734, upload-time = "2025-12-29T12:55:20.718Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Closes #943. Adds jinja templating to our docs
