### PR TITLE
fix(docs): don't say `enter_accept` defaults to true in example config.toml

### DIFF
--- a/crates/atuin-client/config.toml
+++ b/crates/atuin-client/config.toml
@@ -169,7 +169,7 @@
 ## 5. Stripe live/test keys
 # secrets_filter = true
 
-## Defaults to true. If enabled, upon hitting enter Atuin will immediately execute the command,
+## If enabled, upon hitting enter Atuin will immediately execute the command,
 ## whereas tab will put the command in the prompt for editing.
 ## If set to false, both enter and tab will place the command in the prompt for editing.
 ## This applies for new installs. Old installs will keep the old behaviour unless configured otherwise.


### PR DESCRIPTION
config.toml says `enter_accept` defaults to true, but it doesn't. The default config.toml explicitly sets to `enter_accept` to true, which is kind of like a default, but saying the default is true is misleading.

Note that the current behavior (`enter_accept` defaults to false but the default config.toml sets it to true) is intended behavior; see `crates/atuin-client/src/settings.rs`. This PR only updates the comment.

Fixes #3856