### PR TITLE
refactor(caps): CapClient owns its client and warms on construction

### DIFF
--- a/crates/atuin-domain/src/caps/client.rs
+++ b/crates/atuin-domain/src/caps/client.rs
@@ -1,12 +1,10 @@
-use std::{collections::HashMap, sync::Arc};
-
-use parking_lot::RwLock;
-use serde::de::DeserializeOwned;
-use tokio::sync::Mutex;
-use url::Url;
-
 use super::{CapKey, Capability, CapsBundle, DuplicateCapability};
 use crate::api::CapabilitiesResponse;
+use parking_lot::RwLock;
+use serde::de::DeserializeOwned;
+use std::{collections::HashMap, sync::Arc};
+use tokio;
+use url::Url;
 
 /// Client-side capability set: advertises its own capabilities and can read the server's.
 ///
@@ -22,10 +20,13 @@ pub struct CapClient {
     /// reads; writes are serialized by `fetching`.
     server: RwLock<Option<ServerCaps>>,
     /// Serializes capability fetches so a burst of stale callers makes a single network hop.
-    fetching: Mutex<()>,
+    fetching: tokio::sync::Mutex<()>,
     /// The server's capabilities endpoint. Passed in by the caller so this crate stays agnostic of
     /// the route (eg `/api/v0/capabilities`).
     capabilities_url: Url,
+    /// Bare client used to fetch `capabilities_url`.
+    http: reqwest::Client,
+    warmed: tokio::sync::watch::Receiver<bool>,
 }
 
 /// The capabilities a server advertises, as last fetched from its capabilities endpoint.
@@ -68,14 +69,26 @@ pub enum ServerSupportError {
 }
 
 impl CapClient {
-    /// Create a client that will negotiate against the given capabilities endpoint.
-    pub fn new(capabilities_url: Url) -> Arc<Self> {
-        Arc::new(Self {
+    /// Create a client that will negotiate against the given capabilities endpoint, using `http`
+    /// (a bare, ideally authenticated client) for its own capability fetches.
+    pub fn new(capabilities_url: Url, http: reqwest::Client) -> Arc<Self> {
+        let (tx, rx) = tokio::sync::watch::channel(false);
+        let new = Arc::new(Self {
             own: CapsBundle::default(),
             server: RwLock::new(None),
-            fetching: Mutex::new(()),
+            fetching: tokio::sync::Mutex::new(()),
             capabilities_url,
-        })
+            http,
+            warmed: rx,
+        });
+
+        let this = new.clone();
+        tokio::spawn(async move {
+            let _ = this.refresh().await;
+            let _ = tx.send(true);
+        });
+
+        new
     }
 
     /// Register a capability this client advertises.
@@ -90,12 +103,12 @@ impl CapClient {
         self.own.get()
     }
 
-    /// Fetch the server's capabilities over the caller's client and patch the local cache.
+    /// Fetch the server's capabilities over the internal client and patch the local cache.
     ///
     /// Fetches are serialized so parallel callers never overlap; this one always fetches.
-    pub async fn refresh(&self, client: &reqwest::Client) -> reqwest::Result<()> {
+    pub async fn refresh(&self) -> reqwest::Result<()> {
         let _fetching = self.fetching.lock().await;
-        let caps = self.fetch_server_caps(client).await?;
+        let caps = self.fetch_server_caps().await?;
         *self.server.write() = Some(caps);
         Ok(())
     }
@@ -104,11 +117,7 @@ impl CapClient {
     ///
     /// Double-checked so a burst of stale callers makes a single fetch, and a caller whose token
     /// already matches `available` does no work.
-    pub async fn refresh_if_stale(
-        &self,
-        client: &reqwest::Client,
-        available: &str,
-    ) -> reqwest::Result<()> {
+    pub async fn refresh_if_stale(&self, available: &str) -> reqwest::Result<()> {
         if !self.is_stale(available) {
             return Ok(());
         }
@@ -116,7 +125,7 @@ impl CapClient {
         if !self.is_stale(available) {
             return Ok(());
         }
-        let caps = self.fetch_server_caps(client).await?;
+        let caps = self.fetch_server_caps().await?;
         *self.server.write() = Some(caps);
         Ok(())
     }
@@ -131,8 +140,9 @@ impl CapClient {
     }
 
     /// Fetch and decode the server's capabilities document.
-    async fn fetch_server_caps(&self, client: &reqwest::Client) -> reqwest::Result<ServerCaps> {
-        let resp: CapabilitiesResponse = client
+    async fn fetch_server_caps(&self) -> reqwest::Result<ServerCaps> {
+        let resp: CapabilitiesResponse = self
+            .http
             .get(self.capabilities_url.clone())
             .send()
             .await?
@@ -148,9 +158,11 @@ impl CapClient {
     /// - `Err(ServerSupportError::NotFetched)` - capabilities have not been fetched yet.
     /// - `Err(ServerSupportError::Malformed)` - advertised, but its value did not deserialize into
     ///   `C`. The caller decides whether that is fatal or a reason to fall back.
-    pub fn get_server<C: Capability + DeserializeOwned>(
+    pub async fn get_server<C: Capability + DeserializeOwned>(
         &self,
     ) -> Result<Option<C>, ServerSupportError> {
+        let _ = self.warmed.clone().wait_for(|&done| done).await;
+
         let server = self.server.read();
         let Some(server) = server.as_ref() else {
             return Err(ServerSupportError::NotFetched);
@@ -165,6 +177,11 @@ impl CapClient {
                 name: C::static_name(),
                 source,
             })
+    }
+
+    /// Whether the server's capabilities have been fetched at least once.
+    pub fn is_fetched(&self) -> bool {
+        self.server.read().is_some()
     }
 
     /// The capability token this client currently knows, or `None` if it has never fetched.
@@ -206,12 +223,12 @@ mod tests {
         let caps_url: Url = format!("{}/api/v0/capabilities", server.uri())
             .parse()
             .unwrap();
-        let client = CapClient::new(caps_url);
+        let client = CapClient::new(caps_url, http_client);
 
         // Nothing fetched yet.
         assert_eq!(client.known_token(), None);
 
-        client.refresh(&http_client).await.unwrap();
+        client.refresh().await.unwrap();
 
         // The token is the server's version, opaque and echoed verbatim.
         assert_eq!(client.known_token(), Some("7".to_string()));
@@ -234,19 +251,10 @@ mod tests {
         let caps_url: Url = format!("{}/api/v0/capabilities", server.uri())
             .parse()
             .unwrap();
-        let client = CapClient::new(caps_url);
+        let client = CapClient::new(caps_url, http_client);
 
-        // Nothing fetched yet, so the capability cannot be observed.
-        assert!(matches!(
-            client.get_server::<CapabilitiesCap>(),
-            Err(ServerSupportError::NotFetched)
-        ));
-
-        client.refresh(&http_client).await.unwrap();
-
-        // Having refreshed, the client observes the capability the server advertised.
         assert_eq!(
-            client.get_server::<CapabilitiesCap>().unwrap(),
+            client.get_server::<CapabilitiesCap>().await.unwrap(),
             Some(CapabilitiesCap { version: 1 })
         );
     }

--- a/crates/atuin-domain/src/caps/client.rs
+++ b/crates/atuin-domain/src/caps/client.rs
@@ -69,8 +69,7 @@ pub enum ServerSupportError {
 }
 
 impl CapClient {
-    /// Create a client that will negotiate against the given capabilities endpoint, using `http`
-    /// (a bare, ideally authenticated client) for its own capability fetches.
+    /// Create a client that will negotiate against the given capabilities endpoint.
     pub fn new(capabilities_url: Url, http: reqwest::Client) -> Arc<Self> {
         let (tx, rx) = tokio::sync::watch::channel(false);
         let new = Arc::new(Self {

--- a/crates/atuin-domain/src/caps/middleware.rs
+++ b/crates/atuin-domain/src/caps/middleware.rs
@@ -40,8 +40,6 @@ pub enum CapMismatch {
 pub struct CapMiddleware {
     /// Source of the known token and the `/api/v0/capabilities` refresh.
     caps: Arc<CapClient>,
-    /// Client used to request the capabilities from the server.
-    http: Client,
     /// How to react to a capability-token mismatch with the server.
     #[builder(default = CapMismatch::Continue)]
     on_mismatch: CapMismatch,
@@ -87,9 +85,8 @@ impl Middleware for CapMiddleware {
                 // Coalesced and idempotent, so a burst drives exactly one fetch. Best-effort: a
                 // refresh failure must not fail the request the server already served.
                 let caps = self.caps.clone();
-                let http = self.http.clone();
                 tokio::spawn(async move {
-                    let _ = caps.refresh_if_stale(&http, &available).await;
+                    let _ = caps.refresh_if_stale(&available).await;
                 });
             }
         }
@@ -117,7 +114,6 @@ impl CapabilitiesExt for Client {
     ) -> ClientWithMiddleware {
         let middleware = CapMiddleware::builder()
             .caps(caps)
-            .http(self.clone())
             .on_mismatch(on_mismatch)
             .build();
         ClientBuilder::new(self).with(middleware).build()
@@ -210,7 +206,7 @@ mod tests {
         let caps_url = format!("{}/api/v0/capabilities", server.uri())
             .parse()
             .unwrap();
-        CapClient::new(caps_url)
+        CapClient::new(caps_url, reqwest::Client::new())
     }
 
     #[rstest]
@@ -252,8 +248,9 @@ mod tests {
             .unwrap();
         assert_eq!(response.status(), 412);
 
-        // `Error` mode never refreshes; the caller handles the 412.
-        assert_eq!(caps_hits(&server).await, 0);
+        // The only caps fetch is the eager warm-up on construction; `Error` mode adds no refresh.
+        await_caps_hit(&server).await;
+        assert_eq!(caps_hits(&server).await, 1);
     }
 
     #[rstest]
@@ -270,8 +267,7 @@ mod tests {
             .unwrap();
 
         let middleware = CapMiddleware::builder()
-            .caps(CapClient::new(caps_url))
-            .http(http_client.clone())
+            .caps(CapClient::new(caps_url, http_client.clone()))
             .on_mismatch(CapMismatch::Continue)
             .build();
         let client = ClientBuilder::new(http_client).with(middleware).build();
@@ -283,14 +279,13 @@ mod tests {
             .unwrap();
 
         assert_eq!(response.status(), 404);
-        let caps_hits = server
-            .received_requests()
-            .await
-            .unwrap()
-            .iter()
-            .filter(|r| r.url.path() == "/api/v0/capabilities")
-            .count();
-        assert_eq!(caps_hits, 0, "a plain 404 must not trigger a refresh");
+        // The eager warm-up is the only caps fetch; a plain 404 adds no further refresh.
+        await_caps_hit(&server).await;
+        assert_eq!(
+            caps_hits(&server).await,
+            1,
+            "a plain 404 must not trigger a refresh beyond the eager warm-up"
+        );
     }
 
     #[rstest]
@@ -309,8 +304,7 @@ mod tests {
             .unwrap();
 
         let middleware = CapMiddleware::builder()
-            .caps(CapClient::new(caps_url))
-            .http(http_client.clone())
+            .caps(CapClient::new(caps_url, http_client.clone()))
             .on_mismatch(CapMismatch::Continue)
             .build();
         let client = ClientBuilder::new(http_client).with(middleware).build();
@@ -322,16 +316,12 @@ mod tests {
             .unwrap();
 
         assert_eq!(response.status(), 412);
-        let caps_hits = server
-            .received_requests()
-            .await
-            .unwrap()
-            .iter()
-            .filter(|r| r.url.path() == "/api/v0/capabilities")
-            .count();
+        // The eager warm-up is the only caps fetch; a 412 without the caps header adds no refresh.
+        await_caps_hit(&server).await;
         assert_eq!(
-            caps_hits, 0,
-            "a 412 without the caps header must not trigger a refresh"
+            caps_hits(&server).await,
+            1,
+            "a 412 without the caps header must not trigger a refresh beyond the eager warm-up"
         );
     }
 


### PR DESCRIPTION
Split out of the `packfile/client-bundling` PR to de-risk review.

## Changes

- **`CapClient` owns its HTTP client.** `new(url, http)` takes the bare `reqwest::Client` and uses it for capability fetches, so `refresh` / `refresh_if_stale` / `fetch_server_caps` no longer take a client argument, and `CapMiddleware` no longer carries its own `http` handle (`with_capabilities` stops cloning one in).
- **Eager warm-up.** `new()` spawns the initial capabilities fetch in the background; `get_server` awaits its completion through a `watch` channel, so the first reader blocks on the in-flight fetch instead of racing to a spurious `NotFetched`.

## Testing

`cargo test -p atuin-domain caps::` — 21 passing.
