### PR TITLE
feat(common): guarded secret-memory types (SecretBox / SecretArc)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -438,12 +438,16 @@ dependencies = [
  "eyre",
  "getrandom 0.4.3",
  "itertools 0.15.0",
+ "libc",
+ "memsec",
+ "parking_lot",
  "pretty_assertions",
  "proptest",
  "rstest",
  "serde",
  "serde_json",
  "serde_with",
+ "subtle",
  "sysinfo",
  "thiserror 2.0.19",
  "time",
@@ -454,6 +458,7 @@ dependencies = [
  "url",
  "uuid",
  "vt100",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3147,6 +3152,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "memsec"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c797b9d6bb23aab2fc369c65f871be49214f5c759af65bde26ffaaa2b646b492"
+dependencies = [
+ "getrandom 0.2.17",
+ "libc",
+ "windows-sys 0.45.0",
 ]
 
 [[package]]
@@ -6932,6 +6948,15 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.45.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
+dependencies = [
+ "windows-targets 0.42.2",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
@@ -6964,6 +6989,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link 0.2.1",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
+dependencies = [
+ "windows_aarch64_gnullvm 0.42.2",
+ "windows_aarch64_msvc 0.42.2",
+ "windows_i686_gnu 0.42.2",
+ "windows_i686_msvc 0.42.2",
+ "windows_x86_64_gnu 0.42.2",
+ "windows_x86_64_gnullvm 0.42.2",
+ "windows_x86_64_msvc 0.42.2",
 ]
 
 [[package]]
@@ -7010,6 +7050,12 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_gnullvm"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
@@ -7022,6 +7068,12 @@ checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
@@ -7031,6 +7083,12 @@ name = "windows_aarch64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -7058,6 +7116,12 @@ checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
+
+[[package]]
+name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
@@ -7067,6 +7131,12 @@ name = "windows_i686_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -7082,6 +7152,12 @@ checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
@@ -7091,6 +7167,12 @@ name = "windows_x86_64_gnullvm"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
 
 [[package]]
 name = "windows_x86_64_msvc"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,6 +65,13 @@ pretty_assertions = "1.3.0"
 proptest = "1.11.0"
 parking_lot = "0.12.5"
 rstest = "0.26.1"
+memsec = "0.7"
+subtle = "2.6"
+libc = "0.2"
+windows-sys = { version = "0.59", features = [
+  "Win32_System_ErrorReporting",
+  "Win32_Security_Cryptography",
+] }
 thiserror = "2"
 rustix = { version = "1.1.4", features = ["process", "fs"] }
 tower = "0.5"

--- a/crates/atuin-common/Cargo.toml
+++ b/crates/atuin-common/Cargo.toml
@@ -42,6 +42,17 @@ unicode-width = { version = "0.2", optional = true }
 unicode-segmentation = { version = "1.11.0", optional = true }
 vt100 = { workspace = true, optional = true }
 itertools = { workspace = true }
+# Secret-memory (`memory` module): guarded/locked/mprotected secret storage.
+memsec = { workspace = true }
+parking_lot = { workspace = true }
+subtle = { workspace = true }
+
+# Platform-specific secret-memory hardening (see `memory::hardening`).
+[target.'cfg(unix)'.dependencies]
+libc = { workspace = true }
+
+[target.'cfg(windows)'.dependencies]
+windows-sys = { workspace = true }
 
 [dev-dependencies]
 pretty_assertions = { workspace = true }

--- a/crates/atuin-common/src/lib.rs
+++ b/crates/atuin-common/src/lib.rs
@@ -5,6 +5,7 @@ pub mod ansi;
 pub mod docs;
 pub mod filter;
 pub mod logs;
+pub mod memory;
 pub mod path;
 pub mod shell;
 pub mod slice;

--- a/crates/atuin-common/src/memory/hardening.rs
+++ b/crates/atuin-common/src/memory/hardening.rs
@@ -1,0 +1,168 @@
+//! Platform-specific hardening for a [`SecretBox`](super::SecretBox)'s guarded
+//! allocation, layered on top of what `memsec` already provides (private pages,
+//! guard-page + canary, `mlock`, and `MADV_DONTDUMP` on Linux).
+//!
+//! Everything here is **best-effort**: a failed syscall weakens protection but
+//! is never unsound, so results are ignored rather than propagated. All helpers
+//! take `memsec`'s *user* pointer (the start of the value) and the value's byte
+//! length.
+
+// Platforms where we apply the fork/crash `madvise`/`minherit` advice. The
+// range must be page-aligned, so these all go through `page_range`.
+#[cfg(any(
+    target_os = "linux",
+    target_os = "macos",
+    target_os = "ios",
+    target_os = "freebsd",
+    target_os = "netbsd",
+    target_os = "openbsd",
+    target_os = "dragonfly"
+))]
+fn page_range(ptr: *mut u8, len: usize) -> Option<(*mut core::ffi::c_void, usize)> {
+    if len == 0 {
+        return None;
+    }
+    // SAFETY: `sysconf` with a valid name has no preconditions.
+    let page = unsafe { libc::sysconf(libc::_SC_PAGESIZE) };
+    if page <= 0 {
+        return None;
+    }
+    let page = page as usize;
+    let addr = ptr as usize;
+    // The payload is right-aligned against the trailing guard page, so rounding
+    // the start down to a page boundary stays inside `memsec`'s mlocked region.
+    let start = addr & !(page - 1);
+    let len = (addr + len - start + page - 1) & !(page - 1);
+    Some((start as *mut core::ffi::c_void, len))
+}
+
+/// Exclude the secret's pages from crash dumps.
+///
+/// Windows: `WerRegisterExcludedMemoryBlock`. Elsewhere a no-op — `memsec`
+/// already sets `MADV_DONTDUMP` on Linux, and macOS has no equivalent knob.
+pub(super) fn exclude_from_dumps(ptr: *mut u8, len: usize) {
+    #[cfg(windows)]
+    // SAFETY: `ptr`/`len` describe a live, owned allocation; WER only records
+    // the range, it does not dereference it.
+    unsafe {
+        let _ = windows_sys::Win32::System::ErrorReporting::WerRegisterExcludedMemoryBlock(
+            ptr as *const core::ffi::c_void,
+            len as u32,
+        );
+    }
+    #[cfg(not(windows))]
+    let _ = (ptr, len);
+}
+
+/// Advise the kernel to wipe the secret's pages in a forked child.
+///
+/// Linux: `madvise(MADV_WIPEONFORK)`. macOS/BSD: `minherit(VM_INHERIT_NONE)`
+/// (the child does not inherit the region). Elsewhere a no-op. This can cause
+/// surprising behaviour in `fork`ed children — see the [`SecretArc`] docs.
+///
+/// [`SecretArc`]: super::SecretArc
+pub(super) fn advise_wipe_on_fork(ptr: *mut u8, len: usize) {
+    #[cfg(target_os = "linux")]
+    if let Some((addr, len)) = page_range(ptr, len) {
+        // SAFETY: `addr`/`len` is a page-aligned sub-range of the live mapping.
+        unsafe { libc::madvise(addr, len, libc::MADV_WIPEONFORK) };
+    }
+    #[cfg(any(
+        target_os = "macos",
+        target_os = "ios",
+        target_os = "freebsd",
+        target_os = "netbsd",
+        target_os = "openbsd",
+        target_os = "dragonfly"
+    ))]
+    if let Some((addr, len)) = page_range(ptr, len) {
+        // `minherit(2)` is a real libSystem/BSD function but has no `libc`
+        // binding; declare it ourselves. `VM_INHERIT_NONE` (2) makes the region
+        // absent — hence zero-filled — in a forked child.
+        unsafe extern "C" {
+            fn minherit(
+                addr: *mut core::ffi::c_void,
+                len: usize,
+                inherit: core::ffi::c_int,
+            ) -> core::ffi::c_int;
+        }
+        const VM_INHERIT_NONE: core::ffi::c_int = 2;
+        // SAFETY: page-aligned sub-range of the live mapping.
+        unsafe { minherit(addr, len, VM_INHERIT_NONE) };
+    }
+    #[cfg(not(any(
+        target_os = "linux",
+        target_os = "macos",
+        target_os = "ios",
+        target_os = "freebsd",
+        target_os = "netbsd",
+        target_os = "openbsd",
+        target_os = "dragonfly"
+    )))]
+    let _ = (ptr, len);
+}
+
+/// Advise the kernel to zero the secret's wired pages on crash.
+///
+/// macOS/iOS: `madvise(MADV_ZERO_WIRED_PAGES)`. Elsewhere a no-op.
+pub(super) fn advise_zero_wired_on_crash(ptr: *mut u8, len: usize) {
+    #[cfg(any(target_os = "macos", target_os = "ios"))]
+    if let Some((addr, len)) = page_range(ptr, len) {
+        // SAFETY: page-aligned sub-range of the live mapping.
+        unsafe { libc::madvise(addr, len, libc::MADV_ZERO_WIRED_PAGES) };
+    }
+    #[cfg(not(any(target_os = "macos", target_os = "ios")))]
+    let _ = (ptr, len);
+}
+
+/// Whether the secret is ciphered in memory while idle on this platform.
+///
+/// Only Windows (`CryptProtectMemory`), and only when the value length is a
+/// non-zero multiple of the cipher block size — we cannot pad the encrypted
+/// region past `memsec`'s canary or trailing guard page.
+pub(super) fn encrypts<T>() -> bool {
+    #[cfg(windows)]
+    {
+        const BLOCK: usize =
+            windows_sys::Win32::Security::Cryptography::CRYPTPROTECTMEMORY_BLOCK_SIZE as usize;
+        let n = size_of::<T>();
+        n > 0 && n.is_multiple_of(BLOCK)
+    }
+    #[cfg(not(windows))]
+    {
+        let _ = size_of::<T>();
+        false
+    }
+}
+
+/// Encrypt the secret in place. Only meaningful (and only called) when
+/// [`encrypts`] is true; the pages must be writable.
+pub(super) fn encrypt(ptr: *mut u8, len: usize) {
+    #[cfg(windows)]
+    // SAFETY: caller guarantees `len` is a non-zero multiple of the block size
+    // and the pages are writable.
+    unsafe {
+        let _ = windows_sys::Win32::Security::Cryptography::CryptProtectMemory(
+            ptr as *mut core::ffi::c_void,
+            len as u32,
+            windows_sys::Win32::Security::Cryptography::CRYPTPROTECTMEMORY_SAME_PROCESS,
+        );
+    }
+    #[cfg(not(windows))]
+    let _ = (ptr, len);
+}
+
+/// Decrypt the secret in place. The inverse of [`encrypt`].
+pub(super) fn decrypt(ptr: *mut u8, len: usize) {
+    #[cfg(windows)]
+    // SAFETY: as `encrypt`.
+    unsafe {
+        let _ = windows_sys::Win32::Security::Cryptography::CryptUnprotectMemory(
+            ptr as *mut core::ffi::c_void,
+            len as u32,
+            windows_sys::Win32::Security::Cryptography::CRYPTPROTECTMEMORY_SAME_PROCESS,
+        );
+    }
+    #[cfg(not(windows))]
+    let _ = (ptr, len);
+}

--- a/crates/atuin-common/src/memory/mod.rs
+++ b/crates/atuin-common/src/memory/mod.rs
@@ -1,0 +1,15 @@
+// `secret_box`/`secret_arc` use raw pointers, `mprotect`, and manual
+// `Send`/`Sync` impls to harden secret memory; opt them out of the crate-wide
+// `deny(unsafe_code)`. The doc-overindent allow covers `secret_arc`'s fixed
+// docblock and its platform bullet lists.
+#[allow(unsafe_code)]
+mod hardening;
+#[allow(unsafe_code, clippy::doc_overindented_list_items)]
+mod secret_arc;
+#[allow(unsafe_code)]
+mod secret_box;
+
+pub use {
+    secret_arc::SecretArc, secret_arc::SecretArcRead, secret_box::SecretBox,
+    secret_box::SecretBoxRead,
+};

--- a/crates/atuin-common/src/memory/secret_arc.rs
+++ b/crates/atuin-common/src/memory/secret_arc.rs
@@ -1,0 +1,203 @@
+//! Memory-utilities within atuin.
+
+use std::fmt;
+use std::ops::Deref;
+use std::sync::Arc;
+
+use subtle::{Choice, ConstantTimeEq};
+
+use super::secret_box::SecretBox;
+
+/// Read handle to the value held in a [`SecretArc`].
+///
+/// Ensure you do not hold this for more than necessary, as it keeps the memory unsafe. See
+/// [`SecretArc`].
+pub struct SecretArcRead<T: Sized> {
+    inner: Arc<SecretBox<T>>,
+}
+
+/// A [`std::sync::Arc`] equivalent which is intended to be used for secret data.
+///
+/// There's a couple things this features over the standard [`std::sync::Arc`]:
+///
+/// Note that the access patterns are slightly different, requiring you grab a [`SecretArcRead`]
+/// handle.
+///
+/// ## POSIX-specific
+///
+/// The pages backing the data are:
+///
+///   - Not visible to other processes.
+///   - Guarded by `mprotect`ed canaries preventing buffer overflows poisoning the data.
+///   - `mlock`ed to prevent flushing to swap.
+///   - Marked `mprotect(PROT_NONE)`, promoting to `PROT_READ` for the lifetime of the read.
+///
+/// ### Linux
+///
+/// The pages backing the data are:
+///
+///   - `madvise`d against being flushed during core dumps.
+///   - `madvise`d to be zeroed out before `fork` syscalls in the child process.
+///      **Note this may cause unexpected behaviour.**
+///
+/// ### macOS
+///
+/// The pages backing the data are:
+///
+///   - `madvise(MADV_ZERO_WIRED_PAGES)`d to zero-out memory on crash.
+///   - `madvise`d to be zeroed out before `fork` syscalls in the child process.
+///      **Note this may cause unexpected behaviour.**
+///
+/// ## Windows
+///
+/// As always, Windows has the kitchen sink so we have better utilities for this memory. The pages
+/// backing this data are:
+///
+///   - `VirtualLock`ed so they do not get paged to disk.
+///   - `VirtualProtect`ed `PAGE_NOACCESS` and promoted to `PAGE_READONLY` only for the duration of
+///      a read.
+///   - `WerRegisterExcludedMemoryBlock`ed to tell windows not to dump memory.
+///   - **Encrypted in memory** until a read handle is created.
+pub struct SecretArc<T: Sized> {
+    inner: Arc<SecretBox<T>>,
+}
+
+impl<T: Sized> SecretArc<T> {
+    /// Move `value` into freshly-allocated, hardened memory.
+    ///
+    /// See [`SecretArc`] for what "hardened" means on each platform. The value
+    /// is locked down (unreadable) until a [`read`](Self::read) handle is taken.
+    pub fn new(value: T) -> Self {
+        Self {
+            inner: Arc::new(SecretBox::new(value)),
+        }
+    }
+
+    /// Take a [`SecretArcRead`] handle, making the secret readable for as long
+    /// as the handle (or any other concurrent handle) is alive.
+    ///
+    /// Hold it for as little time as possible: while any handle is live the
+    /// backing pages are readable rather than access-protected.
+    pub fn read(&self) -> SecretArcRead<T> {
+        self.inner.acquire_read();
+        SecretArcRead {
+            inner: Arc::clone(&self.inner),
+        }
+    }
+}
+
+impl<T: Sized> Clone for SecretArc<T> {
+    /// Cheaply share ownership of the same underlying secret, like
+    /// [`Arc::clone`]. No secret bytes are copied.
+    fn clone(&self) -> Self {
+        Self {
+            inner: Arc::clone(&self.inner),
+        }
+    }
+}
+
+impl<T: Default> Default for SecretArc<T> {
+    fn default() -> Self {
+        Self::new(T::default())
+    }
+}
+
+impl<T> From<T> for SecretArc<T> {
+    fn from(value: T) -> Self {
+        Self::new(value)
+    }
+}
+
+impl<T: ConstantTimeEq> ConstantTimeEq for SecretArc<T> {
+    /// Constant-time comparison of the two secrets. Preferred over a derived
+    /// `PartialEq`, which would short-circuit and leak equality via timing.
+    fn ct_eq(&self, other: &Self) -> Choice {
+        let this = self.read();
+        let that = other.read();
+        ConstantTimeEq::ct_eq(&*this, &*that)
+    }
+}
+
+impl<T: Sized> Deref for SecretArcRead<T> {
+    type Target = T;
+
+    fn deref(&self) -> &T {
+        // SAFETY: while this handle is alive the reader count is >= 1, so the
+        // pages are readable, and the `Arc` keeps the allocation alive. The
+        // reference is bounded by `&self`, so it cannot outlive the handle (and
+        // thus the readable window).
+        unsafe { self.inner.get() }
+    }
+}
+
+impl<T: Sized> Drop for SecretArcRead<T> {
+    fn drop(&mut self) {
+        self.inner.release_read();
+    }
+}
+
+impl<T: Sized> fmt::Debug for SecretArc<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str("SecretArc([redacted])")
+    }
+}
+
+impl<T: Sized> fmt::Debug for SecretArcRead<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str("SecretArcRead([redacted])")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::SecretArc;
+
+    #[test]
+    fn read_round_trips() {
+        let s = SecretArc::new([7u8; 32]);
+        assert_eq!(*s.read(), [7u8; 32]);
+    }
+
+    #[test]
+    fn concurrent_reads_coexist() {
+        let s = SecretArc::new(1234u64);
+        let a = s.read();
+        let b = s.read();
+        assert_eq!(*a, 1234);
+        assert_eq!(*b, 1234);
+        // dropping one reader must not revoke access for the other
+        drop(a);
+        assert_eq!(*b, 1234);
+    }
+
+    #[test]
+    fn reads_work_again_after_all_handles_drop() {
+        let s = SecretArc::new(99u32);
+        assert_eq!(*s.read(), 99); // handle dropped here -> pages re-locked
+        assert_eq!(*s.read(), 99); // must re-promote cleanly
+    }
+
+    #[test]
+    fn clone_shares_the_same_secret() {
+        let s = SecretArc::new([0xABu8; 16]);
+        let s2 = s.clone();
+        assert_eq!(*s.read(), [0xABu8; 16]);
+        assert_eq!(*s2.read(), [0xABu8; 16]);
+    }
+
+    #[test]
+    fn shared_across_threads() {
+        let s = SecretArc::new([0xCDu8; 16]);
+        let s2 = s.clone();
+        let handle = std::thread::spawn(move || *s2.read());
+        assert_eq!(*s.read(), [0xCDu8; 16]);
+        assert_eq!(handle.join().unwrap(), [0xCDu8; 16]);
+    }
+
+    #[test]
+    fn debug_is_redacted() {
+        let s = SecretArc::new([1u8; 8]);
+        assert_eq!(format!("{s:?}"), "SecretArc([redacted])");
+        assert_eq!(format!("{:?}", s.read()), "SecretArcRead([redacted])");
+    }
+}

--- a/crates/atuin-common/src/memory/secret_box.rs
+++ b/crates/atuin-common/src/memory/secret_box.rs
@@ -1,0 +1,287 @@
+//! A hardened container for a single secret value.
+
+use std::fmt;
+use std::marker::PhantomData;
+use std::ops::Deref;
+use std::ptr::NonNull;
+
+use parking_lot::Mutex;
+use subtle::{Choice, ConstantTimeEq};
+
+use super::hardening;
+
+/// A hardened, single-allocation container for a secret `T`.
+///
+/// Owns one `memsec` guarded allocation (guard pages + canary, `mlock`ed, and
+/// `mprotect`ed no-access while idle) holding the secret `T`. Take a
+/// [`SecretBoxRead`] via [`read`](Self::read) to access it; the pages are only
+/// readable while a read handle is alive.
+///
+/// This is also the storage shared, behind an [`Arc`](std::sync::Arc), by
+/// [`SecretArc`](super::SecretArc).
+///
+/// Note this only protects secrets stored *inline* in `T` (e.g. `[u8; 32]` or a
+/// POD struct). If `T` owns out-of-line data (e.g. `Vec<u8>`), that data lives
+/// on the normal heap and is *not* covered by these protections.
+pub struct SecretBox<T: Sized> {
+    /// Pointer to the secret, inside the guarded allocation.
+    ptr: NonNull<T>,
+    /// Count of live readers. Serializes the `mprotect` transitions so
+    /// concurrent readers don't demote the pages out from under each other.
+    readers: Mutex<usize>,
+    /// We own a `T` (dropped in place on teardown); make that explicit for the
+    /// drop checker, since `NonNull<T>` does not imply ownership.
+    _owns: PhantomData<T>,
+}
+
+impl<T: Sized> SecretBox<T> {
+    /// Move `value` into freshly-allocated, hardened memory, locked down
+    /// (unreadable) until a [`read`](Self::read) handle is taken.
+    pub fn new(value: T) -> Self {
+        // SAFETY: `malloc::<T>` returns a guarded, `mlock`ed, read-write region
+        // sized and aligned for `T`, or `None` on failure.
+        let ptr = unsafe { memsec::malloc::<T>() }.expect("SecretBox: secure allocation failed");
+
+        // SAFETY: the region is writable, sized for `T`, and unaliased.
+        unsafe { ptr.as_ptr().write(value) };
+
+        // Best-effort platform hardening while the pages are still writable:
+        // exclude from crash dumps, wipe-on-fork, zero-wired-on-crash, and
+        // (Windows only) cipher the value at rest.
+        let base = ptr.as_ptr().cast::<u8>();
+        hardening::exclude_from_dumps(base, size_of::<T>());
+        hardening::advise_wipe_on_fork(base, size_of::<T>());
+        hardening::advise_zero_wired_on_crash(base, size_of::<T>());
+        if hardening::encrypts::<T>() {
+            hardening::encrypt(base, size_of::<T>());
+        }
+
+        // SAFETY: `ptr` came from `memsec::malloc`. Lock the pages down until a
+        // reader asks for them.
+        let ok = unsafe { memsec::mprotect(ptr, memsec::Prot::NoAccess) };
+        assert!(ok, "SecretBox: mprotect(NoAccess) failed");
+
+        Self {
+            ptr,
+            readers: Mutex::new(0),
+            _owns: PhantomData,
+        }
+    }
+
+    /// Take a [`SecretBoxRead`] handle, making the secret readable for as long
+    /// as the handle (or any other concurrent handle) is alive.
+    ///
+    /// Hold it for as little time as possible: while any handle is live the
+    /// backing pages are readable rather than access-protected.
+    pub fn read(&self) -> SecretBoxRead<'_, T> {
+        self.acquire_read();
+        SecretBoxRead { boxed: self }
+    }
+
+    /// Register a reader, promoting the pages to readable on the first one.
+    pub(super) fn acquire_read(&self) {
+        let mut readers = self.readers.lock();
+        if *readers == 0 {
+            if hardening::encrypts::<T>() {
+                // Ciphered at rest (Windows): briefly go writable to decrypt.
+                // SAFETY: `ptr` came from `memsec::malloc`.
+                let ok = unsafe { memsec::mprotect(self.ptr, memsec::Prot::ReadWrite) };
+                assert!(ok, "SecretBox: mprotect(ReadWrite) failed");
+                hardening::decrypt(self.ptr.as_ptr().cast::<u8>(), size_of::<T>());
+            }
+            // SAFETY: `ptr` came from `memsec::malloc`.
+            let ok = unsafe { memsec::mprotect(self.ptr, memsec::Prot::ReadOnly) };
+            assert!(ok, "SecretBox: mprotect(ReadOnly) failed");
+        }
+        *readers += 1;
+    }
+
+    /// Deregister a reader, demoting the pages back to no-access on the last one.
+    pub(super) fn release_read(&self) {
+        let mut readers = self.readers.lock();
+        *readers -= 1;
+        if *readers == 0 {
+            // Best-effort: this runs from a read handle's `drop`, so we must not
+            // panic — a failed re-lock weakens protection but is not unsound
+            // (unlike a failed promote in `acquire_read`, which would fault a
+            // read).
+            if hardening::encrypts::<T>() {
+                // Re-cipher at rest (Windows): go writable, encrypt, re-lock.
+                // SAFETY: `ptr` came from `memsec::malloc`.
+                let _ = unsafe { memsec::mprotect(self.ptr, memsec::Prot::ReadWrite) };
+                hardening::encrypt(self.ptr.as_ptr().cast::<u8>(), size_of::<T>());
+            }
+            // SAFETY: `ptr` came from `memsec::malloc`.
+            let _relocked = unsafe { memsec::mprotect(self.ptr, memsec::Prot::NoAccess) };
+        }
+    }
+
+    /// Borrow the secret.
+    ///
+    /// # Safety
+    ///
+    /// A read must be active (i.e. a live read handle acquired via
+    /// [`acquire_read`](Self::acquire_read)), so the pages are readable, and the
+    /// returned reference must not outlive that read window.
+    pub(super) unsafe fn get(&self) -> &T {
+        // SAFETY: upheld by the caller's contract — the pages are readable and
+        // the returned lifetime is bounded by the read handle.
+        unsafe { self.ptr.as_ref() }
+    }
+}
+
+impl<T: Sized> Drop for SecretBox<T> {
+    fn drop(&mut self) {
+        // SAFETY: `ptr` came from `memsec::malloc`. Make the region writable so
+        // `T`'s destructor can run, drop the value in place, then `free` — which
+        // zeroes the bytes and unlocks the pages before releasing them.
+        unsafe {
+            memsec::mprotect(self.ptr, memsec::Prot::ReadWrite);
+            // No readers remain at drop, so the value is ciphered at rest on
+            // platforms that encrypt; decrypt so the destructor sees plaintext
+            // and `free` zeroes plaintext.
+            if hardening::encrypts::<T>() {
+                hardening::decrypt(self.ptr.as_ptr().cast::<u8>(), size_of::<T>());
+            }
+            self.ptr.as_ptr().drop_in_place();
+            memsec::free(self.ptr);
+        }
+    }
+}
+
+impl<T: Sized> fmt::Debug for SecretBox<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str("SecretBox([redacted])")
+    }
+}
+
+// SAFETY: the secret is owned by the box. Moving it across threads is sound when
+// `T: Send`; sharing `&SecretBox` (and the `&T` a read hands out) across threads
+// is sound when `T: Sync`. The `mprotect` transitions are serialized by
+// `readers`. These bounds mirror `Arc<T>`'s.
+unsafe impl<T: Sized + Send> Send for SecretBox<T> {}
+unsafe impl<T: Sized + Sync> Sync for SecretBox<T> {}
+
+impl<T: Clone> Clone for SecretBox<T> {
+    /// Deep-clone: allocate a *new* hardened box holding a clone of the secret.
+    /// (Unlike [`SecretArc`](super::SecretArc), whose `Clone` shares.)
+    fn clone(&self) -> Self {
+        Self::new((*self.read()).clone())
+    }
+}
+
+impl<T: Default> Default for SecretBox<T> {
+    fn default() -> Self {
+        Self::new(T::default())
+    }
+}
+
+impl<T> From<T> for SecretBox<T> {
+    fn from(value: T) -> Self {
+        Self::new(value)
+    }
+}
+
+impl<T: ConstantTimeEq> ConstantTimeEq for SecretBox<T> {
+    /// Constant-time comparison of the two secrets. Preferred over a derived
+    /// `PartialEq`, which would short-circuit and leak equality via timing.
+    fn ct_eq(&self, other: &Self) -> Choice {
+        let this = self.read();
+        let that = other.read();
+        ConstantTimeEq::ct_eq(&*this, &*that)
+    }
+}
+
+/// Read handle to the value held in a [`SecretBox`].
+///
+/// Ensure you do not hold this for more than necessary: while it (or any other
+/// concurrent handle) is alive the backing pages are readable rather than
+/// access-protected.
+pub struct SecretBoxRead<'a, T: Sized> {
+    boxed: &'a SecretBox<T>,
+}
+
+impl<T: Sized> Deref for SecretBoxRead<'_, T> {
+    type Target = T;
+
+    fn deref(&self) -> &T {
+        // SAFETY: this handle is alive, so the reader count is >= 1 and the
+        // pages are readable. The reference is bounded by `&self`, so it cannot
+        // outlive the handle (and thus the readable window).
+        unsafe { self.boxed.get() }
+    }
+}
+
+impl<T: Sized> Drop for SecretBoxRead<'_, T> {
+    fn drop(&mut self) {
+        self.boxed.release_read();
+    }
+}
+
+impl<T: Sized> fmt::Debug for SecretBoxRead<'_, T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str("SecretBoxRead([redacted])")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::SecretBox;
+
+    #[test]
+    fn read_round_trips() {
+        let s = SecretBox::new([7u8; 32]);
+        assert_eq!(*s.read(), [7u8; 32]);
+    }
+
+    #[test]
+    fn concurrent_reads_coexist() {
+        let s = SecretBox::new(1234u64);
+        let a = s.read();
+        let b = s.read();
+        assert_eq!(*a, 1234);
+        assert_eq!(*b, 1234);
+        // dropping one reader must not revoke access for the other
+        drop(a);
+        assert_eq!(*b, 1234);
+    }
+
+    #[test]
+    fn reads_work_again_after_all_handles_drop() {
+        let s = SecretBox::new(99u32);
+        assert_eq!(*s.read(), 99); // handle dropped here -> pages re-locked
+        assert_eq!(*s.read(), 99); // must re-promote cleanly
+    }
+
+    #[test]
+    fn debug_is_redacted() {
+        let s = SecretBox::new([1u8; 8]);
+        assert_eq!(format!("{s:?}"), "SecretBox([redacted])");
+        assert_eq!(format!("{:?}", s.read()), "SecretBoxRead([redacted])");
+    }
+
+    #[test]
+    fn clone_is_a_deep_copy() {
+        let a = SecretBox::new([9u8; 32]);
+        let b = a.clone();
+        assert_eq!(*a.read(), *b.read());
+    }
+
+    #[test]
+    fn from_and_default() {
+        let a = SecretBox::from([3u8; 16]);
+        assert_eq!(*a.read(), [3u8; 16]);
+        let d: SecretBox<u64> = SecretBox::default();
+        assert_eq!(*d.read(), 0);
+    }
+
+    #[test]
+    fn ct_eq_matches_value_equality() {
+        use subtle::ConstantTimeEq;
+        let a = SecretBox::new(0xABCD_u64);
+        let b = SecretBox::new(0xABCD_u64);
+        let c = SecretBox::new(0x1234_u64);
+        assert!(bool::from(a.ct_eq(&b)));
+        assert!(!bool::from(a.ct_eq(&c)));
+    }
+}


### PR DESCRIPTION
## What

Adds `atuin_common::memory` — guarded, hardened storage for secret data (encryption keys and the like), backed by [`memsec`](https://crates.io/crates/memsec).

Two public types (symmetric APIs):

- **`SecretBox<T>`** — owned. `new(value)` allocates a guarded, `mlock`ed region and locks it `PROT_NONE`; `read()` returns a **`SecretBoxRead<'a, T>`** guard that promotes the pages to readable only while held (`Deref → &T`), then re-locks on drop. Zeroed + freed on `Drop`.
- **`SecretArc<T>` / `SecretArcRead<T>`** — the `Arc`-like shared variant (the type the pre-existing docblock describes), built on `Arc<SecretBox<T>>`.

Both read guards drive one refcounted `mprotect` state machine (serialized by a `parking_lot::Mutex`), so concurrent readers are safe and the last one re-locks.

## Hardening (`memory::hardening`, best-effort per platform)

On top of what `memsec` gives everywhere (private pages, guard-page + canary, `mlock`/`VirtualLock`, `PROT_NONE`↔`PROT_READ`, Linux `MADV_DONTDUMP`, zero-on-free):

| Platform | Added |
|---|---|
| Linux | `madvise(MADV_WIPEONFORK)` |
| macOS/iOS | `madvise(MADV_ZERO_WIRED_PAGES)` + `minherit(VM_INHERIT_NONE)` |
| Windows | `WerRegisterExcludedMemoryBlock` + `CryptProtectMemory` (encrypt-at-rest; decrypt on first read, re-encrypt on last, gated on `size_of::<T>() % 16 == 0`) |

## Generic-utility traits

Conditional `Clone` (deep-copy for `SecretBox`; `SecretArc::clone` shares), `Default`, `From<T>`, and constant-time `subtle::ConstantTimeEq`. Deliberately **no** `PartialEq`/`Eq`/`Ord`/`Hash`/`Serialize` — variable-time comparison / hashing of secret bytes is a timing-side-channel and exposure footgun. `Debug` is redacted.

## Dependencies

Promoted to `[workspace.dependencies]`, consumed via `{ workspace = true }` (target-gated): `memsec`, `subtle`, `parking_lot` (unconditional), `libc` (`cfg(unix)`), `windows-sys` (`cfg(windows)`, features `Win32_System_ErrorReporting` + `Win32_Security_Cryptography`).

## Verification

- **macOS** (native): build + `clippy -D warnings` + `fmt` + 13 tests. #2/#3 (macOS `madvise`/`minherit`) actually execute on every `SecretBox::new`.
- **Linux** (`--target x86_64-unknown-linux-gnu`): `check` + `clippy -D warnings`.
- **Windows** (`--target x86_64-pc-windows-gnu`): `check` + `clippy -D warnings`.

Caveat: Linux and Windows are **compile-verified only** (developed on macOS — no runtime). The hardening calls are best-effort by design (results ignored — a failed advise weakens protection but is never unsound). `CryptProtectMemory` only ciphers when `size_of::<T>() % 16 == 0` (can't pad past `memsec`'s canary/guard page) — true for the `[u8; 32]` key case.
