### PR TITLE
refactor(encryption): introduce PasetoV4Key newtype for the encryption key

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -426,6 +426,7 @@ dependencies = [
  "url",
  "uuid",
  "whoami",
+ "zeroize",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,6 +64,7 @@ typed-builder = "0.23.2"
 pretty_assertions = "1.3.0"
 proptest = "1.11.0"
 parking_lot = "0.12.5"
+zeroize = "1"
 rstest = "0.26.1"
 thiserror = "2"
 rustix = { version = "1.1.4", features = ["process", "fs"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,7 @@ time = { version = "0.3.47", features = [
 ] }
 clap = { version = "4.5.7", features = ["derive"] }
 config = { version = "0.15.8", default-features = false, features = ["toml"] }
-derive_more = { version = "2", features = ["as_ref", "deref", "display", "error", "from", "into"] }
+derive_more = { version = "2", features = ["as_ref", "deref", "display", "error", "from", "into", "debug"] }
 directories = "6.0.0"
 eyre = "0.6"
 fs-err = "3.1"

--- a/crates/atuin-client/Cargo.toml
+++ b/crates/atuin-client/Cargo.toml
@@ -27,6 +27,7 @@ vendored-tls = ["reqwest?/native-tls-vendored"]
 derive_more = { workspace = true }
 tracing = { workspace = true }
 base64 = { workspace = true }
+zeroize = { workspace = true }
 time = { workspace = true, features = ["macros", "formatting", "parsing"] }
 clap = { workspace = true }
 eyre = { workspace = true }

--- a/crates/atuin-client/benches/record/encryption.rs
+++ b/crates/atuin-client/benches/record/encryption.rs
@@ -24,7 +24,7 @@ fn encrypt(bencher: divan::Bencher, n: usize) {
     bencher.with_inputs(|| decrypted_records(n)).bench_values(
         |records: Vec<Record<DecryptedData>>| {
             for record in records {
-                divan::black_box(record.encrypt::<PasetoV4>(KEY.into()));
+                divan::black_box(record.encrypt::<PasetoV4>(&KEY.into()));
             }
         },
     );
@@ -36,12 +36,12 @@ fn decrypt(bencher: divan::Bencher, n: usize) {
         .with_inputs(|| {
             decrypted_records(n)
                 .into_iter()
-                .map(|record| record.encrypt::<PasetoV4>(KEY.into()))
+                .map(|record| record.encrypt::<PasetoV4>(&KEY.into()))
                 .collect::<Vec<Record<EncryptedData>>>()
         })
         .bench_values(|records: Vec<Record<EncryptedData>>| {
             for record in records {
-                divan::black_box(record.decrypt::<PasetoV4>(KEY.into()).unwrap());
+                divan::black_box(record.decrypt::<PasetoV4>(&KEY.into()).unwrap());
             }
         });
 }

--- a/crates/atuin-client/benches/record/encryption.rs
+++ b/crates/atuin-client/benches/record/encryption.rs
@@ -1,7 +1,7 @@
 use atuin_client::history::HISTORY_TAG;
 use atuin_client::history::Version;
 use atuin_client::history::store::HistoryRecord;
-use atuin_client::record::encryption::PASETO_V4;
+use atuin_client::record::encryption::PasetoV4;
 use atuin_common::utils::uuid_v7;
 use atuin_domain::record::{DecryptedData, EncryptedData, Host, HostId, Record};
 
@@ -24,7 +24,7 @@ fn encrypt(bencher: divan::Bencher, n: usize) {
     bencher.with_inputs(|| decrypted_records(n)).bench_values(
         |records: Vec<Record<DecryptedData>>| {
             for record in records {
-                divan::black_box(record.encrypt::<PASETO_V4>(&KEY));
+                divan::black_box(record.encrypt::<PasetoV4>(KEY.into()));
             }
         },
     );
@@ -36,12 +36,12 @@ fn decrypt(bencher: divan::Bencher, n: usize) {
         .with_inputs(|| {
             decrypted_records(n)
                 .into_iter()
-                .map(|record| record.encrypt::<PASETO_V4>(&KEY))
+                .map(|record| record.encrypt::<PasetoV4>(KEY.into()))
                 .collect::<Vec<Record<EncryptedData>>>()
         })
         .bench_values(|records: Vec<Record<EncryptedData>>| {
             for record in records {
-                divan::black_box(record.decrypt::<PASETO_V4>(&KEY).unwrap());
+                divan::black_box(record.decrypt::<PasetoV4>(KEY.into()).unwrap());
             }
         });
 }

--- a/crates/atuin-client/src/encryption.rs
+++ b/crates/atuin-client/src/encryption.rs
@@ -10,8 +10,8 @@
 
 use std::io::prelude::*;
 
+pub use crate::record::encryption::PasetoV4Key;
 use base64::prelude::{BASE64_STANDARD, Engine};
-pub use crypto_secretbox::Key;
 use crypto_secretbox::{KeyInit, XSalsa20Poly1305, aead::OsRng};
 use eyre::{Context, Result, bail, ensure, eyre};
 use fs_err as fs;
@@ -19,14 +19,14 @@ use rmp::Marker;
 
 use crate::settings::Settings;
 
-pub fn generate_encoded_key() -> Result<(Key, String)> {
-    let key = XSalsa20Poly1305::generate_key(&mut OsRng);
+pub fn generate_encoded_key() -> Result<(PasetoV4Key, String)> {
+    let key = PasetoV4Key::from(<[u8; 32]>::from(XSalsa20Poly1305::generate_key(&mut OsRng)));
     let encoded = encode_key(&key)?;
 
     Ok((key, encoded))
 }
 
-pub fn new_key(settings: &Settings) -> Result<Key> {
+pub fn new_key(settings: &Settings) -> Result<PasetoV4Key> {
     let path = &settings.key_path;
 
     if path.exists() {
@@ -42,7 +42,7 @@ pub fn new_key(settings: &Settings) -> Result<Key> {
 }
 
 // Loads the secret key, will create + save if it doesn't exist
-pub fn load_key(settings: &Settings) -> Result<Key> {
+pub fn load_key(settings: &Settings) -> Result<PasetoV4Key> {
     let path = &settings.key_path;
 
     let key = if path.exists() {
@@ -55,7 +55,8 @@ pub fn load_key(settings: &Settings) -> Result<Key> {
     Ok(key)
 }
 
-pub fn encode_key(key: &Key) -> Result<String> {
+pub fn encode_key(key: &PasetoV4Key) -> Result<String> {
+    let key = key.as_bytes();
     let mut buf = vec![];
     rmp::encode::write_array_len(&mut buf, key.len() as u32)
         .wrap_err("could not encode key to message pack")?;
@@ -68,7 +69,7 @@ pub fn encode_key(key: &Key) -> Result<String> {
     Ok(buf)
 }
 
-pub fn decode_key(key: String) -> Result<Key> {
+pub fn decode_key(key: String) -> Result<PasetoV4Key> {
     use rmp::decode;
 
     let buf = BASE64_STANDARD
@@ -96,11 +97,11 @@ pub fn decode_key(key: String) -> Result<Key> {
                     let len = decode::read_array_len(&mut bytes).map_err(|err| eyre!("{err:?}"))?;
                     ensure!(len == 32, "encryption key is not the correct size");
 
-                    let mut key = Key::default();
+                    let mut key = [0u8; 32];
                     for i in &mut key {
                         *i = rmp::decode::read_int(&mut bytes).map_err(|err| eyre!("{err:?}"))?;
                     }
-                    Ok(key)
+                    Ok(key.into())
                 }
                 _ => {
                     bail!("could not decode encryption key");
@@ -114,7 +115,7 @@ pub fn decode_key(key: String) -> Result<Key> {
 mod test {
     #[test]
     fn key_encodings() {
-        use super::{Key, decode_key, encode_key};
+        use super::{PasetoV4Key, decode_key, encode_key};
 
         // a history of our key encodings.
         // v11.0.0 xCAbWypb0msJ2Kq+8j4GVEWUlDX7deKnrTRSIopuqXxc5Q==
@@ -129,7 +130,7 @@ mod test {
         // b8b57c8 xCAbWypb0msJ2Kq+8j4GVEWUlDX7deKnrTRSIopuqXxc5Q==                     (https://github.com/atuinsh/atuin/pull/1057)
         // 8c94d79 3AAgG1sqW8zSawnM2MyqzL7M8j4GVEXMlMyUNcz7dczizKfMrTRSIsyKbsypfFzM5Q== (https://github.com/atuinsh/atuin/pull/1089)
 
-        let key = Key::from([
+        let key = PasetoV4Key::from([
             27, 91, 42, 91, 210, 107, 9, 216, 170, 190, 242, 62, 6, 84, 69, 148, 148, 53, 251, 117,
             226, 167, 173, 52, 82, 34, 138, 110, 169, 124, 92, 229,
         ]);

--- a/crates/atuin-client/src/history/store.rs
+++ b/crates/atuin-client/src/history/store.rs
@@ -7,8 +7,9 @@ use rmp::decode::Bytes;
 
 use crate::{
     database::{Database, current_context},
-    record::{encryption::PASETO_V4, sqlite_store::SqliteStore},
+    record::{encryption::PasetoV4, sqlite_store::SqliteStore},
 };
+use crate::record::encryption::PasetoV4Key;
 use atuin_domain::record::{DecryptedData, Host, HostId, Record, RecordId, RecordIdx};
 
 use super::{HISTORY_TAG, History, HistoryId, Version};
@@ -17,7 +18,7 @@ use super::{HISTORY_TAG, History, HistoryId, Version};
 pub struct HistoryStore {
     pub store: SqliteStore,
     pub host_id: HostId,
-    pub encryption_key: [u8; 32],
+    pub encryption_key: PasetoV4Key,
 }
 
 #[derive(Debug, Eq, PartialEq, Clone)]
@@ -115,7 +116,7 @@ impl HistoryRecord {
 }
 
 impl HistoryStore {
-    pub fn new(store: SqliteStore, host_id: HostId, encryption_key: [u8; 32]) -> Self {
+    pub fn new(store: SqliteStore, host_id: HostId, encryption_key: PasetoV4Key) -> Self {
         HistoryStore {
             store,
             host_id,
@@ -142,7 +143,7 @@ impl HistoryStore {
         let id = record.id;
 
         self.store
-            .push(&record.encrypt::<PASETO_V4>(&self.encryption_key))
+            .push(&record.encrypt::<PasetoV4>(self.encryption_key))
             .await?;
 
         Ok((id, idx))
@@ -170,7 +171,7 @@ impl HistoryStore {
                 .data(bytes)
                 .build();
 
-            let record = record.encrypt::<PASETO_V4>(&self.encryption_key);
+            let record = record.encrypt::<PasetoV4>(self.encryption_key);
 
             ret.push(record);
         }
@@ -224,7 +225,7 @@ impl HistoryStore {
             let hist = match Version::from_name(version.as_str()) {
                 Some(_) => {
                     record
-                        .decrypt::<PASETO_V4>(&self.encryption_key)
+                        .decrypt::<PasetoV4>(self.encryption_key)
                         .and_then(|decrypted| {
                             HistoryRecord::deserialize(&decrypted.data, version.as_str())
                         })
@@ -304,7 +305,7 @@ impl HistoryStore {
                 // Skip records we can't decrypt or decode, rather than failing the entire build.
                 let record =
                     match Version::from_name(version.as_str()) {
-                        Some(_) => record.decrypt::<PASETO_V4>(&self.encryption_key).and_then(
+                        Some(_) => record.decrypt::<PasetoV4>(self.encryption_key).and_then(
                             |decrypted| {
                                 HistoryRecord::deserialize(&decrypted.data, version.as_str())
                             },
@@ -419,7 +420,7 @@ mod tests {
     use crate::{
         database::Sqlite,
         history::{HISTORY_TAG, Version, store::HistoryRecord, store::HistoryStore},
-        record::{encryption::PASETO_V4, sqlite_store::SqliteStore},
+        record::{encryption::PasetoV4, sqlite_store::SqliteStore},
         settings::test_local_timeout,
     };
 
@@ -454,7 +455,7 @@ mod tests {
             .await
             .unwrap();
         let host_id = HostId(atuin_common::utils::uuid_v7());
-        let history_store = HistoryStore::new(store.clone(), host_id, [0u8; 32]);
+        let history_store = HistoryStore::new(store.clone(), host_id, [0u8; 32].into());
         (store, host_id, history_store)
     }
 
@@ -536,7 +537,7 @@ mod tests {
             .build();
 
         store
-            .push(&corrupt.encrypt::<PASETO_V4>(&[1u8; 32]))
+            .push(&corrupt.encrypt::<PasetoV4>([1u8; 32].into()))
             .await
             .unwrap();
 

--- a/crates/atuin-client/src/history/store.rs
+++ b/crates/atuin-client/src/history/store.rs
@@ -5,11 +5,11 @@ use futures::{Stream, StreamExt, TryStreamExt, future, stream};
 use indicatif::{ProgressBar, ProgressState, ProgressStyle};
 use rmp::decode::Bytes;
 
+use crate::record::encryption::PasetoV4Key;
 use crate::{
     database::{Database, current_context},
     record::{encryption::PasetoV4, sqlite_store::SqliteStore},
 };
-use crate::record::encryption::PasetoV4Key;
 use atuin_domain::record::{DecryptedData, Host, HostId, Record, RecordId, RecordIdx};
 
 use super::{HISTORY_TAG, History, HistoryId, Version};
@@ -223,13 +223,11 @@ impl HistoryStore {
             // A record we can't decrypt or decode must not block the rest of the store -
             // skip it, and load everything else.
             let hist = match Version::from_name(version.as_str()) {
-                Some(_) => {
-                    record
-                        .decrypt::<PasetoV4>(self.encryption_key)
-                        .and_then(|decrypted| {
-                            HistoryRecord::deserialize(&decrypted.data, version.as_str())
-                        })
-                }
+                Some(_) => record
+                    .decrypt::<PasetoV4>(self.encryption_key)
+                    .and_then(|decrypted| {
+                        HistoryRecord::deserialize(&decrypted.data, version.as_str())
+                    }),
                 None => Err(eyre!("unknown history version {version:?}")),
             };
 
@@ -303,15 +301,16 @@ impl HistoryStore {
                 let version = record.version.clone();
 
                 // Skip records we can't decrypt or decode, rather than failing the entire build.
-                let record =
-                    match Version::from_name(version.as_str()) {
-                        Some(_) => record.decrypt::<PasetoV4>(self.encryption_key).and_then(
-                            |decrypted| {
+                let record = match Version::from_name(version.as_str()) {
+                    Some(_) => {
+                        record
+                            .decrypt::<PasetoV4>(self.encryption_key)
+                            .and_then(|decrypted| {
                                 HistoryRecord::deserialize(&decrypted.data, version.as_str())
-                            },
-                        ),
-                        None => Err(eyre!("unknown history version {version:?}")),
-                    };
+                            })
+                    }
+                    None => Err(eyre!("unknown history version {version:?}")),
+                };
 
                 let record = match record {
                     Ok(record) => record,

--- a/crates/atuin-client/src/history/store.rs
+++ b/crates/atuin-client/src/history/store.rs
@@ -143,7 +143,7 @@ impl HistoryStore {
         let id = record.id;
 
         self.store
-            .push(&record.encrypt::<PasetoV4>(self.encryption_key))
+            .push(&record.encrypt::<PasetoV4>(&self.encryption_key))
             .await?;
 
         Ok((id, idx))
@@ -171,7 +171,7 @@ impl HistoryStore {
                 .data(bytes)
                 .build();
 
-            let record = record.encrypt::<PasetoV4>(self.encryption_key);
+            let record = record.encrypt::<PasetoV4>(&self.encryption_key);
 
             ret.push(record);
         }
@@ -224,7 +224,7 @@ impl HistoryStore {
             // skip it, and load everything else.
             let hist = match Version::from_name(version.as_str()) {
                 Some(_) => record
-                    .decrypt::<PasetoV4>(self.encryption_key)
+                    .decrypt::<PasetoV4>(&self.encryption_key)
                     .and_then(|decrypted| {
                         HistoryRecord::deserialize(&decrypted.data, version.as_str())
                     }),
@@ -304,7 +304,7 @@ impl HistoryStore {
                 let record = match Version::from_name(version.as_str()) {
                     Some(_) => {
                         record
-                            .decrypt::<PasetoV4>(self.encryption_key)
+                            .decrypt::<PasetoV4>(&self.encryption_key)
                             .and_then(|decrypted| {
                                 HistoryRecord::deserialize(&decrypted.data, version.as_str())
                             })
@@ -536,7 +536,7 @@ mod tests {
             .build();
 
         store
-            .push(&corrupt.encrypt::<PasetoV4>([1u8; 32].into()))
+            .push(&corrupt.encrypt::<PasetoV4>(&[1u8; 32].into()))
             .await
             .unwrap();
 

--- a/crates/atuin-client/src/login.rs
+++ b/crates/atuin-client/src/login.rs
@@ -5,7 +5,7 @@ use tokio::io::AsyncWriteExt;
 
 use crate::{
     api_client,
-    encryption::{Key, decode_key, encode_key, load_key},
+    encryption::{PasetoV4Key, decode_key, encode_key, load_key},
     record::sqlite_store::SqliteStore,
     settings::Settings,
 };
@@ -19,7 +19,7 @@ pub async fn login(
 ) -> Result<String> {
     // try parse the key as a mnemonic...
     let key = match bip39::Mnemonic::from_phrase(&key, bip39::Language::English) {
-        Ok(mnemonic) => encode_key(Key::from_slice(mnemonic.entropy()))?,
+        Ok(mnemonic) => encode_key(&PasetoV4Key::try_from(mnemonic.entropy())?)?,
         Err(err) => {
             match err {
                 // assume they copied in the base64 key
@@ -51,17 +51,16 @@ pub async fn login(
 
         // 1. check if the saved key and the provided key match. if so, nothing to do.
         // 2. if not, re-encrypt the local history and overwrite the key
-        let current_key: [u8; 32] = load_key(settings)?.into();
+        let current_key = load_key(settings)?;
 
         let encoded = key.clone(); // gonna want to save it in a bit
-        let new_key: [u8; 32] = decode_key(key)
-            .context("could not decode provided key - is not valid base64")?
-            .into();
+        let new_key = decode_key(key)
+            .context("could not decode provided key - is not valid base64")?;
 
         if new_key != current_key {
             println!("\nRe-encrypting local store with new key");
 
-            store.re_encrypt(&current_key, &new_key).await?;
+            store.re_encrypt(current_key, new_key).await?;
 
             println!("Writing new key");
             let mut file = File::create(key_path).await?;

--- a/crates/atuin-client/src/login.rs
+++ b/crates/atuin-client/src/login.rs
@@ -60,7 +60,7 @@ pub async fn login(
         if new_key != current_key {
             println!("\nRe-encrypting local store with new key");
 
-            store.re_encrypt(current_key, new_key).await?;
+            store.re_encrypt(&current_key, &new_key).await?;
 
             println!("Writing new key");
             let mut file = File::create(key_path).await?;

--- a/crates/atuin-client/src/login.rs
+++ b/crates/atuin-client/src/login.rs
@@ -54,8 +54,8 @@ pub async fn login(
         let current_key = load_key(settings)?;
 
         let encoded = key.clone(); // gonna want to save it in a bit
-        let new_key = decode_key(key)
-            .context("could not decode provided key - is not valid base64")?;
+        let new_key =
+            decode_key(key).context("could not decode provided key - is not valid base64")?;
 
         if new_key != current_key {
             println!("\nRe-encrypting local store with new key");

--- a/crates/atuin-client/src/record/encryption.rs
+++ b/crates/atuin-client/src/record/encryption.rs
@@ -1,5 +1,4 @@
 use std::array::TryFromSliceError;
-use std::fmt;
 
 use atuin_domain::record::{
     AdditionalData, DecryptedData, EncryptedData, Encryption, HostId, RecordId, RecordIdx,
@@ -19,7 +18,8 @@ pub struct PasetoV4;
 /// Key used for [`PasetoV4`] encryption.
 ///
 /// Intentionally **not** Copy to support zeroing out on Drop.
-#[derive(Clone, PartialEq, Eq)]
+#[derive(Clone, PartialEq, Eq, derive_more::From, derive_more::Debug)]
+#[debug("PasetoV4Key(*******)")]
 pub struct PasetoV4Key([u8; 32]);
 
 impl PasetoV4Key {
@@ -34,23 +34,11 @@ impl PasetoV4Key {
     }
 }
 
-impl From<[u8; 32]> for PasetoV4Key {
-    fn from(bytes: [u8; 32]) -> Self {
-        Self(bytes)
-    }
-}
-
 impl TryFrom<&[u8]> for PasetoV4Key {
     type Error = TryFromSliceError;
 
     fn try_from(bytes: &[u8]) -> std::result::Result<Self, Self::Error> {
         <[u8; 32]>::try_from(bytes).map(Self)
-    }
-}
-
-impl fmt::Debug for PasetoV4Key {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.write_str("PasetoV4Key([redacted])")
     }
 }
 

--- a/crates/atuin-client/src/record/encryption.rs
+++ b/crates/atuin-client/src/record/encryption.rs
@@ -1,3 +1,6 @@
+use std::array::TryFromSliceError;
+use std::fmt;
+
 use atuin_domain::record::{
     AdditionalData, DecryptedData, EncryptedData, Encryption, HostId, RecordId, RecordIdx,
 };
@@ -10,8 +13,57 @@ use rusty_paseto::core::{
 use serde::{Deserialize, Serialize};
 
 /// Use PASETO V4 Local encryption using the additional data as an implicit assertion.
-#[allow(non_camel_case_types)]
-pub struct PASETO_V4;
+pub struct PasetoV4;
+
+/// The 32-byte symmetric key that [`PasetoV4`] uses to wrap and unwrap records.
+///
+/// This is a newtype around the raw key bytes so the key is passed around as a
+/// distinct type rather than a bare `[u8; 32]`. It is [`Copy`]: the key is small
+/// and cheap to copy, so it is passed by value.
+///
+/// Note that being `Copy` precludes zeroizing the bytes on drop; this matches
+/// the previous `[u8; 32]` representation, which was also copied freely.
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub struct PasetoV4Key([u8; 32]);
+
+impl PasetoV4Key {
+    /// Borrow the raw key bytes.
+    pub fn as_bytes(&self) -> &[u8; 32] {
+        &self.0
+    }
+
+    /// Consume the key, returning the raw bytes.
+    pub fn into_bytes(self) -> [u8; 32] {
+        self.0
+    }
+}
+
+impl From<[u8; 32]> for PasetoV4Key {
+    fn from(bytes: [u8; 32]) -> Self {
+        Self(bytes)
+    }
+}
+
+impl From<PasetoV4Key> for [u8; 32] {
+    fn from(key: PasetoV4Key) -> Self {
+        key.0
+    }
+}
+
+impl TryFrom<&[u8]> for PasetoV4Key {
+    type Error = TryFromSliceError;
+
+    fn try_from(bytes: &[u8]) -> std::result::Result<Self, Self::Error> {
+        <[u8; 32]>::try_from(bytes).map(Self)
+    }
+}
+
+impl fmt::Debug for PasetoV4Key {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        // Never print the key material.
+        f.write_str("PasetoV4Key([redacted])")
+    }
+}
 
 /*
 Why do we use a random content-encryption key?
@@ -51,19 +103,21 @@ will need the HSM. This allows the encryption path to still be extremely fast (n
 that happens in the background can make the network calls to the HSM
 */
 
-impl Encryption for PASETO_V4 {
+impl Encryption for PasetoV4 {
+    type Key = PasetoV4Key;
+
     fn re_encrypt(
         mut data: EncryptedData,
         _ad: AdditionalData,
-        old_key: &[u8; 32],
-        new_key: &[u8; 32],
+        old_key: PasetoV4Key,
+        new_key: PasetoV4Key,
     ) -> Result<EncryptedData> {
         let cek = Self::decrypt_cek(data.content_encryption_key, old_key)?;
         data.content_encryption_key = Self::encrypt_cek(cek, new_key);
         Ok(data)
     }
 
-    fn encrypt(data: DecryptedData, ad: AdditionalData, key: &[u8; 32]) -> EncryptedData {
+    fn encrypt(data: DecryptedData, ad: AdditionalData, key: PasetoV4Key) -> EncryptedData {
         // generate a random key for this entry
         // aka content-encryption-key (CEK)
         let random_key = Key::<V4, Local>::new_os_random();
@@ -91,7 +145,7 @@ impl Encryption for PASETO_V4 {
         }
     }
 
-    fn decrypt(data: EncryptedData, ad: AdditionalData, key: &[u8; 32]) -> Result<DecryptedData> {
+    fn decrypt(data: EncryptedData, ad: AdditionalData, key: PasetoV4Key) -> Result<DecryptedData> {
         let token = data.data;
         let cek = Self::decrypt_cek(data.content_encryption_key, key)?;
 
@@ -113,9 +167,9 @@ impl Encryption for PASETO_V4 {
     }
 }
 
-impl PASETO_V4 {
-    fn decrypt_cek(wrapped_cek: String, key: &[u8; 32]) -> Result<Key<V4, Local>> {
-        let wrapping_key = Key::<V4, Local>::from_bytes(*key);
+impl PasetoV4 {
+    fn decrypt_cek(wrapped_cek: String, key: PasetoV4Key) -> Result<Key<V4, Local>> {
+        let wrapping_key = Key::<V4, Local>::from_bytes(key.into_bytes());
 
         // let wrapping_key = PasetoSymmetricKey::from(Key::from(key));
 
@@ -144,9 +198,9 @@ impl PASETO_V4 {
         Ok(wpk.unwrap_key(&wrapping_key)?)
     }
 
-    fn encrypt_cek(cek: Key<V4, Local>, key: &[u8; 32]) -> String {
+    fn encrypt_cek(cek: Key<V4, Local>, key: PasetoV4Key) -> String {
         // aka key-encryption-key (KEK)
-        let wrapping_key = Key::<V4, Local>::from_bytes(*key);
+        let wrapping_key = Key::<V4, Local>::from_bytes(key.into_bytes());
 
         // wrap the random key so we can decrypt it later
         let wrapped_cek = AtuinFooter {
@@ -249,8 +303,8 @@ mod tests {
             idx: &idx,
         };
 
-        let encrypted = PASETO_V4::encrypt(data.clone(), ad, &key.to_bytes());
-        let decrypted = PASETO_V4::decrypt(encrypted, ad, &key.to_bytes()).unwrap();
+        let encrypted = PasetoV4::encrypt(data.clone(), ad, key.to_bytes().into());
+        let decrypted = PasetoV4::decrypt(encrypted, ad, key.to_bytes().into()).unwrap();
         assert_eq!(decrypted, data);
     }
 
@@ -270,8 +324,8 @@ mod tests {
             idx: &idx,
         };
 
-        let encrypted = PASETO_V4::encrypt(data.clone(), ad, &key.to_bytes());
-        let encrypted2 = PASETO_V4::encrypt(data, ad, &key.to_bytes());
+        let encrypted = PasetoV4::encrypt(data.clone(), ad, key.to_bytes().into());
+        let encrypted2 = PasetoV4::encrypt(data, ad, key.to_bytes().into());
 
         assert_ne!(
             encrypted.data, encrypted2.data,
@@ -297,8 +351,8 @@ mod tests {
             idx: &idx,
         };
 
-        let encrypted = PASETO_V4::encrypt(data, ad, &key.to_bytes());
-        let error = PASETO_V4::decrypt(encrypted, ad, &fake_key.to_bytes()).unwrap_err();
+        let encrypted = PasetoV4::encrypt(data, ad, key.to_bytes().into());
+        let error = PasetoV4::decrypt(encrypted, ad, fake_key.to_bytes().into()).unwrap_err();
         let message = error.to_string();
 
         assert!(message.contains(
@@ -315,7 +369,7 @@ mod tests {
     fn cannot_decrypt_cek_with_missing_footer_contents() {
         let key = Key::<V4, Local>::new_os_random();
 
-        let Err(error) = PASETO_V4::decrypt_cek("{}".to_owned(), &key.to_bytes()) else {
+        let Err(error) = PasetoV4::decrypt_cek("{}".to_owned(), key.to_bytes().into()) else {
             panic!("missing footer contents should result in an error");
         };
 
@@ -341,13 +395,13 @@ mod tests {
             idx: &idx,
         };
 
-        let encrypted = PASETO_V4::encrypt(data, ad, &key.to_bytes());
+        let encrypted = PasetoV4::encrypt(data, ad, key.to_bytes().into());
 
         let ad = AdditionalData {
             id: &RecordId(uuid_v7()),
             ..ad
         };
-        let _ = PASETO_V4::decrypt(encrypted, ad, &key.to_bytes()).unwrap_err();
+        let _ = PasetoV4::decrypt(encrypted, ad, key.to_bytes().into()).unwrap_err();
     }
 
     #[rstest]
@@ -369,10 +423,14 @@ mod tests {
             idx: &idx,
         };
 
-        let encrypted1 = PASETO_V4::encrypt(data.clone(), ad, &key1.to_bytes());
-        let encrypted2 =
-            PASETO_V4::re_encrypt(encrypted1.clone(), ad, &key1.to_bytes(), &key2.to_bytes())
-                .unwrap();
+        let encrypted1 = PasetoV4::encrypt(data.clone(), ad, key1.to_bytes().into());
+        let encrypted2 = PasetoV4::re_encrypt(
+            encrypted1.clone(),
+            ad,
+            key1.to_bytes().into(),
+            key2.to_bytes().into(),
+        )
+        .unwrap();
 
         // we only re-encrypt the content keys
         assert_eq!(encrypted1.data, encrypted2.data);
@@ -381,39 +439,39 @@ mod tests {
             encrypted2.content_encryption_key
         );
 
-        let decrypted = PASETO_V4::decrypt(encrypted2, ad, &key2.to_bytes()).unwrap();
+        let decrypted = PasetoV4::decrypt(encrypted2, ad, key2.to_bytes().into()).unwrap();
 
         assert_eq!(decrypted, data);
     }
 
     #[rstest]
     fn full_record_round_trip(sample_record: Record<DecryptedData>) {
-        let key = [0x55; 32];
-        let encrypted = sample_record.encrypt::<PASETO_V4>(&key);
+        let key = PasetoV4Key::from([0x55; 32]);
+        let encrypted = sample_record.encrypt::<PasetoV4>(key);
 
         assert!(!encrypted.data.data.is_empty());
         assert!(!encrypted.data.content_encryption_key.is_empty());
 
-        let decrypted = encrypted.decrypt::<PASETO_V4>(&key).unwrap();
+        let decrypted = encrypted.decrypt::<PasetoV4>(key).unwrap();
 
         assert_eq!(decrypted.data.0, [1, 2, 3, 4]);
     }
 
     #[rstest]
     fn full_record_round_trip_fail(sample_record: Record<DecryptedData>) {
-        let key = [0x55; 32];
-        let encrypted = sample_record.encrypt::<PASETO_V4>(&key);
+        let key = PasetoV4Key::from([0x55; 32]);
+        let encrypted = sample_record.encrypt::<PasetoV4>(key);
 
         let mut enc1 = encrypted.clone();
         enc1.host = Host::new(HostId(uuid_v7()));
         let _ = enc1
-            .decrypt::<PASETO_V4>(&key)
+            .decrypt::<PasetoV4>(key)
             .expect_err("tampering with the host should result in auth failure");
 
         let mut enc2 = encrypted;
         enc2.id = RecordId(uuid_v7());
         let _ = enc2
-            .decrypt::<PASETO_V4>(&key)
+            .decrypt::<PasetoV4>(key)
             .expect_err("tampering with the id should result in auth failure");
     }
 }

--- a/crates/atuin-client/src/record/encryption.rs
+++ b/crates/atuin-client/src/record/encryption.rs
@@ -11,6 +11,7 @@ use rusty_paseto::core::{
     ImplicitAssertion, Key as DataKey, Local as LocalPurpose, Paseto, PasetoNonce, Payload, V4,
 };
 use serde::{Deserialize, Serialize};
+use zeroize::Zeroize;
 
 /// Use PASETO V4 Local encryption using the additional data as an implicit assertion.
 pub struct PasetoV4;
@@ -54,7 +55,9 @@ impl fmt::Debug for PasetoV4Key {
 }
 
 impl Drop for PasetoV4Key {
-    fn drop(&mut self) {}
+    fn drop(&mut self) {
+        self.0.zeroize();
+    }
 }
 
 /*

--- a/crates/atuin-client/src/record/encryption.rs
+++ b/crates/atuin-client/src/record/encryption.rs
@@ -15,15 +15,13 @@ use serde::{Deserialize, Serialize};
 /// Use PASETO V4 Local encryption using the additional data as an implicit assertion.
 pub struct PasetoV4;
 
-/// The 32-byte symmetric key that [`PasetoV4`] uses to wrap and unwrap records.
+/// Key used for [`PasetoV4`] encryption.
 ///
-/// This is a newtype around the raw key bytes so the key is passed around as a
-/// distinct type rather than a bare `[u8; 32]`. It is [`Copy`]: the key is small
-/// and cheap to copy, so it is passed by value.
-///
-/// Note that being `Copy` precludes zeroizing the bytes on drop; this matches
-/// the previous `[u8; 32]` representation, which was also copied freely.
-#[derive(Clone, Copy, PartialEq, Eq)]
+/// A newtype around the raw key bytes. It is deliberately **not** `Copy`: the
+/// key is secret material, so every copy should be an explicit `clone`, and
+/// keeping it non-`Copy` leaves room to zeroize the bytes on drop in future (a
+/// `Copy` type cannot implement `Drop`). It is passed by reference.
+#[derive(Clone, PartialEq, Eq)]
 pub struct PasetoV4Key([u8; 32]);
 
 impl PasetoV4Key {
@@ -31,22 +29,11 @@ impl PasetoV4Key {
     pub fn as_bytes(&self) -> &[u8; 32] {
         &self.0
     }
-
-    /// Consume the key, returning the raw bytes.
-    pub fn into_bytes(self) -> [u8; 32] {
-        self.0
-    }
 }
 
 impl From<[u8; 32]> for PasetoV4Key {
     fn from(bytes: [u8; 32]) -> Self {
         Self(bytes)
-    }
-}
-
-impl From<PasetoV4Key> for [u8; 32] {
-    fn from(key: PasetoV4Key) -> Self {
-        key.0
     }
 }
 
@@ -109,15 +96,15 @@ impl Encryption for PasetoV4 {
     fn re_encrypt(
         mut data: EncryptedData,
         _ad: AdditionalData,
-        old_key: PasetoV4Key,
-        new_key: PasetoV4Key,
+        old_key: &PasetoV4Key,
+        new_key: &PasetoV4Key,
     ) -> Result<EncryptedData> {
         let cek = Self::decrypt_cek(data.content_encryption_key, old_key)?;
         data.content_encryption_key = Self::encrypt_cek(cek, new_key);
         Ok(data)
     }
 
-    fn encrypt(data: DecryptedData, ad: AdditionalData, key: PasetoV4Key) -> EncryptedData {
+    fn encrypt(data: DecryptedData, ad: AdditionalData, key: &PasetoV4Key) -> EncryptedData {
         // generate a random key for this entry
         // aka content-encryption-key (CEK)
         let random_key = Key::<V4, Local>::new_os_random();
@@ -145,7 +132,7 @@ impl Encryption for PasetoV4 {
         }
     }
 
-    fn decrypt(data: EncryptedData, ad: AdditionalData, key: PasetoV4Key) -> Result<DecryptedData> {
+    fn decrypt(data: EncryptedData, ad: AdditionalData, key: &PasetoV4Key) -> Result<DecryptedData> {
         let token = data.data;
         let cek = Self::decrypt_cek(data.content_encryption_key, key)?;
 
@@ -168,8 +155,8 @@ impl Encryption for PasetoV4 {
 }
 
 impl PasetoV4 {
-    fn decrypt_cek(wrapped_cek: String, key: PasetoV4Key) -> Result<Key<V4, Local>> {
-        let wrapping_key = Key::<V4, Local>::from_bytes(key.into_bytes());
+    fn decrypt_cek(wrapped_cek: String, key: &PasetoV4Key) -> Result<Key<V4, Local>> {
+        let wrapping_key = Key::<V4, Local>::from_bytes(*key.as_bytes());
 
         // let wrapping_key = PasetoSymmetricKey::from(Key::from(key));
 
@@ -198,9 +185,9 @@ impl PasetoV4 {
         Ok(wpk.unwrap_key(&wrapping_key)?)
     }
 
-    fn encrypt_cek(cek: Key<V4, Local>, key: PasetoV4Key) -> String {
+    fn encrypt_cek(cek: Key<V4, Local>, key: &PasetoV4Key) -> String {
         // aka key-encryption-key (KEK)
-        let wrapping_key = Key::<V4, Local>::from_bytes(key.into_bytes());
+        let wrapping_key = Key::<V4, Local>::from_bytes(*key.as_bytes());
 
         // wrap the random key so we can decrypt it later
         let wrapped_cek = AtuinFooter {
@@ -303,8 +290,8 @@ mod tests {
             idx: &idx,
         };
 
-        let encrypted = PasetoV4::encrypt(data.clone(), ad, key.to_bytes().into());
-        let decrypted = PasetoV4::decrypt(encrypted, ad, key.to_bytes().into()).unwrap();
+        let encrypted = PasetoV4::encrypt(data.clone(), ad, &key.to_bytes().into());
+        let decrypted = PasetoV4::decrypt(encrypted, ad, &key.to_bytes().into()).unwrap();
         assert_eq!(decrypted, data);
     }
 
@@ -324,8 +311,8 @@ mod tests {
             idx: &idx,
         };
 
-        let encrypted = PasetoV4::encrypt(data.clone(), ad, key.to_bytes().into());
-        let encrypted2 = PasetoV4::encrypt(data, ad, key.to_bytes().into());
+        let encrypted = PasetoV4::encrypt(data.clone(), ad, &key.to_bytes().into());
+        let encrypted2 = PasetoV4::encrypt(data, ad, &key.to_bytes().into());
 
         assert_ne!(
             encrypted.data, encrypted2.data,
@@ -351,8 +338,8 @@ mod tests {
             idx: &idx,
         };
 
-        let encrypted = PasetoV4::encrypt(data, ad, key.to_bytes().into());
-        let error = PasetoV4::decrypt(encrypted, ad, fake_key.to_bytes().into()).unwrap_err();
+        let encrypted = PasetoV4::encrypt(data, ad, &key.to_bytes().into());
+        let error = PasetoV4::decrypt(encrypted, ad, &fake_key.to_bytes().into()).unwrap_err();
         let message = error.to_string();
 
         assert!(message.contains(
@@ -369,7 +356,7 @@ mod tests {
     fn cannot_decrypt_cek_with_missing_footer_contents() {
         let key = Key::<V4, Local>::new_os_random();
 
-        let Err(error) = PasetoV4::decrypt_cek("{}".to_owned(), key.to_bytes().into()) else {
+        let Err(error) = PasetoV4::decrypt_cek("{}".to_owned(), &key.to_bytes().into()) else {
             panic!("missing footer contents should result in an error");
         };
 
@@ -395,13 +382,13 @@ mod tests {
             idx: &idx,
         };
 
-        let encrypted = PasetoV4::encrypt(data, ad, key.to_bytes().into());
+        let encrypted = PasetoV4::encrypt(data, ad, &key.to_bytes().into());
 
         let ad = AdditionalData {
             id: &RecordId(uuid_v7()),
             ..ad
         };
-        let _ = PasetoV4::decrypt(encrypted, ad, key.to_bytes().into()).unwrap_err();
+        let _ = PasetoV4::decrypt(encrypted, ad, &key.to_bytes().into()).unwrap_err();
     }
 
     #[rstest]
@@ -423,12 +410,12 @@ mod tests {
             idx: &idx,
         };
 
-        let encrypted1 = PasetoV4::encrypt(data.clone(), ad, key1.to_bytes().into());
+        let encrypted1 = PasetoV4::encrypt(data.clone(), ad, &key1.to_bytes().into());
         let encrypted2 = PasetoV4::re_encrypt(
             encrypted1.clone(),
             ad,
-            key1.to_bytes().into(),
-            key2.to_bytes().into(),
+            &key1.to_bytes().into(),
+            &key2.to_bytes().into(),
         )
         .unwrap();
 
@@ -439,7 +426,7 @@ mod tests {
             encrypted2.content_encryption_key
         );
 
-        let decrypted = PasetoV4::decrypt(encrypted2, ad, key2.to_bytes().into()).unwrap();
+        let decrypted = PasetoV4::decrypt(encrypted2, ad, &key2.to_bytes().into()).unwrap();
 
         assert_eq!(decrypted, data);
     }
@@ -447,12 +434,12 @@ mod tests {
     #[rstest]
     fn full_record_round_trip(sample_record: Record<DecryptedData>) {
         let key = PasetoV4Key::from([0x55; 32]);
-        let encrypted = sample_record.encrypt::<PasetoV4>(key);
+        let encrypted = sample_record.encrypt::<PasetoV4>(&key);
 
         assert!(!encrypted.data.data.is_empty());
         assert!(!encrypted.data.content_encryption_key.is_empty());
 
-        let decrypted = encrypted.decrypt::<PasetoV4>(key).unwrap();
+        let decrypted = encrypted.decrypt::<PasetoV4>(&key).unwrap();
 
         assert_eq!(decrypted.data.0, [1, 2, 3, 4]);
     }
@@ -460,18 +447,18 @@ mod tests {
     #[rstest]
     fn full_record_round_trip_fail(sample_record: Record<DecryptedData>) {
         let key = PasetoV4Key::from([0x55; 32]);
-        let encrypted = sample_record.encrypt::<PasetoV4>(key);
+        let encrypted = sample_record.encrypt::<PasetoV4>(&key);
 
         let mut enc1 = encrypted.clone();
         enc1.host = Host::new(HostId(uuid_v7()));
         let _ = enc1
-            .decrypt::<PasetoV4>(key)
+            .decrypt::<PasetoV4>(&key)
             .expect_err("tampering with the host should result in auth failure");
 
         let mut enc2 = encrypted;
         enc2.id = RecordId(uuid_v7());
         let _ = enc2
-            .decrypt::<PasetoV4>(key)
+            .decrypt::<PasetoV4>(&key)
             .expect_err("tampering with the id should result in auth failure");
     }
 }

--- a/crates/atuin-client/src/record/encryption.rs
+++ b/crates/atuin-client/src/record/encryption.rs
@@ -17,14 +17,16 @@ pub struct PasetoV4;
 
 /// Key used for [`PasetoV4`] encryption.
 ///
-/// A newtype around the raw key bytes. It is deliberately **not** `Copy`: the
-/// key is secret material, so every copy should be an explicit `clone`, and
-/// keeping it non-`Copy` leaves room to zeroize the bytes on drop in future (a
-/// `Copy` type cannot implement `Drop`). It is passed by reference.
+/// Intentionally **not** Copy to support zeroing out on Drop.
 #[derive(Clone, PartialEq, Eq)]
 pub struct PasetoV4Key([u8; 32]);
 
 impl PasetoV4Key {
+    /// A key with every byte set to zero.
+    pub const fn zero() -> Self {
+        Self([0u8; 32])
+    }
+
     /// Borrow the raw key bytes.
     pub fn as_bytes(&self) -> &[u8; 32] {
         &self.0
@@ -47,9 +49,12 @@ impl TryFrom<&[u8]> for PasetoV4Key {
 
 impl fmt::Debug for PasetoV4Key {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        // Never print the key material.
         f.write_str("PasetoV4Key([redacted])")
     }
+}
+
+impl Drop for PasetoV4Key {
+    fn drop(&mut self) {}
 }
 
 /*
@@ -132,7 +137,11 @@ impl Encryption for PasetoV4 {
         }
     }
 
-    fn decrypt(data: EncryptedData, ad: AdditionalData, key: &PasetoV4Key) -> Result<DecryptedData> {
+    fn decrypt(
+        data: EncryptedData,
+        ad: AdditionalData,
+        key: &PasetoV4Key,
+    ) -> Result<DecryptedData> {
         let token = data.data;
         let cek = Self::decrypt_cek(data.content_encryption_key, key)?;
 

--- a/crates/atuin-client/src/record/encryption.rs
+++ b/crates/atuin-client/src/record/encryption.rs
@@ -33,30 +33,25 @@ impl PasetoV4Key {
     }
 
     /// Borrow the raw key bytes.
-    #[inline]
     pub fn as_bytes(&self) -> &[u8; 32] {
         &self.0
     }
 
     /// Equivalent to [`rusty_paserk::Key::new_os_random()`].
-    #[inline]
     pub fn new_os_random() -> Self {
         rusty_paserk::Key::<rusty_paserk::V4, rusty_paserk::Local>::new_os_random().into()
     }
 
-    #[inline]
     pub fn try_new_random() -> Result<Self, rusty_paseto::PasetoError> {
         let paseto: rusty_paseto::Key<32> = rusty_paseto::Key::<32>::try_new_random()?;
         Ok(paseto.into())
     }
 
-    #[inline]
     pub fn key_id(&self) -> PaserkV4KeyId {
         let paserk: rusty_paserk::Key<rusty_paserk::V4, rusty_paserk::Local> = self.into();
         paserk.to_id()
     }
 
-    #[inline]
     pub fn wrap_pie(&self, wrapping: &PasetoV4Key) -> PaserkV4PieWrappedKey {
         let p_self: rusty_paserk::Key<rusty_paserk::V4, rusty_paserk::Local> = self.into();
         let p_wrapping: rusty_paserk::Key<rusty_paserk::V4, rusty_paserk::Local> = wrapping.into();

--- a/crates/atuin-client/src/record/encryption.rs
+++ b/crates/atuin-client/src/record/encryption.rs
@@ -5,12 +5,15 @@ use atuin_domain::record::{
 };
 use base64::{Engine, engine::general_purpose};
 use eyre::{Context, Result, ensure};
-use rusty_paserk::{Key, KeyId, Local, PieWrappedKey};
-use rusty_paseto::core::{
-    ImplicitAssertion, Key as DataKey, Local as LocalPurpose, Paseto, PasetoNonce, Payload, V4,
-};
+use rusty_paserk;
+use rusty_paseto::Paseto;
+use rusty_paseto::core as rusty_paseto;
 use serde::{Deserialize, Serialize};
 use zeroize::Zeroize;
+
+type PaserkV4KeyId = rusty_paserk::KeyId<rusty_paserk::V4, rusty_paserk::Local>;
+type PaserkV4PieWrappedKey = rusty_paserk::PieWrappedKey<rusty_paserk::V4, rusty_paserk::Local>;
+type PasetoV4Nonce<'a> = rusty_paseto::PasetoNonce<'a, rusty_paseto::V4, rusty_paseto::Local>;
 
 /// Use PASETO V4 Local encryption using the additional data as an implicit assertion.
 pub struct PasetoV4;
@@ -24,13 +27,47 @@ pub struct PasetoV4Key([u8; 32]);
 
 impl PasetoV4Key {
     /// A key with every byte set to zero.
+    #[must_use]
     pub const fn zero() -> Self {
         Self([0u8; 32])
     }
 
     /// Borrow the raw key bytes.
+    #[inline]
     pub fn as_bytes(&self) -> &[u8; 32] {
         &self.0
+    }
+
+    /// Equivalent to [`rusty_paserk::Key::new_os_random()`].
+    #[inline]
+    pub fn new_os_random() -> Self {
+        rusty_paserk::Key::<rusty_paserk::V4, rusty_paserk::Local>::new_os_random().into()
+    }
+
+    #[inline]
+    pub fn try_new_random() -> Result<Self, rusty_paseto::PasetoError> {
+        let paseto: rusty_paseto::Key<32> = rusty_paseto::Key::<32>::try_new_random()?;
+        Ok(paseto.into())
+    }
+
+    #[inline]
+    pub fn key_id(&self) -> PaserkV4KeyId {
+        let paserk: rusty_paserk::Key<rusty_paserk::V4, rusty_paserk::Local> = self.into();
+        paserk.to_id()
+    }
+
+    #[inline]
+    pub fn wrap_pie(&self, wrapping: &PasetoV4Key) -> PaserkV4PieWrappedKey {
+        let p_self: rusty_paserk::Key<rusty_paserk::V4, rusty_paserk::Local> = self.into();
+        let p_wrapping: rusty_paserk::Key<rusty_paserk::V4, rusty_paserk::Local> = wrapping.into();
+
+        p_self.wrap_pie(&p_wrapping)
+    }
+}
+
+impl Drop for PasetoV4Key {
+    fn drop(&mut self) {
+        self.0.zeroize();
     }
 }
 
@@ -42,9 +79,35 @@ impl TryFrom<&[u8]> for PasetoV4Key {
     }
 }
 
-impl Drop for PasetoV4Key {
-    fn drop(&mut self) {
-        self.0.zeroize();
+impl From<&PasetoV4Key> for rusty_paserk::Key<rusty_paserk::V4, rusty_paserk::Local> {
+    fn from(value: &PasetoV4Key) -> Self {
+        Self::from_bytes(*value.as_bytes())
+    }
+}
+
+impl From<rusty_paserk::Key<rusty_paserk::V4, rusty_paserk::Local>> for PasetoV4Key {
+    fn from(value: rusty_paserk::Key<rusty_paserk::V4, rusty_paserk::Local>) -> Self {
+        Self(value.to_bytes())
+    }
+}
+
+impl From<&PasetoV4Key>
+    for rusty_paseto::PasetoSymmetricKey<rusty_paseto::V4, rusty_paseto::Local>
+{
+    fn from(value: &PasetoV4Key) -> Self {
+        rusty_paserk::Key::<rusty_paserk::V4, rusty_paserk::Local>::from(value).into()
+    }
+}
+
+impl From<&PasetoV4Key> for rusty_paseto::Key<32> {
+    fn from(value: &PasetoV4Key) -> Self {
+        rusty_paseto::Key::<32>::from(value.0)
+    }
+}
+
+impl From<rusty_paseto::Key<32>> for PasetoV4Key {
+    fn from(value: rusty_paseto::Key<32>) -> Self {
+        Self(*value)
     }
 }
 
@@ -96,14 +159,14 @@ impl Encryption for PasetoV4 {
         new_key: &PasetoV4Key,
     ) -> Result<EncryptedData> {
         let cek = Self::decrypt_cek(data.content_encryption_key, old_key)?;
-        data.content_encryption_key = Self::encrypt_cek(cek, new_key);
+        data.content_encryption_key = Self::encrypt_cek(&cek, new_key);
         Ok(data)
     }
 
     fn encrypt(data: DecryptedData, ad: AdditionalData, key: &PasetoV4Key) -> EncryptedData {
         // generate a random key for this entry
         // aka content-encryption-key (CEK)
-        let random_key = Key::<V4, Local>::new_os_random();
+        let random_key = PasetoV4Key::try_new_random().expect("could not source from random");
 
         // encode the implicit assertions
         let assertions = Assertions::from(ad).encode();
@@ -113,18 +176,19 @@ impl Encryption for PasetoV4 {
             data: general_purpose::URL_SAFE_NO_PAD.encode(data.0),
         })
         .expect("json encoding can't fail");
-        let nonce = DataKey::<32>::try_new_random().expect("could not source from random");
-        let nonce = PasetoNonce::<V4, LocalPurpose>::from(&nonce);
+        let nonce: rusty_paseto::Key<32> =
+            (&PasetoV4Key::try_new_random().expect("could not source from random")).into();
+        let nonce = PasetoV4Nonce::from(&nonce);
 
-        let token = Paseto::<V4, LocalPurpose>::builder()
-            .set_payload(Payload::from(payload.as_str()))
-            .set_implicit_assertion(ImplicitAssertion::from(assertions.as_str()))
-            .try_encrypt(&random_key.into(), &nonce)
+        let token = Paseto::<rusty_paseto::V4, rusty_paseto::Local>::builder()
+            .set_payload(rusty_paseto::Payload::from(payload.as_str()))
+            .set_implicit_assertion(rusty_paseto::ImplicitAssertion::from(assertions.as_str()))
+            .try_encrypt(&(&random_key).into(), &nonce)
             .expect("error encrypting atuin data");
 
         EncryptedData {
             data: token,
-            content_encryption_key: Self::encrypt_cek(random_key, key),
+            content_encryption_key: Self::encrypt_cek(&random_key, key),
         }
     }
 
@@ -140,11 +204,11 @@ impl Encryption for PasetoV4 {
         let assertions = Assertions::from(ad).encode();
 
         // decrypt the payload with the footer and implicit assertions
-        let payload = Paseto::<V4, LocalPurpose>::try_decrypt(
+        let payload = Paseto::<rusty_paseto::V4, rusty_paseto::Local>::try_decrypt(
             &token,
-            &cek.into(),
+            &(&cek).into(),
             None,
-            ImplicitAssertion::from(&*assertions),
+            rusty_paseto::ImplicitAssertion::from(&*assertions),
         )
         .context("could not decrypt entry")?;
 
@@ -155,8 +219,8 @@ impl Encryption for PasetoV4 {
 }
 
 impl PasetoV4 {
-    fn decrypt_cek(wrapped_cek: String, key: &PasetoV4Key) -> Result<Key<V4, Local>> {
-        let wrapping_key = Key::<V4, Local>::from_bytes(*key.as_bytes());
+    fn decrypt_cek(wrapped_cek: String, key: &PasetoV4Key) -> Result<PasetoV4Key> {
+        let wrapping_key: rusty_paserk::Key<rusty_paserk::V4, rusty_paserk::Local> = key.into();
 
         // let wrapping_key = PasetoSymmetricKey::from(Key::from(key));
 
@@ -182,17 +246,15 @@ impl PasetoV4 {
         );
 
         // decrypt the random key
-        Ok(wpk.unwrap_key(&wrapping_key)?)
+        Ok(wpk.unwrap_key(&wrapping_key)?.into())
     }
 
-    fn encrypt_cek(cek: Key<V4, Local>, key: &PasetoV4Key) -> String {
-        // aka key-encryption-key (KEK)
-        let wrapping_key = Key::<V4, Local>::from_bytes(*key.as_bytes());
-
+    /// Note that wrapping is a key-encryption-key (KEK)
+    fn encrypt_cek(cek: &PasetoV4Key, wrapping_key: &PasetoV4Key) -> String {
         // wrap the random key so we can decrypt it later
         let wrapped_cek = AtuinFooter {
-            wpk: cek.wrap_pie(&wrapping_key),
-            kid: wrapping_key.to_id(),
+            wpk: cek.wrap_pie(wrapping_key),
+            kid: wrapping_key.key_id(),
         };
         serde_json::to_string(&wrapped_cek).expect("could not serialize wrapped cek")
     }
@@ -208,9 +270,9 @@ struct AtuinPayload {
 /// <https://github.com/paseto-standard/paseto-spec/blob/master/docs/02-Implementation-Guide/04-Claims.md#optional-footer-claims>
 struct AtuinFooter {
     /// Wrapped key
-    wpk: PieWrappedKey<V4, Local>,
+    wpk: PaserkV4PieWrappedKey,
     /// ID of the key which was used to wrap
-    kid: KeyId<V4, Local>,
+    kid: PaserkV4KeyId,
 }
 
 /// Used in the implicit assertions. This is not encrypted and not stored in the data blob.
@@ -251,8 +313,8 @@ mod tests {
     use super::*;
 
     #[fixture]
-    fn key() -> Key<V4, Local> {
-        Key::<V4, Local>::new_os_random()
+    fn key() -> PasetoV4Key {
+        PasetoV4Key::new_os_random()
     }
 
     #[fixture]
@@ -279,7 +341,7 @@ mod tests {
     }
 
     #[rstest]
-    fn round_trip(key: Key<V4, Local>, data: DecryptedData, ad_parts: (RecordId, HostId)) {
+    fn round_trip(key: PasetoV4Key, data: DecryptedData, ad_parts: (RecordId, HostId)) {
         let (rid, hid) = ad_parts;
         let idx = 0;
         let ad = AdditionalData {
@@ -290,14 +352,14 @@ mod tests {
             idx: &idx,
         };
 
-        let encrypted = PasetoV4::encrypt(data.clone(), ad, &key.to_bytes().into());
-        let decrypted = PasetoV4::decrypt(encrypted, ad, &key.to_bytes().into()).unwrap();
+        let encrypted = PasetoV4::encrypt(data.clone(), ad, &key);
+        let decrypted = PasetoV4::decrypt(encrypted, ad, &key).unwrap();
         assert_eq!(decrypted, data);
     }
 
     #[rstest]
     fn same_entry_different_output(
-        key: Key<V4, Local>,
+        key: PasetoV4Key,
         data: DecryptedData,
         ad_parts: (RecordId, HostId),
     ) {
@@ -311,8 +373,8 @@ mod tests {
             idx: &idx,
         };
 
-        let encrypted = PasetoV4::encrypt(data.clone(), ad, &key.to_bytes().into());
-        let encrypted2 = PasetoV4::encrypt(data, ad, &key.to_bytes().into());
+        let encrypted = PasetoV4::encrypt(data.clone(), ad, &key);
+        let encrypted2 = PasetoV4::encrypt(data, ad, &key);
 
         assert_ne!(
             encrypted.data, encrypted2.data,
@@ -322,11 +384,11 @@ mod tests {
 
     #[rstest]
     fn cannot_decrypt_different_key(
-        key: Key<V4, Local>,
+        key: PasetoV4Key,
         data: DecryptedData,
         ad_parts: (RecordId, HostId),
     ) {
-        let fake_key = Key::<V4, Local>::new_os_random();
+        let fake_key = PasetoV4Key::new_os_random();
 
         let (rid, hid) = ad_parts;
         let idx = 0;
@@ -338,8 +400,8 @@ mod tests {
             idx: &idx,
         };
 
-        let encrypted = PasetoV4::encrypt(data, ad, &key.to_bytes().into());
-        let error = PasetoV4::decrypt(encrypted, ad, &fake_key.to_bytes().into()).unwrap_err();
+        let encrypted = PasetoV4::encrypt(data, ad, &key);
+        let error = PasetoV4::decrypt(encrypted, ad, &fake_key).unwrap_err();
         let message = error.to_string();
 
         assert!(message.contains(
@@ -347,16 +409,16 @@ mod tests {
         ));
         assert!(message.contains(&format!(
             "Currently using {}, expecting {}.",
-            fake_key.to_id(),
-            key.to_id()
+            fake_key.key_id(),
+            key.key_id()
         )));
     }
 
     #[rstest]
     fn cannot_decrypt_cek_with_missing_footer_contents() {
-        let key = Key::<V4, Local>::new_os_random();
+        let key = PasetoV4Key::new_os_random();
 
-        let Err(error) = PasetoV4::decrypt_cek("{}".to_owned(), &key.to_bytes().into()) else {
+        let Err(error) = PasetoV4::decrypt_cek("{}".to_owned(), &key) else {
             panic!("missing footer contents should result in an error");
         };
 
@@ -368,7 +430,7 @@ mod tests {
 
     #[rstest]
     fn cannot_decrypt_different_id(
-        key: Key<V4, Local>,
+        key: PasetoV4Key,
         data: DecryptedData,
         ad_parts: (RecordId, HostId),
     ) {
@@ -382,23 +444,19 @@ mod tests {
             idx: &idx,
         };
 
-        let encrypted = PasetoV4::encrypt(data, ad, &key.to_bytes().into());
+        let encrypted = PasetoV4::encrypt(data, ad, &key);
 
         let ad = AdditionalData {
             id: &RecordId(uuid_v7()),
             ..ad
         };
-        let _ = PasetoV4::decrypt(encrypted, ad, &key.to_bytes().into()).unwrap_err();
+        let _ = PasetoV4::decrypt(encrypted, ad, &key).unwrap_err();
     }
 
     #[rstest]
-    fn re_encrypt_round_trip(
-        key: Key<V4, Local>,
-        data: DecryptedData,
-        ad_parts: (RecordId, HostId),
-    ) {
+    fn re_encrypt_round_trip(key: PasetoV4Key, data: DecryptedData, ad_parts: (RecordId, HostId)) {
         let key1 = key;
-        let key2 = Key::<V4, Local>::new_os_random();
+        let key2 = PasetoV4Key::new_os_random();
 
         let (rid, hid) = ad_parts;
         let idx = 0;
@@ -410,14 +468,8 @@ mod tests {
             idx: &idx,
         };
 
-        let encrypted1 = PasetoV4::encrypt(data.clone(), ad, &key1.to_bytes().into());
-        let encrypted2 = PasetoV4::re_encrypt(
-            encrypted1.clone(),
-            ad,
-            &key1.to_bytes().into(),
-            &key2.to_bytes().into(),
-        )
-        .unwrap();
+        let encrypted1 = PasetoV4::encrypt(data.clone(), ad, &key1);
+        let encrypted2 = PasetoV4::re_encrypt(encrypted1.clone(), ad, &key1, &key2).unwrap();
 
         // we only re-encrypt the content keys
         assert_eq!(encrypted1.data, encrypted2.data);
@@ -426,7 +478,7 @@ mod tests {
             encrypted2.content_encryption_key
         );
 
-        let decrypted = PasetoV4::decrypt(encrypted2, ad, &key2.to_bytes().into()).unwrap();
+        let decrypted = PasetoV4::decrypt(encrypted2, ad, &key2).unwrap();
 
         assert_eq!(decrypted, data);
     }

--- a/crates/atuin-client/src/record/encryption.rs
+++ b/crates/atuin-client/src/record/encryption.rs
@@ -101,7 +101,7 @@ impl From<&PasetoV4Key>
 
 impl From<&PasetoV4Key> for rusty_paseto::Key<32> {
     fn from(value: &PasetoV4Key) -> Self {
-        rusty_paseto::Key::<32>::from(value.0)
+        value.0.into()
     }
 }
 

--- a/crates/atuin-client/src/record/sqlite_store.rs
+++ b/crates/atuin-client/src/record/sqlite_store.rs
@@ -16,8 +16,8 @@ use sqlx::{
     },
 };
 
-use atuin_common::utils;
 use crate::record::encryption::PasetoV4Key;
+use atuin_common::utils;
 use atuin_domain::record::{
     EncryptedData, Host, HostId, Record, RecordId, RecordIdx, RecordStatus,
 };
@@ -535,7 +535,9 @@ mod tests {
         let mut tail = record();
         records.push(tail.clone());
         for _ in 1..10000 {
-            tail = tail.append(vec![1, 2, 3]).encrypt::<PasetoV4>([0; 32].into());
+            tail = tail
+                .append(vec![1, 2, 3])
+                .encrypt::<PasetoV4>([0; 32].into());
             records.push(tail.clone());
         }
 

--- a/crates/atuin-client/src/record/sqlite_store.rs
+++ b/crates/atuin-client/src/record/sqlite_store.rs
@@ -302,7 +302,7 @@ impl SqliteStore {
 
     /// Reencrypt every single item in this store with a new key
     /// Be careful - this may mess with sync.
-    pub async fn re_encrypt(&self, old_key: PasetoV4Key, new_key: PasetoV4Key) -> Result<()> {
+    pub async fn re_encrypt(&self, old_key: &PasetoV4Key, new_key: &PasetoV4Key) -> Result<()> {
         // Load all the records
         // In memory like some of the other code here
         // This will never be called in a hot loop, and only under the following circumstances
@@ -341,7 +341,7 @@ impl SqliteStore {
 
     /// Verify that every record in this store can be decrypted with the current key
     /// Someday maybe also check each tag/record can be deserialized, but not for now.
-    pub async fn verify(&self, key: PasetoV4Key) -> Result<()> {
+    pub async fn verify(&self, key: &PasetoV4Key) -> Result<()> {
         let all = self.load_all().await?;
 
         all.into_iter()
@@ -353,7 +353,7 @@ impl SqliteStore {
 
     /// Verify that every record in this store can be decrypted with the current key
     /// Someday maybe also check each tag/record can be deserialized, but not for now.
-    pub async fn purge(&self, key: PasetoV4Key) -> Result<()> {
+    pub async fn purge(&self, key: &PasetoV4Key) -> Result<()> {
         let all = self.load_all().await?;
 
         for record in all.iter() {
@@ -511,7 +511,7 @@ mod tests {
         for _ in 1..100 {
             tail = tail
                 .append(vec![1, 2, 3, 4])
-                .encrypt::<PasetoV4>([0; 32].into());
+                .encrypt::<PasetoV4>(&[0; 32].into());
             store.push(&tail).await.unwrap();
         }
 
@@ -537,7 +537,7 @@ mod tests {
         for _ in 1..10000 {
             tail = tail
                 .append(vec![1, 2, 3])
-                .encrypt::<PasetoV4>([0; 32].into());
+                .encrypt::<PasetoV4>(&[0; 32].into());
             records.push(tail.clone());
         }
 
@@ -565,7 +565,7 @@ mod tests {
                 .idx(i)
                 .data(DecryptedData(data.clone()))
                 .build()
-                .encrypt::<PasetoV4>(key);
+                .encrypt::<PasetoV4>(&key);
             store
                 .push(&record)
                 .await
@@ -576,26 +576,26 @@ mod tests {
         let all = store.all_tagged("test").await.unwrap();
         assert_eq!(all.len(), 10, "failed to fetch all records");
         for record in all {
-            let decrypted = record.decrypt::<PasetoV4>(key).unwrap();
+            let decrypted = record.decrypt::<PasetoV4>(&key).unwrap();
             assert_eq!(decrypted.data.0, data);
         }
 
         // after re-encrypting: the old key fails, the new key works
         let (new_key, _) = generate_encoded_key().unwrap();
         store
-            .re_encrypt(key, new_key)
+            .re_encrypt(&key, &new_key)
             .await
             .expect("failed to re-encrypt store");
 
         let all = store.all_tagged("test").await.unwrap();
         for record in all.iter() {
             assert!(
-                record.clone().decrypt::<PasetoV4>(key).is_err(),
+                record.clone().decrypt::<PasetoV4>(&key).is_err(),
                 "old key still decrypts after re-encrypt"
             );
         }
         for record in all {
-            let decrypted = record.decrypt::<PasetoV4>(new_key).unwrap();
+            let decrypted = record.decrypt::<PasetoV4>(&new_key).unwrap();
             assert_eq!(decrypted.data.0, data);
         }
 

--- a/crates/atuin-client/src/record/sqlite_store.rs
+++ b/crates/atuin-client/src/record/sqlite_store.rs
@@ -17,12 +17,13 @@ use sqlx::{
 };
 
 use atuin_common::utils;
+use crate::record::encryption::PasetoV4Key;
 use atuin_domain::record::{
     EncryptedData, Host, HostId, Record, RecordId, RecordIdx, RecordStatus,
 };
 use uuid::Uuid;
 
-use super::encryption::PASETO_V4;
+use super::encryption::PasetoV4;
 
 #[derive(Debug, Clone)]
 pub struct SqliteStore {
@@ -301,7 +302,7 @@ impl SqliteStore {
 
     /// Reencrypt every single item in this store with a new key
     /// Be careful - this may mess with sync.
-    pub async fn re_encrypt(&self, old_key: &[u8; 32], new_key: &[u8; 32]) -> Result<()> {
+    pub async fn re_encrypt(&self, old_key: PasetoV4Key, new_key: PasetoV4Key) -> Result<()> {
         // Load all the records
         // In memory like some of the other code here
         // This will never be called in a hot loop, and only under the following circumstances
@@ -313,7 +314,7 @@ impl SqliteStore {
 
         let re_encrypted = all
             .into_iter()
-            .map(|record| record.re_encrypt::<PASETO_V4>(old_key, new_key))
+            .map(|record| record.re_encrypt::<PasetoV4>(old_key, new_key))
             .collect::<Result<Vec<_>>>()?;
 
         // next up, we delete all the old data and reinsert the new stuff
@@ -340,11 +341,11 @@ impl SqliteStore {
 
     /// Verify that every record in this store can be decrypted with the current key
     /// Someday maybe also check each tag/record can be deserialized, but not for now.
-    pub async fn verify(&self, key: &[u8; 32]) -> Result<()> {
+    pub async fn verify(&self, key: PasetoV4Key) -> Result<()> {
         let all = self.load_all().await?;
 
         all.into_iter()
-            .map(|record| record.decrypt::<PASETO_V4>(key))
+            .map(|record| record.decrypt::<PasetoV4>(key))
             .collect::<Result<Vec<_>>>()?;
 
         Ok(())
@@ -352,11 +353,11 @@ impl SqliteStore {
 
     /// Verify that every record in this store can be decrypted with the current key
     /// Someday maybe also check each tag/record can be deserialized, but not for now.
-    pub async fn purge(&self, key: &[u8; 32]) -> Result<()> {
+    pub async fn purge(&self, key: PasetoV4Key) -> Result<()> {
         let all = self.load_all().await?;
 
         for record in all.iter() {
-            match record.clone().decrypt::<PASETO_V4>(key) {
+            match record.clone().decrypt::<PasetoV4>(key) {
                 Ok(_) => continue,
                 Err(_) => {
                     println!(
@@ -380,7 +381,7 @@ mod tests {
     use rstest::{fixture, rstest};
 
     use crate::{
-        encryption::generate_encoded_key, record::encryption::PASETO_V4,
+        encryption::generate_encoded_key, record::encryption::PasetoV4,
         settings::test_local_timeout,
     };
 
@@ -508,7 +509,9 @@ mod tests {
         store.push(&tail).await.expect("failed to push record");
 
         for _ in 1..100 {
-            tail = tail.append(vec![1, 2, 3, 4]).encrypt::<PASETO_V4>(&[0; 32]);
+            tail = tail
+                .append(vec![1, 2, 3, 4])
+                .encrypt::<PasetoV4>([0; 32].into());
             store.push(&tail).await.unwrap();
         }
 
@@ -532,7 +535,7 @@ mod tests {
         let mut tail = record();
         records.push(tail.clone());
         for _ in 1..10000 {
-            tail = tail.append(vec![1, 2, 3]).encrypt::<PASETO_V4>(&[0; 32]);
+            tail = tail.append(vec![1, 2, 3]).encrypt::<PasetoV4>([0; 32].into());
             records.push(tail.clone());
         }
 
@@ -560,7 +563,7 @@ mod tests {
                 .idx(i)
                 .data(DecryptedData(data.clone()))
                 .build()
-                .encrypt::<PASETO_V4>(&key.into());
+                .encrypt::<PasetoV4>(key);
             store
                 .push(&record)
                 .await
@@ -571,26 +574,26 @@ mod tests {
         let all = store.all_tagged("test").await.unwrap();
         assert_eq!(all.len(), 10, "failed to fetch all records");
         for record in all {
-            let decrypted = record.decrypt::<PASETO_V4>(&key.into()).unwrap();
+            let decrypted = record.decrypt::<PasetoV4>(key).unwrap();
             assert_eq!(decrypted.data.0, data);
         }
 
         // after re-encrypting: the old key fails, the new key works
         let (new_key, _) = generate_encoded_key().unwrap();
         store
-            .re_encrypt(&key.into(), &new_key.into())
+            .re_encrypt(key, new_key)
             .await
             .expect("failed to re-encrypt store");
 
         let all = store.all_tagged("test").await.unwrap();
         for record in all.iter() {
             assert!(
-                record.clone().decrypt::<PASETO_V4>(&key.into()).is_err(),
+                record.clone().decrypt::<PasetoV4>(key).is_err(),
                 "old key still decrypts after re-encrypt"
             );
         }
         for record in all {
-            let decrypted = record.decrypt::<PASETO_V4>(&new_key.into()).unwrap();
+            let decrypted = record.decrypt::<PasetoV4>(new_key).unwrap();
             assert_eq!(decrypted.data.0, data);
         }
 

--- a/crates/atuin-client/src/record/sync.rs
+++ b/crates/atuin-client/src/record/sync.rs
@@ -327,7 +327,7 @@ pub async fn sync_remote(
 pub async fn check_encryption_key(
     client: &Client<'_>,
     remote_index: &RecordStatus,
-    encryption_key: PasetoV4Key,
+    encryption_key: &PasetoV4Key,
 ) -> Result<(), SyncError> {
     let sample = remote_index
         .hosts
@@ -358,7 +358,7 @@ pub async fn check_encryption_key(
 pub async fn sync(
     settings: &Settings,
     store: &SqliteStore,
-    encryption_key: PasetoV4Key,
+    encryption_key: &PasetoV4Key,
 ) -> Result<(i64, Vec<RecordId>), SyncError> {
     let client = build_client(settings).await?;
     let (diff, remote_index) = diff(&client, store).await?;
@@ -465,7 +465,7 @@ mod tests {
 
         let local_ahead = shared_record
             .append(vec![1, 2, 3])
-            .encrypt::<PasetoV4>([0; 32].into());
+            .encrypt::<PasetoV4>(&[0; 32].into());
 
         assert_eq!(local_ahead.idx, 1);
 
@@ -510,53 +510,53 @@ mod tests {
         let local_only_20 = test_record();
         let local_only_21 = local_only_20
             .append(vec![1, 2, 3])
-            .encrypt::<PasetoV4>([0; 32].into());
+            .encrypt::<PasetoV4>(&[0; 32].into());
         let local_only_22 = local_only_21
             .append(vec![1, 2, 3])
-            .encrypt::<PasetoV4>([0; 32].into());
+            .encrypt::<PasetoV4>(&[0; 32].into());
         let local_only_23 = local_only_22
             .append(vec![1, 2, 3])
-            .encrypt::<PasetoV4>([0; 32].into());
+            .encrypt::<PasetoV4>(&[0; 32].into());
 
         let remote_only = test_record();
 
         let remote_only_20 = test_record();
         let remote_only_21 = remote_only_20
             .append(vec![2, 3, 2])
-            .encrypt::<PasetoV4>([0; 32].into());
+            .encrypt::<PasetoV4>(&[0; 32].into());
         let remote_only_22 = remote_only_21
             .append(vec![2, 3, 2])
-            .encrypt::<PasetoV4>([0; 32].into());
+            .encrypt::<PasetoV4>(&[0; 32].into());
         let remote_only_23 = remote_only_22
             .append(vec![2, 3, 2])
-            .encrypt::<PasetoV4>([0; 32].into());
+            .encrypt::<PasetoV4>(&[0; 32].into());
         let remote_only_24 = remote_only_23
             .append(vec![2, 3, 2])
-            .encrypt::<PasetoV4>([0; 32].into());
+            .encrypt::<PasetoV4>(&[0; 32].into());
 
         let second_shared = test_record();
         let second_shared_remote_ahead = second_shared
             .append(vec![1, 2, 3])
-            .encrypt::<PasetoV4>([0; 32].into());
+            .encrypt::<PasetoV4>(&[0; 32].into());
         let second_shared_remote_ahead2 = second_shared_remote_ahead
             .append(vec![1, 2, 3])
-            .encrypt::<PasetoV4>([0; 32].into());
+            .encrypt::<PasetoV4>(&[0; 32].into());
 
         let third_shared = test_record();
         let third_shared_local_ahead = third_shared
             .append(vec![1, 2, 3])
-            .encrypt::<PasetoV4>([0; 32].into());
+            .encrypt::<PasetoV4>(&[0; 32].into());
         let third_shared_local_ahead2 = third_shared_local_ahead
             .append(vec![1, 2, 3])
-            .encrypt::<PasetoV4>([0; 32].into());
+            .encrypt::<PasetoV4>(&[0; 32].into());
 
         let fourth_shared = test_record();
         let fourth_shared_remote_ahead = fourth_shared
             .append(vec![1, 2, 3])
-            .encrypt::<PasetoV4>([0; 32].into());
+            .encrypt::<PasetoV4>(&[0; 32].into());
         let fourth_shared_remote_ahead2 = fourth_shared_remote_ahead
             .append(vec![1, 2, 3])
-            .encrypt::<PasetoV4>([0; 32].into());
+            .encrypt::<PasetoV4>(&[0; 32].into());
 
         let local = vec![
             shared_record.clone(),

--- a/crates/atuin-client/src/record/sync.rs
+++ b/crates/atuin-client/src/record/sync.rs
@@ -4,9 +4,10 @@ use std::{cmp::Ordering, fmt::Write};
 use eyre::Result;
 use thiserror::Error;
 
-use super::{encryption::PASETO_V4, sqlite_store::SqliteStore};
+use super::{encryption::PasetoV4, sqlite_store::SqliteStore};
 use crate::{api_client::Client, settings::Settings};
 
+use crate::record::encryption::PasetoV4Key;
 use atuin_domain::record::{Diff, HostId, RecordId, RecordIdx, RecordStatus};
 use indicatif::{ProgressBar, ProgressState, ProgressStyle};
 
@@ -326,7 +327,7 @@ pub async fn sync_remote(
 pub async fn check_encryption_key(
     client: &Client<'_>,
     remote_index: &RecordStatus,
-    encryption_key: &[u8; 32],
+    encryption_key: PasetoV4Key,
 ) -> Result<(), SyncError> {
     let sample = remote_index
         .hosts
@@ -348,7 +349,7 @@ pub async fn check_encryption_key(
     };
 
     record
-        .decrypt::<PASETO_V4>(encryption_key)
+        .decrypt::<PasetoV4>(encryption_key)
         .map_err(|_| SyncError::WrongKey)?;
 
     Ok(())
@@ -357,7 +358,7 @@ pub async fn check_encryption_key(
 pub async fn sync(
     settings: &Settings,
     store: &SqliteStore,
-    encryption_key: &[u8; 32],
+    encryption_key: PasetoV4Key,
 ) -> Result<(i64, Vec<RecordId>), SyncError> {
     let client = build_client(settings).await?;
     let (diff, remote_index) = diff(&client, store).await?;
@@ -378,7 +379,7 @@ mod tests {
 
     use crate::{
         record::{
-            encryption::PASETO_V4,
+            encryption::PasetoV4,
             sqlite_store::SqliteStore,
             sync::{self, Operation},
         },
@@ -464,7 +465,7 @@ mod tests {
 
         let local_ahead = shared_record
             .append(vec![1, 2, 3])
-            .encrypt::<PASETO_V4>(&[0; 32]);
+            .encrypt::<PasetoV4>([0; 32].into());
 
         assert_eq!(local_ahead.idx, 1);
 
@@ -509,53 +510,53 @@ mod tests {
         let local_only_20 = test_record();
         let local_only_21 = local_only_20
             .append(vec![1, 2, 3])
-            .encrypt::<PASETO_V4>(&[0; 32]);
+            .encrypt::<PasetoV4>([0; 32].into());
         let local_only_22 = local_only_21
             .append(vec![1, 2, 3])
-            .encrypt::<PASETO_V4>(&[0; 32]);
+            .encrypt::<PasetoV4>([0; 32].into());
         let local_only_23 = local_only_22
             .append(vec![1, 2, 3])
-            .encrypt::<PASETO_V4>(&[0; 32]);
+            .encrypt::<PasetoV4>([0; 32].into());
 
         let remote_only = test_record();
 
         let remote_only_20 = test_record();
         let remote_only_21 = remote_only_20
             .append(vec![2, 3, 2])
-            .encrypt::<PASETO_V4>(&[0; 32]);
+            .encrypt::<PasetoV4>([0; 32].into());
         let remote_only_22 = remote_only_21
             .append(vec![2, 3, 2])
-            .encrypt::<PASETO_V4>(&[0; 32]);
+            .encrypt::<PasetoV4>([0; 32].into());
         let remote_only_23 = remote_only_22
             .append(vec![2, 3, 2])
-            .encrypt::<PASETO_V4>(&[0; 32]);
+            .encrypt::<PasetoV4>([0; 32].into());
         let remote_only_24 = remote_only_23
             .append(vec![2, 3, 2])
-            .encrypt::<PASETO_V4>(&[0; 32]);
+            .encrypt::<PasetoV4>([0; 32].into());
 
         let second_shared = test_record();
         let second_shared_remote_ahead = second_shared
             .append(vec![1, 2, 3])
-            .encrypt::<PASETO_V4>(&[0; 32]);
+            .encrypt::<PasetoV4>([0; 32].into());
         let second_shared_remote_ahead2 = second_shared_remote_ahead
             .append(vec![1, 2, 3])
-            .encrypt::<PASETO_V4>(&[0; 32]);
+            .encrypt::<PasetoV4>([0; 32].into());
 
         let third_shared = test_record();
         let third_shared_local_ahead = third_shared
             .append(vec![1, 2, 3])
-            .encrypt::<PASETO_V4>(&[0; 32]);
+            .encrypt::<PasetoV4>([0; 32].into());
         let third_shared_local_ahead2 = third_shared_local_ahead
             .append(vec![1, 2, 3])
-            .encrypt::<PASETO_V4>(&[0; 32]);
+            .encrypt::<PasetoV4>([0; 32].into());
 
         let fourth_shared = test_record();
         let fourth_shared_remote_ahead = fourth_shared
             .append(vec![1, 2, 3])
-            .encrypt::<PASETO_V4>(&[0; 32]);
+            .encrypt::<PasetoV4>([0; 32].into());
         let fourth_shared_remote_ahead2 = fourth_shared_remote_ahead
             .append(vec![1, 2, 3])
-            .encrypt::<PASETO_V4>(&[0; 32]);
+            .encrypt::<PasetoV4>([0; 32].into());
 
         let local = vec![
             shared_record.clone(),

--- a/crates/atuin-common/src/lib.rs
+++ b/crates/atuin-common/src/lib.rs
@@ -5,6 +5,7 @@ pub mod ansi;
 pub mod docs;
 pub mod filter;
 pub mod logs;
+pub mod memory;
 pub mod path;
 pub mod shell;
 pub mod slice;

--- a/crates/atuin-common/src/lib.rs
+++ b/crates/atuin-common/src/lib.rs
@@ -5,7 +5,6 @@ pub mod ansi;
 pub mod docs;
 pub mod filter;
 pub mod logs;
-pub mod memory;
 pub mod path;
 pub mod shell;
 pub mod slice;

--- a/crates/atuin-daemon/src/components/history.rs
+++ b/crates/atuin-daemon/src/components/history.rs
@@ -89,7 +89,7 @@ impl Component for HistoryComponent {
         // Create the history store
         let host_id = Settings::host_id().await?;
         let history_store =
-            HistoryStore::new(handle.store().clone(), host_id, *handle.encryption_key());
+            HistoryStore::new(handle.store().clone(), host_id, handle.encryption_key());
 
         *self.inner.history_store.write().await = Some(history_store);
         *self.inner.handle.write().await = Some(handle);

--- a/crates/atuin-daemon/src/components/history.rs
+++ b/crates/atuin-daemon/src/components/history.rs
@@ -88,8 +88,11 @@ impl Component for HistoryComponent {
     async fn start(&mut self, handle: DaemonHandle) -> Result<()> {
         // Create the history store
         let host_id = Settings::host_id().await?;
-        let history_store =
-            HistoryStore::new(handle.store().clone(), host_id, handle.encryption_key().clone());
+        let history_store = HistoryStore::new(
+            handle.store().clone(),
+            host_id,
+            handle.encryption_key().clone(),
+        );
 
         *self.inner.history_store.write().await = Some(history_store);
         *self.inner.handle.write().await = Some(handle);

--- a/crates/atuin-daemon/src/components/history.rs
+++ b/crates/atuin-daemon/src/components/history.rs
@@ -89,7 +89,7 @@ impl Component for HistoryComponent {
         // Create the history store
         let host_id = Settings::host_id().await?;
         let history_store =
-            HistoryStore::new(handle.store().clone(), host_id, handle.encryption_key());
+            HistoryStore::new(handle.store().clone(), host_id, handle.encryption_key().clone());
 
         *self.inner.history_store.write().await = Some(history_store);
         *self.inner.handle.write().await = Some(handle);

--- a/crates/atuin-daemon/src/components/sync.rs
+++ b/crates/atuin-daemon/src/components/sync.rs
@@ -125,7 +125,7 @@ async fn sync_loop(handle: DaemonHandle, mut cmd_rx: mpsc::Receiver<SyncCommand>
     };
 
     // Create the stores we need
-    let encryption_key = *handle.encryption_key();
+    let encryption_key = handle.encryption_key();
     let history_store = HistoryStore::new(handle.store().clone(), host_id, encryption_key);
     let alias_store = AliasStore::new(handle.store().clone(), host_id, encryption_key);
     let var_store = VarStore::new(handle.store().clone(), host_id, encryption_key);

--- a/crates/atuin-daemon/src/components/sync.rs
+++ b/crates/atuin-daemon/src/components/sync.rs
@@ -126,8 +126,7 @@ async fn sync_loop(handle: DaemonHandle, mut cmd_rx: mpsc::Receiver<SyncCommand>
 
     // Create the stores we need
     let encryption_key = handle.encryption_key();
-    let history_store =
-        HistoryStore::new(handle.store().clone(), host_id, encryption_key.clone());
+    let history_store = HistoryStore::new(handle.store().clone(), host_id, encryption_key.clone());
     let alias_store = AliasStore::new(handle.store().clone(), host_id, encryption_key.clone());
     let var_store = VarStore::new(handle.store().clone(), host_id, encryption_key.clone());
 

--- a/crates/atuin-daemon/src/components/sync.rs
+++ b/crates/atuin-daemon/src/components/sync.rs
@@ -126,9 +126,10 @@ async fn sync_loop(handle: DaemonHandle, mut cmd_rx: mpsc::Receiver<SyncCommand>
 
     // Create the stores we need
     let encryption_key = handle.encryption_key();
-    let history_store = HistoryStore::new(handle.store().clone(), host_id, encryption_key);
-    let alias_store = AliasStore::new(handle.store().clone(), host_id, encryption_key);
-    let var_store = VarStore::new(handle.store().clone(), host_id, encryption_key);
+    let history_store =
+        HistoryStore::new(handle.store().clone(), host_id, encryption_key.clone());
+    let alias_store = AliasStore::new(handle.store().clone(), host_id, encryption_key.clone());
+    let var_store = VarStore::new(handle.store().clone(), host_id, encryption_key.clone());
 
     // Don't backoff by more than 30 mins (with a random jitter of up to 1 min)
     let max_interval: f64 = 60.0 * 30.0 + rand::thread_rng().gen_range(0.0..60.0);

--- a/crates/atuin-daemon/src/daemon.rs
+++ b/crates/atuin-daemon/src/daemon.rs
@@ -12,8 +12,8 @@
 use std::sync::Arc;
 
 use atuin_client::{
-    database::Sqlite as HistoryDatabase, encryption, record::sqlite_store::SqliteStore,
-    settings::Settings,
+    database::Sqlite as HistoryDatabase, encryption, encryption::PasetoV4Key,
+    record::sqlite_store::SqliteStore, settings::Settings,
 };
 use enum_dispatch::enum_dispatch;
 use eyre::{Context, Result};
@@ -38,7 +38,7 @@ pub struct DaemonState {
     settings: RwLock<Settings>,
 
     // Encryption key (immutable - derived at startup)
-    encryption_key: [u8; 32],
+    encryption_key: PasetoV4Key,
 
     // Database handles
     history_db: HistoryDatabase,
@@ -137,8 +137,8 @@ impl DaemonHandle {
     }
 
     /// Get the encryption key.
-    pub fn encryption_key(&self) -> &[u8; 32] {
-        &self.state.encryption_key
+    pub fn encryption_key(&self) -> PasetoV4Key {
+        self.state.encryption_key
     }
 
     // ---- Database ----
@@ -446,9 +446,8 @@ impl DaemonBuilder {
             .ok_or_else(|| eyre::eyre!("history_db is required"))?;
 
         // Load encryption key
-        let encryption_key: [u8; 32] = encryption::load_key(&self.settings)
-            .context("could not load encryption key")?
-            .into();
+        let encryption_key = encryption::load_key(&self.settings)
+            .context("could not load encryption key")?;
 
         // Create the event bus
         let (event_tx, _) = broadcast::channel(64);

--- a/crates/atuin-daemon/src/daemon.rs
+++ b/crates/atuin-daemon/src/daemon.rs
@@ -137,8 +137,8 @@ impl DaemonHandle {
     }
 
     /// Get the encryption key.
-    pub fn encryption_key(&self) -> PasetoV4Key {
-        self.state.encryption_key
+    pub fn encryption_key(&self) -> &PasetoV4Key {
+        &self.state.encryption_key
     }
 
     // ---- Database ----

--- a/crates/atuin-daemon/src/daemon.rs
+++ b/crates/atuin-daemon/src/daemon.rs
@@ -446,8 +446,8 @@ impl DaemonBuilder {
             .ok_or_else(|| eyre::eyre!("history_db is required"))?;
 
         // Load encryption key
-        let encryption_key = encryption::load_key(&self.settings)
-            .context("could not load encryption key")?;
+        let encryption_key =
+            encryption::load_key(&self.settings).context("could not load encryption key")?;
 
         // Create the event bus
         let (event_tx, _) = broadcast::channel(64);

--- a/crates/atuin-domain/src/record.rs
+++ b/crates/atuin-domain/src/record.rs
@@ -200,21 +200,24 @@ impl RecordStatus {
 }
 
 pub trait Encryption {
+    /// The key type this encryption scheme uses to wrap and unwrap records.
+    type Key;
+
     fn re_encrypt(
         data: EncryptedData,
         ad: AdditionalData,
-        old_key: &[u8; 32],
-        new_key: &[u8; 32],
+        old_key: Self::Key,
+        new_key: Self::Key,
     ) -> Result<EncryptedData> {
         let data = Self::decrypt(data, ad, old_key)?;
         Ok(Self::encrypt(data, ad, new_key))
     }
-    fn encrypt(data: DecryptedData, ad: AdditionalData, key: &[u8; 32]) -> EncryptedData;
-    fn decrypt(data: EncryptedData, ad: AdditionalData, key: &[u8; 32]) -> Result<DecryptedData>;
+    fn encrypt(data: DecryptedData, ad: AdditionalData, key: Self::Key) -> EncryptedData;
+    fn decrypt(data: EncryptedData, ad: AdditionalData, key: Self::Key) -> Result<DecryptedData>;
 }
 
 impl Record<DecryptedData> {
-    pub fn encrypt<E: Encryption>(self, key: &[u8; 32]) -> Record<EncryptedData> {
+    pub fn encrypt<E: Encryption>(self, key: E::Key) -> Record<EncryptedData> {
         let ad = AdditionalData {
             id: &self.id,
             version: &self.version,
@@ -235,7 +238,7 @@ impl Record<DecryptedData> {
 }
 
 impl Record<EncryptedData> {
-    pub fn decrypt<E: Encryption>(self, key: &[u8; 32]) -> Result<Record<DecryptedData>> {
+    pub fn decrypt<E: Encryption>(self, key: E::Key) -> Result<Record<DecryptedData>> {
         let ad = AdditionalData {
             id: &self.id,
             version: &self.version,
@@ -256,8 +259,8 @@ impl Record<EncryptedData> {
 
     pub fn re_encrypt<E: Encryption>(
         self,
-        old_key: &[u8; 32],
-        new_key: &[u8; 32],
+        old_key: E::Key,
+        new_key: E::Key,
     ) -> Result<Record<EncryptedData>> {
         let ad = AdditionalData {
             id: &self.id,

--- a/crates/atuin-domain/src/record.rs
+++ b/crates/atuin-domain/src/record.rs
@@ -206,18 +206,18 @@ pub trait Encryption {
     fn re_encrypt(
         data: EncryptedData,
         ad: AdditionalData,
-        old_key: Self::Key,
-        new_key: Self::Key,
+        old_key: &Self::Key,
+        new_key: &Self::Key,
     ) -> Result<EncryptedData> {
         let data = Self::decrypt(data, ad, old_key)?;
         Ok(Self::encrypt(data, ad, new_key))
     }
-    fn encrypt(data: DecryptedData, ad: AdditionalData, key: Self::Key) -> EncryptedData;
-    fn decrypt(data: EncryptedData, ad: AdditionalData, key: Self::Key) -> Result<DecryptedData>;
+    fn encrypt(data: DecryptedData, ad: AdditionalData, key: &Self::Key) -> EncryptedData;
+    fn decrypt(data: EncryptedData, ad: AdditionalData, key: &Self::Key) -> Result<DecryptedData>;
 }
 
 impl Record<DecryptedData> {
-    pub fn encrypt<E: Encryption>(self, key: E::Key) -> Record<EncryptedData> {
+    pub fn encrypt<E: Encryption>(self, key: &E::Key) -> Record<EncryptedData> {
         let ad = AdditionalData {
             id: &self.id,
             version: &self.version,
@@ -238,7 +238,7 @@ impl Record<DecryptedData> {
 }
 
 impl Record<EncryptedData> {
-    pub fn decrypt<E: Encryption>(self, key: E::Key) -> Result<Record<DecryptedData>> {
+    pub fn decrypt<E: Encryption>(self, key: &E::Key) -> Result<Record<DecryptedData>> {
         let ad = AdditionalData {
             id: &self.id,
             version: &self.version,
@@ -259,8 +259,8 @@ impl Record<EncryptedData> {
 
     pub fn re_encrypt<E: Encryption>(
         self,
-        old_key: E::Key,
-        new_key: E::Key,
+        old_key: &E::Key,
+        new_key: &E::Key,
     ) -> Result<Record<EncryptedData>> {
         let ad = AdditionalData {
             id: &self.id,

--- a/crates/atuin-dotfiles/src/store.rs
+++ b/crates/atuin-dotfiles/src/store.rs
@@ -9,7 +9,7 @@ use atuin_common::utils::unquote;
 use atuin_domain::record::{DecryptedData, Host, HostId};
 use eyre::{Result, bail, ensure, eyre};
 
-use atuin_client::record::encryption::PASETO_V4;
+use atuin_client::record::encryption::{PasetoV4, PasetoV4Key};
 
 use crate::shell::Alias;
 
@@ -126,12 +126,12 @@ impl AliasRecord {
 pub struct AliasStore {
     pub store: SqliteStore,
     pub host_id: HostId,
-    pub encryption_key: [u8; 32],
+    pub encryption_key: PasetoV4Key,
 }
 
 impl AliasStore {
     // will want to init the actual kv store when that is done
-    pub fn new(store: SqliteStore, host_id: HostId, encryption_key: [u8; 32]) -> AliasStore {
+    pub fn new(store: SqliteStore, host_id: HostId, encryption_key: PasetoV4Key) -> AliasStore {
         AliasStore {
             store,
             host_id,
@@ -247,7 +247,7 @@ impl AliasStore {
             .build();
 
         self.store
-            .push(&record.encrypt::<PASETO_V4>(&self.encryption_key))
+            .push(&record.encrypt::<PasetoV4>(self.encryption_key))
             .await?;
 
         // set mutates shell config, so build again
@@ -283,7 +283,7 @@ impl AliasStore {
             .build();
 
         self.store
-            .push(&record.encrypt::<PASETO_V4>(&self.encryption_key))
+            .push(&record.encrypt::<PasetoV4>(self.encryption_key))
             .await?;
 
         // delete mutates shell config, so build again
@@ -305,7 +305,7 @@ impl AliasStore {
             // Skip records we can't decrypt or decode, rather than failing the entire build.
             let ar = match version.as_str() {
                 CONFIG_SHELL_ALIAS_VERSION => record
-                    .decrypt::<PASETO_V4>(&self.encryption_key)
+                    .decrypt::<PasetoV4>(self.encryption_key)
                     .and_then(|decrypted| {
                         AliasRecord::deserialize(&decrypted.data, version.as_str())
                     }),
@@ -372,7 +372,7 @@ mod tests {
         let key: [u8; 32] = XSalsa20Poly1305::generate_key(&mut OsRng).into();
         let host_id = atuin_domain::record::HostId(atuin_common::utils::uuid_v7());
 
-        (AliasStore::new(store.clone(), host_id, key), store)
+        (AliasStore::new(store.clone(), host_id, key.into()), store)
     }
 
     #[test]
@@ -448,7 +448,7 @@ alias kgap='kubectl get pods --all-namespaces'
     #[rstest]
     #[tokio::test]
     async fn build_aliases_skips_corrupt_records(#[future] alias_store: (AliasStore, SqliteStore)) {
-        use atuin_client::record::encryption::PASETO_V4;
+        use atuin_client::record::encryption::PasetoV4;
         use atuin_domain::record::{DecryptedData, Host};
 
         use super::CONFIG_SHELL_ALIAS_TAG;
@@ -469,7 +469,7 @@ alias kgap='kubectl get pods --all-namespaces'
             .build();
 
         store
-            .push(&corrupt.encrypt::<PASETO_V4>(&corrupt_key))
+            .push(&corrupt.encrypt::<PasetoV4>(corrupt_key.into()))
             .await
             .unwrap();
 

--- a/crates/atuin-dotfiles/src/store.rs
+++ b/crates/atuin-dotfiles/src/store.rs
@@ -247,7 +247,7 @@ impl AliasStore {
             .build();
 
         self.store
-            .push(&record.encrypt::<PasetoV4>(self.encryption_key))
+            .push(&record.encrypt::<PasetoV4>(&self.encryption_key))
             .await?;
 
         // set mutates shell config, so build again
@@ -283,7 +283,7 @@ impl AliasStore {
             .build();
 
         self.store
-            .push(&record.encrypt::<PasetoV4>(self.encryption_key))
+            .push(&record.encrypt::<PasetoV4>(&self.encryption_key))
             .await?;
 
         // delete mutates shell config, so build again
@@ -305,7 +305,7 @@ impl AliasStore {
             // Skip records we can't decrypt or decode, rather than failing the entire build.
             let ar = match version.as_str() {
                 CONFIG_SHELL_ALIAS_VERSION => record
-                    .decrypt::<PasetoV4>(self.encryption_key)
+                    .decrypt::<PasetoV4>(&self.encryption_key)
                     .and_then(|decrypted| {
                         AliasRecord::deserialize(&decrypted.data, version.as_str())
                     }),
@@ -469,7 +469,7 @@ alias kgap='kubectl get pods --all-namespaces'
             .build();
 
         store
-            .push(&corrupt.encrypt::<PasetoV4>(corrupt_key.into()))
+            .push(&corrupt.encrypt::<PasetoV4>(&corrupt_key.into()))
             .await
             .unwrap();
 

--- a/crates/atuin-dotfiles/src/store/var.rs
+++ b/crates/atuin-dotfiles/src/store/var.rs
@@ -8,7 +8,7 @@ use atuin_client::record::sqlite_store::SqliteStore;
 use atuin_domain::record::{DecryptedData, Host, HostId};
 use eyre::{Result, bail, ensure, eyre};
 
-use atuin_client::record::encryption::PASETO_V4;
+use atuin_client::record::encryption::{PasetoV4, PasetoV4Key};
 
 use crate::shell::Var;
 
@@ -101,12 +101,12 @@ impl VarRecord {
 pub struct VarStore {
     pub store: SqliteStore,
     pub host_id: HostId,
-    pub encryption_key: [u8; 32],
+    pub encryption_key: PasetoV4Key,
 }
 
 impl VarStore {
     // will want to init the actual kv store when that is done
-    pub fn new(store: SqliteStore, host_id: HostId, encryption_key: [u8; 32]) -> VarStore {
+    pub fn new(store: SqliteStore, host_id: HostId, encryption_key: PasetoV4Key) -> VarStore {
         VarStore {
             store,
             host_id,
@@ -294,7 +294,7 @@ impl VarStore {
             .build();
 
         self.store
-            .push(&record.encrypt::<PASETO_V4>(&self.encryption_key))
+            .push(&record.encrypt::<PasetoV4>(self.encryption_key))
             .await?;
 
         // set mutates shell config, so build again
@@ -330,7 +330,7 @@ impl VarStore {
             .build();
 
         self.store
-            .push(&record.encrypt::<PASETO_V4>(&self.encryption_key))
+            .push(&record.encrypt::<PasetoV4>(self.encryption_key))
             .await?;
 
         // delete mutates shell config, so build again
@@ -353,7 +353,7 @@ impl VarStore {
             let ar =
                 match version.as_str() {
                     DOTFILES_VAR_VERSION => record
-                        .decrypt::<PASETO_V4>(&self.encryption_key)
+                        .decrypt::<PasetoV4>(self.encryption_key)
                         .and_then(|decrypted| {
                             VarRecord::deserialize(&decrypted.data, version.as_str())
                         }),
@@ -408,7 +408,7 @@ mod tests {
         let key: [u8; 32] = XSalsa20Poly1305::generate_key(&mut OsRng).into();
         let host_id = atuin_domain::record::HostId(atuin_common::utils::uuid_v7());
 
-        VarStore::new(store, host_id, key)
+        VarStore::new(store, host_id, key.into())
     }
 
     #[test]

--- a/crates/atuin-dotfiles/src/store/var.rs
+++ b/crates/atuin-dotfiles/src/store/var.rs
@@ -294,7 +294,7 @@ impl VarStore {
             .build();
 
         self.store
-            .push(&record.encrypt::<PasetoV4>(self.encryption_key))
+            .push(&record.encrypt::<PasetoV4>(&self.encryption_key))
             .await?;
 
         // set mutates shell config, so build again
@@ -330,7 +330,7 @@ impl VarStore {
             .build();
 
         self.store
-            .push(&record.encrypt::<PasetoV4>(self.encryption_key))
+            .push(&record.encrypt::<PasetoV4>(&self.encryption_key))
             .await?;
 
         // delete mutates shell config, so build again
@@ -353,7 +353,7 @@ impl VarStore {
             let ar =
                 match version.as_str() {
                     DOTFILES_VAR_VERSION => record
-                        .decrypt::<PasetoV4>(self.encryption_key)
+                        .decrypt::<PasetoV4>(&self.encryption_key)
                         .and_then(|decrypted| {
                             VarRecord::deserialize(&decrypted.data, version.as_str())
                         }),

--- a/crates/atuin-kv/src/store.rs
+++ b/crates/atuin-kv/src/store.rs
@@ -101,7 +101,7 @@ impl KvStore {
         let id = record.id;
 
         self.record_store
-            .push(&record.encrypt::<PasetoV4>(self.encryption_key))
+            .push(&record.encrypt::<PasetoV4>(&self.encryption_key))
             .await?;
 
         Ok((id, idx))
@@ -123,7 +123,7 @@ impl KvStore {
             let kv = match record.version.as_str() {
                 "v0" | KV_VERSION => {
                     record
-                        .decrypt::<PasetoV4>(self.encryption_key)
+                        .decrypt::<PasetoV4>(&self.encryption_key)
                         .and_then(|decrypted| {
                             KvRecord::deserialize(&decrypted.data, &decrypted.version)
                         })

--- a/crates/atuin-kv/src/store.rs
+++ b/crates/atuin-kv/src/store.rs
@@ -120,15 +120,16 @@ impl KvStore {
         // only visit each KV once, inserting or deleting based on the first time we see it
         for record in tagged {
             // Skip records we can't decrypt or decode, rather than failing the entire build.
-            let kv =
-                match record.version.as_str() {
-                    "v0" | KV_VERSION => record
+            let kv = match record.version.as_str() {
+                "v0" | KV_VERSION => {
+                    record
                         .decrypt::<PasetoV4>(self.encryption_key)
                         .and_then(|decrypted| {
                             KvRecord::deserialize(&decrypted.data, &decrypted.version)
-                        }),
-                    version => Err(eyre!("unknown version {version:?}")),
-                };
+                        })
+                }
+                version => Err(eyre!("unknown version {version:?}")),
+            };
 
             let kv = match kv {
                 Ok(kv) => kv,

--- a/crates/atuin-kv/src/store.rs
+++ b/crates/atuin-kv/src/store.rs
@@ -2,7 +2,7 @@ use std::collections::HashSet;
 
 use eyre::{Result, eyre};
 
-use atuin_client::record::encryption::PASETO_V4;
+use atuin_client::record::encryption::{PasetoV4, PasetoV4Key};
 use atuin_client::record::sqlite_store::SqliteStore;
 use atuin_domain::record::{Host, HostId, Record, RecordId, RecordIdx};
 use entry::KvEntry;
@@ -18,7 +18,7 @@ pub struct KvStore {
     pub record_store: SqliteStore,
     pub kv_db: Database,
     pub host_id: HostId,
-    pub encryption_key: [u8; 32],
+    pub encryption_key: PasetoV4Key,
 }
 
 impl KvStore {
@@ -26,7 +26,7 @@ impl KvStore {
         record_store: SqliteStore,
         kv_db: Database,
         host_id: HostId,
-        encryption_key: [u8; 32],
+        encryption_key: PasetoV4Key,
     ) -> Self {
         KvStore {
             record_store,
@@ -101,7 +101,7 @@ impl KvStore {
         let id = record.id;
 
         self.record_store
-            .push(&record.encrypt::<PASETO_V4>(&self.encryption_key))
+            .push(&record.encrypt::<PasetoV4>(self.encryption_key))
             .await?;
 
         Ok((id, idx))
@@ -123,7 +123,7 @@ impl KvStore {
             let kv =
                 match record.version.as_str() {
                     "v0" | KV_VERSION => record
-                        .decrypt::<PASETO_V4>(&self.encryption_key)
+                        .decrypt::<PasetoV4>(self.encryption_key)
                         .and_then(|decrypted| {
                             KvRecord::deserialize(&decrypted.data, &decrypted.version)
                         }),
@@ -191,7 +191,7 @@ mod tests {
         let record_store = SqliteStore::new("sqlite::memory:", 1.0).await.unwrap();
         let kv_db = Database::new("sqlite::memory:", 1.0).await.unwrap();
         let host_id = atuin_domain::record::HostId(atuin_common::utils::uuid_v7());
-        let encryption_key = [0; 32];
+        let encryption_key = PasetoV4Key::from([0; 32]);
         Ok(KvStore::new(record_store, kv_db, host_id, encryption_key))
     }
 

--- a/crates/atuin-scripts/src/store.rs
+++ b/crates/atuin-scripts/src/store.rs
@@ -46,7 +46,7 @@ impl ScriptStore {
         let id = record.id;
 
         self.store
-            .push(&record.encrypt::<PasetoV4>(self.encryption_key))
+            .push(&record.encrypt::<PasetoV4>(&self.encryption_key))
             .await?;
 
         Ok((id, idx))
@@ -80,7 +80,7 @@ impl ScriptStore {
             let script = match record.version.as_str() {
                 SCRIPT_VERSION => {
                     record
-                        .decrypt::<PasetoV4>(self.encryption_key)
+                        .decrypt::<PasetoV4>(&self.encryption_key)
                         .and_then(|decrypted| {
                             ScriptRecord::deserialize(&decrypted.data, SCRIPT_VERSION)
                         })

--- a/crates/atuin-scripts/src/store.rs
+++ b/crates/atuin-scripts/src/store.rs
@@ -1,6 +1,6 @@
 use eyre::{Result, eyre};
 
-use atuin_client::record::encryption::PASETO_V4;
+use atuin_client::record::encryption::{PasetoV4, PasetoV4Key};
 use atuin_client::record::sqlite_store::SqliteStore;
 use atuin_domain::record::{Host, HostId, Record, RecordId, RecordIdx};
 use record::ScriptRecord;
@@ -15,11 +15,11 @@ pub mod script;
 pub struct ScriptStore {
     pub store: SqliteStore,
     pub host_id: HostId,
-    pub encryption_key: [u8; 32],
+    pub encryption_key: PasetoV4Key,
 }
 
 impl ScriptStore {
-    pub fn new(store: SqliteStore, host_id: HostId, encryption_key: [u8; 32]) -> Self {
+    pub fn new(store: SqliteStore, host_id: HostId, encryption_key: PasetoV4Key) -> Self {
         ScriptStore {
             store,
             host_id,
@@ -46,7 +46,7 @@ impl ScriptStore {
         let id = record.id;
 
         self.store
-            .push(&record.encrypt::<PASETO_V4>(&self.encryption_key))
+            .push(&record.encrypt::<PasetoV4>(self.encryption_key))
             .await?;
 
         Ok((id, idx))
@@ -80,7 +80,7 @@ impl ScriptStore {
             let script = match record.version.as_str() {
                 SCRIPT_VERSION => {
                     record
-                        .decrypt::<PASETO_V4>(&self.encryption_key)
+                        .decrypt::<PasetoV4>(self.encryption_key)
                         .and_then(|decrypted| {
                             ScriptRecord::deserialize(&decrypted.data, SCRIPT_VERSION)
                         })

--- a/crates/atuin/src/command/client/account/login.rs
+++ b/crates/atuin/src/command/client/account/login.rs
@@ -6,7 +6,7 @@ use tokio::{fs::File, io::AsyncWriteExt};
 
 use atuin_client::{
     auth::{self, AuthClient, AuthResponse},
-    encryption::{Key, decode_key, encode_key, load_key},
+    encryption::{PasetoV4Key, decode_key, encode_key, load_key},
     record::sqlite_store::SqliteStore,
     record::sync::{self, SyncError},
     settings::{Settings, SyncAuth},
@@ -203,7 +203,7 @@ impl Cmd {
         } else {
             // try parse the key as a mnemonic...
             match bip39::Mnemonic::from_phrase(&key, bip39::Language::English) {
-                Ok(mnemonic) => encode_key(Key::from_slice(mnemonic.entropy()))?,
+                Ok(mnemonic) => encode_key(&PasetoV4Key::try_from(mnemonic.entropy())?)?,
                 Err(err) => {
                     match err {
                         // assume they copied in the base64 key
@@ -251,17 +251,16 @@ impl Cmd {
 
             // 1. check if the saved key and the provided key match. if so, nothing to do.
             // 2. if not, re-encrypt the local history and overwrite the key
-            let current_key: [u8; 32] = load_key(settings)?.into();
+            let current_key = load_key(settings)?;
 
             let encoded = key.clone(); // gonna want to save it in a bit
-            let new_key: [u8; 32] = decode_key(key)
-                .context("Could not decode provided key; is not valid base64-encoded key")?
-                .into();
+            let new_key = decode_key(key)
+                .context("Could not decode provided key; is not valid base64-encoded key")?;
 
             if new_key != current_key {
                 println!("\nRe-encrypting local store with new key");
 
-                store.re_encrypt(&current_key, &new_key).await?;
+                store.re_encrypt(current_key, new_key).await?;
 
                 println!("Writing new key");
                 let mut file = File::create(key_path).await?;
@@ -274,9 +273,7 @@ impl Cmd {
 }
 
 async fn verify_key_against_remote(settings: &Settings) -> Result<()> {
-    let key: [u8; 32] = load_key(settings)
-        .context("could not load encryption key for verification")?
-        .into();
+    let key = load_key(settings).context("could not load encryption key for verification")?;
 
     let client = sync::build_client(settings).await?;
     let remote_index = match client.record_status().await {
@@ -287,7 +284,7 @@ async fn verify_key_against_remote(settings: &Settings) -> Result<()> {
         }
     };
 
-    match sync::check_encryption_key(&client, &remote_index, &key).await {
+    match sync::check_encryption_key(&client, &remote_index, key).await {
         Ok(()) => Ok(()),
         Err(SyncError::WrongKey) => {
             // Roll back the saved session so the user is not left in a
@@ -331,19 +328,19 @@ fn read_user_input(name: &'static str) -> String {
 
 #[cfg(test)]
 mod tests {
-    use atuin_client::encryption::Key;
+    use atuin_client::encryption::PasetoV4Key;
 
     #[test]
     fn mnemonic_round_trip() {
-        let key = Key::from([
+        let key = PasetoV4Key::from([
             3, 1, 4, 1, 5, 9, 2, 6, 5, 3, 5, 8, 9, 7, 9, 3, 2, 3, 8, 4, 6, 2, 6, 4, 3, 3, 8, 3, 2,
             7, 9, 5,
         ]);
-        let phrase = bip39::Mnemonic::from_entropy(&key, bip39::Language::English)
+        let phrase = bip39::Mnemonic::from_entropy(key.as_bytes(), bip39::Language::English)
             .unwrap()
             .into_phrase();
         let mnemonic = bip39::Mnemonic::from_phrase(&phrase, bip39::Language::English).unwrap();
-        assert_eq!(mnemonic.entropy(), key.as_slice());
+        assert_eq!(mnemonic.entropy(), key.as_bytes().as_slice());
         assert_eq!(
             phrase,
             "adapt amused able anxiety mother adapt beef gaze amount else seat alcohol cage lottery avoid scare alcohol cactus school avoid coral adjust catch pink"

--- a/crates/atuin/src/command/client/account/login.rs
+++ b/crates/atuin/src/command/client/account/login.rs
@@ -260,7 +260,7 @@ impl Cmd {
             if new_key != current_key {
                 println!("\nRe-encrypting local store with new key");
 
-                store.re_encrypt(current_key, new_key).await?;
+                store.re_encrypt(&current_key, &new_key).await?;
 
                 println!("Writing new key");
                 let mut file = File::create(key_path).await?;
@@ -284,7 +284,7 @@ async fn verify_key_against_remote(settings: &Settings) -> Result<()> {
         }
     };
 
-    match sync::check_encryption_key(&client, &remote_index, key).await {
+    match sync::check_encryption_key(&client, &remote_index, &key).await {
         Ok(()) => Ok(()),
         Err(SyncError::WrongKey) => {
             // Roll back the saved session so the user is not left in a

--- a/crates/atuin/src/command/client/dotfiles/alias.rs
+++ b/crates/atuin/src/command/client/dotfiles/alias.rs
@@ -156,8 +156,8 @@ impl Cmd {
             return Ok(());
         }
 
-        let encryption_key = encryption::load_key(settings)
-            .context("could not load encryption key")?;
+        let encryption_key =
+            encryption::load_key(settings).context("could not load encryption key")?;
         let host_id = Settings::host_id().await?;
 
         let alias_store = AliasStore::new(store, host_id, encryption_key);

--- a/crates/atuin/src/command/client/dotfiles/alias.rs
+++ b/crates/atuin/src/command/client/dotfiles/alias.rs
@@ -156,9 +156,8 @@ impl Cmd {
             return Ok(());
         }
 
-        let encryption_key: [u8; 32] = encryption::load_key(settings)
-            .context("could not load encryption key")?
-            .into();
+        let encryption_key = encryption::load_key(settings)
+            .context("could not load encryption key")?;
         let host_id = Settings::host_id().await?;
 
         let alias_store = AliasStore::new(store, host_id, encryption_key);

--- a/crates/atuin/src/command/client/dotfiles/var.rs
+++ b/crates/atuin/src/command/client/dotfiles/var.rs
@@ -156,8 +156,8 @@ impl Cmd {
             return Ok(());
         }
 
-        let encryption_key = encryption::load_key(settings)
-            .context("could not load encryption key")?;
+        let encryption_key =
+            encryption::load_key(settings).context("could not load encryption key")?;
         let host_id = Settings::host_id().await?;
 
         let var_store = VarStore::new(store, host_id, encryption_key);

--- a/crates/atuin/src/command/client/dotfiles/var.rs
+++ b/crates/atuin/src/command/client/dotfiles/var.rs
@@ -156,9 +156,8 @@ impl Cmd {
             return Ok(());
         }
 
-        let encryption_key: [u8; 32] = encryption::load_key(settings)
-            .context("could not load encryption key")?
-            .into();
+        let encryption_key = encryption::load_key(settings)
+            .context("could not load encryption key")?;
         let host_id = Settings::host_id().await?;
 
         let var_store = VarStore::new(store, host_id, encryption_key);

--- a/crates/atuin/src/command/client/history.rs
+++ b/crates/atuin/src/command/client/history.rs
@@ -609,8 +609,7 @@ pub(super) async fn end_history_entry(
     let db = Sqlite::new(db_path, settings.local_timeout).await?;
     let store = SqliteStore::new(record_store_path, settings.local_timeout).await?;
 
-    let encryption_key = encryption::load_key(settings)
-        .context("could not load encryption key")?;
+    let encryption_key = encryption::load_key(settings).context("could not load encryption key")?;
     let host_id = Settings::host_id().await?;
     let history_store = HistoryStore::new(store.clone(), host_id, encryption_key);
 
@@ -1011,8 +1010,8 @@ impl Cmd {
                 settings.timezone,
             );
         } else {
-            let encryption_key = encryption::load_key(settings)
-                .context("could not load encryption key")?;
+            let encryption_key =
+                encryption::load_key(settings).context("could not load encryption key")?;
             let host_id = Settings::host_id().await?;
             let history_store = HistoryStore::new(store.clone(), host_id, encryption_key);
 
@@ -1064,8 +1063,8 @@ impl Cmd {
                 settings.timezone,
             );
         } else {
-            let encryption_key = encryption::load_key(settings)
-                .context("could not load encryption key")?;
+            let encryption_key =
+                encryption::load_key(settings).context("could not load encryption key")?;
             let host_id = Settings::host_id().await?;
             let history_store = HistoryStore::new(store.clone(), host_id, encryption_key);
 
@@ -1131,8 +1130,8 @@ impl Cmd {
                 let db = Sqlite::new(db_path, settings.local_timeout).await?;
                 let store = SqliteStore::new(record_store_path, settings.local_timeout).await?;
 
-                let encryption_key = encryption::load_key(settings)
-                    .context("could not load encryption key")?;
+                let encryption_key =
+                    encryption::load_key(settings).context("could not load encryption key")?;
 
                 let host_id = Settings::host_id().await?;
                 let history_store = HistoryStore::new(store.clone(), host_id, encryption_key);

--- a/crates/atuin/src/command/client/history.rs
+++ b/crates/atuin/src/command/client/history.rs
@@ -545,7 +545,7 @@ async fn handle_end(
         #[cfg(feature = "sync")]
         {
             let (_, downloaded) =
-                record::sync::sync(settings, &store, &history_store.encryption_key).await?;
+                record::sync::sync(settings, &store, history_store.encryption_key).await?;
             Settings::save_sync_time().await?;
 
             crate::sync::build(settings, &store, db, Some(&downloaded)).await?;
@@ -609,9 +609,8 @@ pub(super) async fn end_history_entry(
     let db = Sqlite::new(db_path, settings.local_timeout).await?;
     let store = SqliteStore::new(record_store_path, settings.local_timeout).await?;
 
-    let encryption_key: [u8; 32] = encryption::load_key(settings)
-        .context("could not load encryption key")?
-        .into();
+    let encryption_key = encryption::load_key(settings)
+        .context("could not load encryption key")?;
     let host_id = Settings::host_id().await?;
     let history_store = HistoryStore::new(store.clone(), host_id, encryption_key);
 
@@ -1012,9 +1011,8 @@ impl Cmd {
                 settings.timezone,
             );
         } else {
-            let encryption_key: [u8; 32] = encryption::load_key(settings)
-                .context("could not load encryption key")?
-                .into();
+            let encryption_key = encryption::load_key(settings)
+                .context("could not load encryption key")?;
             let host_id = Settings::host_id().await?;
             let history_store = HistoryStore::new(store.clone(), host_id, encryption_key);
 
@@ -1066,9 +1064,8 @@ impl Cmd {
                 settings.timezone,
             );
         } else {
-            let encryption_key: [u8; 32] = encryption::load_key(settings)
-                .context("could not load encryption key")?
-                .into();
+            let encryption_key = encryption::load_key(settings)
+                .context("could not load encryption key")?;
             let host_id = Settings::host_id().await?;
             let history_store = HistoryStore::new(store.clone(), host_id, encryption_key);
 
@@ -1134,9 +1131,8 @@ impl Cmd {
                 let db = Sqlite::new(db_path, settings.local_timeout).await?;
                 let store = SqliteStore::new(record_store_path, settings.local_timeout).await?;
 
-                let encryption_key: [u8; 32] = encryption::load_key(settings)
-                    .context("could not load encryption key")?
-                    .into();
+                let encryption_key = encryption::load_key(settings)
+                    .context("could not load encryption key")?;
 
                 let host_id = Settings::host_id().await?;
                 let history_store = HistoryStore::new(store.clone(), host_id, encryption_key);

--- a/crates/atuin/src/command/client/history.rs
+++ b/crates/atuin/src/command/client/history.rs
@@ -545,7 +545,7 @@ async fn handle_end(
         #[cfg(feature = "sync")]
         {
             let (_, downloaded) =
-                record::sync::sync(settings, &store, history_store.encryption_key).await?;
+                record::sync::sync(settings, &store, &history_store.encryption_key).await?;
             Settings::save_sync_time().await?;
 
             crate::sync::build(settings, &store, db, Some(&downloaded)).await?;

--- a/crates/atuin/src/command/client/init.rs
+++ b/crates/atuin/src/command/client/init.rs
@@ -87,8 +87,8 @@ impl Cmd {
         let record_store_path = &settings.record_store_path;
         let sqlite_store = SqliteStore::new(record_store_path, settings.local_timeout).await?;
 
-        let encryption_key = encryption::load_key(settings)
-            .context("could not load encryption key")?;
+        let encryption_key =
+            encryption::load_key(settings).context("could not load encryption key")?;
         let host_id = Settings::host_id().await?;
 
         let alias_store = AliasStore::new(sqlite_store.clone(), host_id, encryption_key);

--- a/crates/atuin/src/command/client/init.rs
+++ b/crates/atuin/src/command/client/init.rs
@@ -91,7 +91,7 @@ impl Cmd {
             encryption::load_key(settings).context("could not load encryption key")?;
         let host_id = Settings::host_id().await?;
 
-        let alias_store = AliasStore::new(sqlite_store.clone(), host_id, encryption_key);
+        let alias_store = AliasStore::new(sqlite_store.clone(), host_id, encryption_key.clone());
         let var_store = VarStore::new(sqlite_store.clone(), host_id, encryption_key);
 
         let options = self.to_options(settings);

--- a/crates/atuin/src/command/client/init.rs
+++ b/crates/atuin/src/command/client/init.rs
@@ -87,9 +87,8 @@ impl Cmd {
         let record_store_path = &settings.record_store_path;
         let sqlite_store = SqliteStore::new(record_store_path, settings.local_timeout).await?;
 
-        let encryption_key: [u8; 32] = encryption::load_key(settings)
-            .context("could not load encryption key")?
-            .into();
+        let encryption_key = encryption::load_key(settings)
+            .context("could not load encryption key")?;
         let host_id = Settings::host_id().await?;
 
         let alias_store = AliasStore::new(sqlite_store.clone(), host_id, encryption_key);

--- a/crates/atuin/src/command/client/kv.rs
+++ b/crates/atuin/src/command/client/kv.rs
@@ -63,9 +63,8 @@ pub enum Cmd {
 
 impl Cmd {
     pub async fn run(&self, settings: &Settings, store: &SqliteStore) -> Result<()> {
-        let encryption_key: [u8; 32] = encryption::load_key(settings)
-            .context("could not load encryption key")?
-            .into();
+        let encryption_key = encryption::load_key(settings)
+            .context("could not load encryption key")?;
 
         let host_id = Settings::host_id().await?;
 

--- a/crates/atuin/src/command/client/kv.rs
+++ b/crates/atuin/src/command/client/kv.rs
@@ -63,8 +63,8 @@ pub enum Cmd {
 
 impl Cmd {
     pub async fn run(&self, settings: &Settings, store: &SqliteStore) -> Result<()> {
-        let encryption_key = encryption::load_key(settings)
-            .context("could not load encryption key")?;
+        let encryption_key =
+            encryption::load_key(settings).context("could not load encryption key")?;
 
         let host_id = Settings::host_id().await?;
 

--- a/crates/atuin/src/command/client/scripts.rs
+++ b/crates/atuin/src/command/client/scripts.rs
@@ -569,7 +569,7 @@ impl Cmd {
         history_db: &impl Database,
     ) -> Result<()> {
         let host_id = Settings::host_id().await?;
-        let encryption_key: [u8; 32] = atuin_client::encryption::load_key(settings)?.into();
+        let encryption_key = atuin_client::encryption::load_key(settings)?;
 
         let script_store = ScriptStore::new(store, host_id, encryption_key);
         let script_db =

--- a/crates/atuin/src/command/client/search.rs
+++ b/crates/atuin/src/command/client/search.rs
@@ -239,7 +239,7 @@ impl Cmd {
         };
         settings.keymap_mode_shell = self.keymap_mode;
 
-        let encryption_key: [u8; 32] = encryption::load_key(settings)?.into();
+        let encryption_key = encryption::load_key(settings)?;
 
         let host_id = Settings::host_id().await?;
         let history_store = HistoryStore::new(store.clone(), host_id, encryption_key);

--- a/crates/atuin/src/command/client/store/pull.rs
+++ b/crates/atuin/src/command/client/store/pull.rs
@@ -53,8 +53,8 @@ impl Pull {
 
         // Skip on --force: local was already wiped above, mismatch is the user's call.
         if !self.force {
-            let key: [u8; 32] = load_key(settings)?.into();
-            sync::check_encryption_key(&client, &remote_index, &key)
+            let key = load_key(settings)?;
+            sync::check_encryption_key(&client, &remote_index, key)
                 .await
                 .map_err(crate::print_error::format_sync_error)?;
         }

--- a/crates/atuin/src/command/client/store/pull.rs
+++ b/crates/atuin/src/command/client/store/pull.rs
@@ -54,7 +54,7 @@ impl Pull {
         // Skip on --force: local was already wiped above, mismatch is the user's call.
         if !self.force {
             let key = load_key(settings)?;
-            sync::check_encryption_key(&client, &remote_index, key)
+            sync::check_encryption_key(&client, &remote_index, &key)
                 .await
                 .map_err(crate::print_error::format_sync_error)?;
         }

--- a/crates/atuin/src/command/client/store/purge.rs
+++ b/crates/atuin/src/command/client/store/purge.rs
@@ -12,7 +12,7 @@ impl Purge {
 
         let key = load_key(settings)?;
 
-        match store.purge(key).await {
+        match store.purge(&key).await {
             Ok(()) => println!("Local store purge completed OK"),
             Err(e) => println!("Failed to purge local store: {e:?}"),
         }

--- a/crates/atuin/src/command/client/store/purge.rs
+++ b/crates/atuin/src/command/client/store/purge.rs
@@ -12,7 +12,7 @@ impl Purge {
 
         let key = load_key(settings)?;
 
-        match store.purge(&key.into()).await {
+        match store.purge(key).await {
             Ok(()) => println!("Local store purge completed OK"),
             Err(e) => println!("Failed to purge local store: {e:?}"),
         }

--- a/crates/atuin/src/command/client/store/push.rs
+++ b/crates/atuin/src/command/client/store/push.rs
@@ -67,8 +67,8 @@ impl Push {
 
         // Skip on --force: that path intentionally replaces remote with local.
         if !self.force {
-            let key: [u8; 32] = load_key(settings)?.into();
-            sync::check_encryption_key(&client, &remote_index, &key)
+            let key = load_key(settings)?;
+            sync::check_encryption_key(&client, &remote_index, key)
                 .await
                 .map_err(crate::print_error::format_sync_error)?;
         }

--- a/crates/atuin/src/command/client/store/push.rs
+++ b/crates/atuin/src/command/client/store/push.rs
@@ -68,7 +68,7 @@ impl Push {
         // Skip on --force: that path intentionally replaces remote with local.
         if !self.force {
             let key = load_key(settings)?;
-            sync::check_encryption_key(&client, &remote_index, key)
+            sync::check_encryption_key(&client, &remote_index, &key)
                 .await
                 .map_err(crate::print_error::format_sync_error)?;
         }

--- a/crates/atuin/src/command/client/store/rebuild.rs
+++ b/crates/atuin/src/command/client/store/rebuild.rs
@@ -73,7 +73,7 @@ impl Rebuild {
 
         let host_id = Settings::host_id().await?;
 
-        let alias_store = AliasStore::new(store.clone(), host_id, encryption_key);
+        let alias_store = AliasStore::new(store.clone(), host_id, encryption_key.clone());
         let var_store = VarStore::new(store.clone(), host_id, encryption_key);
 
         alias_store.build().await?;

--- a/crates/atuin/src/command/client/store/rebuild.rs
+++ b/crates/atuin/src/command/client/store/rebuild.rs
@@ -55,7 +55,7 @@ impl Rebuild {
         store: SqliteStore,
         database: &dyn Database,
     ) -> Result<()> {
-        let encryption_key: [u8; 32] = encryption::load_key(settings)?.into();
+        let encryption_key = encryption::load_key(settings)?;
 
         let host_id = Settings::host_id().await?;
         let history_store = HistoryStore::new(store, host_id, encryption_key);
@@ -69,7 +69,7 @@ impl Rebuild {
     }
 
     async fn rebuild_dotfiles(&self, settings: &Settings, store: SqliteStore) -> Result<()> {
-        let encryption_key: [u8; 32] = encryption::load_key(settings)?.into();
+        let encryption_key = encryption::load_key(settings)?;
 
         let host_id = Settings::host_id().await?;
 
@@ -83,7 +83,7 @@ impl Rebuild {
     }
 
     async fn rebuild_scripts(&self, settings: &Settings, store: SqliteStore) -> Result<()> {
-        let encryption_key: [u8; 32] = encryption::load_key(settings)?.into();
+        let encryption_key = encryption::load_key(settings)?;
         let host_id = Settings::host_id().await?;
         let script_store = ScriptStore::new(store, host_id, encryption_key);
         let database =

--- a/crates/atuin/src/command/client/store/rekey.rs
+++ b/crates/atuin/src/command/client/store/rekey.rs
@@ -45,7 +45,7 @@ impl Rekey {
         let current_key = load_key(settings)?;
         let new_key = decode_key(key.clone())?;
 
-        store.re_encrypt(current_key, new_key).await?;
+        store.re_encrypt(&current_key, &new_key).await?;
 
         println!("Store rewritten. Saving new key");
         let mut file = File::create(settings.key_path.clone()).await?;

--- a/crates/atuin/src/command/client/store/rekey.rs
+++ b/crates/atuin/src/command/client/store/rekey.rs
@@ -3,7 +3,7 @@ use eyre::{Result, bail};
 use tokio::{fs::File, io::AsyncWriteExt};
 
 use atuin_client::{
-    encryption::{Key, decode_key, encode_key, generate_encoded_key, load_key},
+    encryption::{PasetoV4Key, decode_key, encode_key, generate_encoded_key, load_key},
     record::sqlite_store::SqliteStore,
     settings::Settings,
 };
@@ -20,7 +20,7 @@ impl Rekey {
             println!("Re-encrypting store with specified key");
 
             match bip39::Mnemonic::from_phrase(&key, bip39::Language::English) {
-                Ok(mnemonic) => encode_key(Key::from_slice(mnemonic.entropy()))?,
+                Ok(mnemonic) => encode_key(&PasetoV4Key::try_from(mnemonic.entropy())?)?,
                 Err(err) => {
                     match err {
                         // assume they copied in the base64 key
@@ -42,10 +42,10 @@ impl Rekey {
             encoded
         };
 
-        let current_key: [u8; 32] = load_key(settings)?.into();
-        let new_key: [u8; 32] = decode_key(key.clone())?.into();
+        let current_key = load_key(settings)?;
+        let new_key = decode_key(key.clone())?;
 
-        store.re_encrypt(&current_key, &new_key).await?;
+        store.re_encrypt(current_key, new_key).await?;
 
         println!("Store rewritten. Saving new key");
         let mut file = File::create(settings.key_path.clone()).await?;

--- a/crates/atuin/src/command/client/store/verify.rs
+++ b/crates/atuin/src/command/client/store/verify.rs
@@ -12,7 +12,7 @@ impl Verify {
 
         let key = load_key(settings)?;
 
-        match store.verify(&key.into()).await {
+        match store.verify(key).await {
             Ok(()) => println!("Local store encryption verified OK"),
             Err(e) => println!("Failed to verify local store encryption: {e:?}"),
         }

--- a/crates/atuin/src/command/client/store/verify.rs
+++ b/crates/atuin/src/command/client/store/verify.rs
@@ -12,7 +12,7 @@ impl Verify {
 
         let key = load_key(settings)?;
 
-        match store.verify(key).await {
+        match store.verify(&key).await {
             Ok(()) => println!("Local store encryption verified OK"),
             Err(e) => println!("Failed to verify local store encryption: {e:?}"),
         }

--- a/crates/atuin/src/command/client/sync.rs
+++ b/crates/atuin/src/command/client/sync.rs
@@ -84,9 +84,9 @@ async fn run(
     let encryption_key = encryption::load_key(settings).context("could not load encryption key")?;
 
     let host_id = Settings::host_id().await?;
-    let history_store = HistoryStore::new(store.clone(), host_id, encryption_key);
+    let history_store = HistoryStore::new(store.clone(), host_id, encryption_key.clone());
 
-    let (uploaded, downloaded) = sync::sync(settings, &store, encryption_key)
+    let (uploaded, downloaded) = sync::sync(settings, &store, &encryption_key)
         .await
         .map_err(crate::print_error::format_sync_error)?;
 
@@ -109,7 +109,7 @@ async fn run(
         println!("Re-running sync due to new records locally");
 
         // we'll want to run sync once more, as there will now be stuff to upload
-        let (uploaded, downloaded) = sync::sync(settings, &store, encryption_key)
+        let (uploaded, downloaded) = sync::sync(settings, &store, &encryption_key)
             .await
             .map_err(crate::print_error::format_sync_error)?;
 

--- a/crates/atuin/src/command/client/sync.rs
+++ b/crates/atuin/src/command/client/sync.rs
@@ -81,8 +81,7 @@ async fn run(
     db: &impl Database,
     store: SqliteStore,
 ) -> Result<()> {
-    let encryption_key = encryption::load_key(settings)
-        .context("could not load encryption key")?;
+    let encryption_key = encryption::load_key(settings).context("could not load encryption key")?;
 
     let host_id = Settings::host_id().await?;
     let history_store = HistoryStore::new(store.clone(), host_id, encryption_key);

--- a/crates/atuin/src/command/client/sync.rs
+++ b/crates/atuin/src/command/client/sync.rs
@@ -64,8 +64,9 @@ impl Cmd {
                     let encode = encode_key(&key).wrap_err("could not encode encryption key")?;
                     println!("{encode}");
                 } else {
-                    let mnemonic = bip39::Mnemonic::from_entropy(&key, bip39::Language::English)
-                        .map_err(|_| eyre::eyre!("invalid key"))?;
+                    let mnemonic =
+                        bip39::Mnemonic::from_entropy(key.as_bytes(), bip39::Language::English)
+                            .map_err(|_| eyre::eyre!("invalid key"))?;
                     println!("{mnemonic}");
                 }
                 Ok(())
@@ -80,14 +81,13 @@ async fn run(
     db: &impl Database,
     store: SqliteStore,
 ) -> Result<()> {
-    let encryption_key: [u8; 32] = encryption::load_key(settings)
-        .context("could not load encryption key")?
-        .into();
+    let encryption_key = encryption::load_key(settings)
+        .context("could not load encryption key")?;
 
     let host_id = Settings::host_id().await?;
     let history_store = HistoryStore::new(store.clone(), host_id, encryption_key);
 
-    let (uploaded, downloaded) = sync::sync(settings, &store, &encryption_key)
+    let (uploaded, downloaded) = sync::sync(settings, &store, encryption_key)
         .await
         .map_err(crate::print_error::format_sync_error)?;
 
@@ -110,7 +110,7 @@ async fn run(
         println!("Re-running sync due to new records locally");
 
         // we'll want to run sync once more, as there will now be stuff to upload
-        let (uploaded, downloaded) = sync::sync(settings, &store, &encryption_key)
+        let (uploaded, downloaded) = sync::sync(settings, &store, encryption_key)
             .await
             .map_err(crate::print_error::format_sync_error)?;
 

--- a/crates/atuin/src/command/client/wrapped.rs
+++ b/crates/atuin/src/command/client/wrapped.rs
@@ -327,7 +327,6 @@ pub async fn run(
     // Load aliases for expansion
     let alias_map: HashMap<String, String> = if settings.dotfiles.enabled {
         if let Ok(encryption_key) = encryption::load_key(settings) {
-            let encryption_key: [u8; 32] = encryption_key.into();
             let host_id = Settings::host_id().await?;
             let alias_store = AliasStore::new(store, host_id, encryption_key);
 

--- a/crates/atuin/src/sync.rs
+++ b/crates/atuin/src/sync.rs
@@ -30,10 +30,10 @@ pub async fn build(
 
     let kv_db = atuin_kv::database::Database::new(settings.kv.db_path.clone(), 1.0).await?;
 
-    let history_store = HistoryStore::new(store.clone(), host_id, encryption_key);
-    let alias_store = AliasStore::new(store.clone(), host_id, encryption_key);
-    let var_store = VarStore::new(store.clone(), host_id, encryption_key);
-    let kv_store = KvStore::new(store.clone(), kv_db, host_id, encryption_key);
+    let history_store = HistoryStore::new(store.clone(), host_id, encryption_key.clone());
+    let alias_store = AliasStore::new(store.clone(), host_id, encryption_key.clone());
+    let var_store = VarStore::new(store.clone(), host_id, encryption_key.clone());
+    let kv_store = KvStore::new(store.clone(), kv_db, host_id, encryption_key.clone());
     let script_store = ScriptStore::new(store.clone(), host_id, encryption_key);
 
     // A failure in one store should not stop the others from building - build as much as

--- a/crates/atuin/src/sync.rs
+++ b/crates/atuin/src/sync.rs
@@ -21,9 +21,8 @@ pub async fn build(
     db: &dyn Database,
     downloaded: Option<&[RecordId]>,
 ) -> Result<()> {
-    let encryption_key: [u8; 32] = atuin_client::encryption::load_key(settings)
-        .context("could not load encryption key")?
-        .into();
+    let encryption_key = atuin_client::encryption::load_key(settings)
+        .context("could not load encryption key")?;
 
     let host_id = Settings::host_id().await?;
 

--- a/crates/atuin/src/sync.rs
+++ b/crates/atuin/src/sync.rs
@@ -21,8 +21,8 @@ pub async fn build(
     db: &dyn Database,
     downloaded: Option<&[RecordId]>,
 ) -> Result<()> {
-    let encryption_key = atuin_client::encryption::load_key(settings)
-        .context("could not load encryption key")?;
+    let encryption_key =
+        atuin_client::encryption::load_key(settings).context("could not load encryption key")?;
 
     let host_id = Settings::host_id().await?;
 


### PR DESCRIPTION
- `newtype` for a `PasetoV4Key` so we stop passing around magic buffers.
 - Zeroizes on `Drop` now.
 - ~~Advised linux not to core dump it.~~
 - Added a custom `Debug` so it doesn't leak accidentally
 
- Renamed `PASETO_V4` to `PasetoV4`. Not sure why it was originally called `PASETO_V4`, open to reverting if the reason is good.