### PR TITLE
feat(client): enable pty-proxy via config

### DIFF
--- a/crates/atuin-client/config.toml
+++ b/crates/atuin-client/config.toml
@@ -294,6 +294,16 @@ enter_accept = true
 ## The port that should be used for TCP on non unix systems
 # tcp_port = 8889
 
+# [pty_proxy]
+## If enabled, `atuin init` will first re-exec your shell inside `atuin pty-proxy`,
+## so you don't need a separate `eval "$(atuin pty-proxy init)"` line in your shell
+## config. Supported for bash, zsh, fish and nu on unix platforms.
+## For the fastest startup, keep your `atuin init` line near the top of your shell
+## config: everything sourced before it runs again inside the proxy.
+## Safe to combine with an existing `atuin pty-proxy init` line — the proxy only
+## starts once.
+# enabled = false
+
 # [theme]
 ## Color theme to use for rendering in the terminal.
 ## There are some built-in themes, including the base theme ("default"),

--- a/crates/atuin-client/src/settings.rs
+++ b/crates/atuin-client/src/settings.rs
@@ -492,6 +492,16 @@ pub struct Daemon {
     pub tcp_port: u64,
 }
 
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
+pub struct PtyProxy {
+    /// If enabled, `atuin init` emits shell code that re-execs the shell
+    /// inside `atuin pty-proxy`, so no separate `atuin pty-proxy init` line
+    /// is needed in shell config. Supported for bash, zsh, fish and nu on
+    /// unix platforms.
+    #[serde(alias = "enable")]
+    pub enabled: bool,
+}
+
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Search {
     /// The list of enabled filter modes, in order of priority.
@@ -1056,6 +1066,9 @@ pub struct Settings {
 
     #[serde(default)]
     pub daemon: Daemon,
+
+    #[serde(default)]
+    pub pty_proxy: PtyProxy,
 
     #[serde(default)]
     pub search: Search,

--- a/crates/atuin-pty-proxy/src/lib.rs
+++ b/crates/atuin-pty-proxy/src/lib.rs
@@ -14,7 +14,7 @@ mod screen;
 #[cfg(unix)]
 pub use capture::{CommandCapture, CommandCaptureSink};
 #[cfg(unix)]
-pub use pty_proxy::PtyProxy;
+pub use pty_proxy::{PtyProxy, Shell, init_script};
 
 #[cfg(not(unix))]
 #[allow(dead_code)]

--- a/crates/atuin-pty-proxy/src/pty_proxy.rs
+++ b/crates/atuin-pty-proxy/src/pty_proxy.rs
@@ -35,7 +35,7 @@ pub struct Init {
 #[derive(Clone, Copy, Debug, Eq, PartialEq, ValueEnum)]
 #[value(rename_all = "lower")]
 #[allow(clippy::enum_variant_names, clippy::doc_markdown)]
-enum Shell {
+pub enum Shell {
     /// Zsh setup
     Zsh,
     /// Bash setup
@@ -152,6 +152,17 @@ fn env_flag(name: &str) -> bool {
             "1" | "true" | "yes" | "on"
         )
     })
+}
+
+/// Shell code that re-execs the current shell inside `atuin pty-proxy`.
+///
+/// Guarded by `ATUIN_PTY_PROXY_ACTIVE`, so it is safe to emit more than once
+/// per shell startup: whichever copy runs first wins and the rest no-op. This
+/// lets `atuin init` embed the preamble (via the `pty_proxy.enabled` setting)
+/// without conflicting with an existing standalone `atuin pty-proxy init`
+/// line in shell config.
+pub fn init_script(shell: Shell) -> &'static str {
+    render_init(shell)
 }
 
 fn render_init(shell: Shell) -> &'static str {

--- a/crates/atuin/src/command/client/init.rs
+++ b/crates/atuin/src/command/client/init.rs
@@ -128,6 +128,43 @@ impl Cmd {
         }
     }
 
+    /// When `pty_proxy.enabled` is set, prepend the pty-proxy exec preamble
+    /// to the init script so the shell re-execs itself inside
+    /// `atuin pty-proxy` — no separate `atuin pty-proxy init` line needed in
+    /// shell config. The preamble is guarded by `ATUIN_PTY_PROXY_ACTIVE`, so
+    /// users who still have the standalone line keep working: whichever copy
+    /// runs first wins and the other no-ops.
+    #[cfg(all(feature = "pty-proxy", unix))]
+    fn pty_proxy_init(&self, settings: &Settings) {
+        if !settings.pty_proxy.enabled {
+            return;
+        }
+
+        let shell = match self.shell {
+            Shell::Zsh => atuin_pty_proxy::Shell::Zsh,
+            Shell::Bash => atuin_pty_proxy::Shell::Bash,
+            Shell::Fish => atuin_pty_proxy::Shell::Fish,
+            Shell::Nu => atuin_pty_proxy::Shell::Nu,
+            Shell::Xonsh | Shell::PowerShell => {
+                eprintln!(
+                    "atuin: pty_proxy.enabled is set, but atuin pty-proxy does not support this shell"
+                );
+                return;
+            }
+        };
+
+        print!("{}", atuin_pty_proxy::init_script(shell));
+    }
+
+    #[cfg(not(all(feature = "pty-proxy", unix)))]
+    fn pty_proxy_init(&self, settings: &Settings) {
+        if settings.pty_proxy.enabled {
+            eprintln!(
+                "atuin: pty_proxy.enabled is set, but this build of atuin does not include pty-proxy support"
+            );
+        }
+    }
+
     pub async fn run(self, settings: &Settings) -> Result<()> {
         if !settings.paths_ok() {
             eprintln!(
@@ -135,6 +172,8 @@ impl Cmd {
             );
             return Ok(());
         }
+
+        self.pty_proxy_init(settings);
 
         if settings.dotfiles.enabled {
             self.dotfiles_init(settings).await?;

--- a/docs/docs/reference/pty-proxy.md
+++ b/docs/docs/reference/pty-proxy.md
@@ -42,7 +42,23 @@ setup, retention limits, and privacy.
 
 ## Initialization
 
-Atuin pty-proxy needs to be initialized separately from your existing Atuin config. Place the init line shown below in your shell's init script, as high in the document as possible, _before_ your normal `atuin init` call.
+The simplest way to enable pty-proxy is via your Atuin config (`~/.config/atuin/config.toml`) — no extra shell config needed:
+
+```toml
+[pty_proxy]
+enabled = true
+```
+
+With this set, your existing `atuin init` line starts the proxy automatically.
+
+!!! tip "Startup performance"
+
+    When enabled this way, the proxy starts wherever your `atuin init` line
+    sits, and everything sourced *before* that line runs a second time inside
+    the proxy. This is harmless, but for the fastest startup keep your
+    `atuin init` line as high in your shell config as possible.
+
+Alternatively, you can initialize pty-proxy explicitly in your shell config. Place the init line shown below as high in the document as possible, _before_ your normal `atuin init` call. Both methods can coexist safely — the proxy only starts once.
 
 === "zsh"
 


### PR DESCRIPTION
## Summary

Adds a `[pty_proxy] enabled` setting. When set, `atuin init` prepends the pty-proxy exec preamble to its output, so the shell re-execs itself inside `atuin pty-proxy` — no separate `eval "$(atuin pty-proxy init)"` line needed in shell config.

- New `pty_proxy.enabled` setting (with `enable` alias), documented in `config.toml` and the pty-proxy reference docs
- `atuin init` emits the preamble for bash, zsh, fish and nu on unix; prints a warning for unsupported shells or non-pty-proxy builds
- Safe to combine with an existing standalone `atuin pty-proxy init` line: the preamble is guarded by `ATUIN_PTY_PROXY_ACTIVE`, so whichever copy runs first wins and the rest no-op

## Atuin Terminal

Verified end-to-end that the proxy still runs inside Atuin Terminal: the config gate in `atuin init` never consults `ATUIN_TERMINAL` — that variable only disables the daemon-bound semantic capture sink (`semantic_command_capture_sink`), so inside Atuin Terminal the proxy still starts, sets `ATUIN_PTY_PROXY_ACTIVE`, and runs the screen parser and socket server, just without double-recording captures. Confirmed with an interactive zsh in a pty with `ATUIN_TERMINAL=1` and `pty_proxy.enabled = true`: the shell re-exec'd into the proxy and received a live `ATUIN_PTY_PROXY_SOCKET`.

## Test plan

- `cargo test -p atuin-pty-proxy` (74 passed)
- Manual: interactive zsh in a pty with `pty_proxy.enabled = true`, with and without `ATUIN_TERMINAL=1` — shell re-execs into the proxy once, nested startup no-ops via the `ATUIN_PTY_PROXY_ACTIVE` guard