### PR TITLE
fix(hook): never let a failed agent hook block the agent's shell

### DIFF
--- a/crates/atuin/src/command/client/hook.rs
+++ b/crates/atuin/src/command/client/hook.rs
@@ -163,15 +163,7 @@ impl Cmd {
     pub async fn run(self, settings: &Settings) -> Result<()> {
         match (self.action, self.agent) {
             (Some(Action::Install { agent }), None) => install(&agent),
-            // Recording is best-effort: agents read a hook's exit code as a
-            // verdict on the command it wrapped, so a failure here must never
-            // stop the agent from running the command.
-            (None, Some(agent)) => {
-                if let Err(err) = handle(&agent, settings).await {
-                    tracing::warn!(error = %err, agent, "agent hook failed");
-                }
-                Ok(())
-            }
+            (None, Some(agent)) => handle(&agent, settings).await,
             (None, None) => {
                 bail!("expected `atuin hook <agent>` or `atuin hook install <agent>`");
             }
@@ -317,13 +309,13 @@ struct ManagedHook {
 }
 
 impl ManagedHook {
-    /// Build the command for `agent`, pinned to the running binary and shielded
-    /// from its own failures.
+    /// Build the command for `agent`, naming the binary that is installing it.
     ///
-    /// Both parts matter. Agents spawn hooks with a minimal `PATH`, where a bare
-    /// `atuin` can miss or resolve to an older build without `hook` — and clap
-    /// exits 2 for an unknown subcommand, which Claude Code reads as "deny this
-    /// Bash call". `|| true` keeps any other failure from doing the same.
+    /// Agents spawn hooks with a minimal `PATH`, where a bare `atuin` can be
+    /// missing entirely or resolve to an older build that has no `hook`
+    /// subcommand — and clap exits 2 for that, which Claude Code reads as "deny
+    /// this Bash call". Pinning the path keeps the hook on the binary that knows
+    /// what to do with it.
     fn new(agent: &'static str, matcher: &'static str) -> Result<Self> {
         let exe = std::env::current_exe()
             .wrap_err("could not locate the atuin executable to install hooks with")?;
@@ -336,15 +328,13 @@ impl ManagedHook {
     }
 
     /// Whether `command` is an Atuin hook for this agent, so reinstalling can
-    /// claim it: a bare `atuin hook <agent>` from an older installer, an
-    /// absolute path to an `atuin` binary, with or without `|| true`.
+    /// claim it: the bare `atuin hook <agent>` older installers wrote, or any
+    /// path to an `atuin` binary invoked the same way.
     fn owns(&self, command: &str) -> bool {
-        let command = command.trim();
-        let command = command
-            .strip_suffix("|| true")
-            .map_or(command, str::trim_end);
-
-        let Some(binary) = command.strip_suffix(&format!(" hook {}", self.agent)) else {
+        let Some(binary) = command
+            .trim()
+            .strip_suffix(&format!(" hook {}", self.agent))
+        else {
             return false;
         };
 
@@ -370,7 +360,7 @@ fn hook_command(exe: &Path, agent: &str) -> String {
         std::borrow::Cow::into_owned,
     );
 
-    format!("{exe} hook {agent} || true")
+    format!("{exe} hook {agent}")
 }
 
 fn add_hook_entries(hooks: &mut Value, hook: &ManagedHook) -> Result<()> {
@@ -529,8 +519,8 @@ mod tests {
         ));
     }
 
-    /// What an install writes today: an absolute binary, quoted, fail-open.
-    const INSTALLED: &str = "/opt/homebrew/bin/atuin hook claude-code || true";
+    /// What an install writes today: the binary it ran from, quoted.
+    const INSTALLED: &str = "/opt/homebrew/bin/atuin hook claude-code";
 
     #[fixture]
     fn hook() -> ManagedHook {
@@ -570,10 +560,9 @@ mod tests {
     }
 
     /// A bare `atuin` can resolve to a build without `hook`, whose clap exits 2
-    /// — which Claude Code reads as "deny this Bash call". The command must name
-    /// the binary that installed it and swallow whatever that binary does.
+    /// — which Claude Code reads as "deny this Bash call".
     #[test]
-    fn hook_command_pins_the_binary_and_fails_open() {
+    fn hook_command_pins_the_installing_binary() {
         assert_eq!(
             hook_command(&PathBuf::from("/opt/homebrew/bin/atuin"), "claude-code"),
             INSTALLED
@@ -584,7 +573,7 @@ mod tests {
     fn hook_command_quotes_a_path_with_spaces() {
         assert_eq!(
             hook_command(&PathBuf::from("/Users/Ada Lovelace/bin/atuin"), "codex"),
-            "'/Users/Ada Lovelace/bin/atuin' hook codex || true"
+            "'/Users/Ada Lovelace/bin/atuin' hook codex"
         );
     }
 
@@ -593,8 +582,7 @@ mod tests {
     #[rstest]
     #[case::bare("atuin hook claude-code", true)]
     #[case::absolute("/usr/local/bin/atuin hook claude-code", true)]
-    #[case::fail_open("/usr/local/bin/atuin hook claude-code || true", true)]
-    #[case::quoted("'/Users/Ada/bin/atuin' hook claude-code || true", true)]
+    #[case::quoted("'/Users/Ada/bin/atuin' hook claude-code", true)]
     #[case::windows(r#""C:\Program Files\atuin\atuin.exe" hook claude-code"#, true)]
     #[case::another_agent("atuin hook codex", false)]
     #[case::another_binary("/usr/bin/echo hook claude-code", false)]

--- a/crates/atuin/src/command/client/hook.rs
+++ b/crates/atuin/src/command/client/hook.rs
@@ -163,7 +163,16 @@ impl Cmd {
     pub async fn run(self, settings: &Settings) -> Result<()> {
         match (self.action, self.agent) {
             (Some(Action::Install { agent }), None) => install(&agent),
-            (None, Some(agent)) => handle(&agent, settings).await,
+            // Recording history is best effort, and never worth blocking
+            // someone's command over. Hooks installed before this shipped have
+            // no `|| true` to fall back on.
+            (None, Some(agent)) => {
+                if let Err(err) = handle(&agent, settings).await {
+                    tracing::warn!(error = %err, agent, "agent hook failed");
+                }
+
+                Ok(())
+            }
             (None, None) => {
                 bail!("expected `atuin hook <agent>` or `atuin hook install <agent>`");
             }
@@ -309,13 +318,15 @@ struct ManagedHook {
 }
 
 impl ManagedHook {
-    /// Build the command for `agent`, naming the binary that is installing it.
+    /// Build the command for `agent`, naming the binary that is installing it
+    /// and discarding whatever that binary exits with.
     ///
     /// Agents spawn hooks with a minimal `PATH`, where a bare `atuin` can be
     /// missing entirely or resolve to an older build that has no `hook`
     /// subcommand — and clap exits 2 for that, which Claude Code reads as "deny
-    /// this Bash call". Pinning the path keeps the hook on the binary that knows
-    /// what to do with it.
+    /// this Bash call". Pinning the path keeps the hook on a binary that knows
+    /// what to do with it; `|| true` covers what the binary can't answer for,
+    /// like failing to start at all.
     fn new(agent: &'static str, matcher: &'static str) -> Result<Self> {
         let exe = std::env::current_exe()
             .wrap_err("could not locate the atuin executable to install hooks with")?;
@@ -329,12 +340,15 @@ impl ManagedHook {
 
     /// Whether `command` is an Atuin hook for this agent, so reinstalling can
     /// claim it: the bare `atuin hook <agent>` older installers wrote, or any
-    /// path to an `atuin` binary invoked the same way.
+    /// path to an `atuin` binary invoked the same way, with or without the
+    /// trailing `|| true`.
     fn owns(&self, command: &str) -> bool {
-        let Some(binary) = command
-            .trim()
-            .strip_suffix(&format!(" hook {}", self.agent))
-        else {
+        let command = command.trim();
+        let command = command
+            .strip_suffix("|| true")
+            .map_or(command, str::trim_end);
+
+        let Some(binary) = command.strip_suffix(&format!(" hook {}", self.agent)) else {
             return false;
         };
 
@@ -360,7 +374,7 @@ fn hook_command(exe: &Path, agent: &str) -> String {
         std::borrow::Cow::into_owned,
     );
 
-    format!("{exe} hook {agent}")
+    format!("{exe} hook {agent} || true")
 }
 
 fn add_hook_entries(hooks: &mut Value, hook: &ManagedHook) -> Result<()> {
@@ -519,8 +533,8 @@ mod tests {
         ));
     }
 
-    /// What an install writes today: the binary it ran from, quoted.
-    const INSTALLED: &str = "/opt/homebrew/bin/atuin hook claude-code";
+    /// What an install writes today: the binary it ran from, quoted, fail-open.
+    const INSTALLED: &str = "/opt/homebrew/bin/atuin hook claude-code || true";
 
     #[fixture]
     fn hook() -> ManagedHook {
@@ -560,9 +574,10 @@ mod tests {
     }
 
     /// A bare `atuin` can resolve to a build without `hook`, whose clap exits 2
-    /// — which Claude Code reads as "deny this Bash call".
+    /// — which Claude Code reads as "deny this Bash call". The command names the
+    /// binary that installed it, and discards whatever that binary exits with.
     #[test]
-    fn hook_command_pins_the_installing_binary() {
+    fn hook_command_pins_the_installing_binary_and_fails_open() {
         assert_eq!(
             hook_command(&PathBuf::from("/opt/homebrew/bin/atuin"), "claude-code"),
             INSTALLED
@@ -573,7 +588,7 @@ mod tests {
     fn hook_command_quotes_a_path_with_spaces() {
         assert_eq!(
             hook_command(&PathBuf::from("/Users/Ada Lovelace/bin/atuin"), "codex"),
-            "'/Users/Ada Lovelace/bin/atuin' hook codex"
+            "'/Users/Ada Lovelace/bin/atuin' hook codex || true"
         );
     }
 
@@ -582,7 +597,8 @@ mod tests {
     #[rstest]
     #[case::bare("atuin hook claude-code", true)]
     #[case::absolute("/usr/local/bin/atuin hook claude-code", true)]
-    #[case::quoted("'/Users/Ada/bin/atuin' hook claude-code", true)]
+    #[case::fail_open("/usr/local/bin/atuin hook claude-code || true", true)]
+    #[case::quoted("'/Users/Ada/bin/atuin' hook claude-code || true", true)]
     #[case::windows(r#""C:\Program Files\atuin\atuin.exe" hook claude-code"#, true)]
     #[case::another_agent("atuin hook codex", false)]
     #[case::another_binary("/usr/bin/echo hook claude-code", false)]

--- a/crates/atuin/src/command/client/hook.rs
+++ b/crates/atuin/src/command/client/hook.rs
@@ -1,11 +1,11 @@
 use std::ffi::OsString;
 use std::io::Read;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use atuin_client::settings::Settings;
 use atuin_common::utils::home_dir;
 use clap::{Parser, Subcommand};
-use eyre::{Result, bail};
+use eyre::{Context, Result, bail};
 use serde_json::Value;
 
 use super::history;
@@ -22,7 +22,8 @@ const OPENCODE_PLUGIN_SOURCE: &str = include_str!("../../../contrib/opencode/atu
 enum InstallKind {
     JsonHooks {
         config_path: &'static [&'static str],
-        hook_command: &'static str,
+        /// Agent name passed to `atuin hook <agent>`.
+        hook_agent: &'static str,
         matcher: &'static str,
     },
     /// An agent that loads TypeScript extensions from a directory, rather than
@@ -63,7 +64,7 @@ const CLAUDE_CODE: AgentSpec = AgentSpec {
     path_root: PathRoot::Home,
     install_kind: InstallKind::JsonHooks {
         config_path: &[".claude", "settings.json"],
-        hook_command: "atuin hook claude-code",
+        hook_agent: "claude-code",
         matcher: "Bash",
     },
 };
@@ -74,7 +75,7 @@ const CODEX: AgentSpec = AgentSpec {
     path_root: PathRoot::Home,
     install_kind: InstallKind::JsonHooks {
         config_path: &[".codex", "hooks.json"],
-        hook_command: "atuin hook codex",
+        hook_agent: "codex",
         matcher: "^Bash$",
     },
 };
@@ -162,7 +163,15 @@ impl Cmd {
     pub async fn run(self, settings: &Settings) -> Result<()> {
         match (self.action, self.agent) {
             (Some(Action::Install { agent }), None) => install(&agent),
-            (None, Some(agent)) => handle(&agent, settings).await,
+            // Recording is best-effort: agents read a hook's exit code as a
+            // verdict on the command it wrapped, so a failure here must never
+            // stop the agent from running the command.
+            (None, Some(agent)) => {
+                if let Err(err) = handle(&agent, settings).await {
+                    tracing::warn!(error = %err, agent, "agent hook failed");
+                }
+                Ok(())
+            }
             (None, None) => {
                 bail!("expected `atuin hook <agent>` or `atuin hook install <agent>`");
             }
@@ -233,8 +242,8 @@ fn install(agent_name: &str) -> Result<()> {
     match agent.install_kind() {
         InstallKind::JsonHooks {
             config_path,
-            hook_command: _,
-            matcher: _,
+            hook_agent,
+            matcher,
         } => {
             let config_path = agent.path(config_path);
 
@@ -255,15 +264,17 @@ fn install(agent_name: &str) -> Result<()> {
                 .entry("hooks")
                 .or_insert_with(|| Value::Object(serde_json::Map::new()));
 
-            add_hook_entries(hooks, &agent)?;
+            let hook = ManagedHook::new(hook_agent, matcher)?;
+            add_hook_entries(hooks, &hook)?;
 
             let content = serde_json::to_string_pretty(&root)?;
             std::fs::write(&config_path, content)?;
 
             eprintln!(
-                "\nAtuin hooks installed for {}. Config: {}",
+                "\nAtuin hooks installed for {}. Config: {}\nHook command: {}",
                 agent.actor_name(),
-                config_path.display()
+                config_path.display(),
+                hook.command
             );
         }
         InstallKind::Extension {
@@ -298,16 +309,71 @@ fn install(agent_name: &str) -> Result<()> {
     Ok(())
 }
 
-fn add_hook_entries(hooks: &mut Value, agent: &Agent) -> Result<()> {
-    let InstallKind::JsonHooks {
-        config_path: _,
-        hook_command,
-        matcher,
-    } = agent.install_kind()
-    else {
-        bail!("agent does not use JSON hooks");
-    };
+/// The hook entry Atuin installs into a JSON-hook agent's config.
+struct ManagedHook {
+    agent: &'static str,
+    matcher: &'static str,
+    command: String,
+}
 
+impl ManagedHook {
+    /// Build the command for `agent`, pinned to the running binary and shielded
+    /// from its own failures.
+    ///
+    /// Both parts matter. Agents spawn hooks with a minimal `PATH`, where a bare
+    /// `atuin` can miss or resolve to an older build without `hook` — and clap
+    /// exits 2 for an unknown subcommand, which Claude Code reads as "deny this
+    /// Bash call". `|| true` keeps any other failure from doing the same.
+    fn new(agent: &'static str, matcher: &'static str) -> Result<Self> {
+        let exe = std::env::current_exe()
+            .wrap_err("could not locate the atuin executable to install hooks with")?;
+
+        Ok(Self {
+            agent,
+            matcher,
+            command: hook_command(&exe, agent),
+        })
+    }
+
+    /// Whether `command` is an Atuin hook for this agent, so reinstalling can
+    /// claim it: a bare `atuin hook <agent>` from an older installer, an
+    /// absolute path to an `atuin` binary, with or without `|| true`.
+    fn owns(&self, command: &str) -> bool {
+        let command = command.trim();
+        let command = command
+            .strip_suffix("|| true")
+            .map_or(command, str::trim_end);
+
+        let Some(binary) = command.strip_suffix(&format!(" hook {}", self.agent)) else {
+            return false;
+        };
+
+        let binary = binary.trim().trim_matches(['\'', '"']);
+        let name = binary.rsplit(['/', '\\']).next().unwrap_or(binary);
+
+        name == "atuin" || name.eq_ignore_ascii_case("atuin.exe")
+    }
+
+    fn entry(&self) -> Value {
+        serde_json::json!({
+            "matcher": self.matcher,
+            "hooks": [{"type": "command", "command": self.command}],
+        })
+    }
+}
+
+/// The command to write into an agent's config, quoted for the POSIX shell
+/// agents run hooks with: bash on Unix, Git Bash on Windows.
+fn hook_command(exe: &Path, agent: &str) -> String {
+    let exe = shlex::try_quote(exe.to_string_lossy().as_ref()).map_or_else(
+        |_| format!("'{}'", exe.display()),
+        std::borrow::Cow::into_owned,
+    );
+
+    format!("{exe} hook {agent} || true")
+}
+
+fn add_hook_entries(hooks: &mut Value, hook: &ManagedHook) -> Result<()> {
     for event_type in HOOK_EVENT_TYPES {
         let event_hooks = hooks
             .as_object_mut()
@@ -319,27 +385,46 @@ fn add_hook_entries(hooks: &mut Value, agent: &Agent) -> Result<()> {
             .as_array_mut()
             .ok_or_else(|| eyre::eyre!("hooks.{event_type} is not an array"))?;
 
-        let already_installed = arr.iter().any(|entry| {
+        // Rewrite hooks we own rather than appending: an install that only ever
+        // appended would leave an existing bare `atuin hook …` in place, and
+        // that stale entry is the one that can block the agent's Bash tool.
+        // Only the first survives, so exactly one Atuin hook fires per event.
+        let mut claimed = false;
+        for entry in arr.iter_mut() {
+            let Some(entry_hooks) = entry.get_mut("hooks").and_then(Value::as_array_mut) else {
+                continue;
+            };
+
+            entry_hooks.retain_mut(|entry_hook| {
+                let Some(command) = entry_hook.get("command").and_then(Value::as_str) else {
+                    return true;
+                };
+                if !hook.owns(command) {
+                    return true;
+                }
+                if claimed {
+                    return false;
+                }
+
+                claimed = true;
+                entry_hook["command"] = Value::String(hook.command.clone());
+                true
+            });
+        }
+
+        arr.retain(|entry| {
             entry
                 .get("hooks")
                 .and_then(Value::as_array)
-                .is_some_and(|hooks| {
-                    hooks.iter().any(|hook| {
-                        hook.get("command").and_then(Value::as_str) == Some(hook_command)
-                    })
-                })
+                .is_none_or(|hooks| !hooks.is_empty())
         });
 
-        if already_installed {
-            eprintln!("hooks.{event_type}: already installed, skipping");
-            continue;
+        if claimed {
+            eprintln!("hooks.{event_type}: refreshed atuin hook");
+        } else {
+            arr.push(hook.entry());
+            eprintln!("hooks.{event_type}: installed atuin hook");
         }
-
-        arr.push(serde_json::json!({
-            "matcher": matcher,
-            "hooks": [{"type": "command", "command": hook_command}],
-        }));
-        eprintln!("hooks.{event_type}: installed atuin hook");
     }
 
     Ok(())
@@ -354,7 +439,7 @@ mod tests {
     };
     use atuin_client::history::is_known_agent;
     use clap::Parser;
-    use rstest::rstest;
+    use rstest::{fixture, rstest};
 
     #[test]
     fn parse_hook_agent_command() {
@@ -442,5 +527,125 @@ mod tests {
             AtuinCmd::Client(client::Cmd::Hook(Cmd { action: None, agent: Some(agent) }))
                 if agent == "codex"
         ));
+    }
+
+    /// What an install writes today: an absolute binary, quoted, fail-open.
+    const INSTALLED: &str = "/opt/homebrew/bin/atuin hook claude-code || true";
+
+    #[fixture]
+    fn hook() -> ManagedHook {
+        ManagedHook {
+            agent: "claude-code",
+            matcher: "Bash",
+            command: INSTALLED.to_owned(),
+        }
+    }
+
+    /// One wrapper entry per hook event, each holding `commands`.
+    fn config(commands: &[&str]) -> Value {
+        let entries: Vec<Value> = commands
+            .iter()
+            .map(|command| {
+                serde_json::json!({
+                    "matcher": "Bash",
+                    "hooks": [{"type": "command", "command": command}],
+                })
+            })
+            .collect();
+
+        HOOK_EVENT_TYPES
+            .iter()
+            .map(|event| ((*event).to_owned(), Value::Array(entries.clone())))
+            .collect()
+    }
+
+    fn commands(hooks: &Value, event: &str) -> Vec<String> {
+        hooks[event]
+            .as_array()
+            .unwrap()
+            .iter()
+            .flat_map(|entry| entry["hooks"].as_array().unwrap())
+            .map(|hook| hook["command"].as_str().unwrap().to_owned())
+            .collect()
+    }
+
+    /// A bare `atuin` can resolve to a build without `hook`, whose clap exits 2
+    /// — which Claude Code reads as "deny this Bash call". The command must name
+    /// the binary that installed it and swallow whatever that binary does.
+    #[test]
+    fn hook_command_pins_the_binary_and_fails_open() {
+        assert_eq!(
+            hook_command(&PathBuf::from("/opt/homebrew/bin/atuin"), "claude-code"),
+            INSTALLED
+        );
+    }
+
+    #[test]
+    fn hook_command_quotes_a_path_with_spaces() {
+        assert_eq!(
+            hook_command(&PathBuf::from("/Users/Ada Lovelace/bin/atuin"), "codex"),
+            "'/Users/Ada Lovelace/bin/atuin' hook codex || true"
+        );
+    }
+
+    /// Reinstalling has to recognize what earlier installers wrote, or it leaves
+    /// the blocking entry behind and adds a second hook beside it.
+    #[rstest]
+    #[case::bare("atuin hook claude-code", true)]
+    #[case::absolute("/usr/local/bin/atuin hook claude-code", true)]
+    #[case::fail_open("/usr/local/bin/atuin hook claude-code || true", true)]
+    #[case::quoted("'/Users/Ada/bin/atuin' hook claude-code || true", true)]
+    #[case::windows(r#""C:\Program Files\atuin\atuin.exe" hook claude-code"#, true)]
+    #[case::another_agent("atuin hook codex", false)]
+    #[case::another_binary("/usr/bin/echo hook claude-code", false)]
+    fn owns_atuin_installed_commands(
+        hook: ManagedHook,
+        #[case] command: &str,
+        #[case] expected: bool,
+    ) {
+        assert_eq!(hook.owns(command), expected);
+    }
+
+    #[rstest]
+    #[case::bare("atuin hook claude-code")]
+    #[case::absolute("/usr/local/bin/atuin hook claude-code")]
+    #[case::current(INSTALLED)]
+    fn install_leaves_one_hook_per_event(hook: ManagedHook, #[case] installed: &str) {
+        let mut hooks = config(&[installed]);
+
+        add_hook_entries(&mut hooks, &hook).unwrap();
+
+        for event in HOOK_EVENT_TYPES {
+            assert_eq!(commands(&hooks, event), vec![INSTALLED.to_owned()]);
+        }
+    }
+
+    /// Two managed hooks would record every command twice.
+    #[rstest]
+    fn install_collapses_duplicate_atuin_hooks(hook: ManagedHook) {
+        let mut hooks = config(&[
+            "atuin hook claude-code",
+            "/usr/local/bin/atuin hook claude-code",
+        ]);
+
+        add_hook_entries(&mut hooks, &hook).unwrap();
+
+        for event in HOOK_EVENT_TYPES {
+            assert_eq!(commands(&hooks, event), vec![INSTALLED.to_owned()]);
+        }
+    }
+
+    #[rstest]
+    fn install_leaves_other_hooks_alone(hook: ManagedHook) {
+        let mut hooks = config(&["/usr/bin/echo hi"]);
+
+        add_hook_entries(&mut hooks, &hook).unwrap();
+
+        for event in HOOK_EVENT_TYPES {
+            assert_eq!(
+                commands(&hooks, event),
+                vec!["/usr/bin/echo hi".to_owned(), INSTALLED.to_owned()]
+            );
+        }
     }
 }

--- a/crates/atuin/src/main.rs
+++ b/crates/atuin/src/main.rs
@@ -1,8 +1,6 @@
 #![warn(clippy::pedantic, clippy::nursery)]
 #![allow(clippy::use_self, clippy::missing_const_for_fn)] // not 100% reliable
 
-use std::ffi::OsString;
-
 use clap::Parser;
 use clap::builder::Styles;
 use clap::builder::styling::{AnsiColor, Effects};
@@ -61,55 +59,6 @@ impl Atuin {
     }
 }
 
-/// Whether this is `atuin hook <agent>`, the per-tool-call event an agent runs
-/// itself — as opposed to `atuin hook install <agent>`, which a user runs and
-/// should see the failures of.
-fn is_agent_hook_event(args: &[OsString]) -> bool {
-    let arg = |index: usize| args.get(index).and_then(|arg| arg.to_str());
-
-    arg(0) == Some("hook")
-        && arg(1).is_some_and(|agent| agent != "install" && !agent.starts_with('-'))
-}
-
 fn main() -> Result<()> {
-    let args: Vec<OsString> = std::env::args_os().collect();
-
-    // An agent reads the exit code of the hook it ran as a verdict on the
-    // command that hook wrapped: Claude Code denies a Bash call outright when a
-    // `PreToolUse` hook exits 2, which is also what clap exits on a bad
-    // invocation. Recording history is best effort and never worth blocking
-    // someone's command over, so this path always reports success — including
-    // when it failed before reaching the hook itself.
-    if is_agent_hook_event(&args[1..]) {
-        if let Err(err) = Atuin::try_parse_from(&args)
-            .map_err(eyre::Report::from)
-            .and_then(Atuin::run)
-        {
-            eprintln!("atuin: hook failed: {err:#}");
-        }
-
-        return Ok(());
-    }
-
-    Atuin::parse_from(args).run()
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use rstest::rstest;
-
-    #[rstest]
-    #[case::event(&["hook", "claude-code"], true)]
-    #[case::alias(&["hook", "claude"], true)]
-    #[case::install(&["hook", "install", "claude-code"], false)]
-    // Swallowing these would print nothing for `atuin hook --help`.
-    #[case::help(&["hook", "--help"], false)]
-    #[case::no_agent(&["hook"], false)]
-    #[case::another_command(&["history", "start"], false)]
-    fn recognizes_the_agent_hook_event(#[case] args: &[&str], #[case] expected: bool) {
-        let args: Vec<OsString> = args.iter().map(OsString::from).collect();
-
-        assert_eq!(is_agent_hook_event(&args), expected);
-    }
+    Atuin::parse().run()
 }

--- a/crates/atuin/src/main.rs
+++ b/crates/atuin/src/main.rs
@@ -1,6 +1,8 @@
 #![warn(clippy::pedantic, clippy::nursery)]
 #![allow(clippy::use_self, clippy::missing_const_for_fn)] // not 100% reliable
 
+use std::ffi::OsString;
+
 use clap::Parser;
 use clap::builder::Styles;
 use clap::builder::styling::{AnsiColor, Effects};
@@ -59,6 +61,55 @@ impl Atuin {
     }
 }
 
+/// Whether this is `atuin hook <agent>`, the per-tool-call event an agent runs
+/// itself — as opposed to `atuin hook install <agent>`, which a user runs and
+/// should see the failures of.
+fn is_agent_hook_event(args: &[OsString]) -> bool {
+    let arg = |index: usize| args.get(index).and_then(|arg| arg.to_str());
+
+    arg(0) == Some("hook")
+        && arg(1).is_some_and(|agent| agent != "install" && !agent.starts_with('-'))
+}
+
 fn main() -> Result<()> {
-    Atuin::parse().run()
+    let args: Vec<OsString> = std::env::args_os().collect();
+
+    // An agent reads the exit code of the hook it ran as a verdict on the
+    // command that hook wrapped: Claude Code denies a Bash call outright when a
+    // `PreToolUse` hook exits 2, which is also what clap exits on a bad
+    // invocation. Recording history is best effort and never worth blocking
+    // someone's command over, so this path always reports success — including
+    // when it failed before reaching the hook itself.
+    if is_agent_hook_event(&args[1..]) {
+        if let Err(err) = Atuin::try_parse_from(&args)
+            .map_err(eyre::Report::from)
+            .and_then(Atuin::run)
+        {
+            eprintln!("atuin: hook failed: {err:#}");
+        }
+
+        return Ok(());
+    }
+
+    Atuin::parse_from(args).run()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rstest::rstest;
+
+    #[rstest]
+    #[case::event(&["hook", "claude-code"], true)]
+    #[case::alias(&["hook", "claude"], true)]
+    #[case::install(&["hook", "install", "claude-code"], false)]
+    // Swallowing these would print nothing for `atuin hook --help`.
+    #[case::help(&["hook", "--help"], false)]
+    #[case::no_agent(&["hook"], false)]
+    #[case::another_command(&["history", "start"], false)]
+    fn recognizes_the_agent_hook_event(#[case] args: &[&str], #[case] expected: bool) {
+        let args: Vec<OsString> = args.iter().map(OsString::from).collect();
+
+        assert_eq!(is_agent_hook_event(&args), expected);
+    }
 }

--- a/docs/docs/guide/agent-hooks.md
+++ b/docs/docs/guide/agent-hooks.md
@@ -90,13 +90,13 @@ atuin hook install claude-code
 
 This adds hook entries to `~/.claude/settings.json`. Claude Code calls Atuin on each `Bash` tool use, passing the event as JSON on `stdin`.
 
-The installed command names the Atuin binary that ran `hook install`, rather than relying on `PATH`:
+The installed command names the Atuin binary that ran `hook install` rather than relying on `PATH`, and ends in `|| true`:
 
 ```
-/home/ellie/.atuin/bin/atuin hook claude-code
+/home/ellie/.atuin/bin/atuin hook claude-code || true
 ```
 
-That matters because Claude Code reads a `PreToolUse` hook that exits 2 as "deny this Bash call", and agents run hooks with a minimal `PATH`, where a bare `atuin` can be missing or resolve to an older build with no `hook` subcommand — which exits 2. Atuin also never fails this command itself: recording history is best effort, so a hook that can't record still reports success and leaves your command alone.
+Both halves keep a failed hook from breaking your shell. Claude Code reads a `PreToolUse` hook that exits 2 as "deny this Bash call", and agents run hooks with a minimal `PATH`, where a bare `atuin` can be missing or resolve to an older build with no `hook` subcommand — which exits 2. Recording history is best effort, so Atuin never blocks a command it failed to record.
 
 ### Codex
 
@@ -104,7 +104,7 @@ That matters because Claude Code reads a `PreToolUse` hook that exits 2 as "deny
 atuin hook install codex
 ```
 
-This adds hook entries to `~/.codex/hooks.json`. Codex calls Atuin on each Bash tool use matching `^Bash$`, using the same pinned command as Claude Code.
+This adds hook entries to `~/.codex/hooks.json`. Codex calls Atuin on each Bash tool use matching `^Bash$`, using the same pinned, fail-open command as Claude Code.
 
 ### opencode
 

--- a/docs/docs/guide/agent-hooks.md
+++ b/docs/docs/guide/agent-hooks.md
@@ -88,7 +88,15 @@ For support tiers, see [Supported platforms](../support.md).
 atuin hook install claude-code
 ```
 
-This adds hook entries to `~/.claude/settings.json`. Claude Code calls `atuin hook claude-code` on each `Bash` tool use, passing the event as JSON on `stdin`.
+This adds hook entries to `~/.claude/settings.json`. Claude Code calls Atuin on each `Bash` tool use, passing the event as JSON on `stdin`.
+
+The installed command names the Atuin binary that ran `hook install` and ends in `|| true`:
+
+```
+/home/ellie/.atuin/bin/atuin hook claude-code || true
+```
+
+Both halves keep a hook failure from breaking your shell. Claude Code reads a `PreToolUse` hook that exits 2 as "deny this Bash call", and agents run hooks with a minimal `PATH`, where a bare `atuin` can be missing or resolve to an older build whose `atuin hook` doesn't exist — an unknown subcommand exits 2. Recording history is best effort, so Atuin never blocks a command it failed to record.
 
 ### Codex
 
@@ -96,7 +104,7 @@ This adds hook entries to `~/.claude/settings.json`. Claude Code calls `atuin ho
 atuin hook install codex
 ```
 
-This adds hook entries to `~/.codex/hooks.json`. Codex calls `atuin hook codex` on each Bash tool use matching `^Bash$`.
+This adds hook entries to `~/.codex/hooks.json`. Codex calls Atuin on each Bash tool use matching `^Bash$`, using the same pinned, fail-open command as Claude Code.
 
 ### opencode
 
@@ -153,12 +161,14 @@ ls ~/.pi/agent/extensions/atuin.ts
 
 ## Re-installing
 
-Running `atuin hook install` again is safe. If hooks are already installed, the command will skip them and print a message:
+Running `atuin hook install` again is safe. For Claude Code and Codex, it rewrites the hook entries Atuin owns to point at the binary you just ran, leaving any hooks you added yourself alone:
 
 ```
-hooks.PreToolUse: already installed, skipping
-hooks.PostToolUse: already installed, skipping
-hooks.PostToolUseFailure: already installed, skipping
+hooks.PreToolUse: refreshed atuin hook
+hooks.PostToolUse: refreshed atuin hook
+hooks.PostToolUseFailure: refreshed atuin hook
 ```
 
-For opencode and pi, reinstalling will also skip if the installed extension already matches the bundled version.
+Re-run it after moving or upgrading your Atuin binary.
+
+For opencode and pi, reinstalling will skip if the installed extension already matches the bundled version.

--- a/docs/docs/guide/agent-hooks.md
+++ b/docs/docs/guide/agent-hooks.md
@@ -90,13 +90,13 @@ atuin hook install claude-code
 
 This adds hook entries to `~/.claude/settings.json`. Claude Code calls Atuin on each `Bash` tool use, passing the event as JSON on `stdin`.
 
-The installed command names the Atuin binary that ran `hook install` and ends in `|| true`:
+The installed command names the Atuin binary that ran `hook install`, rather than relying on `PATH`:
 
 ```
-/home/ellie/.atuin/bin/atuin hook claude-code || true
+/home/ellie/.atuin/bin/atuin hook claude-code
 ```
 
-Both halves keep a hook failure from breaking your shell. Claude Code reads a `PreToolUse` hook that exits 2 as "deny this Bash call", and agents run hooks with a minimal `PATH`, where a bare `atuin` can be missing or resolve to an older build whose `atuin hook` doesn't exist — an unknown subcommand exits 2. Recording history is best effort, so Atuin never blocks a command it failed to record.
+That matters because Claude Code reads a `PreToolUse` hook that exits 2 as "deny this Bash call", and agents run hooks with a minimal `PATH`, where a bare `atuin` can be missing or resolve to an older build with no `hook` subcommand — which exits 2. Atuin also never fails this command itself: recording history is best effort, so a hook that can't record still reports success and leaves your command alone.
 
 ### Codex
 
@@ -104,7 +104,7 @@ Both halves keep a hook failure from breaking your shell. Claude Code reads a `P
 atuin hook install codex
 ```
 
-This adds hook entries to `~/.codex/hooks.json`. Codex calls Atuin on each Bash tool use matching `^Bash$`, using the same pinned, fail-open command as Claude Code.
+This adds hook entries to `~/.codex/hooks.json`. Codex calls Atuin on each Bash tool use matching `^Bash$`, using the same pinned command as Claude Code.
 
 ### opencode
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Checks
- [x] I am happy for maintainers to push small adjustments to this PR, to speed up the review cycle
- [x] I have checked that there are no existing pull requests for the same thing

## The problem

This started from a user's tweet: their "git bash is broken", and Claude Code told them an Atuin hook was to blame and that they had the wrong version.

That is a real failure mode, and the version detail is the giveaway. Claude Code treats a `PreToolUse` hook that exits 2 as *deny this Bash call*. Our installer writes a bare `atuin hook claude-code`, and agents spawn hooks with a minimal `PATH` — so it can resolve to no binary at all, or to an older Atuin that has no `hook` subcommand, and clap exits 2 for an unknown subcommand. Every Bash tool call the agent makes is then denied, with the tool itself looking broken.

Two things make it worse:

- The installer adds these hooks automatically whenever it detects `~/.claude`, so people who never opted into agent hooks are exposed. (Keeping the auto-install; it just has to be safe.)
- Two atuins on `PATH` is exactly the state [#2415](https://github.com/atuinsh/atuin/issues/2415) describes, so "wrong version" is common in practice, not exotic.

[#3698](https://github.com/atuinsh/atuin/issues/3698) is the milder version of this, where the hook exits 127 because `atuin` isn't on the agent's `PATH`.

## Changes

**The installed command names the binary that installed it, and can't fail.** The path comes from `current_exe()`, as the daemon already does, so an older or absent `atuin` on the agent's `PATH` never gets to answer the hook:

```
/home/ellie/.atuin/bin/atuin hook claude-code || true
```

`|| true` is what covers the cases the binary can't answer for itself — clap exiting 2 inside an older Atuin, or the pinned binary having since been deleted. The guard belongs in the config, not in `main`: checking argv on every invocation would tax every command, including the `history start`/`end` hot path, for something only the hook cares about.

**The hook swallows its own errors too.** `atuin hook <agent>` logs and returns success rather than propagating, which is what protects anyone whose config was written before this shipped and so has no `|| true` to fall back on.

**Reinstall repairs instead of appending.** `add_hook_entries` claims the entries Atuin owns — bare or absolute, quoted or not, with or without the suffix — rewrites the first to the current command, and drops the rest so one hook fires per event. Hooks the user wrote are untouched. Without this, the broken bare entry would sit there forever and the fix would never reach anyone who already has one.

While in here, the JSON-hook agent specs carry `hook_agent` rather than a pre-baked `hook_command` string, and the install path builds a `ManagedHook` that owns the command, the matcher, and the ownership test. That removes two "agent does not use JSON hooks" re-destructuring branches that could never fire.

## Verification

`cargo fmt --check`, both clippy passes with `-D warnings -D clippy::redundant_clone`, `RUSTDOCFLAGS="-D warnings" cargo doc --document-private-items --no-deps -p atuin`, and `cargo test -p atuin hook` (51 passed) are all clean.

Unit tests cover the installed command and its quoting, ownership across every command form an installer has written, and the three reinstall outcomes: a bare entry is upgraded in place, duplicates collapse to one, and unrelated hooks survive.

I also ran a built binary against the failure modes, with `HOME` pointed at a scratch directory. Malformed JSON on stdin and an unknown agent both exit 0 from the binary itself. Running the installed command exits 0 when the pinned binary has been deleted and when `config.toml` won't parse — the latter being a case the binary can't catch on its own, since it fails during settings loading before the hook command runs. `atuin hook install` still exits 1 on failure, since a user runs that themselves and should see it.

A fresh install writes the fail-open command, and reinstalling over a config holding both a bare and an absolute Atuin hook plus an unrelated `Write` hook leaves exactly one Atuin entry per event with the unrelated hook intact.

**Not verified against a live agent.** I don't have Claude Code with a stale Atuin on `PATH` here, so the exit-2 blocking behaviour is from Claude Code's [hooks documentation](https://code.claude.com/docs/en/hooks) ("exit code 2 blocks the tool call") rather than something I reproduced.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f5b74a79-9208-4d40-94dd-9d8dfd9b7c35?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f5b74a79-9208-4d40-94dd-9d8dfd9b7c35&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

