### PR TITLE
fix(ui): honor configured command column width

### DIFF
--- a/crates/atuin-client/config.toml
+++ b/crates/atuin-client/config.toml
@@ -371,7 +371,7 @@ enter_accept = true
 ##   host      (15) - Hostname where command was run
 ##   user      (10) - Username
 ##   exit      (3)  - Exit code (colored by success/failure)
-##   command   (*)  - The command itself (expands by default)
+##   command   (20) - The command itself (expands by default; 20 when fixed)
 ##
 ## The "expand" option (default: true for command, false for others) makes a
 ## column fill remaining space. Only one column should have expand = true.

--- a/crates/atuin-client/src/settings.rs
+++ b/crates/atuin-client/src/settings.rs
@@ -811,13 +811,12 @@ pub enum UiColumnType {
     User,
     /// Exit code
     Exit,
-    /// The command itself (should be last, expands to fill)
+    /// The command itself (expands to fill by default)
     Command,
 }
 
 impl UiColumnType {
     /// Returns the default width for this column type (in characters).
-    /// The Command column returns 0 as it expands to fill remaining space.
     #[must_use]
     pub fn default_width(&self) -> u16 {
         match self {
@@ -834,7 +833,7 @@ impl UiColumnType {
                     3 // Usually a byte on Unix
                 }
             }
-            Self::Command => 0, // Expands to fill
+            Self::Command => 20,
         }
     }
 }
@@ -943,7 +942,7 @@ impl<'de> serde::Deserialize<'de> for UiColumn {
 pub struct Ui {
     /// Columns to display in interactive search, from left to right.
     /// The indicator column (" > ") is always shown first implicitly.
-    /// The "command" column should be last as it expands to fill remaining space.
+    /// The "command" column expands to fill remaining space by default.
     /// Can be simple strings or objects with type and width.
     #[serde(default = "Ui::default_columns")]
     pub columns: Vec<UiColumn>,
@@ -1939,7 +1938,7 @@ mod tests {
 
     /// Forces both `LazyLock`s, so a typo in either constant fails here rather
     /// than panicking at runtime.
-    #[test]
+    #[rstest]
     fn default_addresses_parse() {
         assert_eq!(super::DEFAULT_SYNC_URL.host_str(), Some("api.atuin.sh"));
         assert_eq!(super::DEFAULT_HUB_URL.host_str(), Some("hub.atuin.sh"));
@@ -1967,7 +1966,7 @@ mod tests {
         assert_eq!(settings.default_filter_mode(git_root), expected);
     }
 
-    #[test]
+    #[rstest]
     fn builder_with_data_dir_uses_custom_paths() -> Result<()> {
         use std::path::PathBuf;
 
@@ -2026,7 +2025,7 @@ mod tests {
         assert!(err.contains(expected_err), "error should mention `{expected_err}`, got: {err}");
     }
 
-    #[test]
+    #[rstest]
     fn effective_data_dir_returns_default_when_not_set() {
         let effective = super::Settings::effective_data_dir();
         let default = atuin_common::utils::data_dir();
@@ -2035,7 +2034,7 @@ mod tests {
         assert!(effective.ends_with("atuin") || effective == default);
     }
 
-    #[test]
+    #[rstest]
     fn keymap_config_deserializes_simple_binding() {
         let json = r#"{"emacs": {"ctrl-c": "exit"}}"#;
         let config: super::KeymapConfig = serde_json::from_str(json).unwrap();
@@ -2045,7 +2044,7 @@ mod tests {
         }
     }
 
-    #[test]
+    #[rstest]
     fn keymap_config_deserializes_conditional_binding() {
         let json = r#"{
             "emacs": {
@@ -2067,7 +2066,7 @@ mod tests {
         }
     }
 
-    #[test]
+    #[rstest]
     fn keymap_config_deserializes_vim_normal() {
         let json = r#"{"vim-normal": {"j": "select-next", "k": "select-previous"}}"#;
         let config: super::KeymapConfig = serde_json::from_str(json).unwrap();
@@ -2075,13 +2074,13 @@ mod tests {
         assert!(config.emacs.is_empty());
     }
 
-    #[test]
+    #[rstest]
     fn keymap_config_is_empty_when_default() {
         let config = super::KeymapConfig::default();
         assert!(config.is_empty());
     }
 
-    #[test]
+    #[rstest]
     fn keymap_config_mixed_modes() {
         let json = r#"{
             "emacs": {"ctrl-c": "exit"},
@@ -2108,7 +2107,20 @@ mod tests {
             .expect("could not deserialize config")
     }
 
-    #[test]
+    #[rstest]
+    fn fixed_command_column_uses_default_width() {
+        let settings = parse_settings(
+            "[ui]\ncolumns = [{ type = \"command\", expand = false }, { type = \"directory\", \
+             expand = true }]\n",
+        );
+
+        assert_eq!(settings.ui.columns[0].column_type, super::UiColumnType::Command);
+        assert_eq!(settings.ui.columns[0].width, 20);
+        assert!(!settings.ui.columns[0].expand);
+        assert!(settings.ui.columns[1].expand);
+    }
+
+    #[rstest]
     fn skim_is_requested_but_resolves_to_fuzzy() {
         let settings = parse_settings("search_mode = \"skim\"\n");
 
@@ -2116,7 +2128,7 @@ mod tests {
         assert_eq!(settings.search_mode(), SearchMode::Fuzzy);
     }
 
-    #[test]
+    #[rstest]
     fn skim_shell_up_key_binding_resolves_to_fuzzy() {
         let settings = parse_settings("search_mode_shell_up_key_binding = \"skim\"\n");
 

--- a/crates/atuin/src/command/client/search/history_list.rs
+++ b/crates/atuin/src/command/client/search/history_list.rs
@@ -297,7 +297,7 @@ impl DrawState<'_> {
         self.draw(&display, Style::from_crossterm(style));
     }
 
-    fn command(&mut self, h: &History, _width: u16) {
+    fn command(&mut self, h: &History, width: u16) {
         let mut style = self.theme.as_style(Meaning::Base);
         let mut row_highlighted = false;
         if !self.alternate_highlight
@@ -322,19 +322,25 @@ impl DrawState<'_> {
             Vec::new()
         };
 
-        // Calculate the available width for the command text.
-        // `self.x` is already past the indicator and any preceding columns,
-        // so the remaining width is how far we can draw.
-        let avail = usize::conv(self.list_area.width.saturating_sub(self.x));
+        // Keep the command inside its allocated column so later columns remain visible.
+        let start_x = self.x;
+        let avail = width.min(self.list_area.width.saturating_sub(start_x));
+        if avail == 0 {
+            return;
+        }
+        let column_end = start_x + avail;
 
         // Truncate long commands from the middle to show both start and end,
         // so users can identify commands even in narrow terminals (issue #3596).
-        let ellipsized =
-            normalized.ellipsize(Measure::Columns(avail), Pos::Middle, Indicator::UNICODE);
+        let ellipsized = normalized.ellipsize(
+            Measure::Columns(usize::conv(avail)),
+            Pos::Middle,
+            Indicator::UNICODE,
+        );
         let display = ellipsized.to_string();
         for (i, ch) in display.char_indices() {
-            if self.x > self.list_area.width {
-                return;
+            if self.x >= column_end {
+                break;
             }
             // Map each output cell back to its source byte and test the existing
             // highlight set; a cell on the spliced ellipsis maps to None and is
@@ -352,6 +358,10 @@ impl DrawState<'_> {
             }
             self.draw(&ch.to_string(), Style::from_crossterm(char_style));
         }
+
+        // A short command still occupies the full column so the next column aligns.
+        let padding = " ".repeat(usize::conv(column_end.saturating_sub(self.x)));
+        self.draw(&padding, Style::from_crossterm(style));
     }
 
     /// Render the absolute datetime column (e.g., "2025-01-22 14:35")
@@ -435,5 +445,74 @@ impl DrawState<'_> {
 
         let w = usize::conv(self.list_area.width - self.x);
         self.x += self.buf.set_stringn(cx, cy, s, w, style).0 - cx;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use atuin_client::settings::{SearchMode, Settings};
+    use atuin_client::theme::ThemeManager;
+    use rstest::rstest;
+
+    use super::*;
+
+    #[rstest]
+    fn command_column_honors_width_before_expanding_directory() {
+        let columns = [
+            UiColumn::new(UiColumnType::Time),
+            UiColumn::new(UiColumnType::Duration),
+            UiColumn::new(UiColumnType::Exit),
+            UiColumn {
+                column_type: UiColumnType::Command,
+                width: UiColumnType::Command.default_width(),
+                expand: false,
+            },
+            UiColumn {
+                column_type: UiColumnType::Directory,
+                width: UiColumnType::Directory.default_width(),
+                expand: true,
+            },
+        ];
+        let settings = Settings::utc();
+        let engine = super::super::engines::engine(SearchMode::Fuzzy, &settings);
+        let mut theme_manager = ThemeManager::new(Some(false), Some(String::new()));
+        let theme = theme_manager.load_theme("default", None);
+        let area = Rect::new(0, 0, 70, 1);
+        let directory_x = 3 + columns[..4].iter().map(|column| column.width).sum::<u16>() + 4;
+
+        for command in ["echo ok", "cargo run --release -- a-command-that-does-not-fit"] {
+            let history: History = History::import()
+                .timestamp(OffsetDateTime::UNIX_EPOCH)
+                .command(command)
+                .cwd("/work/project")
+                .exit(0)
+                .duration(1_000_000)
+                .build()
+                .into();
+            let history = [history];
+            let mut buf = Buffer::empty(area);
+            let mut state = ListState::default();
+            let now = || OffsetDateTime::UNIX_EPOCH;
+
+            HistoryList::new(
+                &history,
+                true,
+                false,
+                &now,
+                UtcOffset::UTC,
+                " > ",
+                theme,
+                HistoryHighlighter {
+                    engine: &engine,
+                    search_input: "",
+                },
+                false,
+                false,
+                &columns,
+            )
+            .render(area, &mut buf, &mut state);
+
+            assert_eq!(buf[(directory_x, 0)].symbol(), "/", "rendered row for {command:?}");
+        }
     }
 }

--- a/docs/docs/configuration/config.md
+++ b/docs/docs/configuration/config.md
@@ -1215,7 +1215,7 @@ Each column can be specified as:
 | `host`      | 15             | Hostname where command was run                  |
 | `user`      | 10             | Username                                        |
 | `exit`      | 3              | Exit code (colored by success/failure)          |
-| `command`   | *              | The command itself (expands by default)         |
+| `command`   | 20             | The command itself (expands by default; width applies when fixed) |
 
 #### Column options
 


### PR DESCRIPTION
## Summary

- keep command rendering within the width assigned by the column layout, including padding short commands so later columns stay aligned
- use a 20-character default when the command column is configured as fixed
- document the fixed width and cover the documented directory-expands layout with configuration and terminal-buffer regression tests

Fixes #3882

## Testing

- `cargo test -p atuin-client --lib`
- `cargo test -p atuin --bin atuin`
- `cargo clippy -p atuin-client -p atuin -- -D warnings -D clippy::redundant_clone`
- `cargo clippy -p atuin-client -p atuin --tests -- -D warnings -D clippy::redundant_clone`
- `cargo fmt --all -- --check`

## Checks

- [x] I am happy for maintainers to push small adjustments to this PR, to speed up the review cycle
- [x] I have checked that there are no existing pull requests for the same thing
