### PR TITLE
fix(search): fall back when daemon-fuzzy fails

### DIFF
--- a/crates/atuin-client/src/settings.rs
+++ b/crates/atuin-client/src/settings.rs
@@ -88,7 +88,7 @@ impl From<RequestedSearchMode> for SearchMode {
 }
 
 impl SearchMode {
-    pub fn as_str(&self) -> &'static str {
+    pub fn as_str(self) -> &'static str {
         match self {
             SearchMode::Prefix => "PREFIX",
             SearchMode::FullText => "FULLTXT",
@@ -97,11 +97,11 @@ impl SearchMode {
         }
     }
 
-    pub fn next(&self, settings: &Settings) -> Self {
+    pub fn next(self, settings: &Settings) -> Self {
         match self {
             SearchMode::Prefix => SearchMode::FullText,
             // if the user is using daemon-fuzzy, we go to daemon-fuzzy
-            SearchMode::FullText if settings.search_mode() == SearchMode::DaemonFuzzy => {
+            SearchMode::FullText if settings.active_search_mode() == SearchMode::DaemonFuzzy => {
                 SearchMode::DaemonFuzzy
             }
             // otherwise fuzzy.
@@ -1036,6 +1036,9 @@ pub struct Settings {
     pub filter_mode_shell_up_key_binding: Option<FilterMode>,
     #[serde(rename = "search_mode_shell_up_key_binding")]
     pub requested_search_mode_shell_up_key_binding: Option<RequestedSearchMode>,
+
+    /// This is not a real setting. Instead, `atuin search` manually sets this field to true if
+    /// the hidden `--shell-up-key-binding` option was passed.
     pub shell_up_key_binding: bool,
     pub inline_height: u16,
     pub inline_height_shell_up_key_binding: Option<u16>,
@@ -1152,6 +1155,19 @@ impl Settings {
     pub fn search_mode_shell_up_key_binding(&self) -> Option<SearchMode> {
         self.requested_search_mode_shell_up_key_binding
             .map(Into::into)
+    }
+
+    /// Return the active search mode depending on whether Atuin was invoked from the "up"
+    /// keybinding.
+    ///
+    /// If Atuin was invoked from the "up" keybinding, this returns
+    /// [`Self::search_mode_shell_up_key_binding`], falling back to [`Self::search_mode`] if that
+    /// binding isn't defined. Otherwise, [`Self::search_mode`] is returned.
+    pub fn active_search_mode(&self) -> SearchMode {
+        self.shell_up_key_binding
+            .then(|| self.search_mode_shell_up_key_binding())
+            .flatten()
+            .unwrap_or_else(|| self.search_mode())
     }
 
     pub(crate) fn effective_data_dir() -> PathBuf {

--- a/crates/atuin-client/src/settings.rs
+++ b/crates/atuin-client/src/settings.rs
@@ -97,11 +97,11 @@ impl SearchMode {
         }
     }
 
-    pub fn next(&self, settings: &Settings) -> Self {
+    pub fn next(self, configured_mode: Self) -> Self {
         match self {
             SearchMode::Prefix => SearchMode::FullText,
             // if the user is using daemon-fuzzy, we go to daemon-fuzzy
-            SearchMode::FullText if settings.search_mode() == SearchMode::DaemonFuzzy => {
+            SearchMode::FullText if configured_mode == SearchMode::DaemonFuzzy => {
                 SearchMode::DaemonFuzzy
             }
             // otherwise fuzzy.

--- a/crates/atuin-client/src/settings.rs
+++ b/crates/atuin-client/src/settings.rs
@@ -97,11 +97,11 @@ impl SearchMode {
         }
     }
 
-    pub fn next(self, configured_mode: Self) -> Self {
+    pub fn next(&self, settings: &Settings) -> Self {
         match self {
             SearchMode::Prefix => SearchMode::FullText,
             // if the user is using daemon-fuzzy, we go to daemon-fuzzy
-            SearchMode::FullText if configured_mode == SearchMode::DaemonFuzzy => {
+            SearchMode::FullText if settings.search_mode() == SearchMode::DaemonFuzzy => {
                 SearchMode::DaemonFuzzy
             }
             // otherwise fuzzy.

--- a/crates/atuin-daemon/src/client.rs
+++ b/crates/atuin-daemon/src/client.rs
@@ -45,26 +45,27 @@ pub enum DaemonClientErrorKind {
     Connect,
     Unavailable,
     Unimplemented,
-    OtherStatus,
+    OtherGrpc,
+    NonGrpc,
 }
 
 #[must_use]
-pub fn classify_error(error: &eyre::Report) -> Option<DaemonClientErrorKind> {
+pub fn classify_error(error: &eyre::Report) -> DaemonClientErrorKind {
     for cause in error.chain() {
         if cause.downcast_ref::<tonic::transport::Error>().is_some() {
-            return Some(DaemonClientErrorKind::Connect);
+            return DaemonClientErrorKind::Connect;
         }
 
         if let Some(status) = cause.downcast_ref::<tonic::Status>() {
-            return Some(match status.code() {
+            return match status.code() {
                 Code::Unavailable => DaemonClientErrorKind::Unavailable,
                 Code::Unimplemented => DaemonClientErrorKind::Unimplemented,
-                _ => DaemonClientErrorKind::OtherStatus,
-            });
+                _ => DaemonClientErrorKind::OtherGrpc,
+            };
         }
     }
 
-    None
+    DaemonClientErrorKind::NonGrpc
 }
 
 // Wrap the grpc client
@@ -568,16 +569,13 @@ mod tests {
     fn internal_status_is_a_daemon_error_but_not_unavailable() {
         let error = eyre::Report::new(tonic::Status::internal("failed to build index"));
 
-        assert_eq!(
-            classify_error(&error),
-            Some(DaemonClientErrorKind::OtherStatus)
-        );
+        assert_eq!(classify_error(&error), DaemonClientErrorKind::OtherGrpc);
     }
 
     #[test]
     fn unrelated_error_is_not_a_daemon_error() {
         let error = eyre::eyre!("local database failed");
 
-        assert_eq!(classify_error(&error), None);
+        assert_eq!(classify_error(&error), DaemonClientErrorKind::NonGrpc);
     }
 }

--- a/crates/atuin-daemon/src/client.rs
+++ b/crates/atuin-daemon/src/client.rs
@@ -45,26 +45,26 @@ pub enum DaemonClientErrorKind {
     Connect,
     Unavailable,
     Unimplemented,
-    Other,
+    OtherStatus,
 }
 
 #[must_use]
-pub fn classify_error(error: &eyre::Report) -> DaemonClientErrorKind {
+pub fn classify_error(error: &eyre::Report) -> Option<DaemonClientErrorKind> {
     for cause in error.chain() {
         if cause.downcast_ref::<tonic::transport::Error>().is_some() {
-            return DaemonClientErrorKind::Connect;
+            return Some(DaemonClientErrorKind::Connect);
         }
 
         if let Some(status) = cause.downcast_ref::<tonic::Status>() {
-            return match status.code() {
+            return Some(match status.code() {
                 Code::Unavailable => DaemonClientErrorKind::Unavailable,
                 Code::Unimplemented => DaemonClientErrorKind::Unimplemented,
-                _ => DaemonClientErrorKind::Other,
-            };
+                _ => DaemonClientErrorKind::OtherStatus,
+            });
         }
     }
 
-    DaemonClientErrorKind::Other
+    None
 }
 
 // Wrap the grpc client
@@ -558,4 +558,26 @@ pub async fn emit_event_with_settings(
     }
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn internal_status_is_a_daemon_error_but_not_unavailable() {
+        let error = eyre::Report::new(tonic::Status::internal("failed to build index"));
+
+        assert_eq!(
+            classify_error(&error),
+            Some(DaemonClientErrorKind::OtherStatus)
+        );
+    }
+
+    #[test]
+    fn unrelated_error_is_not_a_daemon_error() {
+        let error = eyre::eyre!("local database failed");
+
+        assert_eq!(classify_error(&error), None);
+    }
 }

--- a/crates/atuin/src/command/client/daemon.rs
+++ b/crates/atuin/src/command/client/daemon.rs
@@ -159,15 +159,20 @@ fn daemon_mismatch_message(version: &str, protocol: u32) -> String {
 }
 
 fn is_legacy_daemon_error(err: &eyre::Report) -> bool {
-    matches!(classify_error(err), DaemonClientErrorKind::Unimplemented)
+    matches!(
+        classify_error(err),
+        Some(DaemonClientErrorKind::Unimplemented)
+    )
 }
 
 pub(super) fn should_retry_after_error(err: &eyre::Report) -> bool {
     matches!(
         classify_error(err),
-        DaemonClientErrorKind::Connect
-            | DaemonClientErrorKind::Unavailable
-            | DaemonClientErrorKind::Unimplemented
+        Some(
+            DaemonClientErrorKind::Connect
+                | DaemonClientErrorKind::Unavailable
+                | DaemonClientErrorKind::Unimplemented
+        )
     )
 }
 

--- a/crates/atuin/src/command/client/daemon.rs
+++ b/crates/atuin/src/command/client/daemon.rs
@@ -159,20 +159,15 @@ fn daemon_mismatch_message(version: &str, protocol: u32) -> String {
 }
 
 fn is_legacy_daemon_error(err: &eyre::Report) -> bool {
-    matches!(
-        classify_error(err),
-        Some(DaemonClientErrorKind::Unimplemented)
-    )
+    matches!(classify_error(err), DaemonClientErrorKind::Unimplemented)
 }
 
 pub(super) fn should_retry_after_error(err: &eyre::Report) -> bool {
     matches!(
         classify_error(err),
-        Some(
-            DaemonClientErrorKind::Connect
-                | DaemonClientErrorKind::Unavailable
-                | DaemonClientErrorKind::Unimplemented
-        )
+        DaemonClientErrorKind::Connect
+            | DaemonClientErrorKind::Unavailable
+            | DaemonClientErrorKind::Unimplemented
     )
 }
 

--- a/crates/atuin/src/command/client/daemon.rs
+++ b/crates/atuin/src/command/client/daemon.rs
@@ -162,7 +162,7 @@ fn is_legacy_daemon_error(err: &eyre::Report) -> bool {
     matches!(classify_error(err), DaemonClientErrorKind::Unimplemented)
 }
 
-fn should_retry_after_error(err: &eyre::Report) -> bool {
+pub(super) fn should_retry_after_error(err: &eyre::Report) -> bool {
     matches!(
         classify_error(err),
         DaemonClientErrorKind::Connect

--- a/crates/atuin/src/command/client/search/engines/daemon.rs
+++ b/crates/atuin/src/command/client/search/engines/daemon.rs
@@ -125,7 +125,7 @@ impl Search {
         db: &dyn Database,
     ) -> Result<Vec<History>> {
         let shells = state.shells.to_filter();
-        let results = db
+        Ok(db
             .search(
                 DbSearchMode::FullText,
                 state.filter_mode,
@@ -138,9 +138,9 @@ impl Search {
                     ..Default::default()
                 },
             )
-            .await
-            .map_or(Vec::new(), |r| r.into_iter().collect());
-        Ok(results)
+            .await?
+            .into_iter()
+            .collect())
     }
 
     #[instrument(skip_all, level = Level::TRACE, name = "hydrate_from_db", fields(count = ids.len()))]

--- a/crates/atuin/src/command/client/search/engines/daemon.rs
+++ b/crates/atuin/src/command/client/search/engines/daemon.rs
@@ -3,7 +3,7 @@ use atuin_client::{
     history::{History, all_user_author_filter},
     settings::Settings,
 };
-use atuin_daemon::client::{DaemonClientErrorKind, SearchClient, SearchParams, classify_error};
+use atuin_daemon::client::{SearchClient, SearchParams};
 use atuin_daemon::search::{normalize_diacritics, truncate_query};
 use eyre::Result;
 use tracing::{Level, debug, instrument, span};
@@ -44,15 +44,6 @@ impl LazyClient {
         SearchClient::new(params.tcp_port).await
     }
 
-    fn should_retry(err: &eyre::Report) -> bool {
-        matches!(
-            classify_error(err),
-            DaemonClientErrorKind::Connect
-                | DaemonClientErrorKind::Unavailable
-                | DaemonClientErrorKind::Unimplemented
-        )
-    }
-
     /// Call a method on [`SearchClient`], autostarting the daemon and retrying if necessary.
     ///
     /// `f` should call the appropriate method on the provided [`SearchClient`].
@@ -60,19 +51,23 @@ impl LazyClient {
     where
         F: AsyncFnMut(&mut SearchClient) -> Result<R>,
     {
-        let client = self.get(params).await?;
-        let err = match f(client).await {
-            Ok(result) => return Ok(result),
+        let err = match self.get(params).await {
+            Ok(client) => match f(client).await {
+                Ok(result) => return Ok(result),
+                Err(err) => err,
+            },
             Err(err) => err,
         };
 
-        if !(params.settings.daemon.autostart && Self::should_retry(&err)) {
+        if !(params.settings.daemon.autostart && daemon::should_retry_after_error(&err)) {
             return Err(err);
         }
 
         debug!("daemon not available, attempting auto-start");
         self.0 = None;
-        daemon::ensure_daemon_running(&params.settings).await?;
+        if let Err(start_error) = daemon::ensure_daemon_running(&params.settings).await {
+            return Err(err.wrap_err(format!("failed to auto-start daemon: {start_error:#}")));
+        }
         let client = self.get(params).await?;
         f(client).await
     }
@@ -211,8 +206,8 @@ impl SearchEngine for Search {
 
         let mut ids = Vec::with_capacity(200);
         span!(Level::TRACE, "daemon_search.resp")
-            .in_scope(async || {
-                while let Ok(Some(response)) = stream.message().await {
+            .in_scope(async || -> Result<()> {
+                while let Some(response) = stream.message().await? {
                     let span2 = span!(
                         Level::TRACE,
                         "daemon_search.resp.item",
@@ -235,8 +230,9 @@ impl SearchEngine for Search {
                     drop(span2_guard);
                     drop(span2);
                 }
+                Ok(())
             })
-            .await;
+            .await?;
         drop(span);
 
         if ids.is_empty() {

--- a/crates/atuin/src/command/client/search/interactive.rs
+++ b/crates/atuin/src/command/client/search/interactive.rs
@@ -113,6 +113,45 @@ pub fn to_compactness(f: &Frame, settings: &Settings) -> Compactness {
     }
 }
 
+struct SearchModeState {
+    mode: SearchMode,
+    pub daemon_failed: bool,
+}
+
+impl SearchModeState {
+    pub fn new(settings: &Settings) -> Self {
+        Self {
+            mode: settings.active_search_mode(),
+            daemon_failed: !cfg!(feature = "daemon"),
+        }
+    }
+
+    /// Return the current search mode.
+    ///
+    /// If [`Self::daemon_failed`] is true and the requested mode is [`SearchMode::DaemonFuzzy`],
+    /// this method will return [`SearchMode::Fuzzy`] instead.
+    pub fn mode(&self) -> SearchMode {
+        if self.is_failed_daemon_fuzzy() {
+            SearchMode::Fuzzy
+        } else {
+            self.mode
+        }
+    }
+
+    /// Return the raw mode, without correcting for unavailable modes.
+    pub fn raw_mode(&self) -> SearchMode {
+        self.mode
+    }
+
+    pub fn advance_to_next_mode(&mut self, settings: &Settings) {
+        self.mode = self.mode.next(settings);
+    }
+
+    pub fn is_failed_daemon_fuzzy(&self) -> bool {
+        self.mode == SearchMode::DaemonFuzzy && self.daemon_failed
+    }
+}
+
 #[allow(clippy::struct_field_names)]
 #[allow(clippy::struct_excessive_bools)]
 pub struct State {
@@ -121,8 +160,7 @@ pub struct State {
     update_needed: Option<Version>,
     results_state: ListState,
     switched_search_mode: bool,
-    search_mode: SearchMode,
-    daemon_fuzzy_fallback: bool,
+    search_mode_state: SearchModeState,
     results_len: usize,
     accept: bool,
     keymap_mode: KeymapMode,
@@ -155,22 +193,28 @@ struct StyleState {
 }
 
 impl State {
+    fn search_mode(&self) -> SearchMode {
+        self.search_mode_state.mode()
+    }
+
     async fn query_results(
         &mut self,
         db: &mut dyn Database,
         settings: &Settings,
     ) -> Result<Vec<History>> {
+        #[cfg(feature = "daemon")]
+        use atuin_daemon::client::{DaemonClientErrorKind, classify_error};
+
         let results = match self.engine.query(&self.search, db).await {
             Ok(results) => results,
             #[cfg(feature = "daemon")]
             Err(error)
-                if self.search_mode == SearchMode::DaemonFuzzy
-                    && atuin_daemon::client::classify_error(&error).is_some() =>
+                if self.search_mode() == SearchMode::DaemonFuzzy
+                    && classify_error(&error) != DaemonClientErrorKind::NonGrpc =>
             {
-                tracing::warn!(?error, "daemon-fuzzy search failed; using fuzzy search");
-                self.search_mode = SearchMode::Fuzzy;
-                self.daemon_fuzzy_fallback = true;
-                self.engine = engines::engine(self.search_mode, settings);
+                tracing::warn!("daemon-fuzzy search failed: {error:#}");
+                self.search_mode_state.daemon_failed = true;
+                self.engine = engines::engine(self.search_mode(), settings);
                 self.engine.query(&self.search, db).await?
             }
             Err(error) => return Err(error),
@@ -674,8 +718,8 @@ impl State {
             }
             Action::CycleSearchMode => {
                 self.switched_search_mode = true;
-                self.search_mode = self.search_mode.next(settings);
-                self.engine = engines::engine(self.search_mode, settings);
+                self.search_mode_state.advance_to_next_mode(settings);
+                self.engine = engines::engine(self.search_mode(), settings);
                 InputAction::Continue
             }
             Action::SwitchContext => {
@@ -974,7 +1018,15 @@ impl State {
         let indicator: String = match compactness {
             Compactness::Ultracompact => {
                 if self.switched_search_mode {
-                    format!("S{}>", self.search_mode.as_str().chars().next().unwrap())
+                    format!(
+                        "S{}>",
+                        self.search_mode_state
+                            .raw_mode()
+                            .as_str()
+                            .chars()
+                            .next()
+                            .unwrap()
+                    )
                 } else if self.search.custom_context.is_some() {
                     format!(
                         "C{}>",
@@ -1176,17 +1228,22 @@ impl State {
     }
 
     fn build_warnings(&self, settings: &Settings, theme: &Theme) -> Text<'static> {
-        let daemon_fallback = self.daemon_fuzzy_fallback && self.search_mode == SearchMode::Fuzzy;
-        if !daemon_fallback && settings.requested_search_mode != RequestedSearchMode::Skim {
+        let get_style = || {
+            Style::from_crossterm(theme.as_style(Meaning::AlertWarn)).add_modifier(Modifier::BOLD)
+        };
+
+        if self.search_mode_state.is_failed_daemon_fuzzy() {
+            return Text::styled(
+                "Warning: daemon-fuzzy search failed; falling back to fuzzy",
+                get_style(),
+            );
+        }
+
+        if settings.requested_search_mode != RequestedSearchMode::Skim {
             return Text::default();
         }
 
-        let style =
-            Style::from_crossterm(theme.as_style(Meaning::AlertWarn)).add_modifier(Modifier::BOLD);
-        if daemon_fallback {
-            return Text::styled("Daemon search failed; using fuzzy.", style);
-        }
-
+        let style = get_style();
         let code_style = Style::from_crossterm(theme.as_style(Meaning::SyntaxCommand))
             .add_modifier(Modifier::BOLD);
 
@@ -1268,7 +1325,7 @@ impl State {
         let (pref, mode) = if self.prefix {
             ("", "PREFIX")
         } else if self.switched_search_mode {
-            (" SRCH:", self.search_mode.as_str())
+            (" SRCH:", self.search_mode_state.raw_mode().as_str())
         } else if self.search.custom_context.is_some() {
             (" CTX:", self.search.filter_mode.as_str())
         } else {
@@ -1827,24 +1884,17 @@ pub async fn history(
     tokio::pin!(history_count);
 
     let initial_context = current_context().await?;
-
-    let mut search_mode = settings.active_search_mode();
-    let daemon_fuzzy_fallback = !cfg!(feature = "daemon") && search_mode == SearchMode::DaemonFuzzy;
-    if daemon_fuzzy_fallback {
-        search_mode = SearchMode::Fuzzy;
-    }
-
+    let search_mode_state = SearchModeState::new(settings);
     let default_filter_mode = settings
         .filter_mode_shell_up_key_binding
         .filter(|_| settings.shell_up_key_binding)
         .unwrap_or_else(|| settings.default_filter_mode(initial_context.git_root.is_some()));
+
     let mut app = State {
         history_count: None,
         results_state: ListState::default(),
         update_needed: None,
         switched_search_mode: false,
-        search_mode,
-        daemon_fuzzy_fallback,
         tab_index: 0,
         inspecting_state: InspectingState {
             current: None,
@@ -1859,7 +1909,8 @@ pub async fn history(
             custom_context: None,
             shells: settings.search.shells.clone(),
         },
-        engine: engines::engine(search_mode, settings),
+        engine: engines::engine(search_mode_state.mode(), settings),
+        search_mode_state,
         results_len: 0,
         accept: false,
         keymap_mode: match settings.keymap_mode {
@@ -1914,7 +1965,7 @@ pub async fn history(
 
         let initial_input = app.search.input.as_str().to_owned();
         let initial_filter_mode = app.search.filter_mode;
-        let initial_search_mode = app.search_mode;
+        let initial_search_mode = app.search_mode();
         let initial_custom_context = app.search.custom_context.clone();
 
         let event_ready = tokio::task::spawn_blocking(|| event::poll(Duration::from_millis(250)));
@@ -2013,7 +2064,7 @@ pub async fn history(
 
         if initial_input != app.search.input.as_str()
             || initial_filter_mode != app.search.filter_mode
-            || initial_search_mode != app.search_mode
+            || initial_search_mode != app.search_mode()
             || initial_custom_context != app.search.custom_context
         {
             results = app.query_results(&mut db, settings).await?;
@@ -2184,7 +2235,8 @@ mod tests {
     use atuin_client::database::Context;
     use atuin_client::history::History;
     use atuin_client::settings::{
-        FilterMode, KeymapMode, Preview, PreviewStrategy, SearchMode, Settings, Shells,
+        FilterMode, KeymapMode, Preview, PreviewStrategy, RequestedSearchMode, SearchMode,
+        Settings, Shells,
     };
     use time::OffsetDateTime;
 
@@ -2192,7 +2244,7 @@ mod tests {
     use crate::command::client::search::history_list::ListState;
     use crate::command::client::search::keybindings::Action;
 
-    use super::{Compactness, InputAction, InspectingState, KeymapSet, State};
+    use super::{Compactness, InputAction, InspectingState, KeymapSet, SearchModeState, State};
 
     #[fixture]
     fn settings() -> Settings {
@@ -2214,8 +2266,10 @@ mod tests {
             update_needed: None,
             results_state: ListState::default(),
             switched_search_mode: false,
-            search_mode: SearchMode::Fuzzy,
-            daemon_fuzzy_fallback: false,
+            search_mode_state: SearchModeState {
+                mode: SearchMode::DaemonFuzzy,
+                daemon_failed: false,
+            },
             results_len,
             accept: false,
             keymap_mode,
@@ -2762,11 +2816,11 @@ mod tests {
     ) {
         use crate::command::client::search::keybindings::Action;
 
-        let original_mode = state.search_mode;
+        let original_mode = state.search_mode();
         let result = state.execute_action(&Action::CycleSearchMode, &settings);
         assert!(matches!(result, super::InputAction::Continue));
         assert!(state.switched_search_mode);
-        assert_ne!(state.search_mode, original_mode);
+        assert_ne!(state.search_mode(), original_mode);
     }
 
     #[cfg(all(feature = "daemon", unix))]
@@ -2776,6 +2830,8 @@ mod tests {
 
         let temp = tempfile::tempdir().unwrap();
         let mut settings = Settings::utc();
+        settings.requested_search_mode = RequestedSearchMode::DaemonFuzzy;
+        settings.daemon.enabled = true;
         settings.daemon.autostart = true;
         settings.daemon.systemd_socket = true;
         settings.daemon.socket_path = temp
@@ -2785,7 +2841,8 @@ mod tests {
             .into_owned();
 
         let mut state = state(KeymapMode::Emacs, 0, 0, FilterMode::Global, "query");
-        state.search_mode = SearchMode::DaemonFuzzy;
+        state.search_mode_state = SearchModeState::new(&settings);
+        assert_eq!(state.search_mode(), SearchMode::DaemonFuzzy);
         state.engine = engines::engine(SearchMode::DaemonFuzzy, &settings);
         let mut db = Sqlite::new("sqlite::memory:", 2.0).await.unwrap();
         let history: History = History::capture()
@@ -2800,12 +2857,15 @@ mod tests {
 
         assert_eq!(results.len(), 1);
         assert_eq!(results[0].command, "echo query match");
-        assert_eq!(state.search_mode, SearchMode::Fuzzy);
-        assert!(state.daemon_fuzzy_fallback);
+        assert_eq!(state.search_mode(), SearchMode::Fuzzy);
+        assert_eq!(state.search_mode_state.raw_mode(), SearchMode::DaemonFuzzy);
+        assert!(state.search_mode_state.daemon_failed);
+        assert!(state.search_mode_state.is_failed_daemon_fuzzy());
 
-        state.search_mode = SearchMode::FullText;
+        state.search_mode_state.mode = SearchMode::FullText;
         state.execute_action(&Action::CycleSearchMode, &settings);
-        assert_eq!(state.search_mode, SearchMode::Fuzzy);
+        assert_eq!(state.search_mode_state.raw_mode(), SearchMode::DaemonFuzzy);
+        assert_eq!(state.search_mode(), SearchMode::Fuzzy);
     }
 
     #[rstest]

--- a/crates/atuin/src/command/client/search/interactive.rs
+++ b/crates/atuin/src/command/client/search/interactive.rs
@@ -154,13 +154,6 @@ struct StyleState {
     inner_width: usize,
 }
 
-fn configured_search_mode(settings: &Settings) -> SearchMode {
-    settings
-        .search_mode_shell_up_key_binding()
-        .filter(|_| settings.shell_up_key_binding)
-        .unwrap_or_else(|| settings.search_mode())
-}
-
 impl State {
     async fn query_results(
         &mut self,
@@ -172,7 +165,7 @@ impl State {
             #[cfg(feature = "daemon")]
             Err(error)
                 if self.search_mode == SearchMode::DaemonFuzzy
-                    && crate::command::client::daemon::should_retry_after_error(&error) =>
+                    && atuin_daemon::client::classify_error(&error).is_some() =>
             {
                 tracing::warn!(?error, "daemon-fuzzy search failed; using fuzzy search");
                 self.search_mode = SearchMode::Fuzzy;
@@ -681,12 +674,10 @@ impl State {
             }
             Action::CycleSearchMode => {
                 self.switched_search_mode = true;
-                let configured_mode = if self.daemon_fuzzy_fallback {
-                    SearchMode::Fuzzy
-                } else {
-                    configured_search_mode(settings)
+                self.search_mode = match self.search_mode.next(settings) {
+                    SearchMode::DaemonFuzzy if self.daemon_fuzzy_fallback => SearchMode::Fuzzy,
+                    mode => mode,
                 };
-                self.search_mode = self.search_mode.next(configured_mode);
                 self.engine = engines::engine(self.search_mode, settings);
                 InputAction::Continue
             }
@@ -1196,11 +1187,7 @@ impl State {
         let style =
             Style::from_crossterm(theme.as_style(Meaning::AlertWarn)).add_modifier(Modifier::BOLD);
         if daemon_fallback {
-            #[cfg(feature = "daemon")]
-            let warning = "Daemon unavailable; using fuzzy. Try atuin daemon restart";
-            #[cfg(not(feature = "daemon"))]
-            let warning = "Daemon support unavailable; using fuzzy. Configure fuzzy search";
-            return Text::styled(warning, style);
+            return Text::styled("Daemon search failed; using fuzzy.", style);
         }
 
         let code_style = Style::from_crossterm(theme.as_style(Meaning::SyntaxCommand))
@@ -1844,7 +1831,13 @@ pub async fn history(
 
     let initial_context = current_context().await?;
 
-    let configured_mode = configured_search_mode(settings);
+    let configured_mode = if settings.shell_up_key_binding {
+        settings
+            .search_mode_shell_up_key_binding()
+            .unwrap_or_else(|| settings.search_mode())
+    } else {
+        settings.search_mode()
+    };
     let daemon_fuzzy_fallback =
         cfg!(not(feature = "daemon")) && configured_mode == SearchMode::DaemonFuzzy;
     let search_mode = if daemon_fuzzy_fallback {

--- a/crates/atuin/src/command/client/search/interactive.rs
+++ b/crates/atuin/src/command/client/search/interactive.rs
@@ -122,6 +122,7 @@ pub struct State {
     results_state: ListState,
     switched_search_mode: bool,
     search_mode: SearchMode,
+    daemon_fuzzy_fallback: bool,
     results_len: usize,
     accept: bool,
     keymap_mode: KeymapMode,
@@ -153,13 +154,34 @@ struct StyleState {
     inner_width: usize,
 }
 
+fn configured_search_mode(settings: &Settings) -> SearchMode {
+    settings
+        .search_mode_shell_up_key_binding()
+        .filter(|_| settings.shell_up_key_binding)
+        .unwrap_or_else(|| settings.search_mode())
+}
+
 impl State {
     async fn query_results(
         &mut self,
         db: &mut dyn Database,
-        smart_sort: bool,
+        settings: &Settings,
     ) -> Result<Vec<History>> {
-        let results = self.engine.query(&self.search, db).await?;
+        let results = match self.engine.query(&self.search, db).await {
+            Ok(results) => results,
+            #[cfg(feature = "daemon")]
+            Err(error)
+                if self.search_mode == SearchMode::DaemonFuzzy
+                    && crate::command::client::daemon::should_retry_after_error(&error) =>
+            {
+                tracing::warn!(?error, "daemon-fuzzy search failed; using fuzzy search");
+                self.search_mode = SearchMode::Fuzzy;
+                self.daemon_fuzzy_fallback = true;
+                self.engine = engines::engine(self.search_mode, settings);
+                self.engine.query(&self.search, db).await?
+            }
+            Err(error) => return Err(error),
+        };
 
         self.inspecting_state = InspectingState {
             current: None,
@@ -169,7 +191,7 @@ impl State {
         self.results_state.select(0);
         self.results_len = results.len();
 
-        if smart_sort {
+        if settings.smart_sort {
             Ok(atuin_history::sort::sort(
                 self.search.input.as_str(),
                 results,
@@ -659,7 +681,12 @@ impl State {
             }
             Action::CycleSearchMode => {
                 self.switched_search_mode = true;
-                self.search_mode = self.search_mode.next(settings);
+                let configured_mode = if self.daemon_fuzzy_fallback {
+                    SearchMode::Fuzzy
+                } else {
+                    configured_search_mode(settings)
+                };
+                self.search_mode = self.search_mode.next(configured_mode);
                 self.engine = engines::engine(self.search_mode, settings);
                 InputAction::Continue
             }
@@ -858,7 +885,7 @@ impl State {
         );
 
         let show_help = settings.show_help && (compactness == Compactness::Full || area.height > 1);
-        let warnings = Self::build_warnings(settings, theme);
+        let warnings = self.build_warnings(settings, theme);
         let warning_height = u16::try_from(warnings.height()).unwrap_or(u16::MAX);
 
         // This is an OR, as it seems more likely for someone to wish to override
@@ -1160,13 +1187,22 @@ impl State {
         .alignment(Alignment::Center)
     }
 
-    fn build_warnings(settings: &Settings, theme: &Theme) -> Text<'static> {
-        if settings.requested_search_mode != RequestedSearchMode::Skim {
+    fn build_warnings(&self, settings: &Settings, theme: &Theme) -> Text<'static> {
+        let daemon_fallback = self.daemon_fuzzy_fallback && self.search_mode == SearchMode::Fuzzy;
+        if !daemon_fallback && settings.requested_search_mode != RequestedSearchMode::Skim {
             return Text::default();
         }
 
         let style =
             Style::from_crossterm(theme.as_style(Meaning::AlertWarn)).add_modifier(Modifier::BOLD);
+        if daemon_fallback {
+            #[cfg(feature = "daemon")]
+            let warning = "Daemon unavailable; using fuzzy. Try atuin daemon restart";
+            #[cfg(not(feature = "daemon"))]
+            let warning = "Daemon support unavailable; using fuzzy. Configure fuzzy search";
+            return Text::styled(warning, style);
+        }
+
         let code_style = Style::from_crossterm(theme.as_style(Meaning::SyntaxCommand))
             .add_modifier(Modifier::BOLD);
 
@@ -1808,12 +1844,13 @@ pub async fn history(
 
     let initial_context = current_context().await?;
 
-    let search_mode = if settings.shell_up_key_binding {
-        settings
-            .search_mode_shell_up_key_binding()
-            .unwrap_or_else(|| settings.search_mode())
+    let configured_mode = configured_search_mode(settings);
+    let daemon_fuzzy_fallback =
+        cfg!(not(feature = "daemon")) && configured_mode == SearchMode::DaemonFuzzy;
+    let search_mode = if daemon_fuzzy_fallback {
+        SearchMode::Fuzzy
     } else {
-        settings.search_mode()
+        configured_mode
     };
     let default_filter_mode = settings
         .filter_mode_shell_up_key_binding
@@ -1825,6 +1862,7 @@ pub async fn history(
         update_needed: None,
         switched_search_mode: false,
         search_mode,
+        daemon_fuzzy_fallback,
         tab_index: 0,
         inspecting_state: InspectingState {
             current: None,
@@ -1871,7 +1909,7 @@ pub async fn history(
         app.draw(f, &[], None, None, settings, theme, popup_mode);
     })?;
 
-    let mut results = app.query_results(&mut db, settings.smart_sort).await?;
+    let mut results = app.query_results(&mut db, settings).await?;
 
     let mut stats: Option<HistoryStats> = None;
     // The id of the history entry `stats` was computed for, so the render loop
@@ -1996,7 +2034,7 @@ pub async fn history(
             || initial_search_mode != app.search_mode
             || initial_custom_context != app.search.custom_context
         {
-            results = app.query_results(&mut db, settings.smart_sort).await?;
+            results = app.query_results(&mut db, settings).await?;
         }
 
         // In custom context mode, when no filter is applied, highlight the entry which was used
@@ -2195,6 +2233,7 @@ mod tests {
             results_state: ListState::default(),
             switched_search_mode: false,
             search_mode: SearchMode::Fuzzy,
+            daemon_fuzzy_fallback: false,
             results_len,
             accept: false,
             keymap_mode,
@@ -2746,6 +2785,45 @@ mod tests {
         assert!(matches!(result, super::InputAction::Continue));
         assert!(state.switched_search_mode);
         assert_ne!(state.search_mode, original_mode);
+    }
+
+    #[cfg(all(feature = "daemon", unix))]
+    #[tokio::test]
+    async fn unavailable_daemon_fuzzy_retries_with_local_fuzzy() {
+        use atuin_client::database::{Database, Sqlite};
+
+        let temp = tempfile::tempdir().unwrap();
+        let mut settings = Settings::utc();
+        settings.daemon.autostart = true;
+        settings.daemon.systemd_socket = true;
+        settings.daemon.socket_path = temp
+            .path()
+            .join("missing.sock")
+            .to_string_lossy()
+            .into_owned();
+
+        let mut state = state(KeymapMode::Emacs, 0, 0, FilterMode::Global, "query");
+        state.search_mode = SearchMode::DaemonFuzzy;
+        state.engine = engines::engine(SearchMode::DaemonFuzzy, &settings);
+        let mut db = Sqlite::new("sqlite::memory:", 2.0).await.unwrap();
+        let history: History = History::capture()
+            .timestamp(OffsetDateTime::now_utc())
+            .command("echo query match")
+            .cwd("/tmp")
+            .build()
+            .into();
+        db.save(&history).await.unwrap();
+
+        let results = state.query_results(&mut db, &settings).await.unwrap();
+
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].command, "echo query match");
+        assert_eq!(state.search_mode, SearchMode::Fuzzy);
+        assert!(state.daemon_fuzzy_fallback);
+
+        state.search_mode = SearchMode::FullText;
+        state.execute_action(&Action::CycleSearchMode, &settings);
+        assert_eq!(state.search_mode, SearchMode::Fuzzy);
     }
 
     #[rstest]

--- a/crates/atuin/src/command/client/search/interactive.rs
+++ b/crates/atuin/src/command/client/search/interactive.rs
@@ -1233,10 +1233,12 @@ impl State {
         };
 
         if self.search_mode_state.is_failed_daemon_fuzzy() {
-            return Text::styled(
-                "Warning: daemon-fuzzy search failed; falling back to fuzzy",
-                get_style(),
-            );
+            let msg = if cfg!(feature = "daemon") {
+                "Warning: daemon-fuzzy search failed; falling back to fuzzy"
+            } else {
+                "Warning: no daemon support; falling back to fuzzy search"
+            };
+            return Text::styled(msg, get_style());
         }
 
         if settings.requested_search_mode != RequestedSearchMode::Skim {

--- a/crates/atuin/src/command/client/search/interactive.rs
+++ b/crates/atuin/src/command/client/search/interactive.rs
@@ -674,10 +674,7 @@ impl State {
             }
             Action::CycleSearchMode => {
                 self.switched_search_mode = true;
-                self.search_mode = match self.search_mode.next(settings) {
-                    SearchMode::DaemonFuzzy if self.daemon_fuzzy_fallback => SearchMode::Fuzzy,
-                    mode => mode,
-                };
+                self.search_mode = self.search_mode.next(settings);
                 self.engine = engines::engine(self.search_mode, settings);
                 InputAction::Continue
             }
@@ -1831,20 +1828,12 @@ pub async fn history(
 
     let initial_context = current_context().await?;
 
-    let configured_mode = if settings.shell_up_key_binding {
-        settings
-            .search_mode_shell_up_key_binding()
-            .unwrap_or_else(|| settings.search_mode())
-    } else {
-        settings.search_mode()
-    };
-    let daemon_fuzzy_fallback =
-        cfg!(not(feature = "daemon")) && configured_mode == SearchMode::DaemonFuzzy;
-    let search_mode = if daemon_fuzzy_fallback {
-        SearchMode::Fuzzy
-    } else {
-        configured_mode
-    };
+    let mut search_mode = settings.active_search_mode();
+    let daemon_fuzzy_fallback = !cfg!(feature = "daemon") && search_mode == SearchMode::DaemonFuzzy;
+    if daemon_fuzzy_fallback {
+        search_mode = SearchMode::Fuzzy;
+    }
+
     let default_filter_mode = settings
         .filter_mode_shell_up_key_binding
         .filter(|_| settings.shell_up_key_binding)


### PR DESCRIPTION
When an interactive `daemon-fuzzy` query fails at the transport or RPC layer, this keeps the search open, switches to local fuzzy search, and shows a concise warning instead of exiting. This also handles errors reported after streaming begins, such as a daemon index-build failure, while unrelated local errors still propagate normally.

Builds without daemon support use the same local fallback and warning when `daemon-fuzzy` is configured.

Fixes #3891.

![Daemon fallback warning](https://github.com/user-attachments/assets/3c8067a8-51b9-4f16-afca-86f2a9c2bd88)

Of the 182 changed lines, 120 are implementation (`+76/-44`) and 62 are tests (`+62/-0`).

#3894 addresses the same issue by keeping daemon mode and displaying the error; this PR switches to local fuzzy search instead, so I left the second box unchecked.

## Checks

- [x] I am happy for maintainers to push small adjustments to this PR, to speed up the review cycle
- [ ] I have checked that there are no existing pull requests for the same thing
