### PR TITLE
refactor(domain): make Record::with_data consume self, add with_data_clone

### DIFF
--- a/crates/atuin-domain/src/record.rs
+++ b/crates/atuin-domain/src/record.rs
@@ -101,7 +101,19 @@ impl<Data> Record<Data> {
             .build()
     }
 
-    pub fn with_data<New>(&self, data: New) -> Record<New> {
+    pub fn with_data<New>(self, data: New) -> Record<New> {
+        Record {
+            id: self.id,
+            idx: self.idx,
+            host: self.host,
+            timestamp: self.timestamp,
+            version: self.version,
+            tag: self.tag,
+            data,
+        }
+    }
+
+    pub fn with_data_clone<New>(&self, data: New) -> Record<New> {
         Record {
             id: self.id,
             idx: self.idx,
@@ -119,7 +131,7 @@ impl Record<DecryptedData> {
         let ad = serde_json::to_string(&AdditionalData::from(self))
             .expect("could not serialize implicit assertions");
         let assertion = paseto_v4::ImplicitAssertion::from(ad.as_str());
-        self.with_data(paseto_v4::encrypt_sync(&self.data, Some(assertion), key).unwrap())
+        self.with_data_clone(paseto_v4::encrypt_sync(&self.data, Some(assertion), key).unwrap())
     }
 }
 
@@ -130,7 +142,7 @@ impl Record<paseto_v4::EncryptedData> {
         let assertion = paseto_v4::ImplicitAssertion::from(ad.as_str());
         let data = paseto_v4::decrypt_sync(&self.data, Some(assertion), key)
             .context("could not decrypt entry")?;
-        Ok(self.with_data(data.into()))
+        Ok(self.with_data_clone(data.into()))
     }
 }
 


### PR DESCRIPTION
`Record::with_data` borrowed `&self` and cloned every field into the returned record:

```rust
pub fn with_data<New>(&self, data: New) -> Record<New> {
    Record { id: self.id, host: self.host.clone(), version: self.version.clone(), tag: self.tag.clone(), ..., data }
}
```

This PR:
- Makes `with_data` take `self` **by value** and move the fields.
- Adds `with_data_clone(&self, ...)` for callers that must keep the original.
- Points the two `&self` callers -- `Record::encrypt` and `Record::decrypt` -- at `with_data_clone`.