### PR TITLE
fix(zsh): don't clobber RPS1 when wrapping the prompt for OSC 133

### DIFF
--- a/crates/atuin/src/shell/atuin.zsh
+++ b/crates/atuin/src/shell/atuin.zsh
@@ -51,9 +51,14 @@ __atuin_osc133_prompt_start=$'%{\033]133;A;cl=line\a%}'
 __atuin_osc133_prompt_end=$'%{\033]133;B\a%}'
 
 __atuin_osc133_wrap_prompt() {
-    local __atuin_prompt="${PROMPT-}"
-    local __atuin_rprompt="${RPROMPT-}"
+    # RPS1 and RPROMPT share a value buffer but track "assigned" separately
+    # (zsh 5.0.6+), so for a user who only ever set RPS1, RPROMPT expands as
+    # unset. Fall back to RPS1 so we don't clobber the shared value (#3758).
+    local __atuin_orig_prompt="${PROMPT-}"
+    local __atuin_orig_rprompt="${RPROMPT-${RPS1-}}"
 
+    local __atuin_prompt="$__atuin_orig_prompt"
+    local __atuin_rprompt="$__atuin_orig_rprompt"
     __atuin_prompt="${__atuin_prompt//$__atuin_osc133_prompt_start/}"
     __atuin_prompt="${__atuin_prompt//$__atuin_osc133_prompt_end/}"
     __atuin_rprompt="${__atuin_rprompt//$__atuin_osc133_prompt_start/}"
@@ -63,8 +68,10 @@ __atuin_osc133_wrap_prompt() {
         PROMPT="${__atuin_osc133_prompt_start}${__atuin_prompt}"
         RPROMPT="${__atuin_rprompt}${__atuin_osc133_prompt_end}"
     else
-        PROMPT="$__atuin_prompt"
-        RPROMPT="$__atuin_rprompt"
+        # Skip no-op writes: assigning RPROMPT marks it (and RPS1) as set,
+        # which we shouldn't do unless we have markers to strip.
+        [[ "$__atuin_orig_prompt" == "$__atuin_prompt" ]] || PROMPT="$__atuin_prompt"
+        [[ "$__atuin_orig_rprompt" == "$__atuin_rprompt" ]] || RPROMPT="$__atuin_rprompt"
     fi
 }
 


### PR DESCRIPTION
Fixes #3758.

RPS1 and RPROMPT share a value buffer in zsh (since 5.0.6) but track "assignedness" separately, so for a user who only ever set `RPS1`, `RPROMPT` expands as unset ([zsh-workers report](https://www.zsh.org/mla/workers/2021/msg01822.html)). The OSC 133 prompt wrapper from #3510 read `${RPROMPT-}` (empty) and wrote it back on every precmd, wiping the shared value and erasing the user's right prompt — even with the pty proxy inactive.

Two changes to `__atuin_osc133_wrap_prompt`:

* Read the right prompt via `${RPROMPT-${RPS1-}}`, so an RPS1-only value is picked up instead of clobbered.
* In the non-pty-proxy path, skip the prompt writes unless there are markers to strip. This avoids marking `RPROMPT` as "set" (which affects both variables) as a side effect for users with no right prompt at all.

When the pty proxy is active, atuin still assigns `RPROMPT` to place the input-start marker; that marks both variables assigned and they mirror from then on, which is also how the marker reaches an RPS1-only prompt.

Verified on zsh 5.9 by sourcing the integration script under `zsh -f` and driving the wrapper through the reported scenario plus proxy-active wrapping, idempotence across precmds, marker cleanup after proxy exit, and later `RPS1` updates. The reported scenario fails against the previous version and passes with this change.
