### PR TITLE
docs(search): document the date format for `--before`/`--after`

### DIFF
--- a/docs/docs/reference/search.md
+++ b/docs/docs/reference/search.md
@@ -23,6 +23,16 @@ appended with a wildcard).
 | `--inline-height`    | Set the maximum number of lines Atuin's interface should take up              |
 | `--help`/`-h`        | Print help                                                                    |
 
+## Dates for `--before` and `--after`
+
+Both accept absolute dates (`2021-04-01`, `2021-04-01T15:00:00`) and relative
+ones (`yesterday 3pm`, `2 hours ago`).
+
+Slash-separated dates are read **day first**, so `01/04/2021` means 1 April
+2021, not 4 January. This is fixed, and is not affected by the
+[`dialect`](../configuration/config.md#dialect) setting — `dialect` applies to
+the [`stats`](stats.md) command only. Prefer the unambiguous `YYYY-MM-DD` form.
+
 ## `atuin search -i`
 
 Use Atuin's interactive search TUI to fuzzy search through your history.
@@ -46,7 +56,7 @@ atuin search -i atuin
 atuin search --exit 0 cargo
 
 # Search for all commands, that failed, from the current dir, and were ran before April 1st 2021
-atuin search --exclude-exit 0 --before 01/04/2021 --cwd .
+atuin search --exclude-exit 0 --before 2021-04-01 --cwd .
 
 # Search for all commands, beginning with cargo, that exited successfully, and were ran after yesterday at 3pm
 atuin search --exit 0 --after "yesterday 3pm" cargo

--- a/docs/docs/reference/search.md
+++ b/docs/docs/reference/search.md
@@ -29,9 +29,9 @@ Both accept absolute dates (`2021-04-01`, `2021-04-01T15:00:00`) and relative
 ones (`yesterday 3pm`, `2 hours ago`).
 
 Slash-separated dates are read **day first**, so `01/04/2021` means 1 April
-2021, not 4 January. This is fixed, and is not affected by the
-[`dialect`](../configuration/config.md#dialect) setting — `dialect` applies to
-the [`stats`](stats.md) command only. Prefer the unambiguous `YYYY-MM-DD` form.
+2021, not 4 January. This isn't configurable: the
+[`dialect`](../configuration/config.md#dialect) setting applies to the
+[`stats`](stats.md) command only. Prefer the unambiguous `YYYY-MM-DD` form.
 
 ## `atuin search -i`
 


### PR DESCRIPTION
`docs/docs/reference/search.md` documented no date format for `--before`/`--after`, and its one dated example was ambiguous in a way that pointed the wrong direction:

```shell
# Search for all commands, that failed, from the current dir, and were ran before April 1st 2021
atuin search --exclude-exit 0 --before 01/04/2021 --cwd .
```

`01/04/2021` annotated "April 1st" is day-first, but `dialect` defaults to `us`. A reader on a default config would reasonably write `04/01/2021` for April 1st and silently get 4 January instead — no error, just a wrong window.

Slash dates are in fact always day-first for these flags: `interim::Dialect::Uk` is hardcoded at both call sites in `database.rs`, and `dialect` is documented as applying to `stats`. So the code and the config docs agree; only this page was misleading.

Verified against a source build:

```console
$ atuin search --before 08/01/2026 --cmd-only | wc -l
0                     # matches 2026-01-08
$ atuin search --before 2026-08-01 --cmd-only | wc -l
1590
```

This switches the example to ISO and adds a short subsection stating the rule and pointing at `dialect`'s actual scope. Docs only — no behaviour change.
