### PR TITLE
feat: add windows/powershell highlighting

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -306,6 +306,7 @@ dependencies = [
  "tree-sitter",
  "tree-sitter-bash",
  "tree-sitter-fish",
+ "tree-sitter-powershell",
  "unicode-width 0.2.2",
  "url",
  "uuid",
@@ -6168,6 +6169,16 @@ name = "tree-sitter-language"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "009994f150cc0cd50ff54917d5bc8bffe8cad10ca10d81c34da2ec421ae61782"
+
+[[package]]
+name = "tree-sitter-powershell"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3faf304d44b9ddd4a7d97804bb8de7daf564336dd5a526dc6de5b39238243022"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
 
 [[package]]
 name = "tree_magic_mini"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -75,6 +75,7 @@ tree-sitter-bash = "0.25.1"
 crypto_secretbox = "0.1.1"
 tiny-bip39 = "2"
 tree-sitter-fish = "3.6.0"
+tree-sitter-powershell = "0.26.4"
 rmp = { version = "0.8.14" }
 ratatui = "0.30.0"
 sql-builder = "3"

--- a/crates/atuin-ai/src/user_context/interpolate.rs
+++ b/crates/atuin-ai/src/user_context/interpolate.rs
@@ -235,6 +235,7 @@ End.",
     )]
     #[case::multiple("A: !`echo one` B: !`echo two`", "A: one B: two")]
     #[tokio::test]
+    #[cfg(not(target_os = "windows"))]
     async fn interpolate_cases(#[case] source: &str, #[case] expected: &str) {
         assert_eq!(interpolate(source, "sh").await, expected);
     }

--- a/crates/atuin-ai/src/user_context/mod.rs
+++ b/crates/atuin-ai/src/user_context/mod.rs
@@ -168,6 +168,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[cfg(not(target_os = "windows"))]
     async fn invalidate_during_gather_is_not_lost() {
         let dir = tempfile::tempdir().unwrap();
         let file = dir.path().join("TERMINAL.md");
@@ -201,6 +202,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[cfg(not(target_os = "windows"))]
     async fn slow_gather_does_not_overwrite_concurrent_result() {
         let dir = tempfile::tempdir().unwrap();
         let file = dir.path().join("TERMINAL.md");

--- a/crates/atuin/Cargo.toml
+++ b/crates/atuin/Cargo.toml
@@ -136,11 +136,12 @@ daemonize = "0.5.0"
 # Enable tree-sitter shell parsing on platforms where tree-sitter's bundled C
 # compiles cleanly. tree-sitter 0.26's portable/endian.h fails on illumos,
 # Windows cross-compiles, and potentially other exotic targets.
-[target.'cfg(any(target_os = "linux", target_os = "macos"))'.dependencies]
+[target.'cfg(any(target_os = "linux", target_os = "macos", target_os = "windows"))'.dependencies]
 atuin-ai = { path = "../atuin-ai", version = "18.20.0-beta.3", optional = true, default-features = false, features = ["tree-sitter"] }
 tree-sitter = { workspace = true }
 tree-sitter-bash = { workspace = true }
 tree-sitter-fish = { workspace = true }
+tree-sitter-powershell = { workspace = true }
 
 [target.'cfg(windows)'.dependencies]
 windows-sys = { version = "0.61.2", features = ["Win32_System_Console"] }

--- a/crates/atuin/src/command/client/search/syntax.rs
+++ b/crates/atuin/src/command/client/search/syntax.rs
@@ -10,7 +10,7 @@ use atuin_client::theme::Meaning;
 ///
 /// Rows are re-classified on every redraw while typing or scrolling, so
 /// results are memoized; repeat frames cost a hash lookup, not a parse.
-#[cfg(any(target_os = "linux", target_os = "macos"))]
+#[cfg(any(target_os = "linux", target_os = "macos", target_os = "windows"))]
 pub fn classify(cmd: &str, shell: Option<&str>) -> Vec<Meaning> {
     use std::cell::RefCell;
     use std::collections::HashMap;
@@ -31,16 +31,17 @@ pub fn classify(cmd: &str, shell: Option<&str>) -> Vec<Meaning> {
     })
 }
 
-#[cfg(any(target_os = "linux", target_os = "macos"))]
+#[cfg(any(target_os = "linux", target_os = "macos", target_os = "windows"))]
 fn parse(cmd: &str, shell: Option<&str>) -> Vec<Meaning> {
     let mut meanings = vec![Meaning::Base; cmd.len()];
 
     let language: tree_sitter::Language = match shell {
         Some("fish") => tree_sitter_fish::language(),
+        Some("powershell" | "pwsh") => tree_sitter_powershell::LANGUAGE.into(),
         // POSIX-ish shells; entries from before the shell was recorded
         // get bash as the best guess
         None | Some("bash" | "zsh" | "sh") => tree_sitter_bash::LANGUAGE.into(),
-        // nu, xonsh, powershell, ...: no grammar available
+        // nu, xonsh, ...: no grammar available
         Some(_) => return meanings,
     };
 
@@ -48,17 +49,21 @@ fn parse(cmd: &str, shell: Option<&str>) -> Vec<Meaning> {
     if parser.set_language(&language).is_ok()
         && let Some(tree) = parser.parse(cmd, None)
     {
-        walk(tree.root_node(), cmd.as_bytes(), &mut meanings);
+        if language.name() == Some("powershell") {
+            highlight_powershell(tree.root_node(), cmd.as_bytes(), &mut meanings);
+        } else {
+            walk(tree.root_node(), cmd.as_bytes(), &mut meanings);
+        }
     }
     meanings
 }
 
-#[cfg(not(any(target_os = "linux", target_os = "macos")))]
+#[cfg(not(any(target_os = "linux", target_os = "macos", target_os = "windows")))]
 pub fn classify(cmd: &str, _shell: Option<&str>) -> Vec<Meaning> {
     vec![Meaning::Base; cmd.len()]
 }
 
-#[cfg(any(target_os = "linux", target_os = "macos"))]
+#[cfg(any(target_os = "linux", target_os = "macos", target_os = "windows"))]
 fn walk(node: tree_sitter::Node, src: &[u8], meanings: &mut [Meaning]) {
     let meaning = match node.kind() {
         "comment" => Some(Meaning::SyntaxComment),
@@ -114,7 +119,45 @@ fn walk(node: tree_sitter::Node, src: &[u8], meanings: &mut [Meaning]) {
     }
 }
 
-#[cfg(all(test, any(target_os = "linux", target_os = "macos")))]
+#[cfg(any(target_os = "linux", target_os = "macos", target_os = "windows"))]
+fn highlight_powershell(node: tree_sitter::Node, src: &[u8], meanings: &mut [Meaning]) {
+    // PowerShell has a different syntax than most shells, so it's handled separately.
+
+    static HIGHLIGHTS_QUERY: std::sync::LazyLock<tree_sitter::Query> =
+        std::sync::LazyLock::new(|| {
+            let language: tree_sitter::Language = tree_sitter_powershell::LANGUAGE.into();
+            tree_sitter::Query::new(&language, tree_sitter_powershell::HIGHLIGHTS_QUERY)
+                .expect("invalid PowerShell highlights query")
+        });
+
+    use tree_sitter::StreamingIterator;
+
+    let mut cursor = tree_sitter::QueryCursor::new();
+    let mut captures = cursor.captures(&HIGHLIGHTS_QUERY, node, src);
+
+    while let Some((m, capture_index)) = captures.next() {
+        let capture = m.captures[*capture_index];
+        let capture_name = HIGHLIGHTS_QUERY.capture_names()[capture.index as usize];
+
+        let meaning = match capture_name {
+            "comment" => Meaning::SyntaxComment,
+            "function" => Meaning::SyntaxCommand,
+            "string" => Meaning::SyntaxString,
+            "operator" | "delimiter" | "keyword" => Meaning::SyntaxOperator,
+            "variable" | "type" | "property" => Meaning::SyntaxVariable,
+            _ => continue, // ignored: array, assignvalue, number
+        };
+
+        if let Some(range) = meanings.get_mut(capture.node.byte_range()) {
+            range.fill(meaning);
+        }
+    }
+}
+
+#[cfg(all(
+    test,
+    any(target_os = "linux", target_os = "macos", target_os = "windows")
+))]
 mod tests {
     use super::{Meaning, classify};
     use rstest::rstest;
@@ -147,9 +190,9 @@ mod tests {
     #[case::fish_set("set -x PATH $PATH", Some("fish"), "cccaffaaaaaavvvvv")]
     #[case::fish_subshell("echo (date) | grep foo", Some("fish"), "ccccaoccccoaoaccccaaaa")]
     #[case::fish_string(r#"echo "hi $name""#, Some("fish"), "ccccassssvvvvvs")]
+    #[case::powershell("$v = rg -i 'foo' $f", Some("powershell"), "vvaaaccaaaasssssavv")]
     #[case::zsh_uses_bash("ls -la", Some("zsh"), "ccafff")]
     #[case::nu_plain("ls -la", Some("nu"), "aaaaaa")]
-    #[case::powershell_plain("ls -la", Some("powershell"), "aaaaaa")]
     fn classify_renders(#[case] cmd: &str, #[case] shell: Option<&str>, #[case] expected: &str) {
         assert_eq!(render_shell(cmd, shell), expected);
     }
@@ -158,7 +201,7 @@ mod tests {
     fn odd_inputs_do_not_panic(
         // unterminated string, non-bash syntax, empty, multibyte
         #[values("echo 'oops", "if (= 1 2) { }", "", "echo héllo")] cmd: &str,
-        #[values(None, Some("fish"), Some("nu"))] shell: Option<&str>,
+        #[values(None, Some("fish"), Some("nu"), Some("powershell"))] shell: Option<&str>,
     ) {
         assert_eq!(classify(cmd, shell).len(), cmd.len());
     }

--- a/docs/docs/configuration/config.md
+++ b/docs/docs/configuration/config.md
@@ -1255,7 +1255,7 @@ The default colors are ANSI palette colors, so they automatically match your
 terminal's color scheme. They can also be customized via the `Syntax*` keys in
 a [theme](../guide/theming.md).
 
-Not available on platforms where tree-sitter doesn't build (for example, Windows),
+Not available on platforms where tree-sitter doesn't build,
 so commands are shown unhighlighted there.
 
 ```toml


### PR DESCRIPTION
This adds highlighting on Windows along with the PowerShell syntax:

<img width="875" height="510" alt="image" src="https://github.com/user-attachments/assets/f210e01f-2041-4087-a8a5-2e13485d06da" />

I don't know why there were comments saying that tree-sitter doesn't build on Windows, or why there's no PowerShell grammar. The build went smoothly both on Windows and Linux, and I simply referenced the `tree-sitter-powershell` crate. ¯\\\_(ツ)\_/¯

I'm not entirely satisfied with this yet, since `Meaning::SyntaxFlag` isn't supported. I'll handle that later.

## Checks
- [x] I am happy for maintainers to push small adjustments to this PR, to speed up the review cycle
- [x] I have checked that there are no existing pull requests for the same thing
