### PR TITLE
fix(nix): add an RPATH for OpenSSL so the built binary runs

### DIFF
--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -33,6 +33,9 @@ jobs:
       - name: Run nix build
         run: nix build --print-build-logs
 
+      - name: Check the built binary runs
+        run: ./result/bin/atuin --version
+
   nixfmt:
     runs-on: depot-ubuntu-24.04
 

--- a/atuin.nix
+++ b/atuin.nix
@@ -40,6 +40,14 @@ rustPlatform.buildRustPackage {
     export LD_LIBRARY_PATH="${lib.makeLibraryPath [ openssl ]}''${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
   '';
 
+  # The linked binary records no RPATH for OpenSSL, so once it leaves the build
+  # sandbox it fails with "libssl.so.3: cannot open shared object file". The
+  # build never notices, because LD_LIBRARY_PATH above is still exported when
+  # postInstall runs the binary to generate completions.
+  postFixup = lib.optionalString stdenv.hostPlatform.isLinux ''
+    patchelf --add-rpath ${lib.makeLibraryPath [ openssl ]} $out/bin/atuin
+  '';
+
   postInstall = ''
     installShellCompletion --cmd atuin \
       --bash <($out/bin/atuin gen-completions -s bash) \


### PR DESCRIPTION
Since #3807 moved TLS from rustls to native-tls, the Nix build produces an `atuin` that can't start:

```
$ nix build github:atuinsh/atuin/v18.19.0
$ ./result/bin/atuin --version
./result/bin/atuin: error while loading shared libraries: libssl.so.3: cannot open shared object file: No such file or directory
```

The binary needs libssl.so.3 and libcrypto.so.3, but it has an empty RPATH and OpenSSL isn't in its runtime closure, so nothing puts it on the loader's path.

What took a while to see is that the build is perfectly happy. The `preBuild` LD_LIBRARY_PATH added in #3807 is still exported when `postInstall` runs `$out/bin/atuin gen-completions`, so completions generate fine and `nix build` goes green. It only breaks once you run the installed binary, which CI never does.

This adds the RPATH in postFixup, guarded to Linux since Darwin doesn't use one. Afterwards OpenSSL shows up in the runtime closure and the binary runs in an empty environment.

I also added a `./result/bin/atuin --version` step to the Nix workflow. Happy to drop it if you'd rather keep this to the fix, but as it stands `nix build` can't catch this class of bug.

Reproduced with `nix build github:atuinsh/atuin/v18.19.0`; main carries the same atuin.nix. Fix built and tested against main (18.20.0-beta.1) on x86_64-linux/NixOS. I haven't tested Darwin.

## Checks
- [x] I am happy for maintainers to push small adjustments to this PR, to speed up the review cycle
- [x] I have checked that there are no existing pull requests for the same thing
