### PR TITLE
feat(hook): record Claude Code's PowerShell tool invocations

### DIFF
--- a/crates/atuin/src/command/client/hook.rs
+++ b/crates/atuin/src/command/client/hook.rs
@@ -64,7 +64,10 @@ const CLAUDE_CODE: AgentSpec = AgentSpec {
     install_kind: InstallKind::JsonHooks {
         config_path: &[".claude", "settings.json"],
         hook_command: "atuin hook claude-code",
-        matcher: "Bash",
+        // Claude Code's matcher is a regex over the tool name. On Windows it
+        // runs shell commands through a `PowerShell` tool rather than `Bash`,
+        // so matching only `Bash` silently records nothing there.
+        matcher: "Bash|PowerShell",
     },
 };
 
@@ -319,7 +322,13 @@ fn add_hook_entries(hooks: &mut Value, agent: &Agent) -> Result<()> {
             .as_array_mut()
             .ok_or_else(|| eyre::eyre!("hooks.{event_type} is not an array"))?;
 
-        let already_installed = arr.iter().any(|entry| {
+        // Atuin owns any entry that invokes its own hook command, so an
+        // existing entry is identified by `command` alone. Its `matcher` can
+        // still be stale: someone who installed while claude-code only matched
+        // `Bash` would otherwise keep that matcher forever, and re-running
+        // install would report "already installed" while the new tool coverage
+        // never reached them.
+        let existing = arr.iter_mut().find(|entry| {
             entry
                 .get("hooks")
                 .and_then(Value::as_array)
@@ -330,8 +339,16 @@ fn add_hook_entries(hooks: &mut Value, agent: &Agent) -> Result<()> {
                 })
         });
 
-        if already_installed {
-            eprintln!("hooks.{event_type}: already installed, skipping");
+        if let Some(entry) = existing {
+            if entry.get("matcher").and_then(Value::as_str) == Some(matcher) {
+                eprintln!("hooks.{event_type}: already installed, skipping");
+            } else {
+                entry
+                    .as_object_mut()
+                    .ok_or_else(|| eyre::eyre!("hooks.{event_type} entry is not an object"))?
+                    .insert("matcher".to_string(), Value::String(matcher.to_string()));
+                eprintln!("hooks.{event_type}: updated matcher to {matcher}");
+            }
             continue;
         }
 
@@ -442,5 +459,96 @@ mod tests {
             AtuinCmd::Client(client::Cmd::Hook(Cmd { action: None, agent: Some(agent) }))
                 if agent == "codex"
         ));
+    }
+
+    /// The matcher an agent installs, for assertions below.
+    fn expected_matcher(agent: &Agent) -> &'static str {
+        let InstallKind::JsonHooks { matcher, .. } = agent.install_kind() else {
+            panic!("agent does not use JSON hooks");
+        };
+        matcher
+    }
+
+    /// A first install writes one entry per event type, carrying the agent's
+    /// current matcher.
+    #[test]
+    fn add_hook_entries_installs_into_an_empty_config() {
+        let agent = Agent::from_name("claude-code").unwrap();
+        let mut hooks = serde_json::json!({});
+
+        add_hook_entries(&mut hooks, &agent).unwrap();
+
+        for event_type in HOOK_EVENT_TYPES {
+            let arr = hooks[*event_type].as_array().unwrap();
+            assert_eq!(arr.len(), 1, "{event_type} should hold exactly one entry");
+            assert_eq!(arr[0]["matcher"], expected_matcher(&agent));
+        }
+    }
+
+    /// Re-running install against an up-to-date config changes nothing — no
+    /// duplicate entries.
+    #[test]
+    fn add_hook_entries_is_idempotent() {
+        let agent = Agent::from_name("claude-code").unwrap();
+        let mut hooks = serde_json::json!({});
+
+        add_hook_entries(&mut hooks, &agent).unwrap();
+        let after_first = hooks.clone();
+        add_hook_entries(&mut hooks, &agent).unwrap();
+
+        assert_eq!(hooks, after_first);
+    }
+
+    /// An entry installed by an older atuin keeps its stale matcher unless
+    /// install rewrites it. Matching on `command` alone would report "already
+    /// installed" and leave the user on the old tool coverage forever.
+    #[test]
+    fn add_hook_entries_refreshes_a_stale_matcher() {
+        let agent = Agent::from_name("claude-code").unwrap();
+        let InstallKind::JsonHooks { hook_command, .. } = agent.install_kind() else {
+            panic!("claude-code does not use JSON hooks");
+        };
+
+        let stale = serde_json::json!({
+            "matcher": "Bash",
+            "hooks": [{"type": "command", "command": hook_command}],
+        });
+        let mut hooks = serde_json::json!({});
+        for event_type in HOOK_EVENT_TYPES {
+            hooks[*event_type] = serde_json::json!([stale.clone()]);
+        }
+
+        add_hook_entries(&mut hooks, &agent).unwrap();
+
+        for event_type in HOOK_EVENT_TYPES {
+            let arr = hooks[*event_type].as_array().unwrap();
+            assert_eq!(arr.len(), 1, "{event_type} should not gain a second entry");
+            assert_eq!(arr[0]["matcher"], expected_matcher(&agent));
+        }
+    }
+
+    /// Hooks the user configured themselves are left alone; only atuin's own
+    /// entry is touched.
+    #[test]
+    fn add_hook_entries_leaves_foreign_entries_untouched() {
+        let agent = Agent::from_name("claude-code").unwrap();
+        let foreign = serde_json::json!({
+            "matcher": "Bash",
+            "hooks": [{"type": "command", "command": "some-other-tool"}],
+        });
+
+        let mut hooks = serde_json::json!({});
+        for event_type in HOOK_EVENT_TYPES {
+            hooks[*event_type] = serde_json::json!([foreign.clone()]);
+        }
+
+        add_hook_entries(&mut hooks, &agent).unwrap();
+
+        for event_type in HOOK_EVENT_TYPES {
+            let arr = hooks[*event_type].as_array().unwrap();
+            assert_eq!(arr.len(), 2, "{event_type} should keep the foreign entry");
+            assert_eq!(arr[0], foreign);
+            assert_eq!(arr[1]["matcher"], expected_matcher(&agent));
+        }
     }
 }

--- a/crates/atuin/src/command/client/hook/event.rs
+++ b/crates/atuin/src/command/client/hook/event.rs
@@ -32,13 +32,13 @@ pub enum ParseError {
 /// An agent hook event Atuin cares about.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum HookEvent {
-    /// A Bash command is about to run; open a history entry.
+    /// A shell command is about to run; open a history entry.
     Start {
         command: NonNulStr,
         intent: Option<String>,
         tool_use_id: String,
     },
-    /// A Bash command finished; close the matching history entry.
+    /// A shell command finished; close the matching history entry.
     End { tool_use_id: String, exit: i64 },
 }
 
@@ -47,7 +47,7 @@ impl From<WireHookEvent> for Option<HookEvent> {
     /// event.
     ///
     /// We **don't** care about:
-    ///   - Non-`Bash` tool invocations.
+    ///   - Tool invocations that aren't a shell tool (`Bash`, `PowerShell`).
     ///   - Tool invocations which are missing a `tool_use_id`.
     fn from(wire: WireHookEvent) -> Self {
         if matches!(wire.tool_name, WireToolName::Other) {
@@ -191,8 +191,46 @@ mod tests {
         }),
         Some(HookEvent::End { tool_use_id: "toolu_abc123".into(), exit: 1 })
     )]
-    // Non-Bash tools are never recorded.
-    #[case::non_bash_tool_skipped(
+    // Claude Code on Windows runs shell commands through a `PowerShell` tool
+    // rather than `Bash`; those are recorded the same way.
+    #[case::powershell_pre_tool_use(
+        json!({
+            "hook_event_name": "PreToolUse",
+            "tool_name": "PowerShell",
+            "tool_input": {"command": "Get-ChildItem", "description": "List files"},
+            "tool_use_id": "toolu_abc123"
+        }),
+        Some(HookEvent::Start {
+            command: non_nul("Get-ChildItem"),
+            intent: Some("List files".into()),
+            tool_use_id: "toolu_abc123".into()
+        })
+    )]
+    // A PowerShell completion closes the entry just like a Bash one. Claude
+    // Code's PowerShell `tool_response` carries no `exitCode`, so this is the
+    // default-zero path.
+    #[case::powershell_post_tool_use(
+        json!({
+            "hook_event_name": "PostToolUse",
+            "tool_name": "PowerShell",
+            "tool_input": {"command": "Get-ChildItem"},
+            "tool_response": {"stdout": "", "stderr": "", "interrupted": false},
+            "tool_use_id": "toolu_abc123"
+        }),
+        Some(HookEvent::End { tool_use_id: "toolu_abc123".into(), exit: 0 })
+    )]
+    // A failed PowerShell command still forces exit 1.
+    #[case::powershell_failure_forces_exit_one(
+        json!({
+            "hook_event_name": "PostToolUseFailure",
+            "tool_name": "PowerShell",
+            "tool_input": {"command": "throw 'boom'"},
+            "tool_use_id": "toolu_abc123"
+        }),
+        Some(HookEvent::End { tool_use_id: "toolu_abc123".into(), exit: 1 })
+    )]
+    // Tools that aren't a shell are never recorded.
+    #[case::non_shell_tool_skipped(
         json!({
             "hook_event_name": "PreToolUse",
             "tool_name": "Write",
@@ -324,11 +362,13 @@ mod tests {
     }
 
     proptest! {
-        /// Any Bash `PreToolUse` with a non-empty command becomes a `Start`
-        /// carrying that command, the tool id, and the optional description as
-        /// intent — regardless of the surrounding fields.
+        /// Any shell-tool `PreToolUse` with a non-empty command becomes a
+        /// `Start` carrying that command, the tool id, and the optional
+        /// description as intent — regardless of the surrounding fields, and
+        /// identically for every shell tool.
         #[test]
-        fn bash_pre_tool_use_yields_start(
+        fn shell_pre_tool_use_yields_start(
+            tool_name in proptest::sample::select(vec!["Bash", "PowerShell"]),
             command in r"[^\p{Cc}]+",
             tool_use_id in r"[^\p{Cc}]+",
             description in proptest::option::of(r"[^\p{Cc}]*"),
@@ -340,7 +380,7 @@ mod tests {
             }
             let input = json!({
                 "hook_event_name": "PreToolUse",
-                "tool_name": "Bash",
+                "tool_name": tool_name,
                 "tool_input": serde_json::Value::Object(tool_input),
                 "tool_use_id": tool_use_id,
             });
@@ -355,15 +395,17 @@ mod tests {
             );
         }
 
-        /// Any Bash `PostToolUse` reports the exit code verbatim, for every i64.
+        /// Any shell-tool `PostToolUse` reports the exit code verbatim, for
+        /// every i64.
         #[test]
-        fn bash_post_tool_use_reports_exit_code(
+        fn shell_post_tool_use_reports_exit_code(
+            tool_name in proptest::sample::select(vec!["Bash", "PowerShell"]),
             exit in any::<i64>(),
             tool_use_id in r"[^\p{Cc}]+",
         ) {
             let input = json!({
                 "hook_event_name": "PostToolUse",
-                "tool_name": "Bash",
+                "tool_name": tool_name,
                 "tool_response": {"exitCode": exit},
                 "tool_use_id": tool_use_id,
             });
@@ -378,12 +420,13 @@ mod tests {
         /// claims.
         #[test]
         fn failure_event_always_exits_one(
+            tool_name in proptest::sample::select(vec!["Bash", "PowerShell"]),
             reported_exit in any::<i64>(),
             tool_use_id in r"[^\p{Cc}]+",
         ) {
             let input = json!({
                 "hook_event_name": "PostToolUseFailure",
-                "tool_name": "Bash",
+                "tool_name": tool_name,
                 "tool_response": {"exitCode": reported_exit},
                 "tool_use_id": tool_use_id,
             });
@@ -394,10 +437,16 @@ mod tests {
             );
         }
 
-        /// Any tool other than Bash is skipped, whatever the event or fields.
+        /// Any tool that isn't a shell tool is skipped, whatever the event or
+        /// fields. Both shell tools must be excluded from the generator: the
+        /// strategy can produce any printable string, so leaving `PowerShell`
+        /// in would make this a rare flake rather than a stable failure.
         #[test]
-        fn non_bash_tool_is_always_skipped(
-            tool_name in r"[^\p{Cc}]+".prop_filter("must not be Bash", |s| s.as_str() != "Bash"),
+        fn non_shell_tool_is_always_skipped(
+            tool_name in r"[^\p{Cc}]+".prop_filter(
+                "must not be a shell tool",
+                |s| !matches!(s.as_str(), "Bash" | "PowerShell"),
+            ),
             event in proptest::sample::select(vec![
                 "PreToolUse", "PostToolUse", "PostToolUseFailure", "Frobnicate",
             ]),

--- a/crates/atuin/src/command/client/hook/wire.rs
+++ b/crates/atuin/src/command/client/hook/wire.rs
@@ -11,6 +11,12 @@ use atuin_common::string::NonNulStr;
 pub enum WireToolName {
     /// The tool the agent requested is a Bash command.
     Bash,
+    /// The tool the agent requested is a PowerShell command.
+    ///
+    /// Claude Code on Windows exposes a separate `PowerShell` tool alongside
+    /// `Bash`, and routes most shell calls through it. Without this variant
+    /// those commands decode to [`WireToolName::Other`] and are dropped.
+    PowerShell,
     /// Unrecognized wire tool name.
     #[serde(other)]
     Other,
@@ -21,7 +27,7 @@ pub enum WireToolName {
 pub struct WireHookEvent {
     /// The lifecycle stage. An unrecognized value decodes to [`HookEventName::Other`].
     pub hook_event_name: HookEventName,
-    /// The tool that ran; we only record `Bash`.
+    /// The tool that ran; we only record shell tools (`Bash`, `PowerShell`).
     pub tool_name: WireToolName,
     /// Correlates a command's start and end across two `atuin hook` invocations.
     pub tool_use_id: String,

--- a/docs/docs/guide/agent-hooks.md
+++ b/docs/docs/guide/agent-hooks.md
@@ -37,10 +37,10 @@ When `atuin hook install` runs, it writes the agent's config file or extension t
 
 The hook lifecycle:
 
-1. **PreToolUse** -- the agent is about to run a Bash command. Atuin records the command, working directory, and timestamp (same as `history start`).
+1. **PreToolUse** -- the agent is about to run a shell command. Atuin records the command, working directory, and timestamp (same as `history start`).
 2. **PostToolUse / PostToolUseFailure** -- the command finished. Atuin records the exit code and duration (same as `history end`).
 
-Atuin only captures `Bash` tool invocations. It ignores other tool types (file writes, web fetches, etc.).
+Atuin only captures shell tool invocations -- `Bash`, plus the `PowerShell` tool Claude Code uses on Windows. It ignores other tool types (file writes, web fetches, etc.).
 
 Agents that load extensions rather than shelling out to a hook command -- opencode and pi -- call `atuin history start` and `atuin history end` directly instead, but record the same thing.
 
@@ -88,7 +88,9 @@ For support tiers, see [Supported platforms](../support.md).
 atuin hook install claude-code
 ```
 
-This adds hook entries to `~/.claude/settings.json`. Claude Code calls `atuin hook claude-code` on each `Bash` tool use, passing the event as JSON on `stdin`.
+This adds hook entries to `~/.claude/settings.json`. Claude Code calls `atuin hook claude-code` on each `Bash` or `PowerShell` tool use, passing the event as JSON on `stdin`. On Windows Claude Code runs most shell commands through its `PowerShell` tool, so the matcher covers both.
+
+If you installed the hooks with an earlier version of Atuin, re-run the command above: it rewrites the existing entry's matcher in place rather than reporting "already installed."
 
 ### Codex
 


### PR DESCRIPTION
## Checks
- [x] I am happy for maintainers to push small adjustments to this PR, to speed up the review cycle
- [x] I have checked that there are no existing pull requests for the same thing

## The problem

On Windows, Claude Code exposes a separate `PowerShell` tool alongside `Bash` and routes most shell calls through it. Atuin records none of them, and never says so:

- `WireToolName` only modelled `Bash`, so a `PowerShell` event decoded to `Other` and `From<WireHookEvent>` returned `None`.
- `atuin hook install claude-code` wrote a `"Bash"` matcher, so the agent never invoked the hook for those tools in the first place.

`atuin hook install claude-code` reports success, the hook entries look right in `settings.json`, and `--author claude-code` stays empty for every command that didn't go through the Bash tool.

## Changes

**Accept the tool.** A `PowerShell` variant on `WireToolName`, and the claude-code install matcher widened to `Bash|PowerShell`. The serde variant name matches the wire value exactly, so no rename is needed. Codex keeps `^Bash$`; the extension-based agents are untouched.

**Refresh stale matchers on re-install.** `add_hook_entries` decided "already installed" from the hook `command` alone. Anyone who installed before this change would re-run install, be told the hooks were already there, and keep the old `Bash`-only matcher — the fix would never reach the people who need it. Atuin still claims an entry by its command, but now rewrites that entry's `matcher` when it differs. Entries the user configured themselves are left alone.

**Docs.** `agent-hooks.md` stated that only `Bash` invocations are captured.

### One thing worth your call

The matcher refresh is a behaviour change: `atuin hook install` used to only ever append, and now edits an existing entry in place. I think it belongs here, because without it this fix silently does nothing for existing users — the same failure mode the PR is about — and there are tests covering that foreign entries stay untouched. But if you'd rather keep install append-only, or take that part as its own PR, say the word and I'll split it.

### On the tests

`non_bash_tool_is_always_skipped` filtered only the literal `"Bash"` out of an arbitrary-string generator. Accepting `PowerShell` would have turned it into a rare flake rather than a stable failure, so it now excludes both shell tools and is renamed `non_shell_tool_is_always_skipped`. The three shell property tests sample over `["Bash", "PowerShell"]` instead of hardcoding `Bash`, asserting the two tools share semantics rather than spot-checking the new one.

## Verification

On a Linux codespace: `cargo fmt --check`, `cargo test -p atuin hook` (44 passed), `cargo clippy -p atuin --all-targets` and `vale` on the changed doc — all clean.

**I could not verify a built binary on real Windows**, as I don't have a Windows Rust toolchain. What *was* verified on Windows is the payload shape and the failure itself: the `PowerShell` tool's `PreToolUse`/`PostToolUse` JSON was captured from a live Claude Code session, and a paired-marker test — one marker through the `Bash` tool, one through `PowerShell`, same session, same moment — confirmed the `Bash`-only matcher records the former and silently drops the latter. The parsing side is covered by the tests above.

One detail from that capture, in case it's useful: Claude Code's `PowerShell` `tool_response` carries no `exitCode`, so successes take the default-zero path and failures arrive as `PostToolUseFailure`, which already forces exit 1. The existing mapping handles both; no change was needed there.

## Note

#3906 touches `hook.rs` as well (agent config-dir env vars). Different region, but flagging it in case you want to sequence them.
