### PR TITLE
feat: offer account login during install setup

### DIFF
--- a/crates/atuin/src/command/client/account/login.rs
+++ b/crates/atuin/src/command/client/account/login.rs
@@ -1,4 +1,4 @@
-use std::io;
+use std::io::{self, IsTerminal};
 
 use clap::Parser;
 use eyre::{Context, Result, bail};
@@ -32,10 +32,15 @@ pub struct Cmd {
     pub from_registration: bool,
 }
 
-fn get_input() -> Result<String> {
+/// Read a line from stdin, returning `None` at end of input. The distinction
+/// matters for the key prompts, which re-prompt on a blank line but must not
+/// spin forever once stdin is exhausted.
+fn get_input() -> Result<Option<String>> {
     let mut input = String::new();
-    io::stdin().read_line(&mut input)?;
-    Ok(input.trim_end_matches(&['\r', '\n'][..]).to_string())
+    if io::stdin().read_line(&mut input)? == 0 {
+        return Ok(None);
+    }
+    Ok(Some(input.trim_end_matches(&['\r', '\n'][..]).to_string()))
 }
 
 impl Cmd {
@@ -66,7 +71,16 @@ impl Cmd {
             self.run_legacy_login(settings, store).await?;
         }
 
-        verify_key_against_remote(settings).await
+        verify_key_against_remote(settings, store, self.interactive()).await
+    }
+
+    /// Whether a rejected key can be corrected by asking for another one.
+    ///
+    /// A key from `--key` is a scripted input: the caller committed to a value
+    /// up front, so a wrong one is an error to report rather than a prompt to
+    /// raise. Only a human typing at a terminal gets to try again.
+    fn interactive(&self) -> bool {
+        self.key.is_none() && io::stdin().is_terminal()
     }
 
     /// Hub login: use the browser flow unless the username was provided for headless use.
@@ -190,71 +204,77 @@ impl Cmd {
             atuin_common::docs::url("guide/sync/#login")
         );
 
-        let key = or_user_input(
-            self.key.clone(),
-            "encryption key [blank to use existing key file]",
-        );
+        let interactive = self.interactive();
+        let mut flag_key = self.key.clone();
 
-        // if provided, the key may be EITHER base64, or a bip mnemonic
-        // try to normalize on base64
-        let loaded_key: Option<paseto_v4::Key> = if key.is_empty() {
-            None
-        } else {
-            Some(paseto_v4::Key::try_from_mnemonic(&key)?)
-        };
+        loop {
+            let key = match flag_key.take() {
+                Some(key) => key,
+                None => match read_user_input("encryption key [blank to use existing key file]") {
+                    Some(key) => key,
+                    // Stdin is exhausted, so re-prompting would spin forever.
+                    None => bail!("No encryption key provided"),
+                },
+            };
 
-        match loaded_key {
-            None => {
-                assert!(
-                    key_path.exists(),
-                    "No key provided and no existing key file found. Please use 'atuin key' on your other machine, or recover your key from a backup"
-                );
+            if key.is_empty() {
+                if !key_path.exists() {
+                    let msg = "No key provided and no existing key file found. Please use 'atuin key' on your other machine, or recover your key from a backup";
+                    if !interactive {
+                        bail!(msg);
+                    }
+                    println!("\n{msg}\n");
+                    continue;
+                }
 
-                let bytes = fs_err::read_to_string(key_path).context(format!(
-                    "Existing key file at '{}' could not be read",
+                paseto_v4::Key::try_load_from_path(key_path).context(format!(
+                    "The key in existing key file at '{}' is invalid",
                     key_path.to_string_lossy()
                 ))?;
 
-                if paseto_v4::Key::decode(&bytes).is_err() {
-                    bail!(format!(
-                        "The key in existing key file at '{}' is invalid",
-                        key_path.to_string_lossy()
-                    ));
-                }
-
-                Ok(())
+                return Ok(());
             }
-            Some(k) => {
-                if !key_path.exists() {
-                    k.try_write_path(key_path)?;
 
-                    return Ok(());
-                }
-
-                // we now know that the user has logged in specifying a key, AND that the key path
-                // exists
-
-                // 1. check if the saved key and the provided key match. if so, nothing to do.
-                // 2. if not, re-encrypt the local history and overwrite the key
-                let current_key = paseto_v4::Key::try_load_from_path(&settings.key_path)?;
-
-                if k != current_key {
-                    println!("\nRe-encrypting local store with new key");
-
-                    store.re_encrypt(&current_key, &k).await?;
-
-                    println!("Writing new key");
-                    k.overwrite_path(key_path)?;
-                }
-
-                Ok(())
+            // The key may be EITHER base64 or a bip39 mnemonic.
+            match paseto_v4::Key::try_from_mnemonic(&key) {
+                Ok(key) => return store_key(settings, store, &key).await,
+                Err(err) if interactive => println!("\n{err}. Please try again.\n"),
+                Err(err) => return Err(err.into()),
             }
         }
     }
 }
 
-async fn verify_key_against_remote(settings: &Settings) -> Result<()> {
-    let key = paseto_v4::Key::try_load_from_path(&settings.key_path)
+/// Write the key to the key file, re-encrypting the local store first if it was
+/// previously encrypted with a different key.
+async fn store_key(settings: &Settings, store: &SqliteStore, key: &paseto_v4::Key) -> Result<()> {
+    let key_path = &settings.key_path;
+
+    if !key_path.exists() {
+        key.try_write_path(key_path)?;
+        return Ok(());
+    }
+
+    let current_key = paseto_v4::Key::try_load_from_path(key_path)?;
+    if *key == current_key {
+        return Ok(());
+    }
+
+    println!("\nRe-encrypting local store with new key");
+    store.re_encrypt(&current_key, key).await?;
+
+    println!("Writing new key");
+    key.overwrite_path(key_path)?;
+
+    Ok(())
+}
+
+async fn verify_key_against_remote(
+    settings: &Settings,
+    store: &SqliteStore,
+    interactive: bool,
+) -> Result<()> {
+    let mut key = paseto_v4::Key::try_load_from_path(&settings.key_path)
         .context("could not load encryption key for verification")?;
 
     let client = sync::build_client(settings).await?;
@@ -266,36 +286,65 @@ async fn verify_key_against_remote(settings: &Settings) -> Result<()> {
         }
     };
 
-    match sync::check_encryption_key(&client, &remote_index, &key).await {
-        Ok(()) => Ok(()),
-        Err(SyncError::WrongKey) => {
-            // Roll back the saved session so the user is not left in a
-            // half-authenticated state with a key that can't read the data.
-            if let Ok(meta) = Settings::meta_store().await {
-                let _ = meta.delete_session().await;
-                let _ = meta.delete_hub_session().await;
+    loop {
+        match sync::check_encryption_key(&client, &remote_index, &key).await {
+            // Only persist a key the server has confirmed can read the data, so
+            // that cancelling out of a retry leaves the local store as it was.
+            Ok(()) => return store_key(settings, store, &key).await,
+            Err(SyncError::WrongKey) => {
+                if !interactive {
+                    logout_wrong_key().await;
+                }
+
+                println!(
+                    "\nThe encryption key on this machine does not match the data on the server."
+                );
+                println!(
+                    "You can find the correct key by running 'atuin key' on a machine that already syncs successfully."
+                );
+
+                let input = read_user_input("encryption key [blank to log out and cancel]");
+                match input {
+                    Some(input) if !input.is_empty() => {
+                        match paseto_v4::Key::try_from_mnemonic(&input) {
+                            Ok(candidate) => key = candidate,
+                            Err(err) => println!("\n{err}. Please try again."),
+                        }
+                    }
+                    // A blank line or exhausted stdin both mean "give up".
+                    _ => logout_wrong_key().await,
+                }
             }
-            crate::print_error::print_error(
-                "Wrong encryption key",
-                "The encryption key on this machine does not match the data on the server. \
-                 You have been logged out.\n\n\
-                 To fix this, find your existing key by running `atuin key` on a machine that \
-                 already syncs successfully, then run `atuin login` again here with that key.",
-            );
-            std::process::exit(1);
-        }
-        Err(e) => {
-            // Non-key error (e.g. transient network issue). Don't fail the
-            // login — the user is authenticated and can sync later when the
-            // network recovers.
-            tracing::warn!("could not verify encryption key against remote: {e}");
-            Ok(())
+            Err(e) => {
+                // Non-key error (e.g. transient network issue). Don't fail the
+                // login — the user is authenticated and can sync later when the
+                // network recovers.
+                tracing::warn!("could not verify encryption key against remote: {e}");
+                return Ok(());
+            }
         }
     }
 }
 
+/// Roll back the saved session so the user is not left in a half-authenticated
+/// state with a key that can't read the data, then exit.
+async fn logout_wrong_key() -> ! {
+    if let Ok(meta) = Settings::meta_store().await {
+        let _ = meta.delete_session().await;
+        let _ = meta.delete_hub_session().await;
+    }
+    crate::print_error::print_error(
+        "Wrong encryption key",
+        "The encryption key on this machine does not match the data on the server. \
+         You have been logged out.\n\n\
+         To fix this, find your existing key by running `atuin key` on a machine that \
+         already syncs successfully, then run `atuin login` again here with that key.",
+    );
+    std::process::exit(1);
+}
+
 pub(super) fn or_user_input(value: Option<String>, name: &'static str) -> String {
-    value.unwrap_or_else(|| read_user_input(name))
+    value.unwrap_or_else(|| read_user_input(name).unwrap_or_default())
 }
 
 pub(super) fn read_user_password() -> String {
@@ -303,7 +352,8 @@ pub(super) fn read_user_password() -> String {
     password.expect("Failed to read from input")
 }
 
-fn read_user_input(name: &'static str) -> String {
+/// Returns `None` if stdin reached end of input before a line was read.
+fn read_user_input(name: &'static str) -> Option<String> {
     eprint!("Please enter {name}: ");
     get_input().expect("Failed to read from input")
 }

--- a/crates/atuin/src/command/client/account/login.rs
+++ b/crates/atuin/src/command/client/account/login.rs
@@ -1,4 +1,4 @@
-use std::io;
+use std::io::{self, IsTerminal};
 
 use clap::Parser;
 use eyre::{Context, Result, bail};
@@ -67,7 +67,7 @@ impl Cmd {
             self.run_legacy_login(settings, store).await?;
         }
 
-        verify_key_against_remote(settings).await
+        verify_key_against_remote(settings, store).await
     }
 
     /// Hub login: use the browser flow unless the username was provided for headless use.
@@ -191,93 +191,110 @@ impl Cmd {
             atuin_common::docs::url("guide/sync/#login")
         );
 
-        let key = or_user_input(
-            self.key.clone(),
-            "encryption key [blank to use existing key file]",
-        );
+        // Only re-prompt on bad input when the key came from an interactive
+        // prompt — a bad --key flag or piped stdin should fail immediately.
+        let mut flag_key = self.key.clone();
+        let interactive = flag_key.is_none() && io::stdin().is_terminal();
 
-        // if provided, the key may be EITHER base64, or a bip mnemonic
-        // try to normalize on base64
-        let key = if key.is_empty() {
-            key
-        } else {
-            // try parse the key as a mnemonic...
-            match bip39::Mnemonic::from_phrase(&key, bip39::Language::English) {
-                Ok(mnemonic) => encode_key(Key::from_slice(mnemonic.entropy()))?,
-                Err(err) => {
-                    match err {
-                        // assume they copied in the base64 key
-                        bip39::ErrorKind::InvalidWord(_) => key,
-                        bip39::ErrorKind::InvalidChecksum => {
-                            bail!("Key mnemonic is not valid")
-                        }
-                        bip39::ErrorKind::InvalidKeysize(_)
-                        | bip39::ErrorKind::InvalidWordLength(_)
-                        | bip39::ErrorKind::InvalidEntropyLength(_, _) => {
-                            bail!("Key is not the correct length")
-                        }
-                    }
-                }
-            }
-        };
+        loop {
+            let key = or_user_input(
+                flag_key.take(),
+                "encryption key [blank to use existing key file]",
+            );
 
-        if key.is_empty() {
-            if key_path.exists() {
-                let bytes = fs_err::read_to_string(key_path).context(format!(
-                    "Existing key file at '{}' could not be read",
-                    key_path.to_string_lossy()
-                ))?;
-                if decode_key(bytes).is_err() {
-                    bail!(format!(
-                        "The key in existing key file at '{}' is invalid",
+            if key.is_empty() {
+                if key_path.exists() {
+                    let bytes = fs_err::read_to_string(key_path).context(format!(
+                        "Existing key file at '{}' could not be read",
                         key_path.to_string_lossy()
-                    ));
+                    ))?;
+                    if decode_key(bytes).is_err() {
+                        bail!(format!(
+                            "The key in existing key file at '{}' is invalid",
+                            key_path.to_string_lossy()
+                        ));
+                    }
+                    return Ok(());
                 }
-            } else {
-                panic!(
-                    "No key provided and no existing key file found. Please use 'atuin key' on your other machine, or recover your key from a backup"
-                )
+
+                let msg = "No key provided and no existing key file found. Please use 'atuin key' on your other machine, or recover your key from a backup";
+                if !interactive {
+                    bail!(msg);
+                }
+                println!("\n{msg}\n");
+                continue;
             }
-        } else if !key_path.exists() {
-            if decode_key(key.clone()).is_err() {
-                bail!("The specified key is invalid");
-            }
 
-            let mut file = File::create(key_path).await?;
-            file.write_all(key.as_bytes()).await?;
-        } else {
-            // we now know that the user has logged in specifying a key, AND that the key path
-            // exists
-
-            // 1. check if the saved key and the provided key match. if so, nothing to do.
-            // 2. if not, re-encrypt the local history and overwrite the key
-            let current_key: [u8; 32] = load_key(settings)?.into();
-
-            let encoded = key.clone(); // gonna want to save it in a bit
-            let new_key: [u8; 32] = decode_key(key)
-                .context("Could not decode provided key; is not valid base64-encoded key")?
-                .into();
-
-            if new_key != current_key {
-                println!("\nRe-encrypting local store with new key");
-
-                store.re_encrypt(&current_key, &new_key).await?;
-
-                println!("Writing new key");
-                let mut file = File::create(key_path).await?;
-                file.write_all(encoded.as_bytes()).await?;
+            match normalize_key(&key) {
+                Ok(encoded) => {
+                    store_key(settings, store, &encoded).await?;
+                    return Ok(());
+                }
+                Err(err) if interactive => {
+                    println!("\n{err}. Please try again.\n");
+                }
+                Err(err) => return Err(err),
             }
         }
-
-        Ok(())
     }
 }
 
-async fn verify_key_against_remote(settings: &Settings) -> Result<()> {
-    let key: [u8; 32] = load_key(settings)
-        .context("could not load encryption key for verification")?
-        .into();
+/// A key may be provided as EITHER base64 or a bip39 mnemonic;
+/// normalize to base64 and validate it.
+fn normalize_key(key: &str) -> Result<String> {
+    // try parse the key as a mnemonic...
+    let encoded = match bip39::Mnemonic::from_phrase(key, bip39::Language::English) {
+        Ok(mnemonic) => encode_key(Key::from_slice(mnemonic.entropy()))?,
+        Err(err) => {
+            match err {
+                // assume they copied in the base64 key
+                bip39::ErrorKind::InvalidWord(_) => key.to_string(),
+                bip39::ErrorKind::InvalidChecksum => {
+                    bail!("Key mnemonic is not valid")
+                }
+                bip39::ErrorKind::InvalidKeysize(_)
+                | bip39::ErrorKind::InvalidWordLength(_)
+                | bip39::ErrorKind::InvalidEntropyLength(_, _) => {
+                    bail!("Key is not the correct length")
+                }
+            }
+        }
+    };
 
+    if decode_key(encoded.clone()).is_err() {
+        bail!("The specified key is invalid");
+    }
+
+    Ok(encoded)
+}
+
+/// Write the key to the key file, re-encrypting the local store first if it
+/// was previously encrypted with a different key.
+async fn store_key(settings: &Settings, store: &SqliteStore, encoded: &str) -> Result<()> {
+    let key_path = &settings.key_path;
+
+    if key_path.exists() {
+        let current_key: [u8; 32] = load_key(settings)?.into();
+        let new_key: [u8; 32] = decode_key(encoded.to_string())
+            .context("Could not decode provided key; is not valid base64-encoded key")?
+            .into();
+
+        if new_key == current_key {
+            return Ok(());
+        }
+
+        println!("\nRe-encrypting local store with new key");
+        store.re_encrypt(&current_key, &new_key).await?;
+        println!("Writing new key");
+    }
+
+    let mut file = File::create(key_path).await?;
+    file.write_all(encoded.as_bytes()).await?;
+
+    Ok(())
+}
+
+async fn verify_key_against_remote(settings: &Settings, store: &SqliteStore) -> Result<()> {
     let client = sync::build_client(settings).await?;
     let remote_index = match client.record_status().await {
         Ok(idx) => idx,
@@ -287,32 +304,61 @@ async fn verify_key_against_remote(settings: &Settings) -> Result<()> {
         }
     };
 
-    match sync::check_encryption_key(&client, &remote_index, &key).await {
-        Ok(()) => Ok(()),
-        Err(SyncError::WrongKey) => {
-            // Roll back the saved session so the user is not left in a
-            // half-authenticated state with a key that can't read the data.
-            if let Ok(meta) = Settings::meta_store().await {
-                let _ = meta.delete_session().await;
-                let _ = meta.delete_hub_session().await;
+    loop {
+        let key: [u8; 32] = load_key(settings)
+            .context("could not load encryption key for verification")?
+            .into();
+
+        match sync::check_encryption_key(&client, &remote_index, &key).await {
+            Ok(()) => return Ok(()),
+            Err(SyncError::WrongKey) => {
+                if !io::stdin().is_terminal() {
+                    logout_wrong_key().await;
+                }
+
+                println!(
+                    "\nThe encryption key on this machine does not match the data on the server."
+                );
+                println!(
+                    "You can find the correct key by running 'atuin key' on a machine that already syncs successfully."
+                );
+
+                let key = read_user_input("encryption key [blank to log out and cancel]");
+                if key.is_empty() {
+                    logout_wrong_key().await;
+                }
+
+                match normalize_key(&key) {
+                    Ok(encoded) => store_key(settings, store, &encoded).await?,
+                    Err(err) => println!("\n{err}. Please try again."),
+                }
             }
-            crate::print_error::print_error(
-                "Wrong encryption key",
-                "The encryption key on this machine does not match the data on the server. \
-                 You have been logged out.\n\n\
-                 To fix this, find your existing key by running `atuin key` on a machine that \
-                 already syncs successfully, then run `atuin login` again here with that key.",
-            );
-            std::process::exit(1);
-        }
-        Err(e) => {
-            // Non-key error (e.g. transient network issue). Don't fail the
-            // login — the user is authenticated and can sync later when the
-            // network recovers.
-            tracing::warn!("could not verify encryption key against remote: {e}");
-            Ok(())
+            Err(e) => {
+                // Non-key error (e.g. transient network issue). Don't fail the
+                // login — the user is authenticated and can sync later when the
+                // network recovers.
+                tracing::warn!("could not verify encryption key against remote: {e}");
+                return Ok(());
+            }
         }
     }
+}
+
+/// Roll back the saved session so the user is not left in a
+/// half-authenticated state with a key that can't read the data, then exit.
+async fn logout_wrong_key() {
+    if let Ok(meta) = Settings::meta_store().await {
+        let _ = meta.delete_session().await;
+        let _ = meta.delete_hub_session().await;
+    }
+    crate::print_error::print_error(
+        "Wrong encryption key",
+        "The encryption key on this machine does not match the data on the server. \
+         You have been logged out.\n\n\
+         To fix this, find your existing key by running `atuin key` on a machine that \
+         already syncs successfully, then run `atuin login` again here with that key.",
+    );
+    std::process::exit(1);
 }
 
 pub(super) fn or_user_input(value: Option<String>, name: &'static str) -> String {

--- a/install.sh
+++ b/install.sh
@@ -138,22 +138,36 @@ Sync your history across all your machines with Atuin Cloud:
 
 EOF
 
-  printf "Sign up for a sync account? [Y/n] "
-  read -r sync_answer </dev/tty || sync_answer="n"
-  sync_answer="${sync_answer:-y}"
+  echo "Set up sync with an Atuin account?"
+  echo ""
+  echo "  1) Yes - create a new account"
+  echo "  2) Log in to an existing account"
+  echo "  3) Skip sync for now"
+  echo ""
+  printf "Select an option [1/2/3] (default 1): "
+  read -r sync_answer </dev/tty || sync_answer="3"
+  sync_answer="${sync_answer:-1}"
 
   case "$sync_answer" in
-    [yY]*)
+    1|[yYcC]*)
       echo ""
       if ! "$ATUIN_BIN" register </dev/tty; then
         echo ""
         echo "Registration did not complete. You can run 'atuin register' any time to try again."
       fi
       ;;
+    2|[lL]*)
+      echo ""
+      if ! "$ATUIN_BIN" login </dev/tty; then
+        echo ""
+        echo "Login did not complete. You can run 'atuin login' any time to try again."
+      fi
+      ;;
     *)
       echo ""
-      printf "Already have an account? Log in with 'atuin login'.\n"
-      echo "You can also run 'atuin register' any time to create one."
+      echo "Skipping sync setup."
+      echo "You can run 'atuin register' any time to create an account,"
+      echo "or 'atuin login' if you already have one."
       ;;
   esac
 

--- a/install.sh
+++ b/install.sh
@@ -137,22 +137,36 @@ Sync your history across all your machines with Atuin Cloud:
 
 EOF
 
-  printf "Sign up for a sync account? [Y/n] "
-  read -r sync_answer </dev/tty || sync_answer="n"
-  sync_answer="${sync_answer:-y}"
+  echo "Would you like to create an Atuin account?"
+  echo ""
+  echo "  1) Yes - create a new account"
+  echo "  2) No - log in to my existing account"
+  echo "  3) Skip sync for now"
+  echo ""
+  printf "Select an option [1/2/3] (default 1): "
+  read -r sync_answer </dev/tty || sync_answer="3"
+  sync_answer="${sync_answer:-1}"
 
   case "$sync_answer" in
-    [yY]*)
+    1|[yYcC]*)
       echo ""
       if ! "$ATUIN_BIN" register </dev/tty; then
         echo ""
         echo "Registration did not complete. You can run 'atuin register' any time to try again."
       fi
       ;;
+    2|[nNlL]*)
+      echo ""
+      if ! "$ATUIN_BIN" login </dev/tty; then
+        echo ""
+        echo "Login did not complete. You can run 'atuin login' any time to try again."
+      fi
+      ;;
     *)
       echo ""
-      printf "Already have an account? Log in with 'atuin login'.\n"
-      echo "You can also run 'atuin register' any time to create one."
+      echo "Skipping sync setup."
+      echo "You can run 'atuin register' any time to create an account,"
+      echo "or 'atuin login' if you already have one."
       ;;
   esac
 


### PR DESCRIPTION
The install script only offered account creation, with existing-account users left to run 'atuin login' on their own. Ask a three-way question instead: create an account (default), log in, or skip sync.

To support the login path, 'atuin login' now re-prompts for the encryption key on invalid input, and on a key that doesn't match the server data, instead of exiting. Non-interactive use (--key flag or piped stdin) keeps the fail-fast behavior.

<!-- Thank you for making a PR! Bug fixes are always welcome, but if you're adding a new feature or changing an existing one, we'd really appreciate if you open an issue, post on the forum, or drop in on Discord -->

## Checks
- [ ] I am happy for maintainers to push small adjustments to this PR, to speed up the review cycle
- [ ] I have checked that there are no existing pull requests for the same thing
