### PR TITLE
devcontainer: temporarily drop tailscale and atuin

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -10,9 +10,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     rm -rf /var/lib/apt/lists/* && \
     mkdir -p /run/sshd
 
-# --- tailscale ---
-RUN curl -fsSL https://tailscale.com/install.sh | sh
-
 # --- rust conveniences ---
 RUN rustup component add rust-analyzer clippy rustfmt && \
     cargo install cargo-nextest --locked || true
@@ -20,7 +17,7 @@ RUN rustup component add rust-analyzer clippy rustfmt && \
 # Use mold by default
 RUN mkdir -p /root/.cargo && printf '[target.x86_64-unknown-linux-gnu]\nlinker = "clang"\nrustflags = ["-C", "link-arg=-fuse-ld=mold"]\n' >> /root/.cargo/config.toml
 
-# --- shell setup (atuin itself is installed by the local feature) ---
+# --- shell setup ---
 RUN chsh -s /usr/bin/zsh root
 
 COPY entrypoint.sh /entrypoint.sh

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -12,7 +12,8 @@
   // prebuilt image. The local ./features/atuin is the seed of a future
   // published ghcr.io/atuinsh/features/atuin.
   "features": {
-    "./features/atuin": {},
+    // "./features/atuin" temporarily disabled — see entrypoint.sh. The feature
+    // itself is still in-tree; re-enable by uncommenting.
     "ghcr.io/devcontainers/features/github-cli:1": {}
     // docker-in-docker works fine under kata (real VM kernel); under runc it
     // needs a privileged pod. Enable only on the kata template:

--- a/.devcontainer/entrypoint.sh
+++ b/.devcontainer/entrypoint.sh
@@ -1,24 +1,13 @@
 #!/bin/bash
 set -e
 
-# ---- tailscale: userspace networking, ephemeral node, tailscale ssh ----
-tailscaled --tun=userspace-networking --statedir=/var/lib/ts-state &
-tailscale up \
-  --authkey="${TS_AUTHKEY}" \
-  --ssh \
-  --hostname="sbx-${SANDBOX_NAME:-$(hostname)}" \
-  || echo "WARN: tailscale up failed; falling back to sshd/exec"
+# NOTE: tailscale and atuin are temporarily removed. Tailscale blocked here
+# waiting on tailnet device approval, and `atuin login` blocked prompting for a
+# 2FA code — both hung the entrypoint before it reached sshd, so the pod came up
+# Ready but with nothing running. Access is via `kubectl exec` / sshd meanwhile.
 
-# ---- sshd: editor/fallback path alongside tailscale ssh ----
+# ---- sshd: access path ----
 /usr/sbin/sshd
-
-# ---- atuin: login + daemon on the fixed socket ----
-mkdir -p /root/.local/run
-if ! atuin status >/dev/null 2>&1; then
-  atuin login -u "${ATUIN_USER}" -p "${ATUIN_PASS}" -k "${ATUIN_KEY}" \
-    || echo "WARN: atuin login failed; check atuin-creds secret"
-fi
-nohup atuin daemon > /root/.local/run/daemon.log 2>&1 &
 
 # ---- optional: dotfiles ----
 # If DOTFILES_REPO is set (via template env), clone + run install script once.

--- a/.devcontainer/features/atuin/install.sh
+++ b/.devcontainer/features/atuin/install.sh
@@ -8,8 +8,11 @@ USER_HOME="/root"
 # bash-isms ("Bad substitution"). Pipe to bash explicitly.
 curl --proto '=https' --tlsv1.2 -LsSf https://setup.atuin.sh | bash
 
-# shell hooks
+# shell hooks. The $(atuin init …) must stay literal so it runs when the shell
+# starts, not here; only $USER_HOME is spliced in.
+# shellcheck disable=SC2016
 echo 'eval "$('"$USER_HOME"'/.atuin/bin/atuin init zsh)"' >>"$USER_HOME/.zshrc"
+# shellcheck disable=SC2016
 echo 'eval "$('"$USER_HOME"'/.atuin/bin/atuin init bash)"' >>"$USER_HOME/.bashrc"
 
 # PATH for non-login shells (kubectl exec)


### PR DESCRIPTION
Remove both tailscale and atuin from the devcontainer, for now. blocking boot

<!-- Thank you for making a PR! Bug fixes are always welcome, but if you're adding a new feature or changing an existing one, we'd really appreciate if you open an issue, post on the forum, or drop in on Discord -->

## Checks
- [ ] I am happy for maintainers to push small adjustments to this PR, to speed up the review cycle
- [ ] I have checked that there are no existing pull requests for the same thing

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/atuinsh/codesmith/atuin/pr/3873"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788728260&installation_model_id=431321&pr_number=3873&repository=atuinsh%2Fatuin&return_to=https%3A%2F%2Fgithub.com%2Fatuinsh%2Fatuin%2Fpull%2F3873&signature=1c65566370ff54559930adaa70819668d1083b5265142333be04e7168528f250"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->