### PR TITLE
fix(sync): fix off-by-one bugs in sync

### DIFF
--- a/crates/atuin-client/src/record/sync.rs
+++ b/crates/atuin-client/src/record/sync.rs
@@ -176,9 +176,10 @@ async fn sync_upload(
     local: RecordIdx,
     remote: Option<RecordIdx>,
     page_size: u64,
-) -> Result<i64, SyncError> {
-    let remote = remote.unwrap_or(0);
-    let expected = local - remote;
+) -> Result<u64, SyncError> {
+    // The first record the remote *doesn't* have.
+    let first_missing_remote = remote.map_or(0, |n| n + 1);
+    let expected = local + 1 - first_missing_remote;
     let mut progress = 0;
 
     let pb = ProgressBar::new(expected);
@@ -194,9 +195,9 @@ async fn sync_upload(
         tag
     );
 
-    loop {
+    while progress < expected {
         let page = store
-            .next(host, &tag, remote + progress, page_size)
+            .next(host, &tag, first_missing_remote + progress, page_size)
             .await
             .map_err(|e| {
                 error!("failed to read upload page: {e:?}");
@@ -216,15 +217,11 @@ async fn sync_upload(
 
         progress += page.len() as u64;
         pb.set_position(progress);
-
-        if progress >= expected {
-            break;
-        }
     }
 
     pb.finish_with_message("Uploaded records");
 
-    Ok(progress as i64)
+    Ok(progress)
 }
 
 async fn sync_download(
@@ -236,8 +233,9 @@ async fn sync_download(
     remote: RecordIdx,
     page_size: u64,
 ) -> Result<Vec<RecordId>, SyncError> {
-    let local = local.unwrap_or(0);
-    let expected = remote - local;
+    // The first record the local store *doesn't* have.
+    let first_missing_local = local.map_or(0, |n| n + 1);
+    let expected = remote + 1 - first_missing_local;
     let mut progress = 0;
     let mut ret = Vec::new();
 
@@ -254,9 +252,9 @@ async fn sync_download(
         .with_key("eta", |state: &ProgressState, w: &mut dyn Write| write!(w, "{:.1}s", state.eta().as_secs_f64()).unwrap())
         .progress_chars("#>-"));
 
-    loop {
+    while progress < expected {
         let page = client
-            .next_records(host, tag.clone(), local + progress, page_size)
+            .next_records(host, tag.clone(), first_missing_local + progress, page_size)
             .await
             .map_err(|e| SyncError::RemoteRequestError { msg: e.to_string() })?;
 
@@ -273,10 +271,6 @@ async fn sync_download(
 
         progress += page.len() as u64;
         pb.set_position(progress);
-
-        if progress >= expected {
-            break;
-        }
     }
 
     pb.finish_with_message("Downloaded records");
@@ -289,7 +283,7 @@ pub async fn sync_remote(
     operations: Vec<Operation>,
     local_store: &SqliteStore,
     page_size: u64,
-) -> Result<(i64, Vec<RecordId>), SyncError> {
+) -> Result<(u64, Vec<RecordId>), SyncError> {
     let mut uploaded = 0;
     let mut downloaded = Vec::new();
 
@@ -359,7 +353,7 @@ pub async fn sync(
     settings: &Settings,
     store: &SqliteStore,
     encryption_key: &paseto_v4::Key,
-) -> Result<(i64, Vec<RecordId>), SyncError> {
+) -> Result<(u64, Vec<RecordId>), SyncError> {
     let client = build_client(settings).await?;
     let (diff, remote_index) = diff(&client, store).await?;
 

--- a/crates/atuin-server/tests/sync.rs
+++ b/crates/atuin-server/tests/sync.rs
@@ -1,0 +1,257 @@
+use atuin_client::api_client;
+use atuin_client::record::sqlite_store::SqliteStore;
+use atuin_client::record::sync;
+use atuin_common::utils::uuid_v7;
+use atuin_domain::record::{EncryptedData, Host, HostId, Record, RecordId, RecordIdx, RecordTag};
+use atuin_server::{Settings as ServerSettings, launch_with_tcp_listener};
+use atuin_server_database::DbSettings;
+use atuin_server_sqlite::Sqlite;
+use futures_util::TryFutureExt;
+use rstest::{fixture, rstest};
+use std::env::temp_dir;
+use std::time::Duration;
+use tokio::net::TcpListener;
+use tokio::sync::oneshot;
+use tokio::task::JoinHandle;
+
+/// A SQLite-backed server on a random port, shut down and cleaned up when it goes out of scope.
+struct TestServer {
+    address: url::Url,
+    db: std::path::PathBuf,
+    shutdown: Option<oneshot::Sender<()>>,
+    handle: JoinHandle<()>,
+}
+
+impl TestServer {
+    /// Register a fresh user, and return a client authenticated as them.
+    async fn register(&self) -> api_client::Client {
+        let username = uuid_v7().as_simple().to_string();
+        let password = uuid_v7().as_simple().to_string();
+        let email = format!("{}@example.com", uuid_v7().as_simple());
+
+        let resp = api_client::register(
+            &self.address,
+            &username,
+            &email,
+            &password,
+            &Default::default(),
+        )
+        .await
+        .unwrap();
+
+        api_client::Client::new(
+            self.address.clone(),
+            api_client::AuthToken::Token(resp.session),
+            5,
+            30,
+            &Default::default(),
+        )
+        .unwrap()
+    }
+}
+
+impl Drop for TestServer {
+    fn drop(&mut self) {
+        if let Some(shutdown) = self.shutdown.take() {
+            let _ = shutdown.send(());
+        }
+        self.handle.abort();
+
+        // The pool may still hold these open, but unlinking an open file is fine.
+        for suffix in ["", "-wal", "-shm"] {
+            let mut path = self.db.clone().into_os_string();
+            path.push(suffix);
+            let _ = std::fs::remove_file(path);
+        }
+    }
+}
+
+#[fixture]
+async fn server() -> TestServer {
+    let db = temp_dir().join(format!("atuin-record-sync-{}.db", uuid_v7().as_simple()));
+
+    let server_settings = ServerSettings {
+        host: "127.0.0.1".to_owned(),
+        port: 0,
+        path: String::new(),
+        open_registration: true,
+        max_record_size: 1024 * 1024 * 1024,
+        register_webhook_url: None,
+        register_webhook_username: String::new(),
+        db_settings: DbSettings {
+            db_uri: format!("sqlite://{}", db.to_str().unwrap()),
+            read_db_uri: None,
+        },
+        metrics: atuin_server::settings::Metrics::default(),
+        fake_version: None,
+    };
+
+    let (shutdown_tx, shutdown_rx) = oneshot::channel();
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+
+    let handle = tokio::spawn(async move {
+        if let Err(e) = launch_with_tcp_listener::<Sqlite>(
+            server_settings,
+            listener,
+            shutdown_rx.unwrap_or_else(|_| ()),
+        )
+        .await
+        {
+            panic!("error running server: {e:?}");
+        }
+    });
+
+    tokio::time::sleep(Duration::from_millis(200)).await;
+
+    TestServer {
+        address: url::Url::parse(&format!("http://{addr}")).expect("valid test server url"),
+        db,
+        shutdown: Some(shutdown_tx),
+        handle,
+    }
+}
+
+fn record(host: HostId, tag: &RecordTag, idx: RecordIdx) -> Record<EncryptedData> {
+    Record::builder()
+        .host(Host::new(host))
+        .version("v0".to_string().into())
+        .tag(tag.clone())
+        .idx(idx)
+        .data(EncryptedData {
+            raw: String::from("some data"),
+            cek: String::from("some key"),
+        })
+        .build()
+}
+
+/// Populate the remote with records `0..=remote_max` and the local store with records
+/// `0..=local_max` (or nothing if `local_max` is [`None`]), then run a real sync.
+///
+/// Returns the records the remote sent us, and the highest record index the local store ends up
+/// with.
+async fn download(
+    server: &TestServer,
+    remote_max: RecordIdx,
+    local_max: Option<RecordIdx>,
+    page_size: u64,
+) -> (Vec<RecordId>, RecordIdx) {
+    let client = server.register().await;
+
+    let host = HostId(uuid_v7());
+    let tag = RecordTag::Other(uuid_v7().as_simple().to_string());
+
+    let records: Vec<Record<EncryptedData>> = (0..=remote_max)
+        .map(|idx| record(host, &tag, idx))
+        .collect();
+
+    client.post_records(&records).await.unwrap();
+
+    let store = SqliteStore::new(":memory:", 2.0).await.unwrap();
+    if let Some(local_max) = local_max {
+        store
+            .push_batch(records.iter().take(local_max as usize + 1))
+            .await
+            .unwrap();
+    }
+
+    let (diff, _) = sync::diff(&client, &store).await.unwrap();
+    let operations = sync::operations(diff, &store).await.unwrap();
+    let (_, downloaded) = sync::sync_remote(&client, operations, &store, page_size)
+        .await
+        .unwrap();
+
+    let status = store.status().await.unwrap();
+    let local_idx = *status.hosts.get(&host).unwrap().get(&tag).unwrap();
+
+    (downloaded, local_idx)
+}
+
+#[rstest]
+#[case::partial_local(5, Some(2), 100, 3)]
+#[case::empty_local(5, None, 100, 6)]
+#[case::exact_page(4, Some(0), 4, 4)]
+#[case::empty_local_page_plus_one(4, None, 4, 5)]
+#[case::empty_local_single_record(0, None, 100, 1)]
+#[case::exact_pages(9, Some(1), 4, 8)]
+#[case::partial_page(6, Some(0), 4, 6)]
+#[tokio::test]
+async fn download_fetches_exactly_the_missing_records(
+    #[future(awt)] server: TestServer,
+    #[case] remote_max: RecordIdx,
+    #[case] local_max: Option<RecordIdx>,
+    #[case] page_size: u64,
+    // The expected number of records to be downloaded.
+    #[case] expected: usize,
+) {
+    let (downloaded, local_idx) = download(&server, remote_max, local_max, page_size).await;
+
+    assert_eq!(local_idx, remote_max, "local store is missing records");
+    assert_eq!(downloaded.len(), expected, "downloaded {downloaded:?}");
+}
+
+/// Populate the local store with records `0..=local_max` and the remote with records
+/// `0..=remote_max` (or nothing if `remote_max` is [`None`]), then run a real sync.
+///
+/// Returns the number of records we sent and highest record index the remote ends up with.
+async fn upload(
+    server: &TestServer,
+    local_max: RecordIdx,
+    remote_max: Option<RecordIdx>,
+    page_size: u64,
+) -> (u64, RecordIdx) {
+    let client = server.register().await;
+
+    let host = HostId(uuid_v7());
+    let tag = RecordTag::Other(uuid_v7().as_simple().to_string());
+
+    let records: Vec<Record<EncryptedData>> =
+        (0..=local_max).map(|idx| record(host, &tag, idx)).collect();
+
+    let store = SqliteStore::new(":memory:", 2.0).await.unwrap();
+    store.push_batch(records.iter()).await.unwrap();
+
+    if let Some(remote_max) = remote_max {
+        client
+            .post_records(&records[..=remote_max as usize])
+            .await
+            .unwrap();
+    }
+
+    let (diff, _) = sync::diff(&client, &store).await.unwrap();
+    let operations = sync::operations(diff, &store).await.unwrap();
+    let (uploaded, _) = sync::sync_remote(&client, operations, &store, page_size)
+        .await
+        .unwrap();
+
+    let status = client.record_status().await.unwrap();
+    let remote_idx = *status.hosts.get(&host).unwrap().get(&tag).unwrap();
+
+    // The PR that added these tests also changed the type of `uploaded` from `i64` to `u64`; the
+    // redundant `as u64` here is just to make it convenient to run these tests before the PR's
+    // fixes, by temporarily reverting all the non-test files.
+    (uploaded as u64, remote_idx)
+}
+
+#[rstest]
+#[case::partial_remote(5, Some(2), 100, 3)]
+#[case::empty_remote(5, None, 100, 6)]
+#[case::exact_page(4, Some(0), 4, 4)]
+#[case::empty_remote_page_plus_one(4, None, 4, 5)]
+#[case::empty_remote_single_record(0, None, 100, 1)]
+#[case::exact_pages(9, Some(1), 4, 8)]
+#[case::partial_page(6, Some(0), 4, 6)]
+#[tokio::test]
+async fn upload_sends_exactly_the_missing_records(
+    #[future(awt)] server: TestServer,
+    #[case] local_max: RecordIdx,
+    #[case] remote_max: Option<RecordIdx>,
+    #[case] page_size: u64,
+    // The expected number of records to be uploaded.
+    #[case] expected: u64,
+) {
+    let (uploaded, remote_idx) = upload(&server, local_max, remote_max, page_size).await;
+
+    assert_eq!(remote_idx, local_max, "remote is missing records");
+    assert_eq!(uploaded, expected);
+}

--- a/crates/atuin-server/tests/sync.rs
+++ b/crates/atuin-server/tests/sync.rs
@@ -230,6 +230,7 @@ async fn upload(
     // The PR that added these tests also changed the type of `uploaded` from `i64` to `u64`; the
     // redundant `as u64` here is just to make it convenient to run these tests before the PR's
     // fixes, by temporarily reverting all the non-test files.
+    #[allow(clippy::unnecessary_cast)]
     (uploaded as u64, remote_idx)
 }
 


### PR DESCRIPTION
Issues fixed:

* The latest record that local and remote both have is unnecessarily uploaded/downloaded again
* If the number of records to upload/download is an exact multiple of the page size, the last record will be skipped
* If one side has no records and the number of records is one more than a multiple of the page size, the last record will be skipped

`cargo test -p atuin-server --test sync` before the fix (commit `f84803d`):

```
failures:
    download_fetches_exactly_the_missing_records::case_1_partial_local
    download_fetches_exactly_the_missing_records::case_3_exact_page
    download_fetches_exactly_the_missing_records::case_4_empty_local_page_plus_one
    download_fetches_exactly_the_missing_records::case_6_exact_pages
    download_fetches_exactly_the_missing_records::case_7_partial_page
    upload_sends_exactly_the_missing_records::case_1_partial_remote
    upload_sends_exactly_the_missing_records::case_3_exact_page
    upload_sends_exactly_the_missing_records::case_4_empty_remote_page_plus_one
    upload_sends_exactly_the_missing_records::case_6_exact_pages
    upload_sends_exactly_the_missing_records::case_7_partial_page

test result: FAILED. 4 passed; 10 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.64s
```

<details>
<summary>Full output</summary>
<pre><code>running 14 tests
test upload_sends_exactly_the_missing_records::case_1_partial_remote ... FAILED
test download_fetches_exactly_the_missing_records::case_3_exact_page ... FAILED
test download_fetches_exactly_the_missing_records::case_6_exact_pages ... FAILED
test download_fetches_exactly_the_missing_records::case_2_empty_local ... ok
test upload_sends_exactly_the_missing_records::case_2_empty_remote ... ok
test download_fetches_exactly_the_missing_records::case_1_partial_local ... FAILED
test download_fetches_exactly_the_missing_records::case_5_empty_local_single_record ... ok
test upload_sends_exactly_the_missing_records::case_4_empty_remote_page_plus_one ... FAILED
test upload_sends_exactly_the_missing_records::case_5_empty_remote_single_record ... ok
test download_fetches_exactly_the_missing_records::case_7_partial_page ... FAILED
test upload_sends_exactly_the_missing_records::case_3_exact_page ... FAILED
test download_fetches_exactly_the_missing_records::case_4_empty_local_page_plus_one ... FAILED
test upload_sends_exactly_the_missing_records::case_7_partial_page ... FAILED
test upload_sends_exactly_the_missing_records::case_6_exact_pages ... FAILED

failures:

---- upload_sends_exactly_the_missing_records::case_1_partial_remote stdout ----
Uploading 3 records to 019ff87c713a77e2be6d78e158b11c92/019ff87c713a77e2be6d78fa29622212

thread 'upload_sends_exactly_the_missing_records::case_1_partial_remote' (1434443) panicked at crates/atuin-server/tests/sync.rs:256:5:
assertion `left == right` failed
  left: 4
 right: 3
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace

---- download_fetches_exactly_the_missing_records::case_3_exact_page stdout ----
Downloading 4 records from 019ff87c71397fa089838e894318ad47/019ff87c71397fa089838e961e99c16b

thread 'download_fetches_exactly_the_missing_records::case_3_exact_page' (1434438) panicked at crates/atuin-server/tests/sync.rs:189:5:
assertion `left == right` failed: local store is missing records
  left: 3
 right: 4

---- download_fetches_exactly_the_missing_records::case_6_exact_pages stdout ----
Downloading 8 records from 019ff87c71397fa089838e619f55069b/019ff87c71397fa089838e7e82bbfee6

thread 'download_fetches_exactly_the_missing_records::case_6_exact_pages' (1434441) panicked at crates/atuin-server/tests/sync.rs:189:5:
assertion `left == right` failed: local store is missing records
  left: 8
 right: 9

---- download_fetches_exactly_the_missing_records::case_1_partial_local stdout ----
Downloading 3 records from 019ff87c71687b0282e95ff453ee04c2/019ff87c71687b0282e9600f0b2e5bfb

thread 'download_fetches_exactly_the_missing_records::case_1_partial_local' (1434436) panicked at crates/atuin-server/tests/sync.rs:190:5:
assertion `left == right` failed: downloaded [RecordId(019ff87c-7168-7b02-82e9-6032c60121af), RecordId(019ff87c-7168-7b02-82e9-60499907fe2e), RecordId(019ff87c-7168-7b02-82e9-60564c14a784), RecordId(019ff87c-7168-7b02-82e9-606e0321fe0d)]
  left: 4
 right: 3

---- upload_sends_exactly_the_missing_records::case_4_empty_remote_page_plus_one stdout ----
Uploading 4 records to 019ff87c719f72a1b0a22ecd84629917/019ff87c719f72a1b0a22ed73fcdd250

thread 'upload_sends_exactly_the_missing_records::case_4_empty_remote_page_plus_one' (1434446) panicked at crates/atuin-server/tests/sync.rs:255:5:
assertion `left == right` failed: remote is missing records
  left: 3
 right: 4

---- download_fetches_exactly_the_missing_records::case_7_partial_page stdout ----
Downloading 6 records from 019ff87c719f72a1b0a22ee0dec78cf5/019ff87c719f72a1b0a22ef3c85ea38e

thread 'download_fetches_exactly_the_missing_records::case_7_partial_page' (1434442) panicked at crates/atuin-server/tests/sync.rs:190:5:
assertion `left == right` failed: downloaded [RecordId(019ff87c-719f-72a1-b0a2-2f5b02f8d07e), RecordId(019ff87c-719f-72a1-b0a2-2f69e58f0d3e), RecordId(019ff87c-719f-72a1-b0a2-2f727cebcde2), RecordId(019ff87c-719f-72a1-b0a2-2f83ef8607ea), RecordId(019ff87c-719f-72a1-b0a2-2f9f46ccd282), RecordId(019ff87c-719f-72a1-b0a2-2fa55c96e710), RecordId(019ff87c-719f-72a1-b0a2-2fb80d6b4897)]
  left: 7
 right: 6

---- upload_sends_exactly_the_missing_records::case_3_exact_page stdout ----
Uploading 4 records to 019ff87c71a176e1a261e63a27b8a5f5/019ff87c71a176e1a261e64b2c063d44

thread 'upload_sends_exactly_the_missing_records::case_3_exact_page' (1434445) panicked at crates/atuin-server/tests/sync.rs:255:5:
assertion `left == right` failed: remote is missing records
  left: 3
 right: 4

---- download_fetches_exactly_the_missing_records::case_4_empty_local_page_plus_one stdout ----
Downloading 4 records from 019ff87c71a176e1a261e5c8c593a069/019ff87c71a176e1a261e5dbcc388abc

thread 'download_fetches_exactly_the_missing_records::case_4_empty_local_page_plus_one' (1434439) panicked at crates/atuin-server/tests/sync.rs:189:5:
assertion `left == right` failed: local store is missing records
  left: 3
 right: 4

---- upload_sends_exactly_the_missing_records::case_7_partial_page stdout ----
Uploading 6 records to 019ff87c71a47fb1bca19029200c6a6f/019ff87c71a47fb1bca1903a6257598a

thread 'upload_sends_exactly_the_missing_records::case_7_partial_page' (1434449) panicked at crates/atuin-server/tests/sync.rs:256:5:
assertion `left == right` failed
  left: 7
 right: 6

---- upload_sends_exactly_the_missing_records::case_6_exact_pages stdout ----
Uploading 8 records to 019ff87c71bd7593acf489e248e7c8ba/019ff87c71bd7593acf489fcec20e772

thread 'upload_sends_exactly_the_missing_records::case_6_exact_pages' (1434448) panicked at crates/atuin-server/tests/sync.rs:255:5:
assertion `left == right` failed: remote is missing records
  left: 8
 right: 9


failures:
    download_fetches_exactly_the_missing_records::case_1_partial_local
    download_fetches_exactly_the_missing_records::case_3_exact_page
    download_fetches_exactly_the_missing_records::case_4_empty_local_page_plus_one
    download_fetches_exactly_the_missing_records::case_6_exact_pages
    download_fetches_exactly_the_missing_records::case_7_partial_page
    upload_sends_exactly_the_missing_records::case_1_partial_remote
    upload_sends_exactly_the_missing_records::case_3_exact_page
    upload_sends_exactly_the_missing_records::case_4_empty_remote_page_plus_one
    upload_sends_exactly_the_missing_records::case_6_exact_pages
    upload_sends_exactly_the_missing_records::case_7_partial_page

test result: FAILED. 4 passed; 10 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.64s
</code></pre>
</details>

`cargo test -p atuin-server --test sync` after the fix (commit `9cb1ade`):

```
test result: ok. 14 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.65s
```