### PR TITLE
fix(search): prepare daemon search index in shell init scripts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1136,9 +1136,9 @@ dependencies = [
 
 [[package]]
 name = "clap_complete"
-version = "4.6.0"
+version = "4.6.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19c9f1dde76b736e3681f28cec9d5a61299cbaae0fce80a68e43724ad56031eb"
+checksum = "3be2ad0423bdbbb0e25bc89add796f3559706d4a95e1bc98e4d9662a957b6a19"
 dependencies = [
  "clap",
 ]

--- a/crates/atuin-daemon/proto/search.proto
+++ b/crates/atuin-daemon/proto/search.proto
@@ -31,6 +31,9 @@ message SearchResponse {
   repeated bytes ids = 2;
 }
 
+// Tells the daemon to build the search index for the given list of shells.
+// This message gets sent from the shell init scripts, to avoid a delay when
+// the first search request is sent.
 message PrepareIndexRequest {
   repeated string shells = 1;
 }

--- a/crates/atuin-daemon/proto/search.proto
+++ b/crates/atuin-daemon/proto/search.proto
@@ -31,6 +31,13 @@ message SearchResponse {
   repeated bytes ids = 2;
 }
 
+message PrepareIndexRequest {
+  repeated string shells = 1;
+}
+
+message PrepareIndexResponse {}
+
 service Search {
   rpc Search(stream SearchRequest) returns (stream SearchResponse);
+  rpc PrepareIndex(PrepareIndexRequest) returns (PrepareIndexResponse);
 }

--- a/crates/atuin-daemon/src/client.rs
+++ b/crates/atuin-daemon/src/client.rs
@@ -28,8 +28,8 @@ use crate::history::{
     TailHistoryRequest, history_client::HistoryClient as HistoryServiceClient,
 };
 use crate::search::{
-    FilterMode as RpcFilterMode, SearchContext as RpcSearchContext, SearchRequest, SearchResponse,
-    search_client::SearchClient as SearchServiceClient,
+    FilterMode as RpcFilterMode, PrepareIndexRequest, SearchContext as RpcSearchContext,
+    SearchRequest, SearchResponse, search_client::SearchClient as SearchServiceClient,
 };
 use crate::semantic::{
     CommandCapture, CommandOutputReply, CommandOutputRequest, OutputRange, RecordCommandsReply,
@@ -260,6 +260,18 @@ impl SearchClient {
             .await?;
 
         Ok(response.into_inner())
+    }
+
+    pub async fn prepare_index(&mut self, shells: OrFilter<Vec<String>>) -> Result<()> {
+        let request = PrepareIndexRequest {
+            // Same as `SearchRequest::shells` -- empty list means "all".
+            shells: match shells.into_list() {
+                filter::Items::All => vec![],
+                filter::Items::Some(vec) => vec,
+            },
+        };
+        self.client.prepare_index(request).await?;
+        Ok(())
     }
 }
 

--- a/crates/atuin-daemon/src/client.rs
+++ b/crates/atuin-daemon/src/client.rs
@@ -262,6 +262,7 @@ impl SearchClient {
         Ok(response.into_inner())
     }
 
+    /// Tell the daemon to build the search index for the given list of shells.
     pub async fn prepare_index(&mut self, shells: OrFilter<Vec<String>>) -> Result<()> {
         let request = PrepareIndexRequest {
             // Same as `SearchRequest::shells` -- empty list means "all".

--- a/crates/atuin-daemon/src/components/search.rs
+++ b/crates/atuin-daemon/src/components/search.rs
@@ -19,7 +19,8 @@ use crate::{
     daemon::{Component, DaemonHandle},
     events::DaemonEvent,
     search::{
-        FilterMode, IndexFilterMode, SearchIndex, SearchRequest, SearchResponse,
+        FilterMode, IndexFilterMode, PrepareIndexRequest, PrepareIndexResponse, SearchIndex,
+        SearchRequest, SearchResponse,
         search_server::{Search as SearchSvc, SearchServer},
     },
 };
@@ -410,6 +411,22 @@ impl SearchSvc for SearchGrpcService {
         // Convert receiver to stream
         let out_stream = tokio_stream::wrappers::ReceiverStream::new(rx);
         Ok(Response::new(Box::pin(out_stream)))
+    }
+
+    async fn prepare_index(
+        &self,
+        request: Request<PrepareIndexRequest>,
+    ) -> Result<Response<PrepareIndexResponse>, Status> {
+        // Same as `SearchRequest::shells` -- empty list means "all".
+        let shells = OrFilter::from_list(request.into_inner().shells).unwrap_or_default();
+        if let Some(index) = self
+            .maybe_rebuild_index(shells)
+            .await
+            .map_err(|()| Status::internal("failed to build index"))?
+        {
+            *self.index.write().await = index;
+        }
+        Ok(Response::new(PrepareIndexResponse {}))
     }
 }
 

--- a/crates/atuin/Cargo.toml
+++ b/crates/atuin/Cargo.toml
@@ -95,7 +95,7 @@ enum_dispatch = { workspace = true }
 async-trait = { workspace = true }
 interim = { workspace = true }
 clap = { workspace = true }
-clap_complete = "4.5.8"
+clap_complete = "4.6.1"
 clap_complete_nushell = "4.5.4"
 fs-err = { workspace = true }
 rpassword = "7.0"

--- a/crates/atuin/src/command/client.rs
+++ b/crates/atuin/src/command/client.rs
@@ -228,7 +228,10 @@ impl Cmd {
             Self::Config(config) => return config.run(&settings).await,
             Self::Lab(cmd) => return cmd.run(&settings).await,
             Self::Internal(cmd) => return cmd.run(&settings).await,
-            Self::InternalDecoy => return Ok(()),
+            Self::InternalDecoy => {
+                eprintln!("error: this command is not meant to be accessed directly");
+                std::process::exit(1);
+            }
             _ => {}
         }
 
@@ -315,6 +318,8 @@ impl Cmd {
 
             #[cfg(feature = "ai")]
             Self::Ai(cmd) => Some(cmd.log_config(settings)),
+
+            Self::Internal(cmd) => cmd.log_config(),
 
             _ => Some(LogConfig::stderr_only()),
         }

--- a/crates/atuin/src/command/client.rs
+++ b/crates/atuin/src/command/client.rs
@@ -132,7 +132,14 @@ pub enum Cmd {
     Lab(lab::Cmd),
 
     /// Internal subcommands, not for direct use by users.
-    #[command(subcommand, hide = true, name = "__internal")]
+    #[command(
+        subcommand,
+        hide = true,
+        name = "__internal",
+        help_template = "error: this command is not meant to be accessed directly",
+        disable_help_flag = true,
+        disable_help_subcommand = true,
+    )]
     Internal(internal::Cmd),
 
     /// We want to exclude the `__internal` subcommand from Clap's `infer_subcommands`; otherwise,
@@ -140,7 +147,12 @@ pub enum Cmd {
     /// `infer_subcommands` for a single command. As a workaround, we define a dummy command with
     /// the same name but with an extra understore, which forces `__internal` to be typed out in
     /// entirety, since any prefix of the name would be ambiguous.
-    #[command(hide = true, name = "__internal_")]
+    #[command(
+        hide = true,
+        name = "__internal_",
+        disable_help_flag = true,
+        disable_help_subcommand = true,
+    )]
     InternalDecoy,
 }
 

--- a/crates/atuin/src/command/client.rs
+++ b/crates/atuin/src/command/client.rs
@@ -25,6 +25,7 @@ mod hook;
 mod import;
 mod info;
 mod init;
+mod internal;
 mod kv;
 mod lab;
 mod scripts;
@@ -130,8 +131,17 @@ pub enum Cmd {
     #[command(subcommand, hide = true)]
     Lab(lab::Cmd),
 
-    #[command(hide = true)]
-    InternalPrepareSearchIndex,
+    /// Internal subcommands, not for direct use by users.
+    #[command(subcommand, hide = true, name = "__internal")]
+    Internal(internal::Cmd),
+
+    /// We want to exclude the `__internal` subcommand from Clap's `infer_subcommands`; otherwise,
+    /// a user could access it simply by typing `atuin _`. However, Clap has no way to disable
+    /// `infer_subcommands` for a single command. As a workaround, we define a dummy command with
+    /// the same name but with an extra understore, which forces `__internal` to be typed out in
+    /// entirety, since any prefix of the name would be ambiguous.
+    #[command(hide = true, name = "__internal_")]
+    InternalDecoy,
 }
 
 impl Cmd {
@@ -205,7 +215,8 @@ impl Cmd {
             Self::Update(update) => return update.run(&settings).await,
             Self::Config(config) => return config.run(&settings).await,
             Self::Lab(cmd) => return cmd.run(&settings).await,
-            Self::InternalPrepareSearchIndex => return search::prepare_index(&settings).await,
+            Self::Internal(cmd) => return cmd.run(&settings).await,
+            Self::InternalDecoy => return Ok(()),
             _ => {}
         }
 
@@ -259,7 +270,8 @@ impl Cmd {
             | Self::Doctor
             | Self::Config(_)
             | Self::Lab(_)
-            | Self::InternalPrepareSearchIndex => {
+            | Self::Internal(_)
+            | Self::InternalDecoy => {
                 unreachable!()
             }
 

--- a/crates/atuin/src/command/client.rs
+++ b/crates/atuin/src/command/client.rs
@@ -129,6 +129,9 @@ pub enum Cmd {
     /// Experimental laboratory features
     #[command(subcommand, hide = true)]
     Lab(lab::Cmd),
+
+    #[command(hide = true)]
+    InternalPrepareSearchIndex,
 }
 
 impl Cmd {
@@ -179,7 +182,10 @@ impl Cmd {
         res
     }
 
-    #[allow(clippy::too_many_lines, clippy::future_not_send)]
+    #[allow(clippy::too_many_lines)]
+    // `atuin_ai::commands::run` is not `Send` because `eye_declare` holds a `StdoutLock` across
+    // await points.
+    #[allow(clippy::future_not_send)]
     async fn run_inner(
         self,
         mut settings: Settings,
@@ -199,6 +205,7 @@ impl Cmd {
             Self::Update(update) => return update.run(&settings).await,
             Self::Config(config) => return config.run(&settings).await,
             Self::Lab(cmd) => return cmd.run(&settings).await,
+            Self::InternalPrepareSearchIndex => return search::prepare_index(&settings).await,
             _ => {}
         }
 
@@ -251,7 +258,8 @@ impl Cmd {
             | Self::Init(_)
             | Self::Doctor
             | Self::Config(_)
-            | Self::Lab(_) => {
+            | Self::Lab(_)
+            | Self::InternalPrepareSearchIndex => {
                 unreachable!()
             }
 

--- a/crates/atuin/src/command/client.rs
+++ b/crates/atuin/src/command/client.rs
@@ -138,7 +138,7 @@ pub enum Cmd {
         name = "__internal",
         help_template = "error: this command is not meant to be accessed directly",
         disable_help_flag = true,
-        disable_help_subcommand = true,
+        disable_help_subcommand = true
     )]
     Internal(internal::Cmd),
 
@@ -151,7 +151,7 @@ pub enum Cmd {
         hide = true,
         name = "__internal_",
         disable_help_flag = true,
-        disable_help_subcommand = true,
+        disable_help_subcommand = true
     )]
     InternalDecoy,
 }

--- a/crates/atuin/src/command/client/internal.rs
+++ b/crates/atuin/src/command/client/internal.rs
@@ -1,6 +1,7 @@
 //! Internal subcommands, not for direct use by users.
 
 use atuin_client::settings::Settings;
+use atuin_common::logs::LogConfig;
 
 #[derive(clap::Subcommand, Debug)]
 pub enum Cmd {
@@ -11,6 +12,14 @@ impl Cmd {
     pub async fn run(self, settings: &Settings) -> eyre::Result<()> {
         match self {
             Self::PrepareSearchIndex => super::search::prepare_index(settings).await,
+        }
+    }
+
+    pub fn log_config(&self) -> Option<LogConfig> {
+        match self {
+            // This command is called from the shell hooks with no stdout/stderr; there's no point
+            // in initializing logging.
+            Self::PrepareSearchIndex => None,
         }
     }
 }

--- a/crates/atuin/src/command/client/internal.rs
+++ b/crates/atuin/src/command/client/internal.rs
@@ -1,0 +1,16 @@
+//! Internal subcommands, not for direct use by users.
+
+use atuin_client::settings::Settings;
+
+#[derive(clap::Subcommand, Debug)]
+pub enum Cmd {
+    PrepareSearchIndex,
+}
+
+impl Cmd {
+    pub async fn run(self, settings: &Settings) -> eyre::Result<()> {
+        match self {
+            Self::PrepareSearchIndex => super::search::prepare_index(settings).await,
+        }
+    }
+}

--- a/crates/atuin/src/command/client/internal.rs
+++ b/crates/atuin/src/command/client/internal.rs
@@ -3,6 +3,7 @@
 use atuin_client::settings::Settings;
 
 #[derive(clap::Subcommand, Debug)]
+#[command(infer_subcommands = false)]
 pub enum Cmd {
     PrepareSearchIndex,
 }

--- a/crates/atuin/src/command/client/internal.rs
+++ b/crates/atuin/src/command/client/internal.rs
@@ -3,7 +3,6 @@
 use atuin_client::settings::Settings;
 
 #[derive(clap::Subcommand, Debug)]
-#[command(infer_subcommands = false)]
 pub enum Cmd {
     PrepareSearchIndex,
 }

--- a/crates/atuin/src/command/client/search.rs
+++ b/crates/atuin/src/command/client/search.rs
@@ -363,6 +363,7 @@ async fn run_non_interactive(
 
 pub async fn prepare_index(settings: &Settings) -> Result<()> {
     use engines::AnySearchEngine;
+    #[cfg(feature = "daemon")]
     if let AnySearchEngine::Daemon(mut search) = engines::engine(settings.search_mode(), settings) {
         search.prepare_index().await?;
     }

--- a/crates/atuin/src/command/client/search.rs
+++ b/crates/atuin/src/command/client/search.rs
@@ -361,6 +361,14 @@ async fn run_non_interactive(
     Ok(results)
 }
 
+pub async fn prepare_index(settings: &Settings) -> Result<()> {
+    use engines::AnySearchEngine;
+    if let AnySearchEngine::Daemon(mut search) = engines::engine(settings.search_mode(), settings) {
+        search.prepare_index().await?;
+    }
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::{AuthorPattern, Cmd};

--- a/crates/atuin/src/command/client/search/engines/daemon.rs
+++ b/crates/atuin/src/command/client/search/engines/daemon.rs
@@ -12,53 +12,36 @@ use uuid::Uuid;
 use super::{SearchEngine, SearchState};
 use crate::command::client::daemon;
 
-pub struct Search {
-    client: Option<SearchClient>,
-    query_id: u64,
-    settings: Settings,
-    #[cfg(unix)]
-    socket_path: String,
-    #[cfg(not(unix))]
-    tcp_port: u64,
-}
+/// A lazily-initialized [`SearchClient`].
+#[derive(Default)]
+struct LazyClient(Option<SearchClient>);
 
-impl Search {
-    pub fn new(settings: &Settings) -> Self {
-        Search {
-            client: None,
-            query_id: 0,
-            settings: settings.clone(),
-            #[cfg(unix)]
-            socket_path: settings.daemon.socket_path.clone(),
-            #[cfg(not(unix))]
-            tcp_port: settings.daemon.tcp_port,
-        }
-    }
-
+impl LazyClient {
+    /// Get the [`SearchClient`].
     #[instrument(skip_all, level = Level::TRACE, name = "get_daemon_client")]
-    async fn get_client(&mut self) -> Result<&mut SearchClient> {
+    pub async fn get(&mut self, params: &ClientParams) -> Result<&mut SearchClient> {
         // TODO: Ideally we would write this as follows, to avoid an `unwrap`:
         //
-        //     Ok(match self.client.as_mut() {
+        //     Ok(match self.0.as_mut() {
         //         Some(client) => client,
-        //         None => self.client.insert(self.connect().await?),
+        //         None => self.0.insert(self.connect(params).await?),
         //     })
         //
         // However, Rust's borrow checker incorrectly rejects this code. This will be fixed by
         // Polonius; see https://rust-lang.github.io/rust-project-goals/2026/polonius.html.
 
-        if self.client.is_none() {
-            return Ok(self.client.insert(self.connect().await?));
+        if self.0.is_none() {
+            return Ok(self.0.insert(self.connect(params).await?));
         }
-        Ok(self.client.as_mut().unwrap())
+        Ok(self.0.as_mut().unwrap())
     }
 
-    async fn connect(&self) -> Result<SearchClient> {
+    async fn connect(&self, params: &ClientParams) -> Result<SearchClient> {
         #[cfg(unix)]
-        return SearchClient::new(self.socket_path.clone()).await;
+        return SearchClient::new(params.socket_path.clone()).await;
 
         #[cfg(not(unix))]
-        SearchClient::new(self.tcp_port).await
+        SearchClient::new(params.tcp_port).await
     }
 
     fn should_retry(err: &eyre::Report) -> bool {
@@ -68,6 +51,65 @@ impl Search {
                 | DaemonClientErrorKind::Unavailable
                 | DaemonClientErrorKind::Unimplemented
         )
+    }
+
+    /// Call a method on [`SearchClient`], autostarting the daemon and retrying if necessary.
+    ///
+    /// `f` should call the appropriate method on the provided [`SearchClient`].
+    async fn try_with_autostart<F, R>(&mut self, params: &ClientParams, mut f: F) -> Result<R>
+    where
+        F: AsyncFnMut(&mut SearchClient) -> Result<R>,
+    {
+        let client = self.get(params).await?;
+        let err = match f(client).await {
+            Ok(result) => return Ok(result),
+            Err(err) => err,
+        };
+
+        if !(params.settings.daemon.autostart && Self::should_retry(&err)) {
+            return Err(err);
+        }
+
+        debug!("daemon not available, attempting auto-start");
+        self.0 = None;
+        daemon::ensure_daemon_running(&params.settings).await?;
+        let client = self.get(params).await?;
+        f(client).await
+    }
+}
+
+/// Required parameters to create a [`SearchClient`].
+///
+/// This is a separate type so that the params can be immutably borrowed multiple times
+/// concurrently; in particular, so that the params can be accessed even when [`LazyClient`] is
+/// mutably borrowed (see [`Search::prepare_index`]).
+struct ClientParams {
+    settings: Settings,
+    #[cfg(unix)]
+    socket_path: String,
+    #[cfg(not(unix))]
+    tcp_port: u64,
+}
+
+pub struct Search {
+    client: LazyClient,
+    params: ClientParams,
+    query_id: u64,
+}
+
+impl Search {
+    pub fn new(settings: &Settings) -> Self {
+        Search {
+            client: LazyClient::default(),
+            params: ClientParams {
+                settings: settings.clone(),
+                #[cfg(unix)]
+                socket_path: settings.daemon.socket_path.clone(),
+                #[cfg(not(unix))]
+                tcp_port: settings.daemon.tcp_port,
+            },
+            query_id: 0,
+        }
     }
 
     fn next_query_id(&mut self) -> u64 {
@@ -116,10 +158,20 @@ impl Search {
         Ok(db.query_history(&sql_query).await?)
     }
 
+    /// Tell the daemon to build the search index.
     pub async fn prepare_index(&mut self) -> Result<()> {
-        let shells = self.settings.search.shells.to_filter().to_vec_filter();
-        let client = self.get_client().await?;
-        client.prepare_index(shells).await
+        self.client
+            .try_with_autostart(&self.params, async |client| {
+                let shells = self
+                    .params
+                    .settings
+                    .search
+                    .shells
+                    .to_filter()
+                    .to_vec_filter();
+                client.prepare_index(shells).await
+            })
+            .await
     }
 }
 
@@ -143,35 +195,19 @@ impl SearchEngine for Search {
         let span =
             span!(Level::TRACE, "daemon_search.req_resp", query = %query, query_id = query_id);
 
-        let params = || SearchParams {
-            query: query.clone(),
-            query_id,
-            filter_mode: state.filter_mode,
-            context: Some(state.context.clone()),
-            shells: state.shells.to_filter().to_vec_filter(),
-        };
-
-        // Try to connect and search; if it fails with a retriable error,
-        // auto-start the daemon and retry once.
-        let first_attempt = async {
-            let client = self.get_client().await?;
-            client.search(params()).await
-        }
-        .await;
-
-        let mut stream = match first_attempt {
-            Ok(stream) => stream,
-            Err(err) if self.settings.daemon.autostart && Self::should_retry(&err) => {
-                debug!("daemon not available, attempting auto-start");
-                self.client = None;
-
-                daemon::ensure_daemon_running(&self.settings).await?;
-
-                let client = self.get_client().await?;
-                client.search(params()).await?
-            }
-            Err(err) => return Err(err),
-        };
+        let mut stream = self
+            .client
+            .try_with_autostart(&self.params, async |client| {
+                let search_params = SearchParams {
+                    query: query.clone(),
+                    query_id,
+                    filter_mode: state.filter_mode,
+                    context: Some(state.context.clone()),
+                    shells: state.shells.to_filter().to_vec_filter(),
+                };
+                client.search(search_params).await
+            })
+            .await?;
 
         let mut ids = Vec::with_capacity(200);
         span!(Level::TRACE, "daemon_search.resp")

--- a/crates/atuin/src/command/client/search/engines/daemon.rs
+++ b/crates/atuin/src/command/client/search/engines/daemon.rs
@@ -37,21 +37,28 @@ impl Search {
 
     #[instrument(skip_all, level = Level::TRACE, name = "get_daemon_client")]
     async fn get_client(&mut self) -> Result<&mut SearchClient> {
+        // TODO: Ideally we would write this as follows, to avoid an `unwrap`:
+        //
+        //     Ok(match self.client.as_mut() {
+        //         Some(client) => client,
+        //         None => self.client.insert(self.connect().await?),
+        //     })
+        //
+        // However, Rust's borrow checker incorrectly rejects this code. This will be fixed by
+        // Polonius; see https://rust-lang.github.io/rust-project-goals/2026/polonius.html.
+
         if self.client.is_none() {
-            self.connect().await?;
+            return Ok(self.client.insert(self.connect().await?));
         }
         Ok(self.client.as_mut().unwrap())
     }
 
-    async fn connect(&mut self) -> Result<()> {
+    async fn connect(&self) -> Result<SearchClient> {
         #[cfg(unix)]
-        let client = SearchClient::new(self.socket_path.clone()).await?;
+        return SearchClient::new(self.socket_path.clone()).await;
 
         #[cfg(not(unix))]
-        let client = SearchClient::new(self.tcp_port).await?;
-
-        self.client = Some(client);
-        Ok(())
+        SearchClient::new(self.tcp_port).await
     }
 
     fn should_retry(err: &eyre::Report) -> bool {
@@ -107,6 +114,12 @@ impl Search {
             placeholders.join(",")
         );
         Ok(db.query_history(&sql_query).await?)
+    }
+
+    pub async fn prepare_index(&mut self) -> Result<()> {
+        let shells = self.settings.search.shells.to_filter().to_vec_filter();
+        let client = self.get_client().await?;
+        client.prepare_index(shells).await
     }
 }
 

--- a/crates/atuin/src/shell/atuin.bash
+++ b/crates/atuin/src/shell/atuin.bash
@@ -719,3 +719,5 @@ if command -v __atuin_load_builtin_preexec > /dev/null; then
     # Free the function from memory
     unset -f __atuin_load_builtin_preexec
 fi
+
+(ATUIN_SHELL=bash atuin __internal prepare-search-index >/dev/null 2>&1 &)

--- a/crates/atuin/src/shell/atuin.fish
+++ b/crates/atuin/src/shell/atuin.fish
@@ -178,4 +178,4 @@ function _atuin_bind_up
 end
 
 ATUIN_SHELL=fish atuin __internal prepare-search-index &>/dev/null &
-disown
+disown 2>/dev/null

--- a/crates/atuin/src/shell/atuin.fish
+++ b/crates/atuin/src/shell/atuin.fish
@@ -176,3 +176,6 @@ function _atuin_bind_up
             up-or-search
     end
 end
+
+ATUIN_SHELL=fish atuin __internal prepare-search-index &>/dev/null &
+disown

--- a/crates/atuin/src/shell/atuin.nu
+++ b/crates/atuin/src/shell/atuin.nu
@@ -118,3 +118,13 @@ $env.config = (
 )
 
 $env.config = ($env.config | default [] keybindings)
+
+with-env { ATUIN_SHELL: nu } {
+    if (version).minor >= 104 or (version).major > 0 {
+        job spawn {
+            atuin __internal prepare-search-index | complete
+        } | ignore
+    } else {
+        do { atuin __internal prepare-search-index } | complete
+    }
+}

--- a/crates/atuin/src/shell/atuin.nu
+++ b/crates/atuin/src/shell/atuin.nu
@@ -119,12 +119,10 @@ $env.config = (
 
 $env.config = ($env.config | default [] keybindings)
 
-with-env { ATUIN_SHELL: nu } {
-    if (version).minor >= 104 or (version).major > 0 {
+if (version).minor >= 104 or (version).major > 0 {
+    with-env { ATUIN_SHELL: nu } {
         job spawn {
             atuin __internal prepare-search-index | complete
         } | ignore
-    } else {
-        do { atuin __internal prepare-search-index } | complete
     }
 }

--- a/crates/atuin/src/shell/atuin.ps1
+++ b/crates/atuin/src/shell/atuin.ps1
@@ -241,4 +241,24 @@ New-Module -Name Atuin -ScriptBlock {
     }
 
     Export-ModuleMember -Function @("Enable-AtuinSearchKeys", "PSConsoleHostReadLine")
+
+    try {
+        # Fire and forget the `prepare-search-index` command to avoid blocking the shell.
+        $process = New-Object System.Diagnostics.Process
+        $process.StartInfo.FileName = "atuin"
+        $process.StartInfo.Arguments = "__internal prepare-search-index"
+        $process.StartInfo.EnvironmentVariables["ATUIN_SHELL"] = "powershell"
+        $process.StartInfo.UseShellExecute = $false
+        $process.StartInfo.CreateNoWindow = $true
+        $process.StartInfo.RedirectStandardInput = $true
+        $process.StartInfo.RedirectStandardOutput = $true
+        $process.StartInfo.RedirectStandardError = $true
+        $process.Start() | Out-Null
+        $process.StandardInput.Close()
+        $process.BeginOutputReadLine()
+        $process.BeginErrorReadLine()
+    }
+    catch {
+        # Ignore errors from `prepare-search-index`; it's only an optimization.
+    }
 } | Import-Module -Global

--- a/crates/atuin/src/shell/atuin.xsh
+++ b/crates/atuin/src/shell/atuin.xsh
@@ -84,3 +84,25 @@ def _custom_keybindings(bindings, **kw):
         @bindings.add(Keys.Up, filter=should_search)
         def up_search(event):
             _search(event, extra_args=["--shell-up-key-binding"])
+
+
+def _atuin_prepare_search_index():
+    env = ${...}.detype()
+    env["ATUIN_SHELL"] = "xonsh"
+    try:
+        # Launch process in the background to avoid blocking the shell.
+        subprocess.Popen(
+            ["atuin", "__internal", "prepare-search-index"],
+            stdin=subprocess.DEVNULL,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            env=env,
+            start_new_session=True,
+        )
+    except OSError:
+        # Ignore errors; `prepare-search-index` is an optimization only.
+        pass
+
+
+_atuin_prepare_search_index()
+del _atuin_prepare_search_index

--- a/crates/atuin/src/shell/atuin.zsh
+++ b/crates/atuin/src/shell/atuin.zsh
@@ -250,3 +250,5 @@ zle -N atuin-up-search-viins _atuin_up_search_viins
 # These are compatibility widget names for "atuin <= 17.2.1" users.
 zle -N _atuin_search_widget _atuin_search
 zle -N _atuin_up_search_widget _atuin_up_search
+
+(ATUIN_SHELL=zsh atuin __internal prepare-search-index >/dev/null 2>&1 &)


### PR DESCRIPTION
Fixes #3857. In the shell init scripts, tell the daemon to build the search index so it's ready by the time the user executes the first query.

The daemon currently builds the index when it starts, but if a user has `search.shells = "auto"` in config.toml (the default), the daemon can't always know which shell the user is actually going to be using, and thus can't build the correct index.

The init script provided by `atuin init`, however, knows exactly which shell is in use, and thus can signal the daemon to build the correct index.

### Implementation details

This PR adds a new hidden command, `atuin __internal prepare-search-index`. If the user has selected the daemon-fuzzy engine, this command will send a new gRPC message, `PrepareIndexRequest`, to the daemon. The call to `atuin __internal prepare-search-index` is executed as a background job in the shell init scripts to avoid blocking the shell, and with stdout/stderr silenced.