### PR TITLE
Fix 5s hang on every command under Tailscale + tmux

### DIFF
--- a/crates/atuin-daemon/src/client.rs
+++ b/crates/atuin-daemon/src/client.rs
@@ -67,6 +67,45 @@ pub fn classify_error(error: &eyre::Report) -> DaemonClientErrorKind {
     DaemonClientErrorKind::Other
 }
 
+/// Read the endpoint the running daemon advertised in its pidfile.
+///
+/// The pidfile contains the daemon's pid, version and, as of the socket-path
+/// mismatch fix, the endpoint it is actually serving on. Returns `None` for
+/// missing or unreadable pidfiles, and for pidfiles written by older daemons
+/// that predate the endpoint line.
+fn pidfile_endpoint(pidfile_path: &str) -> Option<String> {
+    let contents = std::fs::read_to_string(pidfile_path).ok()?;
+    let mut lines = contents.lines();
+    let _pid = lines.next()?;
+    let _version = lines.next()?;
+    let endpoint = lines.next()?.trim();
+    (!endpoint.is_empty()).then(|| endpoint.to_string())
+}
+
+/// The socket path clients should use to reach the daemon.
+///
+/// The `daemon.socket_path` default is environment-dependent: it lives under
+/// `$XDG_RUNTIME_DIR` when that variable is set and under the data directory
+/// otherwise. A client and a daemon started from different environments (a
+/// PAM login shell vs. a tmux server spawned by a remote command, cron,
+/// containers, ...) can therefore silently disagree about where the socket
+/// lives, leaving every shell hook to time out against a socket that was
+/// never created. Prefer the path the daemon actually bound, as advertised
+/// in its pidfile, whenever that socket still exists.
+#[cfg(unix)]
+#[must_use]
+pub fn daemon_socket_path(settings: &Settings) -> String {
+    match pidfile_endpoint(&settings.daemon.pidfile_path) {
+        Some(advertised)
+            if advertised != settings.daemon.socket_path
+                && std::path::Path::new(&advertised).exists() =>
+        {
+            advertised
+        }
+        _ => settings.daemon.socket_path.clone(),
+    }
+}
+
 // Wrap the grpc client
 impl HistoryClient {
     #[cfg(unix)]
@@ -356,7 +395,7 @@ impl SemanticClient {
 
     #[cfg(unix)]
     pub async fn from_settings(settings: &Settings) -> Result<Self> {
-        Self::new(settings.daemon.socket_path.clone()).await
+        Self::new(daemon_socket_path(settings)).await
     }
 
     #[cfg(not(unix))]
@@ -452,7 +491,7 @@ impl ControlClient {
     /// Connect using settings.
     #[cfg(unix)]
     pub async fn from_settings(settings: &Settings) -> Result<Self> {
-        Self::new(settings.daemon.socket_path.clone()).await
+        Self::new(daemon_socket_path(settings)).await
     }
 
     /// Connect using settings.
@@ -558,4 +597,43 @@ pub async fn emit_event_with_settings(
     }
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use std::io::Write;
+
+    use super::pidfile_endpoint;
+
+    fn write_pidfile(contents: &str) -> tempfile::NamedTempFile {
+        let mut file = tempfile::NamedTempFile::new().unwrap();
+        file.write_all(contents.as_bytes()).unwrap();
+        file
+    }
+
+    #[test]
+    fn pidfile_endpoint_reads_advertised_endpoint() {
+        let file = write_pidfile("1234\n18.9.0\n/run/user/1000/atuin.sock\n");
+        assert_eq!(
+            pidfile_endpoint(file.path().to_str().unwrap()),
+            Some("/run/user/1000/atuin.sock".to_string())
+        );
+    }
+
+    #[test]
+    fn pidfile_endpoint_ignores_legacy_two_line_format() {
+        let file = write_pidfile("1234\n18.9.0\n");
+        assert_eq!(pidfile_endpoint(file.path().to_str().unwrap()), None);
+    }
+
+    #[test]
+    fn pidfile_endpoint_ignores_blank_endpoint_line() {
+        let file = write_pidfile("1234\n18.9.0\n   \n");
+        assert_eq!(pidfile_endpoint(file.path().to_str().unwrap()), None);
+    }
+
+    #[test]
+    fn pidfile_endpoint_ignores_missing_pidfile() {
+        assert_eq!(pidfile_endpoint("/nonexistent/atuin-daemon.pid"), None);
+    }
 }

--- a/crates/atuin/src/command/client/daemon.rs
+++ b/crates/atuin/src/command/client/daemon.rs
@@ -109,7 +109,7 @@ struct PidfileGuard {
 }
 
 impl PidfileGuard {
-    fn acquire(path: &Path) -> Result<Self> {
+    fn acquire(path: &Path, endpoint: &str) -> Result<Self> {
         let mut file = open_lock_file(path)?;
 
         match file.try_lock() {
@@ -124,10 +124,15 @@ impl PidfileGuard {
             }
         }
 
+        // The endpoint line lets clients discover the socket the daemon
+        // actually serves on, even when their own environment resolves a
+        // different `daemon.socket_path` default (e.g. `XDG_RUNTIME_DIR`
+        // set in the client's session but not the daemon's, or vice versa).
         file.set_len(0)
             .wrap_err_with(|| format!("could not truncate daemon pidfile {}", path.display()))?;
         writeln!(file, "{}", std::process::id())
             .and_then(|()| writeln!(file, "{DAEMON_VERSION}"))
+            .and_then(|()| writeln!(file, "{endpoint}"))
             .wrap_err_with(|| format!("could not write daemon pidfile {}", path.display()))?;
 
         Ok(Self { file })
@@ -225,7 +230,7 @@ async fn connect_client(settings: &Settings) -> Result<HistoryClient> {
         #[cfg(not(unix))]
         settings.daemon.tcp_port,
         #[cfg(unix)]
-        settings.daemon.socket_path.clone(),
+        atuin_daemon::client::daemon_socket_path(settings),
     )
     .await
 }
@@ -283,7 +288,20 @@ fn remove_stale_socket_if_present(settings: &Settings) -> Result<()> {
         return Ok(());
     }
 
-    let socket_path = Path::new(&settings.daemon.socket_path);
+    remove_socket_if_stale(Path::new(&settings.daemon.socket_path))?;
+
+    // A dead daemon may still advertise a different socket path in the
+    // pidfile; clean that up too so clients stop preferring it.
+    let advertised = atuin_daemon::client::daemon_socket_path(settings);
+    if advertised != settings.daemon.socket_path {
+        remove_socket_if_stale(Path::new(&advertised))?;
+    }
+
+    Ok(())
+}
+
+#[cfg(unix)]
+fn remove_socket_if_stale(socket_path: &Path) -> Result<()> {
     if !socket_path.exists() {
         return Ok(());
     }
@@ -568,7 +586,10 @@ async fn status_cmd(settings: &Settings) -> Result<()> {
             println!("  Protocol: {}", status.protocol);
             println!("  Healthy:  {}", status.healthy);
             #[cfg(unix)]
-            println!("  Socket:   {}", settings.daemon.socket_path);
+            println!(
+                "  Socket:   {}",
+                atuin_daemon::client::daemon_socket_path(settings)
+            );
             #[cfg(not(unix))]
             println!("  Port:     {}", settings.daemon.tcp_port);
         }
@@ -669,11 +690,21 @@ async fn run(
     }
 
     let pidfile_path = PathBuf::from(&settings.daemon.pidfile_path);
-    let _pidfile_guard = PidfileGuard::acquire(&pidfile_path)?;
+    let _pidfile_guard = PidfileGuard::acquire(&pidfile_path, &served_endpoint(&settings))?;
 
     atuin_daemon::boot(settings, store, history_db).await?;
 
     Ok(())
+}
+
+/// The endpoint this daemon will serve on, advertised to clients via the
+/// pidfile.
+fn served_endpoint(settings: &Settings) -> String {
+    #[cfg(unix)]
+    return settings.daemon.socket_path.clone();
+
+    #[cfg(not(unix))]
+    return settings.daemon.tcp_port.to_string();
 }
 
 /// Force cleanup: kill existing daemon process and remove socket.
@@ -785,27 +816,28 @@ mod tests {
         #[from(pidfile)] (_tmp, pidfile): (tempfile::TempDir, PathBuf),
     ) {
         {
-            let _guard = PidfileGuard::acquire(&pidfile).unwrap();
+            let _guard = PidfileGuard::acquire(&pidfile, "/run/user/1000/atuin.sock").unwrap();
             // Guard holds an exclusive lock — on Windows other handles cannot
             // read the file, so we verify contents after the guard is dropped.
         }
 
         let contents = std::fs::read_to_string(&pidfile).unwrap();
         let lines: Vec<&str> = contents.lines().collect();
-        assert_eq!(lines.len(), 2);
+        assert_eq!(lines.len(), 3);
         assert_eq!(lines[0], std::process::id().to_string());
         assert_eq!(lines[1], DAEMON_VERSION);
+        assert_eq!(lines[2], "/run/user/1000/atuin.sock");
 
         // After guard is dropped, lock should be released — acquiring again must succeed.
-        let _guard2 = PidfileGuard::acquire(&pidfile).unwrap();
+        let _guard2 = PidfileGuard::acquire(&pidfile, "/run/user/1000/atuin.sock").unwrap();
     }
 
     #[rstest]
     fn test_pidfile_guard_prevents_double_acquire(
         #[from(pidfile)] (_tmp, pidfile): (tempfile::TempDir, PathBuf),
     ) {
-        let _guard = PidfileGuard::acquire(&pidfile).unwrap();
-        let result = PidfileGuard::acquire(&pidfile);
+        let _guard = PidfileGuard::acquire(&pidfile, "/run/user/1000/atuin.sock").unwrap();
+        let result = PidfileGuard::acquire(&pidfile, "/run/user/1000/atuin.sock");
         assert!(result.is_err());
     }
 }

--- a/crates/atuin/src/command/client/search/engines/daemon.rs
+++ b/crates/atuin/src/command/client/search/engines/daemon.rs
@@ -37,8 +37,11 @@ impl LazyClient {
     }
 
     async fn connect(&self, params: &ClientParams) -> Result<SearchClient> {
+        // Resolve the socket path at connect time so we pick up the socket
+        // the running daemon advertises in its pidfile, which may differ
+        // from this process's environment-derived default.
         #[cfg(unix)]
-        return SearchClient::new(params.socket_path.clone()).await;
+        return SearchClient::new(atuin_daemon::client::daemon_socket_path(&params.settings)).await;
 
         #[cfg(not(unix))]
         SearchClient::new(params.tcp_port).await
@@ -85,8 +88,6 @@ impl LazyClient {
 /// mutably borrowed (see [`Search::prepare_index`]).
 struct ClientParams {
     settings: Settings,
-    #[cfg(unix)]
-    socket_path: String,
     #[cfg(not(unix))]
     tcp_port: u64,
 }
@@ -103,8 +104,6 @@ impl Search {
             client: LazyClient::default(),
             params: ClientParams {
                 settings: settings.clone(),
-                #[cfg(unix)]
-                socket_path: settings.daemon.socket_path.clone(),
                 #[cfg(not(unix))]
                 tcp_port: settings.daemon.tcp_port,
             },


### PR DESCRIPTION
## Human

I have a server set up with atuin and ssh over Tailscale. I connect using a mixture of regular ssh, and for long-lived sessions, tmux. I noticed that if I run the two after one another, the second one will have a ~5s delay between each command, making the terminal basically unusable. I ran some tests and realized that this is due to the socket path being different in each environment, while atuin is stuck using the first path. The rest of this PR was developed and tested by Claude Fable 5 against the live system, and reviewed by me.

### Workaround
in `~/.config/atuin/config.toml`, set a consistent `socket_path`:

```toml
[daemon]
socket_path = "/home/user/.local/share/atuin/atuin.sock"
```

Then restart the daemon.

## AI
### The problem

The default `daemon.socket_path` is environment-dependent (#2171, since v18.5.0): it resolves to `$XDG_RUNTIME_DIR/atuin.sock` when that variable is set, and to the data directory otherwise. The client and the daemon each resolve this default **independently, from their own environment** - so a daemon autostarted from a session without `XDG_RUNTIME_DIR` binds a different socket than a client running in a PAM login session looks for. Sessions without `XDG_RUNTIME_DIR` are common: tmux servers created via a remote command (`ssh host tmux -CC new`, e.g. iTerm2's tmux integration), cron jobs, containers, and SSH implementations that skip PAM for exec sessions (e.g. Tailscale SSH).

The pidfile, unlike the socket, always lives in the data directory - so the two "worlds" share coordination state but not the socket. With autostart (#3180, since v18.13.0) this *wedges* instead of failing: `ensure_daemon_running` probes the wrong socket, then blocks in `wait_for_pidfile_available` on the flock held by the **perfectly healthy** daemon until `startup_timeout` (≈4s with defaults) expires. This repeats for both the `history start` and `history end` hooks of **every command typed** in the mismatched session, and never self-heals or surfaces an error. Users just experience "every command takes ~5 seconds to run", indefinitely.

### Repro (before this patch)

```bash
# daemon born without XDG_RUNTIME_DIR (any remote-command/tmux/cron context)
env -u XDG_RUNTIME_DIR atuin daemon start &

# client in a login session with it set:
export XDG_RUNTIME_DIR=/run/user/$(id -u)
time atuin history start -- echo hi     # ~4s, falls back to sqlite
atuin daemon status                     # "Daemon is not running" (it is!)
```

### The fix

The daemon now writes the endpoint it actually serves on as a third pidfile line, and clients prefer that advertised socket over their own environment-derived defaultl exists:

- `PidfileGuard::acquire` writes pid / version / endpoint.
- New `client::daemon_socket_path(settings)` resolves configured → advertised, used by `connect_client`, `SemanticClient::from_settings`, `ControlClient::from_settingarch engine (which now resolves at connect time instead of caching an env-derived path at construction).
- `remove_stale_socket_if_present` also cleans up a stale *advertised* socket before respawning, so clients stop preferring a dead one.
- `atuin daemon status` prints the effective socket.

### Compatibility

- **Old daemon + new client:** two-line pidfile → endpoint parses as `None` → configured path, behavior unchanged.
- **New daemon + old client:** old clients only read the pid line; the extra line is ignored.
- **Explicit `daemon.socket_path` in config:** daemon and client read the same config, so advertised == configured and nothing changes.

## Testing

- 4 new unit tests for pidfile parsing (advertised / legacy two-line / blank line / missing file).
- Manual end-to-end: daemon started without `XDG_RUNTIME_DIR`, client with it set — `history start` connects in ~16ms (previously timed out for ~4s and fell back), anrrectly reports the running daemon and its socket.
- `cargo check`, `cargo clippy`, `cargo fmt --check`, `cargo test -p atuin-daemon --lib` all clean.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/atuinsh/atuin/blob/main/CONTRIBUTING.md) guide
- [x] I have run the tests locally