### PR TITLE
feat: add devcontainers

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,28 @@
+FROM mcr.microsoft.com/devcontainers/rust:1-bookworm
+
+# --- system + build deps ---
+# protobuf-compiler: atuin daemon (tonic/prost) needs protoc at build time.
+# mold: fast linker, big win on iterative Rust builds.
+RUN apt-get update && apt-get install -y --no-install-recommends \
+      openssh-server zsh tmux ripgrep fd-find jq \
+      protobuf-compiler mold clang \
+      sqlite3 libssl-dev pkg-config && \
+    rm -rf /var/lib/apt/lists/* && \
+    mkdir -p /run/sshd
+
+# --- tailscale ---
+RUN curl -fsSL https://tailscale.com/install.sh | sh
+
+# --- rust conveniences ---
+RUN rustup component add rust-analyzer clippy rustfmt && \
+    cargo install cargo-nextest --locked || true
+
+# Use mold by default
+RUN mkdir -p /root/.cargo && printf '[target.x86_64-unknown-linux-gnu]\nlinker = "clang"\nrustflags = ["-C", "link-arg=-fuse-ld=mold"]\n' >> /root/.cargo/config.toml
+
+# --- shell setup (atuin itself is installed by the local feature) ---
+RUN chsh -s /usr/bin/zsh root
+
+COPY entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
+ENTRYPOINT ["/entrypoint.sh"]

--- a/.devcontainer/devcontainer-lock.json
+++ b/.devcontainer/devcontainer-lock.json
@@ -1,0 +1,9 @@
+{
+  "features": {
+    "ghcr.io/devcontainers/features/github-cli:1": {
+      "version": "1.1.0",
+      "resolved": "ghcr.io/devcontainers/features/github-cli@sha256:d22f50b70ed75339b4eed1ba9ecde3a1791f90e88d37936517e3bace0bbad671",
+      "integrity": "sha256:d22f50b70ed75339b4eed1ba9ecde3a1791f90e88d37936517e3bace0bbad671"
+    }
+  }
+}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,41 @@
+{
+  "name": "atuin-dev",
+  "build": {
+    "dockerfile": "Dockerfile",
+    "context": "."
+  },
+  "remoteUser": "root",
+  "overrideCommand": false,
+  "workspaceFolder": "/workspaces/atuin",
+
+  // Features are applied at `devcontainer build` time, so they bake into the
+  // prebuilt image. The local ./features/atuin is the seed of a future
+  // published ghcr.io/atuinsh/features/atuin.
+  "features": {
+    "./features/atuin": {},
+    "ghcr.io/devcontainers/features/github-cli:1": {}
+    // docker-in-docker works fine under kata (real VM kernel); under runc it
+    // needs a privileged pod. Enable only on the kata template:
+    // "ghcr.io/devcontainers/features/docker-in-docker:2": {}
+  },
+
+  // IMPORTANT: lifecycle hooks (postCreateCommand etc.) only run when the
+  // devcontainer CLI/editor *launches* the container. Our sandboxes are
+  // launched by agent-sandbox as plain pods, so hooks never fire there.
+  // Rule: anything the sandbox needs goes in the Dockerfile or entrypoint.sh,
+  // never in a lifecycle hook.
+
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "rust-lang.rust-analyzer",
+        "tamasfe.even-better-toml",
+        "vadimcn.vscode-lldb"
+      ]
+    }
+  },
+
+  "containerEnv": {
+    "CARGO_TARGET_DIR": "/workspaces/.cargo-target"
+  }
+}

--- a/.devcontainer/entrypoint.sh
+++ b/.devcontainer/entrypoint.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+set -e
+
+# ---- tailscale: userspace networking, ephemeral node, tailscale ssh ----
+tailscaled --tun=userspace-networking --statedir=/var/lib/ts-state &
+tailscale up \
+  --authkey="${TS_AUTHKEY}" \
+  --ssh \
+  --hostname="sbx-${SANDBOX_NAME:-$(hostname)}" \
+  || echo "WARN: tailscale up failed; falling back to sshd/exec"
+
+# ---- sshd: editor/fallback path alongside tailscale ssh ----
+/usr/sbin/sshd
+
+# ---- atuin: login + daemon on the fixed socket ----
+mkdir -p /root/.local/run
+if ! atuin status >/dev/null 2>&1; then
+  atuin login -u "${ATUIN_USER}" -p "${ATUIN_PASS}" -k "${ATUIN_KEY}" \
+    || echo "WARN: atuin login failed; check atuin-creds secret"
+fi
+nohup atuin daemon > /root/.local/run/daemon.log 2>&1 &
+
+# ---- optional: dotfiles ----
+# If DOTFILES_REPO is set (via template env), clone + run install script once.
+if [ -n "${DOTFILES_REPO:-}" ] && [ ! -d /root/.dotfiles ]; then
+  git clone --depth 1 "${DOTFILES_REPO}" /root/.dotfiles && \
+    ( cd /root/.dotfiles && ( ./install.sh || ./setup.sh || true ) )
+fi
+
+# ---- main process ----
+# Swap for the pty-proxy / `atuin lab share` invocation when testing share.
+exec sleep infinity

--- a/.devcontainer/features/atuin/devcontainer-feature.json
+++ b/.devcontainer/features/atuin/devcontainer-feature.json
@@ -1,0 +1,14 @@
+{
+  "id": "atuin",
+  "version": "0.1.0",
+  "name": "Atuin",
+  "description": "Installs atuin, shell hooks for zsh/bash, and a sandbox-safe daemon config (fixed socket path, no XDG_RUNTIME_DIR dependency).",
+  "options": {
+    "syncAddress": {
+      "type": "string",
+      "default": "",
+      "description": "Override sync server address (empty = default)"
+    }
+  },
+  "installsAfter": ["ghcr.io/devcontainers/features/common-utils"]
+}

--- a/.devcontainer/features/atuin/install.sh
+++ b/.devcontainer/features/atuin/install.sh
@@ -1,0 +1,27 @@
+#!/bin/sh
+# Feature install script — runs at image build time as root.
+set -e
+
+USER_HOME="/root"
+
+# setup.atuin.sh is a bash script; Debian's /bin/sh is dash and chokes on its
+# bash-isms ("Bad substitution"). Pipe to bash explicitly.
+curl --proto '=https' --tlsv1.2 -LsSf https://setup.atuin.sh | bash
+
+# shell hooks
+echo 'eval "$('"$USER_HOME"'/.atuin/bin/atuin init zsh)"' >>"$USER_HOME/.zshrc"
+echo 'eval "$('"$USER_HOME"'/.atuin/bin/atuin init bash)"' >>"$USER_HOME/.bashrc"
+
+# PATH for non-login shells (kubectl exec)
+ln -sf "$USER_HOME/.atuin/bin/atuin" /usr/local/bin/atuin
+
+# sandbox-safe config: fixed daemon socket, since pods have no logind
+# session and therefore no XDG_RUNTIME_DIR.
+mkdir -p "$USER_HOME/.config/atuin"
+cat >"$USER_HOME/.config/atuin/config.toml" <<TOML
+$([ -n "${SYNCADDRESS}" ] && echo "sync_address = \"${SYNCADDRESS}\"")
+
+[daemon]
+enabled = true
+socket_path = "/root/.local/run/atuin.sock"
+TOML

--- a/.github/workflows/devcontainer.yaml
+++ b/.github/workflows/devcontainer.yaml
@@ -1,0 +1,49 @@
+name: build-devcontainer
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - '.devcontainer/**'
+      - '.github/workflows/devcontainer.yaml'
+  pull_request:
+    paths:
+      - '.devcontainer/**'
+      - '.github/workflows/devcontainer.yaml'
+  workflow_dispatch:
+
+jobs:
+  build:
+    concurrency:
+      group: ${{ github.ref }}-devcontainer
+      cancel-in-progress: true
+    permissions:
+      packages: write
+      contents: read
+
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Get Repo Owner
+        run: echo "REPO_OWNER=$(echo ${{ github.repository_owner }} | tr '[:upper:]' '[:lower:]')" >> $GITHUB_ENV
+
+      - uses: docker/setup-buildx-action@v3
+
+      - name: Login to container registry
+        uses: docker/login-action@v4
+        with:
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+          registry: ghcr.io
+
+      # Builds via the devcontainer CLI rather than plain `docker build`, so the
+      # `features` in devcontainer.json (including the local ./features/atuin)
+      # get baked into the published image.
+      - name: Build and push
+        uses: devcontainers/ci@v0.3
+        with:
+          imageName: ghcr.io/${{ env.REPO_OWNER }}/atuin-devcontainer
+          imageTag: latest,${{ github.sha }}
+          cacheFrom: ghcr.io/${{ env.REPO_OWNER }}/atuin-devcontainer:latest
+          push: ${{ github.event_name == 'pull_request' && 'never' || 'always' }}


### PR DESCRIPTION
I want to be able to easily spin up remote devenvs, so here I am adding a devcontainer spec. I imagine it will grow a LOT soon, but this is just to test the machinery.

## Checks
- [ ] I am happy for maintainers to push small adjustments to this PR, to speed up the review cycle
- [ ] I have checked that there are no existing pull requests for the same thing

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/atuinsh/codesmith/atuin/pr/3871"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788725102&installation_model_id=431321&pr_number=3871&repository=atuinsh%2Fatuin&return_to=https%3A%2F%2Fgithub.com%2Fatuinsh%2Fatuin%2Fpull%2F3871&signature=dbf1d1d5cefa9269c31ce3f6d42618579e8fca00790947322a39234ae0bcf661"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->