### PR TITLE
fix: silence hub 401 log spam during installer login

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -158,7 +158,8 @@ EOF
       ;;
     2|[lL]*)
       echo ""
-      if ! "$ATUIN_BIN" login </dev/tty; then
+      # Silences pre-#3916 401 log spam; drop once that fix is in the latest release.
+      if ! ATUIN_LOG="warn,atuin_client::hub=off" "$ATUIN_BIN" login </dev/tty; then
         echo ""
         echo "Login did not complete. You can run 'atuin login' any time to try again."
       fi


### PR DESCRIPTION
Releases before #3916 log an ERROR for every auth poll that returns 401 

Set the ATUIN_LOG var to hide this