### PR TITLE
refactor(client): own sync_addr via Arc<Url>, drop Client lifetime

### DIFF
--- a/crates/atuin-client/src/api_client.rs
+++ b/crates/atuin-client/src/api_client.rs
@@ -1,5 +1,6 @@
 use std::collections::HashMap;
 use std::env;
+use std::sync::Arc;
 use std::time::Duration;
 
 use eyre::{Result, bail};
@@ -45,8 +46,9 @@ impl AuthToken {
     }
 }
 
-pub struct Client<'a> {
-    sync_addr: &'a Url,
+#[derive(Debug, Clone)]
+pub struct Client {
+    sync_addr: Arc<Url>,
     client: reqwest::Client,
 }
 
@@ -240,9 +242,9 @@ async fn handle_resp_error(resp: Response) -> Result<Response> {
     Ok(resp)
 }
 
-impl<'a> Client<'a> {
+impl Client {
     pub fn new(
-        sync_addr: &'a Url,
+        sync_addr: impl Into<Arc<Url>>,
         auth: AuthToken,
         connect_timeout: u64,
         timeout: u64,
@@ -256,7 +258,7 @@ impl<'a> Client<'a> {
         headers.insert(ATUIN_HEADER_VERSION, ATUIN_CARGO_VERSION.parse()?);
 
         Ok(Client {
-            sync_addr,
+            sync_addr: sync_addr.into(),
             client: client_builder(extra_headers)
                 .default_headers(headers)
                 .connect_timeout(Duration::from_secs(connect_timeout))

--- a/crates/atuin-client/src/record/sync.rs
+++ b/crates/atuin-client/src/record/sync.rs
@@ -58,9 +58,9 @@ pub enum Operation {
     },
 }
 
-pub async fn build_client(settings: &Settings) -> Result<Client<'_>, SyncError> {
+pub async fn build_client(settings: &Settings) -> Result<Client, SyncError> {
     Client::new(
-        &settings.sync_address,
+        settings.sync_address.clone(),
         settings
             .sync_auth_token()
             .await
@@ -73,7 +73,7 @@ pub async fn build_client(settings: &Settings) -> Result<Client<'_>, SyncError> 
 }
 
 pub async fn diff(
-    client: &Client<'_>,
+    client: &Client,
     store: &SqliteStore,
 ) -> Result<(Vec<Diff>, RecordStatus), SyncError> {
     let local_index = store
@@ -170,7 +170,7 @@ pub async fn operations(
 
 async fn sync_upload(
     store: &SqliteStore,
-    client: &Client<'_>,
+    client: &Client,
     host: HostId,
     tag: String,
     local: RecordIdx,
@@ -229,7 +229,7 @@ async fn sync_upload(
 
 async fn sync_download(
     store: &SqliteStore,
-    client: &Client<'_>,
+    client: &Client,
     host: HostId,
     tag: String,
     local: Option<RecordIdx>,
@@ -285,7 +285,7 @@ async fn sync_download(
 }
 
 pub async fn sync_remote(
-    client: &Client<'_>,
+    client: &Client,
     operations: Vec<Operation>,
     local_store: &SqliteStore,
     page_size: u64,
@@ -325,7 +325,7 @@ pub async fn sync_remote(
 }
 
 pub async fn check_encryption_key(
-    client: &Client<'_>,
+    client: &Client,
     remote_index: &RecordStatus,
     encryption_key: &paseto_v4::Key,
 ) -> Result<(), SyncError> {

--- a/crates/atuin-server/tests/common/mod.rs
+++ b/crates/atuin-server/tests/common/mod.rs
@@ -69,11 +69,11 @@ pub async fn start_server(path: &str) -> (url::Url, oneshot::Sender<()>, JoinHan
     (url, shutdown_tx, server)
 }
 
-pub async fn register_inner<'a>(
-    address: &'a url::Url,
+pub async fn register_inner(
+    address: &url::Url,
     username: &str,
     password: &str,
-) -> api_client::Client<'a> {
+) -> api_client::Client {
     let email = format!("{}@example.com", uuid_v7().as_simple());
 
     // registration works
@@ -83,7 +83,7 @@ pub async fn register_inner<'a>(
             .unwrap();
 
     api_client::Client::new(
-        address,
+        address.clone(),
         api_client::AuthToken::Token(registration_response.session),
         5,
         30,
@@ -93,11 +93,7 @@ pub async fn register_inner<'a>(
 }
 
 #[allow(dead_code)]
-pub async fn login(
-    address: &url::Url,
-    username: String,
-    password: String,
-) -> api_client::Client<'_> {
+pub async fn login(address: &url::Url, username: String, password: String) -> api_client::Client {
     // registration works
     let login_response = api_client::login(
         address,
@@ -108,7 +104,7 @@ pub async fn login(
     .unwrap();
 
     api_client::Client::new(
-        address,
+        address.clone(),
         api_client::AuthToken::Token(login_response.session),
         5,
         30,
@@ -118,7 +114,7 @@ pub async fn login(
 }
 
 #[allow(dead_code)]
-pub async fn register(address: &url::Url) -> api_client::Client<'_> {
+pub async fn register(address: &url::Url) -> api_client::Client {
     let username = uuid_v7().as_simple().to_string();
     let password = uuid_v7().as_simple().to_string();
     register_inner(address, &username, &password).await

--- a/crates/atuin/src/command/client/store/push.rs
+++ b/crates/atuin/src/command/client/store/push.rs
@@ -44,7 +44,7 @@ impl Push {
             println!("Clearing remote store");
 
             let client = Client::new(
-                &settings.sync_address,
+                settings.sync_address.clone(),
                 settings.sync_auth_token().await?,
                 settings.network_connect_timeout,
                 settings.network_timeout * 10, // we may be deleting a lot of data... so up the

--- a/crates/atuin/src/command/client/sync/status.rs
+++ b/crates/atuin/src/command/client/sync/status.rs
@@ -9,7 +9,7 @@ pub async fn run(settings: &Settings) -> Result<()> {
     }
 
     let client = api_client::Client::new(
-        &settings.sync_address,
+        settings.sync_address.clone(),
         settings.sync_auth_token().await?,
         settings.network_connect_timeout,
         settings.network_timeout,


### PR DESCRIPTION
There are some nasty `Arc`s inside of `reqwest::Client`, so the value of holding a reference to `Url` is so marginal over just adding an `Arc`