### PR TITLE
feat: add a bunch more secret patterns

### DIFF
--- a/crates/atuin-client/src/secrets.rs
+++ b/crates/atuin-client/src/secrets.rs
@@ -102,10 +102,12 @@ pub static SECRET_PATTERNS: &[(&str, &str, TestValue)] = &[
     ),
     (
         "Slack webhook",
-        "T[a-zA-Z0-9_]{8}/B[a-zA-Z0-9_]{8}/[a-zA-Z0-9_]{24}",
-        TestValue::Single(
+        "T[a-zA-Z0-9_]{8,12}/B[a-zA-Z0-9_]{8,12}/[a-zA-Z0-9_]{24}",
+        TestValue::Multiple(&[
             "https://hooks.slack.com/services/T00000000/B00000000/XXXXXXXXXXXXXXXXXXXXXXXX",
-        ),
+            // Slack has since grown its team/bot IDs past the original 9 characters
+            "https://hooks.slack.com/services/T00000000A00/B00000000A00/XXXXXXXXXXXXXXXXXXXXXXXX",
+        ]),
     ),
     (
         "Stripe test key",
@@ -132,6 +134,144 @@ pub static SECRET_PATTERNS: &[(&str, &str, TestValue)] = &[
         "pul-[0-9a-f]{40}",
         TestValue::Single("pul-683c2770662c51d960d72ec27613be7653c5cb26"),
     ),
+    (
+        // Covers Anthropic (sk-ant-…), OpenAI (sk-proj-…, sk-…), OpenRouter (sk-or-v1-…)
+        // and the many smaller providers that copied the prefix.
+        "`sk-` prefixed API key",
+        "sk-[A-Za-z0-9_-]{32,}",
+        TestValue::Multiple(&[
+            "sk-ant-api03-0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000AA",
+            "sk-proj-000000000000000000000000000000000000000000000000",
+            "sk-or-v1-0000000000000000000000000000000000000000000000000000000000000000",
+        ]),
+    ),
+    (
+        "Atuin Hub API token",
+        "atapi_[0-9a-f]{48}",
+        TestValue::Single("atapi_000000000000000000000000000000000000000000000000"),
+    ),
+    (
+        "Tailscale key",
+        "tskey-(?:auth|api|client|scim)-[A-Za-z0-9]{10,}-[A-Za-z0-9]{10,}",
+        TestValue::Single("tskey-auth-k0000000000CNTRL-m00000000000000000000000000"),
+    ),
+    (
+        "PlanetScale password/token",
+        "pscale_(?:pw|tkn|oauth)_[A-Za-z0-9_-]{32,}",
+        TestValue::Single("pscale_pw_00000000000000000000000000000000000000"),
+    ),
+    (
+        "Google OAuth client secret",
+        "GOCSPX-[A-Za-z0-9_-]{28}",
+        TestValue::Single("GOCSPX-0000000000000000000000000000"),
+    ),
+    (
+        "PostHog API key",
+        "ph[cxsp]_[A-Za-z0-9]{40,}",
+        TestValue::Single("phc_0000000000000000000000000000000000000000000"),
+    ),
+    (
+        "Resend API key",
+        "re_[A-Za-z0-9]{8,}_[A-Za-z0-9]{20,}",
+        TestValue::Single("re_00000000_000000000000000000000000"),
+    ),
+    (
+        "Tigris storage key",
+        "tid_[A-Za-z0-9_-]{32,}|tsec_[A-Za-z0-9_-]{48,}",
+        TestValue::Multiple(&[
+            "tid_eh_00000000000000000000000000000000000000000000000",
+            "tsec_000000000000000000000000000000000000000000000000000000000000000000000000",
+        ]),
+    ),
+    (
+        "Fireworks AI API key",
+        "fw_[A-Za-z0-9]{20,}",
+        TestValue::Single("fw_00000000000000000000000"),
+    ),
+    (
+        "Firecrawl API key",
+        "fc-[0-9a-f]{32}",
+        TestValue::Single("fc-00000000000000000000000000000000"),
+    ),
+    (
+        "JSON web token",
+        r"\beyJ[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}",
+        TestValue::Single(
+            "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIwMDAwMDAwMCJ9.0000000000000000000000000000000",
+        ),
+    ),
+    (
+        "Phoenix signed token",
+        r"SFMyNTY\.[A-Za-z0-9_-]{16,}\.[A-Za-z0-9_-]{16,}",
+        TestValue::Single(
+            "SFMyNTY.g2gDbQAAACQwMDAwMDAwMC0wMDAwbgYA00000000dwhpbmZpbml0eQ.0000000000000000000000000000000000000000000",
+        ),
+    ),
+    (
+        "Connection URI with inline credentials",
+        r"\b(?:postgres|postgresql|mysql|mariadb|mongodb\+srv|mongodb|rediss|redis|amqps|amqp|clickhouse|https|http)://[^\s:@/]+:[^\s:@/]+@",
+        TestValue::Multiple(&[
+            "psql 'postgres://someuser:hunter2@db.example.com:6432/mydb?sslmode=require'",
+            "http://default:hunter2@10.0.0.1:8123/analytics",
+        ]),
+    ),
+    (
+        "Authorization header with a literal token",
+        r"(?i)authorization:\s*(?:bearer|basic|token)\s+[A-Za-z0-9][A-Za-z0-9._~+/=-]{15,}",
+        TestValue::Single(
+            r#"curl -H "Authorization: Bearer 000000000000000000000000000000000000""#,
+        ),
+    ),
+    (
+        // `kubectl create secret generic … --from-literal=…` puts the secret value
+        // straight on the command line.
+        "Kubernetes secret literal",
+        r"--from-literal[= ]",
+        TestValue::Single("kubectl create secret generic mysecret --from-literal=password=hunter2"),
+    ),
+    (
+        // `kubectl` is required so this doesn't swallow every command that merely
+        // mentions creating a secret.
+        "Kubernetes secret create/patch",
+        r"kubectl\s.*\b(?:create|patch|replace|edit)\s+secrets?\b",
+        TestValue::Multiple(&[
+            "kubectl -n hub create secret generic hub-secret",
+            "kubectl -n hub patch secret hub-secret --type merge -p '{}'",
+        ]),
+    ),
+    (
+        // Catch-all for the common `NAME=value` shape, whichever vendor it belongs to.
+        "Secret-shaped environment variable assignment",
+        r"[A-Z][A-Z0-9_]*(?:SECRET|TOKEN|PASSWORD|PASSWD|API_?KEY|ACCESS_KEY|CREDENTIALS?)[A-Z0-9_]*\s*=\s*\S",
+        TestValue::Multiple(&[
+            "export ANTHROPIC_API_KEY=hunter2",
+            "PGPASSWORD=hunter2 psql -h db.example.com",
+            "--from-literal=OAUTH_GH_CLIENT_SECRET='hunter2'",
+        ]),
+    ),
+];
+
+/// Commands that must **not** be caught by [`SECRET_PATTERNS`].
+///
+/// The secrets filter drops matching commands from history entirely, so a false
+/// positive silently loses real history. Anything added here is a shape that
+/// looks secret-adjacent but isn't.
+#[cfg(test)]
+static NON_SECRETS: &[&str] = &[
+    "export PATH=\"$PATH:~/bin/\"",
+    "export RUSTC_WRAPPER=sccache",
+    "echo $ANTHROPIC_API_KEY",
+    "unset GITHUB_TOKEN",
+    "psql 'postgres://localhost:5432/atuin_dev'",
+    "psql 'postgres://ellie@localhost:5432/atuin_dev'",
+    "curl -H \"Authorization: Bearer $FIRECRAWL_API\" http://localhost:4000",
+    "curl -i -H \"Authorization: Bearer ${GITHUB_TEST}\" https://api.github.com/repos/atuinsh/infra",
+    "kubectl -n hub get secret hub-secret -o yaml",
+    "kubectl patch pvc server-volume-0 -n monitoring -p '{\"spec\":{}}'",
+    "docker run -u 1000:1000 --rm alpine",
+    "git commit -m 'create secret scanning for the new endpoint'",
+    "git clone git@github.com:nixpulvis/oursh.git",
+    "cargo run -p atuin -- search -i",
 ];
 
 /// The `regex` expressions from [`SECRET_PATTERNS`] compiled into a `RegexSet`.
@@ -145,7 +285,19 @@ mod tests {
     use regex::Regex;
     use rstest::rstest;
 
-    use crate::secrets::{SECRET_PATTERNS, TestValue};
+    use crate::secrets::{NON_SECRETS, SECRET_PATTERNS, SECRET_PATTERNS_RE, TestValue};
+
+    #[test]
+    fn non_secrets() {
+        for command in NON_SECRETS {
+            let matches = SECRET_PATTERNS_RE.matches(command);
+            let names: Vec<_> = matches.into_iter().map(|i| SECRET_PATTERNS[i].0).collect();
+            assert!(
+                names.is_empty(),
+                "\"{command}\" is not a secret, but matched: {names:?}"
+            );
+        }
+    }
 
     #[rstest]
     fn secrets(#[values(false, true)] embed: bool) {


### PR DESCRIPTION
All of these secrets are invalid. Shush scanners and agents.

## Checks
- [ ] I am happy for maintainers to push small adjustments to this PR, to speed up the review cycle
- [ ] I have checked that there are no existing pull requests for the same thing

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/atuinsh/codesmith/atuin/pr/3872"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788727830&installation_model_id=431321&pr_number=3872&repository=atuinsh%2Fatuin&return_to=https%3A%2F%2Fgithub.com%2Fatuinsh%2Fatuin%2Fpull%2F3872&signature=c2d7f131c2596507aca51e25400ac0639ed60aaa2808739eb986be47e3b8618d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->