### PR TITLE
feat: Add turn time and tips to Atuin AI

### DIFF
--- a/crates/atuin-ai/src/commands/inline.rs
+++ b/crates/atuin-ai/src/commands/inline.rs
@@ -334,6 +334,7 @@ async fn run_inline_tui(
         cached_usage,
         initial_prompt,
         !usage_is_fresh,
+        settings.clone(),
     );
     let options =
         eye_declare::RunOptions::default().keyboard(eye_declare::KeyboardProtocol::Enhanced);

--- a/crates/atuin-ai/src/fsm/effects.rs
+++ b/crates/atuin-ai/src/fsm/effects.rs
@@ -76,6 +76,11 @@ pub(crate) enum Effect {
     /// Archive current session and start fresh (IO only — state already updated by FSM).
     ArchiveSession,
 
+    // ─── Turn lifecycle ─────────────────────────────────────────
+    /// A turn finished cleanly (stream done and all tools resolved, or the
+    /// turn ended in a suggested command). Not emitted on cancel or error.
+    TurnEnded,
+
     // ─── Timers ─────────────────────────────────────────────────
     /// Schedule a timer that fires an event after the given delay.
     ScheduleTimeout {

--- a/crates/atuin-ai/src/fsm/mod.rs
+++ b/crates/atuin-ai/src/fsm/mod.rs
@@ -476,7 +476,7 @@ impl AgentFsm {
                     input,
                 });
                 self.state = AgentState::Idle { confirmation: None };
-                vec![Effect::Persist]
+                vec![Effect::TurnEnded, Effect::Persist]
             }
 
             (
@@ -1169,7 +1169,7 @@ impl AgentFsm {
         } else {
             // No tools — turn is done, go idle
             self.state = AgentState::Idle { confirmation: None };
-            vec![Effect::Persist]
+            vec![Effect::TurnEnded, Effect::Persist]
         }
     }
 

--- a/crates/atuin-ai/src/fsm/tests.rs
+++ b/crates/atuin-ai/src/fsm/tests.rs
@@ -86,6 +86,65 @@ fn stream_done_without_tools_goes_idle(#[from(new_fsm)] mut fsm: AgentFsm) {
     )));
 }
 
+#[rstest]
+fn stream_done_without_tools_emits_turn_ended(#[from(new_fsm)] mut fsm: AgentFsm) {
+    fsm.handle(Event::UserSubmit("hello".into()));
+    fsm.handle(Event::StreamStarted);
+
+    let effects = fsm.handle(Event::StreamDone {
+        session_id: "s1".into(),
+    });
+
+    assert!(effects.iter().any(|e| matches!(e, Effect::TurnEnded)));
+}
+
+#[rstest]
+fn suggest_command_emits_turn_ended(#[from(new_fsm)] mut fsm: AgentFsm) {
+    fsm.handle(Event::UserSubmit("list files".into()));
+    fsm.handle(Event::StreamStarted);
+
+    let effects = fsm.handle(Event::SuggestCommand {
+        id: "t1".into(),
+        input: json!({"command": "ls"}),
+    });
+
+    assert_eq!(fsm.state, AgentState::Idle { confirmation: None });
+    assert!(effects.iter().any(|e| matches!(e, Effect::TurnEnded)));
+}
+
+#[rstest]
+fn turn_ended_waits_for_the_continuation_stream(#[from(new_fsm)] mut fsm: AgentFsm) {
+    fsm.handle(Event::UserSubmit("read".into()));
+    fsm.handle(Event::StreamStarted);
+    fsm.handle(Event::StreamToolCall {
+        id: "t1".into(),
+        name: "read_file".into(),
+        input: json!({"file_path": "/tmp/test.txt"}),
+    });
+    fsm.handle(Event::StreamDone {
+        session_id: "".into(),
+    });
+    fsm.handle(Event::PermissionResolved {
+        tool_id: "t1".into(),
+        response: PermissionResponse::Allowed,
+    });
+
+    // Tool completes → continuation starts; the turn is not over yet.
+    let effects = fsm.handle(Event::ToolExecutionDone {
+        tool_id: "t1".into(),
+        outcome: crate::tools::ToolOutcome::Success("contents".into()),
+        preview: None,
+    });
+    assert!(!effects.iter().any(|e| matches!(e, Effect::TurnEnded)));
+
+    // The continuation stream finishing ends the turn.
+    fsm.handle(Event::StreamStarted);
+    let effects = fsm.handle(Event::StreamDone {
+        session_id: "".into(),
+    });
+    assert!(effects.iter().any(|e| matches!(e, Effect::TurnEnded)));
+}
+
 // ============================================================================
 // Tool lifecycle
 // ============================================================================
@@ -301,6 +360,10 @@ fn cancel_during_streaming_goes_idle(#[from(new_fsm)] mut fsm: AgentFsm) {
     assert_eq!(fsm.state, AgentState::Idle { confirmation: None });
     assert!(effects.iter().any(|e| matches!(e, Effect::AbortStream)));
     assert!(effects.iter().any(|e| matches!(e, Effect::Persist)));
+    assert!(
+        !effects.iter().any(|e| matches!(e, Effect::TurnEnded)),
+        "cancel is not a clean turn end"
+    );
     // Partial text committed with cancel suffix
     assert!(fsm.ctx.events.iter().any(|e| matches!(
         e,

--- a/crates/atuin-ai/src/tui/app.rs
+++ b/crates/atuin-ai/src/tui/app.rs
@@ -982,7 +982,6 @@ impl AiApp {
         let tip_ctx = TipContext {
             settings: &self.settings,
             model_set: self.fsm.ctx.model.is_some(),
-            has_command: self.has_command(),
             has_context_files,
         };
         self.tips.next(&tip_ctx)

--- a/crates/atuin-ai/src/tui/app.rs
+++ b/crates/atuin-ai/src/tui/app.rs
@@ -1746,7 +1746,11 @@ mod tests {
             "responded line should clear on new turn:\n{screen}"
         );
         assert!(
-            screen.contains("└ Tip: /model switches models"),
+            screen.contains("└ Tip:"),
+            "second turn should show a tip\n{screen}"
+        );
+        assert!(
+            !screen.contains("└ Tip: press Esc to interrupt a response"),
             "second turn should pull the next tip:\n{screen}"
         );
     }

--- a/crates/atuin-ai/src/tui/app.rs
+++ b/crates/atuin-ai/src/tui/app.rs
@@ -974,9 +974,16 @@ impl AiApp {
 
     /// Pull the next relevant tip for a starting turn.
     fn pull_tip(&mut self) -> Option<&'static Tip> {
+        let has_context_files = self
+            .io
+            .as_ref()
+            .map(|io| io.user_context_cache.has_gathered())
+            .unwrap_or(None);
         let tip_ctx = TipContext {
             settings: &self.settings,
             model_set: self.fsm.ctx.model.is_some(),
+            has_command: self.has_command(),
+            has_context_files,
         };
         self.tips.next(&tip_ctx)
     }

--- a/crates/atuin-ai/src/tui/app.rs
+++ b/crates/atuin-ai/src/tui/app.rs
@@ -4,6 +4,9 @@
 use std::cell::RefCell;
 use std::collections::{HashMap, HashSet};
 use std::path::PathBuf;
+use std::time::{Duration, Instant};
+
+use atuin_client::settings::Settings;
 
 use crossterm::event::{KeyCode, KeyEventKind};
 use eye_declare::{
@@ -26,6 +29,7 @@ use crate::tui::recall::RecallState;
 use crate::tui::select::{SelectMsg, SelectState};
 use crate::tui::slash::{SlashCommandRegistry, SlashCommandSearchResult};
 use crate::tui::state::ConversationEvent;
+use crate::tui::tips::{Tip, TipContext, TipRotation};
 use crate::tui::view;
 use crate::tui::view::turn::{TurnBuilder, UiTurn, UiTurnKind};
 use crate::usage::UsageSnapshot;
@@ -138,6 +142,22 @@ pub(crate) struct AiApp {
     /// leading blank row).
     pushed_turns: usize,
     exiting: bool,
+    /// Config snapshot from startup; tip relevance predicates read it.
+    settings: Settings,
+    tips: TipRotation,
+    /// When the in-flight turn started; survives continuation streams.
+    turn_started_at: Option<Instant>,
+    /// The tip pulled for the in-flight turn, shown under the spinner.
+    turn_tip: Option<&'static Tip>,
+    /// The last turn's clean completion — "Responded in …" plus its tip.
+    /// Cleared when a new turn starts and on /new.
+    responded: Option<Responded>,
+}
+
+/// A completed turn's summary, rendered where the spinner used to be.
+struct Responded {
+    elapsed: Duration,
+    tip: Option<&'static Tip>,
 }
 
 impl AiApp {
@@ -151,6 +171,7 @@ impl AiApp {
         usage: Option<UsageSnapshot>,
         initial_prompt: Option<String>,
         usage_stale: bool,
+        settings: Settings,
     ) -> Self {
         Self {
             in_git_project: io.app_ctx.git_root.is_some(),
@@ -158,6 +179,8 @@ impl AiApp {
             usage,
             initial_prompt,
             usage_stale,
+            settings,
+            tips: TipRotation::new(),
             ..Self::headless(fsm, resume_notice, slash_registry, skill_names)
         }
     }
@@ -195,6 +218,11 @@ impl AiApp {
             pushed_events: 0,
             pushed_turns: 0,
             exiting: false,
+            settings: Settings::utc(),
+            tips: TipRotation::starting_at(0),
+            turn_started_at: None,
+            turn_tip: None,
+            responded: None,
         }
     }
 
@@ -307,8 +335,14 @@ impl AiApp {
         if let Event::ToolExecutionDone { tool_id, .. } = &event {
             self.tool_interrupts.remove(tool_id);
         }
+        let was_busy = self.is_busy();
         let effects = self.fsm.handle(event);
         tracing::trace!(?effects, state = ?self.fsm.state, "FSM transition");
+        if !was_busy && self.is_busy() {
+            self.turn_started_at = Some(Instant::now());
+            self.responded = None;
+            self.turn_tip = self.pull_tip();
+        }
         // The event list only shrinks when the FSM resets the session
         // (/new archives and clears it). What was pushed stays in
         // scrollback; the frontier restarts for the new list — a stale
@@ -341,7 +375,20 @@ impl AiApp {
                 // drops the HTTP stream. Esc-cancels-generation is this.
                 Effect::AbortStream => self.streaming = None,
                 Effect::Persist => self.persist(),
+                Effect::TurnEnded => {
+                    let elapsed = self
+                        .turn_started_at
+                        .take()
+                        .map(|t| t.elapsed())
+                        .unwrap_or_default();
+                    self.responded = Some(Responded {
+                        elapsed,
+                        tip: self.turn_tip.take(),
+                    });
+                }
                 Effect::ArchiveSession => {
+                    self.responded = None;
+                    self.turn_tip = None;
                     if let Some(io) = &self.io {
                         let _ = io.persist.send(PersistJob::Archive);
                     }
@@ -817,8 +864,6 @@ impl AiApp {
             ctx.push(view::turn_view(
                 turn,
                 self.pushed_turns == 0 && i == 0,
-                false,
-                false,
                 None,
             ));
             self.pushed_turns += 1;
@@ -925,6 +970,15 @@ impl AiApp {
             editor.clear();
             editor.insert_str(text);
         }
+    }
+
+    /// Pull the next relevant tip for a starting turn.
+    fn pull_tip(&mut self) -> Option<&'static Tip> {
+        let tip_ctx = TipContext {
+            settings: &self.settings,
+            model_set: self.fsm.ctx.model.is_some(),
+        };
+        self.tips.next(&tip_ctx)
     }
 
     fn submit(&mut self, ctx: &mut Ctx<'_, Self>) {
@@ -1129,23 +1183,22 @@ impl App for AiApp {
                 },
             )
             .children(turns.iter().enumerate().map(|(i, turn)| {
-                let status_text = ((i == last).then_some(status_text.as_deref())).flatten();
+                let working = (busy && i == last && asking.is_none()).then_some(view::Working {
+                    status: status_text.as_deref(),
+                    tip: self.turn_tip,
+                });
 
-                view::turn_view(
-                    turn,
-                    self.pushed_turns == 0 && i == 0,
-                    busy && i == last,
-                    asking.is_some(),
-                    status_text,
-                )
+                view::turn_view(turn, self.pushed_turns == 0 && i == 0, working)
             }))
             .when(needs_pending_banner, |c| {
-                c.child(view::agent_turn_view(
-                    &[],
-                    true,
-                    asking.is_some(),
-                    status_text.as_deref(),
-                ))
+                let working = asking.is_none().then_some(view::Working {
+                    status: status_text.as_deref(),
+                    tip: self.turn_tip,
+                });
+                c.child(view::agent_turn_view(&[], working))
+            })
+            .when_some(self.responded.as_ref(), |c, responded| {
+                c.child(view::responded_view(responded.elapsed, responded.tip))
             })
             .when_some(
                 match &self.fsm.state {
@@ -1645,6 +1698,94 @@ mod tests {
         let all = h.all_lines();
         assert!(all.contains("Atuin is a shell history tool."));
         assert!(!h.app().fsm.ctx.current_response.contains("Atuin"));
+    }
+
+    #[rstest]
+    fn tip_hangs_off_the_spinner_while_streaming() {
+        let mut h = Harness::new(app_with(AgentFsm::new(vec![], "t".into())));
+        h.type_str("hello");
+        h.press(KeyCode::Enter);
+        h.stream(Event::StreamStarted);
+
+        let screen = h.screen();
+        // Headless apps start the rotation at tip 0.
+        assert!(
+            screen.contains("└ Tip: press Esc to interrupt a response"),
+            "tip dropper missing under spinner:\n{screen}"
+        );
+    }
+
+    #[rstest]
+    fn responded_line_replaces_the_spinner_on_done() {
+        let mut h = Harness::new(app_with(AgentFsm::new(vec![], "t".into())));
+        h.type_str("hello");
+        h.press(KeyCode::Enter);
+        h.stream(Event::StreamStarted);
+        h.stream(Event::StreamChunk("Hi!".into()));
+        h.stream(Event::StreamDone {
+            session_id: "s1".into(),
+        });
+
+        let screen = h.screen();
+        assert!(
+            screen.contains("Responded in"),
+            "responded line missing:\n{screen}"
+        );
+        assert!(
+            screen.contains("└ Tip: press Esc to interrupt a response"),
+            "turn's tip should ride along onto the responded line:\n{screen}"
+        );
+
+        // The next submit clears it and rotates to a fresh tip.
+        h.type_str("more");
+        h.press(KeyCode::Enter);
+        h.stream(Event::StreamStarted);
+        let screen = h.screen();
+        assert!(
+            !screen.contains("Responded in"),
+            "responded line should clear on new turn:\n{screen}"
+        );
+        assert!(
+            screen.contains("└ Tip: /model switches models"),
+            "second turn should pull the next tip:\n{screen}"
+        );
+    }
+
+    #[rstest]
+    fn cancelled_turn_shows_no_responded_line() {
+        let mut h = Harness::new(app_with(AgentFsm::new(vec![], "t".into())));
+        h.type_str("hello");
+        h.press(KeyCode::Enter);
+        h.stream(Event::StreamStarted);
+        h.stream(Event::StreamChunk("partial".into()));
+        h.press(KeyCode::Esc);
+
+        assert!(!h.app().is_busy());
+        assert!(
+            !h.all_lines().contains("Responded in"),
+            "cancel is not a clean completion:\n{}",
+            h.all_lines()
+        );
+    }
+
+    #[rstest]
+    fn tips_disabled_in_settings_suppresses_the_tip_line() {
+        let mut app = app_with(AgentFsm::new(vec![], "t".into()));
+        app.settings.ai.tips = Some(false);
+        let mut h = Harness::new(app);
+        h.type_str("hello");
+        h.press(KeyCode::Enter);
+        h.stream(Event::StreamStarted);
+        h.stream(Event::StreamDone {
+            session_id: "s1".into(),
+        });
+
+        let all = h.all_lines();
+        assert!(!all.contains("Tip:"), "tips disabled but shown:\n{all}");
+        assert!(
+            all.contains("Responded in"),
+            "responded line should still show:\n{all}"
+        );
     }
 
     #[rstest]

--- a/crates/atuin-ai/src/tui/mod.rs
+++ b/crates/atuin-ai/src/tui/mod.rs
@@ -6,6 +6,7 @@ pub(crate) mod recall;
 pub(crate) mod select;
 pub(crate) mod slash;
 pub(crate) mod state;
+pub(crate) mod tips;
 pub(crate) mod tools_exec;
 pub(crate) mod view;
 

--- a/crates/atuin-ai/src/tui/tips.rs
+++ b/crates/atuin-ai/src/tui/tips.rs
@@ -1,0 +1,179 @@
+//! Feature tips surfaced under the turn spinner and the "Responded in"
+//! line. One tip is pulled per turn and rides through both.
+
+use atuin_client::settings::Settings;
+
+/// Facts a tip's relevance predicate may consult. Assembled fresh at each
+/// pull so predicates see current session state, not startup state.
+pub(crate) struct TipContext<'a> {
+    pub settings: &'a Settings,
+    /// A model is pinned — via `ai.model` or /model this session.
+    pub model_set: bool,
+}
+
+pub(crate) struct Tip {
+    /// Stable key — the hook for cross-session "already seen" persistence.
+    #[cfg_attr(not(test), allow(dead_code))]
+    pub id: &'static str,
+    /// Rendered after a "Tip: " prefix; keep it to one short sentence.
+    pub text: &'static str,
+    /// `None` = always relevant.
+    pub relevant: Option<fn(&TipContext) -> bool>,
+}
+
+pub(crate) const TIPS: &[Tip] = &[
+    Tip {
+        id: "esc-interrupt",
+        text: "press Esc to interrupt a response",
+        relevant: None,
+    },
+    Tip {
+        id: "model",
+        text: "Atuin AI offers multiple models; try a new one with /model",
+        relevant: Some(|ctx| !ctx.model_set),
+    },
+    Tip {
+        id: "recall",
+        text: "Up/Down recall messages you've sent this session",
+        relevant: None,
+    },
+    Tip {
+        id: "send-cwd",
+        text: "You can ensure Atuin AI always knows your cwd with `atuin config set ai.opening.send_cwd true`",
+        relevant: Some(|ctx| {
+            let ai = &ctx.settings.ai;
+            !ai.opening.send_cwd.or(ai.send_cwd).unwrap_or(false)
+        }),
+    },
+    Tip {
+        id: "new-session",
+        text: "/new archives this session and starts fresh",
+        relevant: None,
+    },
+    Tip {
+        id: "send-last-command",
+        text: "Send your last command to Atuin AI automatically with `atuin config set ai.opening.send_last_command true`",
+        relevant: Some(|ctx| !ctx.settings.ai.opening.send_last_command.unwrap_or(false)),
+    },
+    Tip {
+        id: "newline",
+        text: "Shift+Enter or Ctrl+J inserts a newline",
+        relevant: None,
+    },
+];
+
+/// Walks `TIPS` in order, skipping tips whose predicate says no. The start
+/// offset is randomized per session so long-running users don't always see
+/// the head of the list.
+pub(crate) struct TipRotation {
+    cursor: usize,
+}
+
+impl TipRotation {
+    pub(crate) fn new() -> Self {
+        let nanos = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.subsec_nanos() as usize)
+            .unwrap_or(0);
+        Self::starting_at(nanos % TIPS.len().max(1))
+    }
+
+    /// Fixed start offset, for deterministic tests.
+    pub(crate) fn starting_at(cursor: usize) -> Self {
+        Self { cursor }
+    }
+
+    /// The next relevant tip, or `None` when tips are disabled or nothing
+    /// currently applies.
+    pub(crate) fn next(&mut self, ctx: &TipContext) -> Option<&'static Tip> {
+        if !ctx.settings.ai.tips.unwrap_or(true) {
+            return None;
+        }
+        for i in 0..TIPS.len() {
+            let idx = (self.cursor + i) % TIPS.len();
+            let tip = &TIPS[idx];
+            if tip.relevant.is_none_or(|applies| applies(ctx)) {
+                self.cursor = idx + 1;
+                return Some(tip);
+            }
+        }
+        None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn settings() -> Settings {
+        Settings::utc()
+    }
+
+    fn ctx(settings: &Settings) -> TipContext<'_> {
+        TipContext {
+            settings,
+            model_set: false,
+        }
+    }
+
+    #[test]
+    fn tips_have_unique_ids() {
+        let mut ids: Vec<_> = TIPS.iter().map(|t| t.id).collect();
+        ids.sort_unstable();
+        ids.dedup();
+        assert_eq!(ids.len(), TIPS.len(), "duplicate tip ids");
+    }
+
+    #[test]
+    fn rotation_walks_in_order_and_wraps() {
+        let settings = settings();
+        let mut rotation = TipRotation::starting_at(0);
+        let first = rotation.next(&ctx(&settings)).unwrap().id;
+        for _ in 1..TIPS.len() {
+            rotation.next(&ctx(&settings)).unwrap();
+        }
+        assert_eq!(
+            rotation.next(&ctx(&settings)).unwrap().id,
+            first,
+            "should wrap to the start"
+        );
+    }
+
+    #[test]
+    fn irrelevant_tips_are_skipped() {
+        let settings = settings();
+        let model_idx = TIPS.iter().position(|t| t.id == "model").unwrap();
+        let mut rotation = TipRotation::starting_at(model_idx);
+
+        let tip = rotation
+            .next(&TipContext {
+                settings: &settings,
+                model_set: true,
+            })
+            .unwrap();
+        assert_ne!(tip.id, "model", "model tip should be skipped when set");
+    }
+
+    #[test]
+    fn send_cwd_tip_respects_both_config_spellings() {
+        let mut settings = settings();
+        let idx = TIPS.iter().position(|t| t.id == "send-cwd").unwrap();
+
+        settings.ai.opening.send_cwd = Some(true);
+        let mut rotation = TipRotation::starting_at(idx);
+        assert_ne!(rotation.next(&ctx(&settings)).unwrap().id, "send-cwd");
+
+        settings.ai.opening.send_cwd = None;
+        settings.ai.send_cwd = Some(true);
+        let mut rotation = TipRotation::starting_at(idx);
+        assert_ne!(rotation.next(&ctx(&settings)).unwrap().id, "send-cwd");
+    }
+
+    #[test]
+    fn disabled_setting_suppresses_all_tips() {
+        let mut settings = settings();
+        settings.ai.tips = Some(false);
+        let mut rotation = TipRotation::starting_at(0);
+        assert!(rotation.next(&ctx(&settings)).is_none());
+    }
+}

--- a/crates/atuin-ai/src/tui/tips.rs
+++ b/crates/atuin-ai/src/tui/tips.rs
@@ -9,8 +9,6 @@ pub(crate) struct TipContext<'a> {
     pub settings: &'a Settings,
     /// A model is pinned — via `ai.model` or /model this session.
     pub model_set: bool,
-    /// A suggested command is present in the current conversation.
-    pub has_command: bool,
     /// Whether context files (`TERMINAL.md`) were gathered for this
     /// invocation. `None` = not gathered yet (first request still in flight).
     pub has_context_files: Option<bool>,
@@ -144,7 +142,6 @@ mod tests {
         TipContext {
             settings,
             model_set: false,
-            has_command: false,
             has_context_files: None,
         }
     }
@@ -191,7 +188,6 @@ mod tests {
             .next(&TipContext {
                 settings: &settings,
                 model_set: true,
-                has_command: false,
                 has_context_files: None,
             })
             .unwrap();

--- a/crates/atuin-ai/src/tui/tips.rs
+++ b/crates/atuin-ai/src/tui/tips.rs
@@ -9,6 +9,11 @@ pub(crate) struct TipContext<'a> {
     pub settings: &'a Settings,
     /// A model is pinned — via `ai.model` or /model this session.
     pub model_set: bool,
+    /// A suggested command is present in the current conversation.
+    pub has_command: bool,
+    /// Whether context files (`TERMINAL.md`) were gathered for this
+    /// invocation. `None` = not gathered yet (first request still in flight).
+    pub has_context_files: Option<bool>,
 }
 
 pub(crate) struct Tip {
@@ -28,18 +33,34 @@ pub(crate) const TIPS: &[Tip] = &[
         relevant: None,
     },
     Tip {
+        id: "ctrl-c-interrupt",
+        text: "Ctrl+C interrupts a running command",
+        relevant: Some(|ctx| {
+            ctx.settings
+                .ai
+                .capabilities
+                .enable_command_execution
+                .unwrap_or(true)
+        }),
+    },
+    Tip {
         id: "model",
-        text: "Atuin AI offers multiple models; try a new one with /model",
+        text: "Atuin AI supports multiple models; try a new one with /model",
         relevant: Some(|ctx| !ctx.model_set),
     },
     Tip {
         id: "recall",
-        text: "Up/Down recall messages you've sent this session",
+        text: "Press Up/Down to recall messages you've sent this session",
+        relevant: None,
+    },
+    Tip {
+        id: "tab-insert",
+        text: "Press Tab to place a suggested command in your prompt instead of running it",
         relevant: None,
     },
     Tip {
         id: "send-cwd",
-        text: "You can ensure Atuin AI always knows your cwd with `atuin config set ai.opening.send_cwd true`",
+        text: "You can include your working directory in AI requests automatically: `atuin config set ai.opening.send_cwd true`",
         relevant: Some(|ctx| {
             let ai = &ctx.settings.ai;
             !ai.opening.send_cwd.or(ai.send_cwd).unwrap_or(false)
@@ -54,6 +75,16 @@ pub(crate) const TIPS: &[Tip] = &[
         id: "send-last-command",
         text: "Send your last command to Atuin AI automatically with `atuin config set ai.opening.send_last_command true`",
         relevant: Some(|ctx| !ctx.settings.ai.opening.send_last_command.unwrap_or(false)),
+    },
+    Tip {
+        id: "reload-context",
+        text: "Run /reload to re-read your TERMINAL.md files mid-session",
+        relevant: Some(|ctx| ctx.has_context_files == Some(true)),
+    },
+    Tip {
+        id: "add-terminal-md",
+        text: "Add a TERMINAL.md to your project to give Atuin AI persistent context",
+        relevant: Some(|ctx| ctx.has_context_files == Some(false)),
     },
     Tip {
         id: "newline",
@@ -113,6 +144,8 @@ mod tests {
         TipContext {
             settings,
             model_set: false,
+            has_command: false,
+            has_context_files: None,
         }
     }
 
@@ -127,16 +160,25 @@ mod tests {
     #[test]
     fn rotation_walks_in_order_and_wraps() {
         let settings = settings();
-        let mut rotation = TipRotation::starting_at(0);
-        let first = rotation.next(&ctx(&settings)).unwrap().id;
-        for _ in 1..TIPS.len() {
-            rotation.next(&ctx(&settings)).unwrap();
-        }
-        assert_eq!(
-            rotation.next(&ctx(&settings)).unwrap().id,
-            first,
-            "should wrap to the start"
+        let c = ctx(&settings);
+        // Some tips are context-gated, so the rotation only cycles through
+        // the ones that apply to this context.
+        let relevant_ids: Vec<&str> = TIPS
+            .iter()
+            .filter(|t| t.relevant.is_none_or(|applies| applies(&c)))
+            .map(|t| t.id)
+            .collect();
+        assert!(
+            relevant_ids.len() >= 2,
+            "test needs at least two relevant tips"
         );
+
+        let mut rotation = TipRotation::starting_at(0);
+        // Pull two full cycles: tips come back in order, then wrap.
+        for &expected in relevant_ids.iter().chain(&relevant_ids) {
+            let tip = rotation.next(&c).unwrap();
+            assert_eq!(tip.id, expected);
+        }
     }
 
     #[test]
@@ -149,6 +191,8 @@ mod tests {
             .next(&TipContext {
                 settings: &settings,
                 model_set: true,
+                has_command: false,
+                has_context_files: None,
             })
             .unwrap();
         assert_ne!(tip.id, "model", "model tip should be skipped when set");

--- a/crates/atuin-ai/src/tui/view/mod.rs
+++ b/crates/atuin-ai/src/tui/view/mod.rs
@@ -16,6 +16,7 @@ use crate::fsm::tools::{InterruptReason, TrackedTool};
 use crate::tools::{ClientToolCall, HistorySearchFilterMode, ToolPreview};
 use crate::tui::events::PermissionResult;
 use crate::tui::select;
+use crate::tui::tips::Tip;
 
 pub(crate) mod input;
 mod trunc;
@@ -69,19 +70,24 @@ fn md(source: impl Into<String>) -> Markdown {
         .streaming(true)
 }
 
-/// Render one turn. `first` suppresses the leading blank row; `busy` shows
-/// the working spinner on the last agent turn; `showing_ui` suppresses it
-/// while a prompt (e.g. permission select) is on screen.
+/// The in-flight indicator hung off the last agent turn: the streaming
+/// status label plus an optional feature tip. `None` = no spinner (turn
+/// sealed, idle, or a prompt like the permission select is on screen).
+pub(crate) struct Working<'a> {
+    pub status: Option<&'a str>,
+    pub tip: Option<&'static Tip>,
+}
+
+/// Render one turn. `first` suppresses the leading blank row; `working`
+/// shows the spinner (and tip) on the last agent turn while streaming.
 pub(crate) fn turn_view(
     turn: &UiTurn,
     first: bool,
-    busy: bool,
-    showing_ui: bool,
-    status_text: Option<&str>,
+    working: Option<Working<'_>>,
 ) -> AnyElement<'static> {
     match &turn.kind {
         UiTurnKind::User { events } => user_turn_view(events, first),
-        UiTurnKind::Agent { events } => agent_turn_view(events, busy, showing_ui, status_text),
+        UiTurnKind::Agent { events } => agent_turn_view(events, working),
         UiTurnKind::OutOfBand { events } => out_of_band_turn_view(events),
     }
 }
@@ -104,9 +110,7 @@ pub(crate) fn user_turn_view(events: &[UiEvent], first_turn: bool) -> AnyElement
 
 pub(crate) fn agent_turn_view(
     events: &[UiEvent],
-    busy: bool,
-    showing_ui: bool,
-    status_text: Option<&str>,
+    working: Option<Working<'_>>,
 ) -> AnyElement<'static> {
     let label_style = Style::default()
         .fg(Color::Yellow)
@@ -120,9 +124,9 @@ pub(crate) fn agent_turn_view(
                 .when(i > 0, |c| c.child(text("")))
                 .child(event_view(event))
         }))
-        .when(busy && !showing_ui, |c| {
+        .when_some(working, |c, working| {
             c.child(
-                spinner(status_text.unwrap_or(""))
+                spinner(working.status.unwrap_or(""))
                     .spinner_style(
                         Style::default()
                             .fg(Color::Yellow)
@@ -136,8 +140,47 @@ pub(crate) fn agent_turn_view(
                     .pad_left(2)
                     .pad_top(1),
             )
+            .when_some(working.tip, |c, tip| c.child(tip_line(tip).pad_left(2)))
         })
         .any()
+}
+
+/// The post-turn line that takes the spinner's place once a turn completes:
+/// how long the response took, with the turn's tip dropped underneath.
+pub(crate) fn responded_view(
+    elapsed: std::time::Duration,
+    tip: Option<&'static Tip>,
+) -> AnyElement<'static> {
+    let dim = Style::default().fg(Color::DarkGray);
+    col()
+        .child(text(format!("Responded in {}", format_elapsed(elapsed))).style(dim))
+        .when_some(tip, |c, tip| c.child(tip_line(tip)))
+        .pad_left(2)
+        .pad_top(1)
+        .any()
+}
+
+/// Tree-connector row for a tip: `└ Tip: …`. Callers pad to align it under
+/// the line it hangs off.
+fn tip_line(tip: &'static Tip) -> impl Element + 'static {
+    let dim = Style::default().fg(Color::DarkGray);
+    row()
+        .fixed(2, text("└ ").style(dim))
+        .fill(text(format!("Tip: {}", tip.text)).style(dim))
+}
+
+/// Humanized elapsed time: sub-minute in seconds ("3.2 seconds",
+/// "42 seconds"), longer as "2m 05s".
+fn format_elapsed(elapsed: std::time::Duration) -> String {
+    let secs = elapsed.as_secs_f64();
+    if secs < 10.0 {
+        format!("{secs:.1} seconds")
+    } else if secs < 60.0 {
+        format!("{} seconds", secs.round() as u64)
+    } else {
+        let total = elapsed.as_secs();
+        format!("{}m {:02}s", total / 60, total % 60)
+    }
 }
 
 pub(crate) fn out_of_band_turn_view(events: &[UiEvent]) -> AnyElement<'static> {
@@ -829,4 +872,19 @@ pub(crate) fn status_bar_view(
 /// `~`-abbreviated).
 fn format_path_for_display(path: &std::path::Path) -> String {
     path.display_rich().relative_to_cwd().tilde_me().to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::format_elapsed;
+    use std::time::Duration;
+
+    #[test]
+    fn elapsed_formats_by_magnitude() {
+        assert_eq!(format_elapsed(Duration::from_millis(600)), "0.6 seconds");
+        assert_eq!(format_elapsed(Duration::from_secs_f64(3.24)), "3.2 seconds");
+        assert_eq!(format_elapsed(Duration::from_secs_f64(42.6)), "43 seconds");
+        assert_eq!(format_elapsed(Duration::from_secs(65)), "1m 05s");
+        assert_eq!(format_elapsed(Duration::from_secs(154)), "2m 34s");
+    }
 }

--- a/crates/atuin-ai/src/tui/view/mod.rs
+++ b/crates/atuin-ai/src/tui/view/mod.rs
@@ -882,8 +882,8 @@ mod tests {
     #[test]
     fn elapsed_formats_by_magnitude() {
         assert_eq!(format_elapsed(Duration::from_millis(600)), "0.6 seconds");
-        assert_eq!(format_elapsed(Duration::from_secs_f64(3.24)), "3.2 seconds");
-        assert_eq!(format_elapsed(Duration::from_secs_f64(42.6)), "43 seconds");
+        assert_eq!(format_elapsed(Duration::from_millis(3240)), "3.2 seconds");
+        assert_eq!(format_elapsed(Duration::from_millis(42600)), "43 seconds");
         assert_eq!(format_elapsed(Duration::from_secs(65)), "1m 05s");
         assert_eq!(format_elapsed(Duration::from_secs(154)), "2m 34s");
     }

--- a/crates/atuin-ai/src/user_context/mod.rs
+++ b/crates/atuin-ai/src/user_context/mod.rs
@@ -80,6 +80,14 @@ impl UserContextCache {
         slot.contexts = None;
     }
 
+    /// Whether context files have been gathered and cached for this
+    /// invocation. `None` when nothing has been gathered yet (no request has
+    /// completed). Doesn't trigger a gather.
+    pub fn has_gathered(&self) -> Option<bool> {
+        let slot = self.lock();
+        slot.contexts.as_ref().map(|ctxs| !ctxs.is_empty())
+    }
+
     /// A poisoned lock means another thread panicked while holding it, but
     /// the cached value is only ever replaced wholesale — it can't be torn.
     /// Recover with the inner value rather than propagating the panic.

--- a/crates/atuin-client/src/settings.rs
+++ b/crates/atuin-client/src/settings.rs
@@ -685,6 +685,9 @@ pub struct Ai {
     /// Tool capability flags.
     #[serde(default)]
     pub capabilities: AiCapabilities,
+
+    /// Whether the AI TUI surfaces feature tips. `None` = enabled.
+    pub tips: Option<bool>,
 }
 
 #[derive(Default, Clone, Debug, Deserialize, Serialize)]

--- a/docs/docs/ai/settings.md
+++ b/docs/docs/ai/settings.md
@@ -58,6 +58,12 @@ Enables YOLO mode, which automatically allows all permission checks. **Use this 
 
 This setting _doesn't_ enable any capabilities. Instead, it only bypasses any permission checks.
 
+### `tips`
+
+Default: `true`
+
+Display tips in Atuin AI at the bottom of agent turns.
+
 ## Capabilities
 
 Settings that control what capabilities are sent to the LLM, which the LLM uses to understand what features the client has available. These are specified under `[ai.capabilities]`.


### PR DESCRIPTION
This PR adds a tip system to Atuin AI, allowing the app to call out lesser known features.

`crates/atuin-ai/src/tui/tips.rs` defines `TIPS`, which is a `const &[Tip]`. Each tip has an ID, text, and a relevance callback (if it turns false, the tip is skipped).

This PR has a few default tips, but we'll certainly want to think through these.

Additionally, Atuin AI now ends a turn with the total time; this is where the tip hangs when a turn is complete.

<img width="405" height="144" alt="image" src="https://github.com/user-attachments/assets/a7d22620-8e98-4375-9bdf-4b139d053bb8" />

Closes ATU-550