### PR TITLE
fix(ai): answer unrecognized tool calls with an error result

### DIFF
--- a/crates/atuin-ai/src/fsm/mod.rs
+++ b/crates/atuin-ai/src/fsm/mod.rs
@@ -809,11 +809,26 @@ impl AgentFsm {
         // Parse the tool call
         let tool = match crate::tools::ClientToolCall::try_from((name.as_str(), &input)) {
             Ok(tool) => tool,
-            Err(_) => {
-                // Unknown tool — push as event but don't track
-                self.ctx
-                    .events
-                    .push(ConversationEvent::ToolCall { id, name, input });
+            Err(err) => {
+                // Unknown tool or malformed input — answer with an error
+                // result rather than leaving the tool_use dangling. Some
+                // providers reject a history where a tool call has no
+                // result, and the error text lets the model correct itself.
+                self.ctx.events.push(ConversationEvent::ToolCall {
+                    id: id.clone(),
+                    name,
+                    input,
+                });
+                self.ctx.events.push(ConversationEvent::ToolResult {
+                    tool_use_id: id.clone(),
+                    content: format!("Error: {err}"),
+                    is_error: true,
+                    remote: false,
+                    content_length: None,
+                });
+                // Counts toward the turn like any resolved tool, so the
+                // continuation fires and the model can retry immediately.
+                self.ctx.current_turn_tool_ids.push(id);
                 return vec![];
             }
         };
@@ -828,7 +843,7 @@ impl AgentFsm {
                 input,
             });
             self.ctx.events.push(ConversationEvent::ToolResult {
-                tool_use_id: id,
+                tool_use_id: id.clone(),
                 content: format!(
                     "Tool not enabled: capability '{required_cap}' was not advertised by this client"
                 ),
@@ -836,6 +851,7 @@ impl AgentFsm {
                 remote: false,
                 content_length: None,
             });
+            self.ctx.current_turn_tool_ids.push(id);
             return vec![];
         }
 

--- a/crates/atuin-ai/src/fsm/mod.rs
+++ b/crates/atuin-ai/src/fsm/mod.rs
@@ -28,6 +28,14 @@ use tools::{ToolManager, ToolState};
 // State
 // ============================================================================
 
+/// Result contents for tool calls the FSM resolves without executing them.
+/// These are persisted in the event log, and the transcript view matches on
+/// them to label the failure ("denied", "cancelled"), so they live as
+/// constants rather than inline strings.
+pub(crate) const RESULT_USER_CANCELLED: &str = "Error: user cancelled this operation";
+pub(crate) const RESULT_DENIED_BY_RULES: &str = "Permission denied on the user's system";
+pub(crate) const RESULT_DENIED_BY_USER: &str = "Permission denied by the user";
+
 /// The discrete states of the agent FSM.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) enum AgentState {
@@ -626,7 +634,7 @@ impl AgentFsm {
                     }
                     self.ctx.events.push(ConversationEvent::ToolResult {
                         tool_use_id: id.clone(),
-                        content: "Error: user cancelled this operation".to_string(),
+                        content: RESULT_USER_CANCELLED.to_string(),
                         is_error: true,
                         remote: false,
                         content_length: None,
@@ -925,7 +933,7 @@ impl AgentFsm {
                 tracked.state = ToolState::Denied;
                 self.ctx.events.push(ConversationEvent::ToolResult {
                     tool_use_id: tool_id,
-                    content: "Permission denied on the user's system".to_string(),
+                    content: RESULT_DENIED_BY_RULES.to_string(),
                     is_error: true,
                     remote: false,
                     content_length: None,
@@ -1001,7 +1009,7 @@ impl AgentFsm {
                 tracked.state = ToolState::Denied;
                 self.ctx.events.push(ConversationEvent::ToolResult {
                     tool_use_id: tool_id,
-                    content: "Permission denied by the user".to_string(),
+                    content: RESULT_DENIED_BY_USER.to_string(),
                     is_error: true,
                     remote: false,
                     content_length: None,

--- a/crates/atuin-ai/src/fsm/tests.rs
+++ b/crates/atuin-ai/src/fsm/tests.rs
@@ -548,6 +548,96 @@ fn permission_deny_completes_turn_and_continues(#[from(new_fsm)] mut fsm: AgentF
 }
 
 // ============================================================================
+// Unknown tools
+// ============================================================================
+
+#[rstest]
+fn unknown_tool_call_gets_error_result(#[from(new_fsm)] mut fsm: AgentFsm) {
+    fsm.handle(Event::UserSubmit("hello".into()));
+    fsm.handle(Event::StreamStarted);
+    fsm.handle(Event::StreamToolCall {
+        id: "t1".into(),
+        name: "execute_socket_command".into(),
+        input: json!({"command": "ls"}),
+    });
+    let effects = fsm.handle(Event::StreamDone {
+        session_id: "".into(),
+    });
+
+    // Both the call and an error result are recorded, so the history sent
+    // upstream never contains a dangling tool_use.
+    assert!(fsm.ctx.events.iter().any(|e| matches!(
+        e,
+        ConversationEvent::ToolCall { id, name, .. } if id == "t1" && name == "execute_socket_command"
+    )));
+    assert!(fsm.ctx.events.iter().any(|e| matches!(
+        e,
+        ConversationEvent::ToolResult { tool_use_id, is_error: true, .. } if tool_use_id == "t1"
+    )));
+
+    // The tool never enters the execution lifecycle, but it resolves the
+    // turn like a completed tool: the continuation starts immediately so
+    // the model sees the error and can retry.
+    assert!(fsm.ctx.tools.get("t1").is_none());
+    assert!(matches!(
+        fsm.state,
+        AgentState::Turn {
+            stream: StreamPhase::Connecting
+        }
+    ));
+    assert!(
+        effects
+            .iter()
+            .any(|e| matches!(e, Effect::StartStream { .. }))
+    );
+}
+
+#[rstest]
+fn unknown_tool_alongside_real_tool_waits_for_both(#[from(new_fsm)] mut fsm: AgentFsm) {
+    fsm.handle(Event::UserSubmit("hello".into()));
+    fsm.handle(Event::StreamStarted);
+    fsm.handle(Event::StreamToolCall {
+        id: "t1".into(),
+        name: "read_file".into(),
+        input: json!({"file_path": "/tmp/test.txt"}),
+    });
+    fsm.handle(Event::StreamToolCall {
+        id: "t2".into(),
+        name: "execute_socket_command".into(),
+        input: json!({"command": "ls"}),
+    });
+    fsm.handle(Event::PermissionResolved {
+        tool_id: "t1".into(),
+        response: PermissionResponse::Allowed,
+    });
+    fsm.handle(Event::StreamDone {
+        session_id: "".into(),
+    });
+
+    // Still waiting on the real tool — the pre-answered unknown call must
+    // not complete the turn early.
+    assert!(matches!(
+        fsm.state,
+        AgentState::Turn {
+            stream: StreamPhase::Done
+        }
+    ));
+
+    let effects = fsm.handle(Event::ToolExecutionDone {
+        tool_id: "t1".into(),
+        outcome: crate::tools::ToolOutcome::Success("contents".into()),
+        preview: None,
+    });
+
+    // Both results now ride the same continuation.
+    assert!(
+        effects
+            .iter()
+            .any(|e| matches!(e, Effect::StartStream { .. }))
+    );
+}
+
+// ============================================================================
 // Shell execution timeouts
 // ============================================================================
 

--- a/crates/atuin-ai/src/fsm/tools.rs
+++ b/crates/atuin-ai/src/fsm/tools.rs
@@ -137,10 +137,14 @@ impl ToolManager {
 
     /// True if all tools from the given set of IDs have reached a terminal state.
     /// Returns true for an empty set (vacuously — no tools to wait for).
+    ///
+    /// IDs with no tracker entry count as resolved: those calls were answered
+    /// synchronously at receipt (unknown tool, missing capability) and never
+    /// enter the execution lifecycle.
     pub fn all_resolved(&self, tool_ids: &[String]) -> bool {
         tool_ids
             .iter()
-            .all(|id| self.get(id).is_some_and(|t| t.is_resolved()))
+            .all(|id| self.get(id).is_none_or(|t| t.is_resolved()))
     }
 
     /// Find the first tool awaiting user permission.

--- a/crates/atuin-ai/src/tui/view/mod.rs
+++ b/crates/atuin-ai/src/tui/view/mod.rs
@@ -201,10 +201,24 @@ fn tool_status_view(name: &str, status: &ToolResultStatus) -> AnyElement<'static
     match status {
         ToolResultStatus::Pending => tool_spinner(format!("Running: {name}"), false).any(),
         ToolResultStatus::Success => tool_spinner(format!("Ran: {name}"), true).any(),
-        ToolResultStatus::Error => text("✗ ")
+        ToolResultStatus::Error { content } => text("✗ ")
             .style(Style::default().fg(Color::Red))
-            .span(format!("{name}: failed"), Style::default().fg(Color::Red))
+            .span(
+                format!("{name}: {}", error_label(content)),
+                Style::default().fg(Color::Red),
+            )
             .any(),
+    }
+}
+
+/// Label for a failed tool call, derived from the result content. The FSM's
+/// no-execution results are stable constants, so exact matches are safe;
+/// anything else (execution errors, unknown tools) is a generic failure.
+fn error_label(content: &str) -> &'static str {
+    match content {
+        crate::fsm::RESULT_DENIED_BY_USER | crate::fsm::RESULT_DENIED_BY_RULES => "denied",
+        crate::fsm::RESULT_USER_CANCELLED => "cancelled",
+        _ => "failed",
     }
 }
 
@@ -400,10 +414,10 @@ fn tool_status_line(
         ToolResultStatus::Success => {
             tool_spinner(format!("{did}: {display_path}{suffix}"), true).any()
         }
-        ToolResultStatus::Error => text("✗ ")
+        ToolResultStatus::Error { content } => text("✗ ")
             .style(Style::default().fg(Color::Red))
             .span(
-                format!("{noun} {display_path}: failed"),
+                format!("{noun} {display_path}: {}", error_label(content)),
                 Style::default().fg(Color::Red),
             )
             .any(),
@@ -431,7 +445,7 @@ fn status_marker_view(status: &ToolResultStatus) -> AnyElement<'static> {
     match status {
         ToolResultStatus::Pending => text("  ").any(),
         ToolResultStatus::Success => text("✓ ").style(Style::default().fg(Color::Green)).any(),
-        ToolResultStatus::Error => text("✗ ").style(Style::default().fg(Color::Red)).any(),
+        ToolResultStatus::Error { .. } => text("✗ ").style(Style::default().fg(Color::Red)).any(),
     }
 }
 

--- a/crates/atuin-ai/src/tui/view/mod.rs
+++ b/crates/atuin-ai/src/tui/view/mod.rs
@@ -203,7 +203,7 @@ fn tool_status_view(name: &str, status: &ToolResultStatus) -> AnyElement<'static
         ToolResultStatus::Success => tool_spinner(format!("Ran: {name}"), true).any(),
         ToolResultStatus::Error => text("✗ ")
             .style(Style::default().fg(Color::Red))
-            .span(format!("{name}: denied"), Style::default().fg(Color::Red))
+            .span(format!("{name}: failed"), Style::default().fg(Color::Red))
             .any(),
     }
 }

--- a/crates/atuin-ai/src/tui/view/turn.rs
+++ b/crates/atuin-ai/src/tui/view/turn.rs
@@ -200,7 +200,11 @@ pub(crate) struct OutOfBandOutputDetails {
 pub(crate) enum ToolResultStatus {
     Pending,
     Success,
-    Error,
+    /// Carries the result content so the view can label the failure
+    /// (user denial vs. anything else).
+    Error {
+        content: String,
+    },
 }
 
 #[derive(Debug)]
@@ -487,7 +491,7 @@ impl<'a> TurnBuilder<'a> {
         }
     }
 
-    fn add_tool_result(&mut self, tool_use_id: &str, _content: &str, is_error: bool) {
+    fn add_tool_result(&mut self, tool_use_id: &str, content: &str, is_error: bool) {
         self.start_agent_turn();
         let events = self.current_events_mut();
         let event = events.iter_mut().find(|e| match e {
@@ -498,7 +502,9 @@ impl<'a> TurnBuilder<'a> {
         });
         if let Some(UiEvent::ToolCall(ToolCallDetails { status, .. })) = event {
             *status = if is_error {
-                ToolResultStatus::Error
+                ToolResultStatus::Error {
+                    content: content.to_string(),
+                }
             } else {
                 ToolResultStatus::Success
             };


### PR DESCRIPTION
A production tool trace showed a model calling `execute_socket_command`, a tool that has never existed. The client recorded the `tool_use` but never produced a result, leaving a dangling call in the conversation history. The session only survived because the provider (DeepSeek) doesn't enforce tool call/result pairing; stricter providers reject the history on the next request, wedging the session.

Unrecognized tool names and unparseable inputs now get an error tool result, and the answered call counts toward turn completion like an executed tool: if it was the only call, the continuation starts as soon as the stream ends, so the model sees the error and can retry immediately; if it was mixed in with real tool calls, the error rides the same continuation once those finish. The capability-gate path gets the same treatment; it already produced an error result but never triggered a continuation on its own. Mechanically, pre-answered calls join `current_turn_tool_ids` and `ToolManager::all_resolved` treats ids with no tracker entry as resolved-by-construction.

This also surfaced a rendering gap: an errored tool call without preview data always rendered as `✗ name: denied`, which was only true for permission denials. `ToolResultStatus::Error` now carries the result content and the label derives from it: "denied" for permission denials, "cancelled" for user cancellation, "failed" for everything else. The FSM's no-execution result strings become shared constants so the view's matches can't drift from what the FSM writes; matching on content (rather than the `ToolManager`, which isn't persisted) keeps labels correct for resumed sessions.
