### PR TITLE
fix(bash): localize "READLINE_{LINE,POINT}" in Bash <= 3.2

### DIFF
--- a/crates/atuin-ai/src/commands/init.rs
+++ b/crates/atuin-ai/src/commands/init.rs
@@ -148,24 +148,30 @@ _atuin_ai_question_mark() {
     fi
 }
 
-# A "bind -x" handler cannot invoke readline bindable functions such as
-# accept-line, so binding '?' directly to the handler could only ever edit
-# READLINE_LINE, never execute it.  We use the same two-step macro dispatch
-# as atuin's main bash integration: '?' expands to two intermediate
-# sequences, the first runs the handler via "bind -x", and the handler
-# decides what the second does by rebinding it — accept-line to execute, a
-# no-op otherwise.  The sequences \C-x\C-_B<n>\a mirror the main
-# integration's \C-x\C-_A<n>\a chain, with B instead of A to avoid
-# colliding with it.
-if ((BASH_VERSINFO[0] >= 5 || BASH_VERSINFO[0] == 4 && BASH_VERSINFO[1] >= 3)); then
-    bind '"\C-x\C-_B0\a": ""'
-    bind -x '"\C-x\C-_B1\a": _atuin_ai_question_mark'
-    bind '"?": "\C-x\C-_B1\a\C-x\C-_B0\a"'
-else
-    # Bash <= 4.2 cannot "bind -x" a key sequence longer than two bytes,
-    # so bind the handler directly.  Enter in the TUI then inserts the
-    # command instead of executing it.
-    bind -x '"?": _atuin_ai_question_mark'
+# We only set up keybinding in Bash >= 4.0.  Bash < 4.0 does not provide
+# READLINE_LINE, so if bound, it would always start an AI session regardless of
+# the contents of the line buffer.  This means that it would make impossible
+# to input "?" in Bash 3.2.
+if ((BASH_VERSINFO[0] >= 4)) || [[ ${BLE_VERSION-} ]]; then
+    # A "bind -x" handler cannot invoke readline bindable functions such as
+    # accept-line, so binding '?' directly to the handler could only ever edit
+    # READLINE_LINE, never execute it.  We use the same two-step macro dispatch
+    # as atuin's main bash integration: '?' expands to two intermediate
+    # sequences, the first runs the handler via "bind -x", and the handler
+    # decides what the second does by rebinding it — accept-line to execute, a
+    # no-op otherwise.  The sequences \C-x\C-_B<n>\a mirror the main
+    # integration's \C-x\C-_A<n>\a chain, with B instead of A to avoid
+    # colliding with it.
+    if ((BASH_VERSINFO[0] >= 5 || BASH_VERSINFO[0] == 4 && BASH_VERSINFO[1] >= 3)); then
+        bind '"\C-x\C-_B0\a": ""'
+        bind -x '"\C-x\C-_B1\a": _atuin_ai_question_mark'
+        bind '"?": "\C-x\C-_B1\a\C-x\C-_B0\a"'
+    else
+        # Bash <= 4.2 cannot "bind -x" a key sequence longer than two bytes,
+        # so bind the handler directly.  Enter in the TUI then inserts the
+        # command instead of executing it.
+        bind -x '"?": _atuin_ai_question_mark'
+    fi
 fi
 "#
     .trim()

--- a/crates/atuin/src/shell/atuin.bash
+++ b/crates/atuin/src/shell/atuin.bash
@@ -193,6 +193,20 @@ __atuin_clear_prompt() {
     printf '%s' "${__atuin_clear_prompt_cache[offset]}"
 }
 
+# Insert $1 into the line buffer of the line editor.  Special handling is
+# needed in Bash <= 3.2 because the old Bash does not support READLINE_LINE and
+# READLINE_POINT.  When this function is called from inside a keybinding set up
+# by `atuin-bind`, the contents is inserted into the command line by macro
+# chaining.
+__atuin_insert_line() {
+    local __atuin_command=$1
+    READLINE_LINE=$__atuin_command
+    READLINE_POINT=${#READLINE_LINE}
+    if [[ ! ${BLE_ATTACHED-} ]] && ((BASH_VERSINFO[0] < 4)) && [[ ${__atuin_macro_chain_keymap-} ]]; then
+        bind -m "$__atuin_macro_chain_keymap" '"'"$__atuin_macro_chain"'": '"$__atuin_macro_insert_line"
+    fi
+}
+
 __atuin_accept_line() {
     local __atuin_command=$1
 
@@ -380,11 +394,7 @@ __atuin_history() {
         __atuin_output=${__atuin_output#__atuin_accept__:}
         __atuin_accept_line "$__atuin_output"
     else
-        READLINE_LINE=$__atuin_output
-        READLINE_POINT=${#READLINE_LINE}
-        if [[ ! ${BLE_ATTACHED-} ]] && ((BASH_VERSINFO[0] < 4)) && [[ ${__atuin_macro_chain_keymap-} ]]; then
-            bind -m "$__atuin_macro_chain_keymap" '"'"$__atuin_macro_chain"'": '"$__atuin_macro_insert_line"
-        fi
+        __atuin_insert_line "$__atuin_output"
     fi
 }
 

--- a/crates/atuin/src/shell/atuin.bash
+++ b/crates/atuin/src/shell/atuin.bash
@@ -196,6 +196,19 @@ __atuin_clear_prompt() {
 __atuin_accept_line() {
     local __atuin_command=$1
 
+    if [[ ${BLE_ATTACHED-} ]]; then
+        ble-edit/content/reset-and-check-dirty "$__atuin_command"
+        ble/widget/accept-line
+        READLINE_LINE=""
+        READLINE_POINT=0
+        return 0
+    elif [[ ${__atuin_macro_chain_keymap-} ]]; then
+        READLINE_LINE=$__atuin_command
+        READLINE_POINT=${#READLINE_LINE}
+        bind -m "$__atuin_macro_chain_keymap" '"'"$__atuin_macro_chain"'": '"$__atuin_macro_accept_line"
+        return 0
+    fi
+
     # Reprint the prompt, accounting for multiple lines
     local __atuin_prompt __atuin_prompt_offset
     __atuin_evaluate_prompt
@@ -259,6 +272,9 @@ __atuin_accept_line() {
     __atuin_evaluate_prompt
     printf '%s' "$__atuin_prompt"
     __atuin_clear_prompt 0
+
+    READLINE_LINE=""
+    READLINE_POINT=0
 }
 
 #------------------------------------------------------------------------------
@@ -362,20 +378,7 @@ __atuin_history() {
 
     if [[ $__atuin_output == __atuin_accept__:* ]]; then
         __atuin_output=${__atuin_output#__atuin_accept__:}
-
-        if [[ ${BLE_ATTACHED-} ]]; then
-            ble-edit/content/reset-and-check-dirty "$__atuin_output"
-            ble/widget/accept-line
-            READLINE_LINE=""
-        elif [[ ${__atuin_macro_chain_keymap-} ]]; then
-            READLINE_LINE=$__atuin_output
-            bind -m "$__atuin_macro_chain_keymap" '"'"$__atuin_macro_chain"'": '"$__atuin_macro_accept_line"
-        else
-            __atuin_accept_line "$__atuin_output"
-            READLINE_LINE=""
-        fi
-
-        READLINE_POINT=${#READLINE_LINE}
+        __atuin_accept_line "$__atuin_output"
     else
         READLINE_LINE=$__atuin_output
         READLINE_POINT=${#READLINE_LINE}

--- a/crates/atuin/src/shell/atuin.bash
+++ b/crates/atuin/src/shell/atuin.bash
@@ -200,15 +200,29 @@ __atuin_clear_prompt() {
 # chaining.
 __atuin_insert_line() {
     local __atuin_command=$1
+
+    # READLINE_LINE and READLINE_POINT are only supported by bash >= 4.0 or
+    # ble.sh.  When it is not supported, we localize them to avoid confusing
+    # bash-preexec.
+    [[ ${BLE_ATTACHED-} ]] || ((BASH_VERSINFO[0] >= 4)) ||
+        local READLINE_LINE="" READLINE_POINT=0
+
     READLINE_LINE=$__atuin_command
     READLINE_POINT=${#READLINE_LINE}
     if [[ ! ${BLE_ATTACHED-} ]] && ((BASH_VERSINFO[0] < 4)) && [[ ${__atuin_macro_chain_keymap-} ]]; then
+        __atuin_expand_line=$__atuin_command
         bind -m "$__atuin_macro_chain_keymap" '"'"$__atuin_macro_chain"'": '"$__atuin_macro_insert_line"
     fi
 }
 
 __atuin_accept_line() {
     local __atuin_command=$1
+
+    # READLINE_LINE and READLINE_POINT are only supported by bash >= 4.0 or
+    # ble.sh.  When it is not supported, we localize them to avoid confusing
+    # bash-preexec.
+    [[ ${BLE_ATTACHED-} ]] || ((BASH_VERSINFO[0] >= 4)) ||
+        local READLINE_LINE="" READLINE_POINT=0
 
     if [[ ${BLE_ATTACHED-} ]]; then
         ble-edit/content/reset-and-check-dirty "$__atuin_command"
@@ -219,6 +233,7 @@ __atuin_accept_line() {
     elif [[ ${__atuin_macro_chain_keymap-} ]]; then
         READLINE_LINE=$__atuin_command
         READLINE_POINT=${#READLINE_LINE}
+        __atuin_expand_line=$__atuin_command
         bind -m "$__atuin_macro_chain_keymap" '"'"$__atuin_macro_chain"'": '"$__atuin_macro_accept_line"
         return 0
     fi
@@ -379,7 +394,7 @@ __atuin_history() {
     # ble.sh.  When it is not supported, we clear them to suppress strange
     # behaviors.
     [[ ${BLE_ATTACHED-} ]] || ((BASH_VERSINFO[0] >= 4)) ||
-        READLINE_LINE="" READLINE_POINT=0
+        local READLINE_LINE="" READLINE_POINT=0
 
     local __atuin_output
     if ! __atuin_output=$(__atuin_search_cmd "$@"); then
@@ -612,7 +627,7 @@ else
             bind -m "$__atuin_keymap" '"\C-x\C-_A1\a": beginning-of-line'
             bind -m "$__atuin_keymap" '"\C-x\C-_A2\a": kill-line'
             # shellcheck disable=SC2016
-            bind -m "$__atuin_keymap" '"\C-x\C-_A3\a": "$READLINE_LINE"'
+            bind -m "$__atuin_keymap" '"\C-x\C-_A3\a": "$__atuin_expand_line"'
             bind -m "$__atuin_keymap" '"\C-x\C-_A4\a": shell-expand-line'
             bind -m "$__atuin_keymap" '"\C-x\C-_A5\a": accept-line'
             bind -m "$__atuin_keymap" '"\C-x\C-_A6\a": end-of-line'
@@ -622,9 +637,9 @@ else
         bind -m vi-command '"\C-x\C-_A7\a": vi-insertion-mode'
         bind -m vi-insert  '"\C-x\C-_A7\a": vi-movement-mode'
 
-        # "\C-x\C-_A10\a": Replace the command line with READLINE_LINE.  When we are
-        #   in the vi-command keymap, we go to vi-insert, input
-        #   "$READLINE_LINE", and come back to vi-command.
+        # "\C-x\C-_A10\a": Replace the command line with $__atuin_expand_line.
+        # When we are in the vi-command keymap, we go to vi-insert, input
+        # "$__atuin_expand_line", and come back to vi-command.
         bind -m emacs      '"\C-x\C-_A10\a": "\C-x\C-_A1\a\C-x\C-_A2\a\C-x\C-_A3\a\C-x\C-_A4\a"'
         bind -m vi-insert  '"\C-x\C-_A10\a": "\C-x\C-_A1\a\C-x\C-_A2\a\C-x\C-_A3\a\C-x\C-_A4\a"'
         bind -m vi-command '"\C-x\C-_A10\a": "\C-x\C-_A1\a\C-x\C-_A2\a\C-x\C-_A7\a\C-x\C-_A3\a\C-x\C-_A7\a\C-x\C-_A4\a"'
@@ -636,6 +651,12 @@ else
     __atuin_bash42_dispatch_selector=
 
     __atuin_bash42_dispatch() {
+        # READLINE_LINE and READLINE_POINT are only supported by bash >= 4.0 or
+        # ble.sh.  When it is not supported, we clear them to suppress strange
+        # behaviors.
+        [[ ${BLE_ATTACHED-} ]] || ((BASH_VERSINFO[0] >= 4)) ||
+            local READLINE_LINE="" READLINE_POINT=0
+
         local s=$__atuin_bash42_dispatch_selector
         __atuin_bash42_dispatch_selector=
         __atuin_widget_run "$((2#0$s))"


### PR DESCRIPTION
<!-- Thank you for making a PR! Bug fixes are always welcome, but if you're adding a new feature or changing an existing one, we'd really appreciate if you open an issue, post on the forum, or drop in on Discord -->

Fixes #3924

I've originally localized those variables in commit a7bed6146 (#1533), but after that, I decided to leave the change to global variables in commit a6abc717b (#2953) for macro chaining in Bash 3.2 to expand the value later. However, I missed that it conflicted with the change in bash-preexec https://github.com/rcaloras/bash-preexec/pull/152.

The first and second commits refactor the code, and the third commit is the fix for the issue.

I checked that the problem reported in #3924 happens with the `main` branch in Bash 3.2, and then I checked that the changes in this PR fix the problem in Bash 3.2.

## Checks
- [x] I am happy for maintainers to push small adjustments to this PR, to speed up the review cycle
- [x] I have checked that there are no existing pull requests for the same thing
