### PR TITLE
chore(release): prepare for release 18.19.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,30 +2,79 @@
 
 All notable changes to this project will be documented in this file.
 
-## [unreleased]
+## 18.19.0
 
 ### Bug Fixes
 
+- *(client)* Avoid panic decoding an empty encryption key ([#3803](https://github.com/atuinsh/atuin/issues/3803))
+- *(client)* Keep sqlx-postgres out of the client crate ([#2884](https://github.com/atuinsh/atuin/issues/2884)) ([#3823](https://github.com/atuinsh/atuin/issues/3823))
+- *(config)* Preserve comments in `atuin config set` ([#3766](https://github.com/atuinsh/atuin/issues/3766))
+- *(search)* Correct fuzzy result ranking ([#3603](https://github.com/atuinsh/atuin/issues/3603)) ([#3624](https://github.com/atuinsh/atuin/issues/3624))
+- Fix atuin-search-bench/benches/search.rs ([#3788](https://github.com/atuinsh/atuin/issues/3788))
+- Close OSC133 C when launching Atuin AI to prevent content erasure ([#3794](https://github.com/atuinsh/atuin/issues/3794))
+- Authenticate beta release push as atuin-bot ([#3809](https://github.com/atuinsh/atuin/issues/3809))
 - Copy vendored axoasset into docker builder stage ([#3816](https://github.com/atuinsh/atuin/issues/3816))
+
+
+### Documentation
+
+- Clarify update check network, provide build command ([#3767](https://github.com/atuinsh/atuin/issues/3767))
+- Remove old i18n docs ([#3787](https://github.com/atuinsh/atuin/issues/3787))
+- Use shell-agnostic install command in quickstart pages ([#3820](https://github.com/atuinsh/atuin/issues/3820))
+- Document named stats periods (today/week/month/year) ([#3821](https://github.com/atuinsh/atuin/issues/3821))
+- State minimum supported Rust version in install guide ([#3822](https://github.com/atuinsh/atuin/issues/3822))
+- Document iTerm2 tmux popup incompatibility ([#3826](https://github.com/atuinsh/atuin/issues/3826))
+- Clarify key binding snippets belong in shell startup file ([#3837](https://github.com/atuinsh/atuin/issues/3837))
+- Mention RustRover in IDE integration guidance ([#3834](https://github.com/atuinsh/atuin/issues/3834))
 
 
 ### Features
 
+- *(client)* Show intent in inspector ([#3804](https://github.com/atuinsh/atuin/issues/3804))
+- *(client)* Enable pty-proxy via config ([#3828](https://github.com/atuinsh/atuin/issues/3828))
+- *(config)* Validate new settings in `atuin config set` before writing them to disk ([#3769](https://github.com/atuinsh/atuin/issues/3769))
+- *(lab)* Experimental `atuin lab share`
+- *(search)* Remove the "skim" engine ([#3825](https://github.com/atuinsh/atuin/issues/3825))
+- Remove word with ALT-Backspace ALT-D ([#2457](https://github.com/atuinsh/atuin/issues/2457))
+- Add scheduled beta release workflow ([#3805](https://github.com/atuinsh/atuin/issues/3805))
 - Migrate TLS backend from rustls to native-tls ([#3807](https://github.com/atuinsh/atuin/issues/3807))
 - Make `update` a real subcommand ([#3813](https://github.com/atuinsh/atuin/issues/3813))
+- Capability negotiation protocol (client + server) ([#3797](https://github.com/atuinsh/atuin/issues/3797))
 
 
 ### Miscellaneous Tasks
 
+- *(ci)* Fix `package` step ([#3770](https://github.com/atuinsh/atuin/issues/3770))
+- Remove Store trait ([#3779](https://github.com/atuinsh/atuin/issues/3779))
+- Daemon search benchmark (divan + CodSpeed) ([#3763](https://github.com/atuinsh/atuin/issues/3763))
+- Run CodSpeed benchmarks on macro runners in walltime mode ([#3786](https://github.com/atuinsh/atuin/issues/3786))
+- Add `OrFilter` as a replacement for `Vec`s as filter lists ([#3768](https://github.com/atuinsh/atuin/issues/3768))
+- Add `atuin-domain` crate for shared domain types ([#3790](https://github.com/atuinsh/atuin/issues/3790))
+- Run CodSpeed walltime benchmarks on depot-macos-26 ([#3791](https://github.com/atuinsh/atuin/issues/3791))
 - Fix deny.toml and get it to run in CI ([#3808](https://github.com/atuinsh/atuin/issues/3808))
 - Remove codspeed workflow ([#3812](https://github.com/atuinsh/atuin/issues/3812))
+- Richer logging for atuin-server ([#2564](https://github.com/atuinsh/atuin/issues/2564))
+- Hide --active sharing ([#3846](https://github.com/atuinsh/atuin/issues/3846))
 
 
 ### Refactor
 
+- *(deps)* Bump thiserror from 2.0.18 to 2.0.19 ([#3839](https://github.com/atuinsh/atuin/issues/3839))
+- *(deps)* Bump strum_macros from 0.27.2 to 0.28.0 ([#3841](https://github.com/atuinsh/atuin/issues/3841))
+- *(deps)* Bump tonic-types from 0.14.5 to 0.14.6 ([#3842](https://github.com/atuinsh/atuin/issues/3842))
+- *(deps)* Bump pulldown-cmark from 0.13.3 to 0.13.4 ([#3840](https://github.com/atuinsh/atuin/issues/3840))
+- *(deps)* Bump itertools from 0.14.0 to 0.15.0 ([#3838](https://github.com/atuinsh/atuin/issues/3838))
 - Adopt enum_dispatch for enum trait delegation ([#3806](https://github.com/atuinsh/atuin/issues/3806))
 
 
+### Testing
+
+- Adopt rstest across the workspace test suite ([#3785](https://github.com/atuinsh/atuin/issues/3785))
+
+
+### Daemon
+
+- Replace nucleo with frizbee, rank by match quality with frecency tiebreak ([#3782](https://github.com/atuinsh/atuin/issues/3782))
 
 ## 18.18.1
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -249,7 +249,7 @@ checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "atuin"
-version = "18.19.0-beta.3"
+version = "18.19.0"
 dependencies = [
  "arboard",
  "async-trait",
@@ -314,7 +314,7 @@ dependencies = [
 
 [[package]]
 name = "atuin-ai"
-version = "18.19.0-beta.3"
+version = "18.19.0"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -372,7 +372,7 @@ dependencies = [
 
 [[package]]
 name = "atuin-client"
-version = "18.19.0-beta.3"
+version = "18.19.0"
 dependencies = [
  "async-trait",
  "atuin-common",
@@ -430,7 +430,7 @@ dependencies = [
 
 [[package]]
 name = "atuin-common"
-version = "18.19.0-beta.3"
+version = "18.19.0"
 dependencies = [
  "base64",
  "derive_more",
@@ -458,7 +458,7 @@ dependencies = [
 
 [[package]]
 name = "atuin-daemon"
-version = "18.19.0-beta.3"
+version = "18.19.0"
 dependencies = [
  "atuin-client",
  "atuin-common",
@@ -495,7 +495,7 @@ dependencies = [
 
 [[package]]
 name = "atuin-domain"
-version = "18.19.0-beta.3"
+version = "18.19.0"
 dependencies = [
  "async-trait",
  "atuin-common",
@@ -526,7 +526,7 @@ dependencies = [
 
 [[package]]
 name = "atuin-dotfiles"
-version = "18.19.0-beta.3"
+version = "18.19.0"
 dependencies = [
  "atuin-client",
  "atuin-common",
@@ -544,7 +544,7 @@ dependencies = [
 
 [[package]]
 name = "atuin-history"
-version = "18.19.0-beta.3"
+version = "18.19.0"
 dependencies = [
  "atuin-client",
  "codspeed-divan-compat",
@@ -558,7 +558,7 @@ dependencies = [
 
 [[package]]
 name = "atuin-kv"
-version = "18.19.0-beta.3"
+version = "18.19.0"
 dependencies = [
  "atuin-client",
  "atuin-common",
@@ -577,7 +577,7 @@ dependencies = [
 
 [[package]]
 name = "atuin-lab-share"
-version = "18.19.0-beta.3"
+version = "18.19.0"
 dependencies = [
  "aes-gcm",
  "atuin-common",
@@ -620,7 +620,7 @@ dependencies = [
 
 [[package]]
 name = "atuin-pty-proxy"
-version = "18.19.0-beta.3"
+version = "18.19.0"
 dependencies = [
  "atuin-common",
  "clap",
@@ -637,7 +637,7 @@ dependencies = [
 
 [[package]]
 name = "atuin-scripts"
-version = "18.19.0-beta.3"
+version = "18.19.0"
 dependencies = [
  "atuin-client",
  "atuin-common",
@@ -674,7 +674,7 @@ dependencies = [
 
 [[package]]
 name = "atuin-server"
-version = "18.19.0-beta.3"
+version = "18.19.0"
 dependencies = [
  "argon2",
  "atuin-client",
@@ -706,7 +706,7 @@ dependencies = [
 
 [[package]]
 name = "atuin-server-database"
-version = "18.19.0-beta.3"
+version = "18.19.0"
 dependencies = [
  "async-trait",
  "atuin-common",
@@ -722,7 +722,7 @@ dependencies = [
 
 [[package]]
 name = "atuin-server-postgres"
-version = "18.19.0-beta.3"
+version = "18.19.0"
 dependencies = [
  "async-trait",
  "atuin-common",
@@ -741,7 +741,7 @@ dependencies = [
 
 [[package]]
 name = "atuin-server-sqlite"
-version = "18.19.0-beta.3"
+version = "18.19.0"
 dependencies = [
  "async-trait",
  "atuin-common",
@@ -5617,7 +5617,7 @@ dependencies = [
 
 [[package]]
 name = "tests-database"
-version = "18.19.0-beta.3"
+version = "18.19.0"
 dependencies = [
  "async-trait",
  "atuin-common",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ resolver = "2"
 exclude = ["ui/backend", "crates/atuin-nucleo/matcher/fuzz"]
 
 [workspace.package]
-version = "18.19.0-beta.3"
+version = "18.19.0"
 authors = ["Ellie Huxtable <ellie@atuin.sh>"]
 rust-version = "1.97.0"
 license = "MIT"
@@ -19,18 +19,18 @@ readme = "README.md"
 [workspace.dependencies]
 async-trait = "0.1.58"
 enum_dispatch = "0.3"
-atuin-client = { path = "crates/atuin-client", version = "18.19.0-beta.3" }
-atuin-common = { path = "crates/atuin-common", version = "18.19.0-beta.3" }
-atuin-daemon = { path = "crates/atuin-daemon", version = "18.19.0-beta.3" }
-atuin-domain = { path = "crates/atuin-domain", version = "18.19.0-beta.3" }
-atuin-dotfiles = { path = "crates/atuin-dotfiles", version = "18.19.0-beta.3" }
-atuin-history = { path = "crates/atuin-history", version = "18.19.0-beta.3" }
-atuin-kv = { path = "crates/atuin-kv", version = "18.19.0-beta.3" }
-atuin-scripts = { path = "crates/atuin-scripts", version = "18.19.0-beta.3" }
-atuin-server = { path = "crates/atuin-server", version = "18.19.0-beta.3" }
-atuin-server-database = { path = "crates/atuin-server-database", version = "18.19.0-beta.3" }
-atuin-server-postgres = { path = "crates/atuin-server-postgres", version = "18.19.0-beta.3" }
-atuin-server-sqlite = { path = "crates/atuin-server-sqlite", version = "18.19.0-beta.3" }
+atuin-client = { path = "crates/atuin-client", version = "18.19.0" }
+atuin-common = { path = "crates/atuin-common", version = "18.19.0" }
+atuin-daemon = { path = "crates/atuin-daemon", version = "18.19.0" }
+atuin-domain = { path = "crates/atuin-domain", version = "18.19.0" }
+atuin-dotfiles = { path = "crates/atuin-dotfiles", version = "18.19.0" }
+atuin-history = { path = "crates/atuin-history", version = "18.19.0" }
+atuin-kv = { path = "crates/atuin-kv", version = "18.19.0" }
+atuin-scripts = { path = "crates/atuin-scripts", version = "18.19.0" }
+atuin-server = { path = "crates/atuin-server", version = "18.19.0" }
+atuin-server-database = { path = "crates/atuin-server-database", version = "18.19.0" }
+atuin-server-postgres = { path = "crates/atuin-server-postgres", version = "18.19.0" }
+atuin-server-sqlite = { path = "crates/atuin-server-sqlite", version = "18.19.0" }
 atuin-nucleo = { path = "crates/atuin-nucleo", version = "0.6.0" }
 atuin-nucleo-matcher = { path = "crates/atuin-nucleo/matcher", version = "0.3.1" }
 frizbee = "0.12.0"

--- a/crates/atuin-client/Cargo.toml
+++ b/crates/atuin-client/Cargo.toml
@@ -81,11 +81,11 @@ strum = { version = "0.27", features = ["strum_macros"] }
 
 [dependencies.atuin-common]
 path = "../atuin-common"
-version = "18.19.0-beta.3"
+version = "18.19.0"
 
 [dependencies.atuin-domain]
 path = "../atuin-domain"
-version = "18.19.0-beta.3"
+version = "18.19.0"
 
 [dev-dependencies]
 tokio = { version = "1", features = ["full"] }
@@ -98,7 +98,7 @@ toml = "1.1"
 # This crate's tests require the `test-utils` feature in atuin-common.
 [dev-dependencies.atuin-common]
 path = "../atuin-common"
-version = "18.19.0-beta.3"
+version = "18.19.0"
 features = ["test-utils"]
 
 [[bench]]

--- a/crates/atuin-daemon/Cargo.toml
+++ b/crates/atuin-daemon/Cargo.toml
@@ -14,12 +14,12 @@ readme.workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-atuin-client = { path = "../atuin-client", version = "18.19.0-beta.3" }
-atuin-common = { path = "../atuin-common", version = "18.19.0-beta.3" }
+atuin-client = { path = "../atuin-client", version = "18.19.0" }
+atuin-common = { path = "../atuin-common", version = "18.19.0" }
 enum_dispatch = { workspace = true }
 derive_more = { workspace = true }
-atuin-dotfiles = { path = "../atuin-dotfiles", version = "18.19.0-beta.3" }
-atuin-history = { path = "../atuin-history", version = "18.19.0-beta.3" }
+atuin-dotfiles = { path = "../atuin-dotfiles", version = "18.19.0" }
+atuin-history = { path = "../atuin-history", version = "18.19.0" }
 
 time = { workspace = true }
 uuid = { workspace = true }

--- a/crates/atuin-dotfiles/Cargo.toml
+++ b/crates/atuin-dotfiles/Cargo.toml
@@ -14,9 +14,9 @@ readme.workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-atuin-common = { path = "../atuin-common", version = "18.19.0-beta.3" }
-atuin-domain = { path = "../atuin-domain", version = "18.19.0-beta.3" }
-atuin-client = { path = "../atuin-client", version = "18.19.0-beta.3" }
+atuin-common = { path = "../atuin-common", version = "18.19.0" }
+atuin-domain = { path = "../atuin-domain", version = "18.19.0" }
+atuin-client = { path = "../atuin-client", version = "18.19.0" }
 derive_more = { workspace = true }
 
 eyre = { workspace = true }

--- a/crates/atuin-history/Cargo.toml
+++ b/crates/atuin-history/Cargo.toml
@@ -14,7 +14,7 @@ readme.workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-atuin-client = { path = "../atuin-client", version = "18.19.0-beta.3" }
+atuin-client = { path = "../atuin-client", version = "18.19.0" }
 
 time = { workspace = true }
 serde = { workspace = true }

--- a/crates/atuin-kv/Cargo.toml
+++ b/crates/atuin-kv/Cargo.toml
@@ -14,9 +14,9 @@ readme.workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-atuin-client = { path = "../atuin-client", version = "18.19.0-beta.3" }
-atuin-common = { path = "../atuin-common", version = "18.19.0-beta.3" }
-atuin-domain = { path = "../atuin-domain", version = "18.19.0-beta.3" }
+atuin-client = { path = "../atuin-client", version = "18.19.0" }
+atuin-common = { path = "../atuin-common", version = "18.19.0" }
+atuin-domain = { path = "../atuin-domain", version = "18.19.0" }
 derive_more = { workspace = true }
 
 tracing = { workspace = true }

--- a/crates/atuin-lab-share/Cargo.toml
+++ b/crates/atuin-lab-share/Cargo.toml
@@ -32,7 +32,7 @@ daemonize = "0.5.0"
 atuin-common = { workspace = true, features = ["unicode"] }
 # The `--active` tap speaks the proxy's subscriber protocol; no cycle —
 # atuin-pty-proxy depends only on atuin-common.
-atuin-pty-proxy = { path = "../atuin-pty-proxy", version = "18.19.0-beta.3" }
+atuin-pty-proxy = { path = "../atuin-pty-proxy", version = "18.19.0" }
 vt100 = { workspace = true }
 crossterm = { workspace = true }
 # `features = ["full"]` at the workspace level includes `signal` and `time`;

--- a/crates/atuin-scripts/Cargo.toml
+++ b/crates/atuin-scripts/Cargo.toml
@@ -14,9 +14,9 @@ readme.workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-atuin-client = { path = "../atuin-client", version = "18.19.0-beta.3" }
-atuin-common = { path = "../atuin-common", version = "18.19.0-beta.3" }
-atuin-domain = { path = "../atuin-domain", version = "18.19.0-beta.3" }
+atuin-client = { path = "../atuin-client", version = "18.19.0" }
+atuin-common = { path = "../atuin-common", version = "18.19.0" }
+atuin-domain = { path = "../atuin-domain", version = "18.19.0" }
 derive_more = { workspace = true }
 
 tracing = { workspace = true }

--- a/crates/atuin-server-database/Cargo.toml
+++ b/crates/atuin-server-database/Cargo.toml
@@ -10,8 +10,8 @@ homepage = { workspace = true }
 repository = { workspace = true }
 
 [dependencies]
-atuin-common = { path = "../atuin-common", version = "18.19.0-beta.3" }
-atuin-domain = { path = "../atuin-domain", version = "18.19.0-beta.3" }
+atuin-common = { path = "../atuin-common", version = "18.19.0" }
+atuin-domain = { path = "../atuin-domain", version = "18.19.0" }
 derive_more = { workspace = true }
 
 async-trait = { workspace = true }

--- a/crates/atuin-server-postgres/Cargo.toml
+++ b/crates/atuin-server-postgres/Cargo.toml
@@ -10,9 +10,9 @@ homepage = { workspace = true }
 repository = { workspace = true }
 
 [dependencies]
-atuin-common = { path = "../atuin-common", version = "18.19.0-beta.3" }
-atuin-domain = { path = "../atuin-domain", version = "18.19.0-beta.3" }
-atuin-server-database = { path = "../atuin-server-database", version = "18.19.0-beta.3" }
+atuin-common = { path = "../atuin-common", version = "18.19.0" }
+atuin-domain = { path = "../atuin-domain", version = "18.19.0" }
+atuin-server-database = { path = "../atuin-server-database", version = "18.19.0" }
 derive_more = { workspace = true }
 
 eyre = { workspace = true }

--- a/crates/atuin-server-sqlite/Cargo.toml
+++ b/crates/atuin-server-sqlite/Cargo.toml
@@ -10,9 +10,9 @@ homepage = { workspace = true }
 repository = { workspace = true }
 
 [dependencies]
-atuin-common = { path = "../atuin-common", version = "18.19.0-beta.3" }
-atuin-domain = { path = "../atuin-domain", version = "18.19.0-beta.3" }
-atuin-server-database = { path = "../atuin-server-database", version = "18.19.0-beta.3" }
+atuin-common = { path = "../atuin-common", version = "18.19.0" }
+atuin-domain = { path = "../atuin-domain", version = "18.19.0" }
+atuin-server-database = { path = "../atuin-server-database", version = "18.19.0" }
 derive_more = { workspace = true }
 
 eyre = { workspace = true }

--- a/crates/atuin-server/Cargo.toml
+++ b/crates/atuin-server/Cargo.toml
@@ -52,7 +52,7 @@ tracing-subscriber = { workspace = true }
 # client's api_client. atuin-client is only a dev dependency here so the client
 # binary crate stays free of server/postgres deps (see issue #2884).
 [dev-dependencies]
-atuin-client = { path = "../atuin-client", version = "18.19.0-beta.3", default-features = false, features = ["sync"] }
+atuin-client = { path = "../atuin-client", version = "18.19.0", default-features = false, features = ["sync"] }
 rstest = { workspace = true }
 futures-util = "0.3"
 tracing-tree = "0.4"

--- a/crates/atuin/Cargo.toml
+++ b/crates/atuin/Cargo.toml
@@ -67,15 +67,15 @@ vendored-tls = ["atuin-client?/vendored-tls", "atuin-lab-share?/vendored-tls"]
 self-update = ["dep:axoupdater"]
 
 [dependencies]
-atuin-ai = { path = "../atuin-ai", version = "18.19.0-beta.3", optional = true, default-features = false }
-atuin-client = { path = "../atuin-client", version = "18.19.0-beta.3", optional = true, default-features = false }
+atuin-ai = { path = "../atuin-ai", version = "18.19.0", optional = true, default-features = false }
+atuin-client = { path = "../atuin-client", version = "18.19.0", optional = true, default-features = false }
 atuin-common = { workspace = true, features = ["unicode"] }
 atuin-domain = { workspace = true }
 atuin-dotfiles = { workspace = true }
 atuin-history = { workspace = true }
-atuin-daemon = { path = "../atuin-daemon", version = "18.19.0-beta.3", optional = true, default-features = false }
-atuin-pty-proxy = { path = "../atuin-pty-proxy", version = "18.19.0-beta.3", optional = true, default-features = false }
-atuin-lab-share = { path = "../atuin-lab-share", version = "18.19.0-beta.3", optional = true }
+atuin-daemon = { path = "../atuin-daemon", version = "18.19.0", optional = true, default-features = false }
+atuin-pty-proxy = { path = "../atuin-pty-proxy", version = "18.19.0", optional = true, default-features = false }
+atuin-lab-share = { path = "../atuin-lab-share", version = "18.19.0", optional = true }
 atuin-scripts = { workspace = true }
 atuin-kv = { workspace = true }
 axoupdater = { version = "0.10", optional = true }
@@ -137,7 +137,7 @@ daemonize = "0.5.0"
 # compiles cleanly. tree-sitter 0.26's portable/endian.h fails on illumos,
 # Windows cross-compiles, and potentially other exotic targets.
 [target.'cfg(any(target_os = "linux", target_os = "macos"))'.dependencies]
-atuin-ai = { path = "../atuin-ai", version = "18.19.0-beta.3", optional = true, default-features = false, features = ["tree-sitter"] }
+atuin-ai = { path = "../atuin-ai", version = "18.19.0", optional = true, default-features = false, features = ["tree-sitter"] }
 tree-sitter = { workspace = true }
 tree-sitter-bash = { workspace = true }
 tree-sitter-fish = { workspace = true }


### PR DESCRIPTION

### Bug Fixes

- *(client)* Avoid panic decoding an empty encryption key ([#3803](https://github.com/atuinsh/atuin/issues/3803))
- *(client)* Keep sqlx-postgres out of the client crate ([#2884](https://github.com/atuinsh/atuin/issues/2884)) ([#3823](https://github.com/atuinsh/atuin/issues/3823))
- *(config)* Preserve comments in `atuin config set` ([#3766](https://github.com/atuinsh/atuin/issues/3766))
- *(search)* Correct fuzzy result ranking ([#3603](https://github.com/atuinsh/atuin/issues/3603)) ([#3624](https://github.com/atuinsh/atuin/issues/3624))
- Fix atuin-search-bench/benches/search.rs ([#3788](https://github.com/atuinsh/atuin/issues/3788))
- Close OSC133 C when launching Atuin AI to prevent content erasure ([#3794](https://github.com/atuinsh/atuin/issues/3794))
- Authenticate beta release push as atuin-bot ([#3809](https://github.com/atuinsh/atuin/issues/3809))
- Copy vendored axoasset into docker builder stage ([#3816](https://github.com/atuinsh/atuin/issues/3816))


### Documentation

- Clarify update check network, provide build command ([#3767](https://github.com/atuinsh/atuin/issues/3767))
- Remove old i18n docs ([#3787](https://github.com/atuinsh/atuin/issues/3787))
- Use shell-agnostic install command in quickstart pages ([#3820](https://github.com/atuinsh/atuin/issues/3820))
- Document named stats periods (today/week/month/year) ([#3821](https://github.com/atuinsh/atuin/issues/3821))
- State minimum supported Rust version in install guide ([#3822](https://github.com/atuinsh/atuin/issues/3822))
- Document iTerm2 tmux popup incompatibility ([#3826](https://github.com/atuinsh/atuin/issues/3826))
- Clarify key binding snippets belong in shell startup file ([#3837](https://github.com/atuinsh/atuin/issues/3837))
- Mention RustRover in IDE integration guidance ([#3834](https://github.com/atuinsh/atuin/issues/3834))


### Features

- *(client)* Show intent in inspector ([#3804](https://github.com/atuinsh/atuin/issues/3804))
- *(client)* Enable pty-proxy via config ([#3828](https://github.com/atuinsh/atuin/issues/3828))
- *(config)* Validate new settings in `atuin config set` before writing them to disk ([#3769](https://github.com/atuinsh/atuin/issues/3769))
- *(lab)* Experimental `atuin lab share`
- *(search)* Remove the "skim" engine ([#3825](https://github.com/atuinsh/atuin/issues/3825))
- Remove word with ALT-Backspace ALT-D ([#2457](https://github.com/atuinsh/atuin/issues/2457))
- Add scheduled beta release workflow ([#3805](https://github.com/atuinsh/atuin/issues/3805))
- Migrate TLS backend from rustls to native-tls ([#3807](https://github.com/atuinsh/atuin/issues/3807))
- Make `update` a real subcommand ([#3813](https://github.com/atuinsh/atuin/issues/3813))
- Capability negotiation protocol (client + server) ([#3797](https://github.com/atuinsh/atuin/issues/3797))


### Miscellaneous Tasks

- *(ci)* Fix `package` step ([#3770](https://github.com/atuinsh/atuin/issues/3770))
- Remove Store trait ([#3779](https://github.com/atuinsh/atuin/issues/3779))
- Daemon search benchmark (divan + CodSpeed) ([#3763](https://github.com/atuinsh/atuin/issues/3763))
- Run CodSpeed benchmarks on macro runners in walltime mode ([#3786](https://github.com/atuinsh/atuin/issues/3786))
- Add `OrFilter` as a replacement for `Vec`s as filter lists ([#3768](https://github.com/atuinsh/atuin/issues/3768))
- Add `atuin-domain` crate for shared domain types ([#3790](https://github.com/atuinsh/atuin/issues/3790))
- Run CodSpeed walltime benchmarks on depot-macos-26 ([#3791](https://github.com/atuinsh/atuin/issues/3791))
- Fix deny.toml and get it to run in CI ([#3808](https://github.com/atuinsh/atuin/issues/3808))
- Remove codspeed workflow ([#3812](https://github.com/atuinsh/atuin/issues/3812))
- Richer logging for atuin-server ([#2564](https://github.com/atuinsh/atuin/issues/2564))
- Hide --active sharing ([#3846](https://github.com/atuinsh/atuin/issues/3846))


### Refactor

- *(deps)* Bump thiserror from 2.0.18 to 2.0.19 ([#3839](https://github.com/atuinsh/atuin/issues/3839))
- *(deps)* Bump strum_macros from 0.27.2 to 0.28.0 ([#3841](https://github.com/atuinsh/atuin/issues/3841))
- *(deps)* Bump tonic-types from 0.14.5 to 0.14.6 ([#3842](https://github.com/atuinsh/atuin/issues/3842))
- *(deps)* Bump pulldown-cmark from 0.13.3 to 0.13.4 ([#3840](https://github.com/atuinsh/atuin/issues/3840))
- *(deps)* Bump itertools from 0.14.0 to 0.15.0 ([#3838](https://github.com/atuinsh/atuin/issues/3838))
- Adopt enum_dispatch for enum trait delegation ([#3806](https://github.com/atuinsh/atuin/issues/3806))


### Testing

- Adopt rstest across the workspace test suite ([#3785](https://github.com/atuinsh/atuin/issues/3785))


### Daemon

- Replace nucleo with frizbee, rank by match quality with frecency tiebreak ([#3782](https://github.com/atuinsh/atuin/issues/3782))