### PR TITLE
refactor(bash): remove redundant check of existing preexec-backend

### DIFF
--- a/crates/atuin/src/shell/atuin.bash
+++ b/crates/atuin/src/shell/atuin.bash
@@ -711,10 +711,20 @@ fi
 
 if command -v __atuin_load_builtin_preexec > /dev/null; then
     if [[ -z ${ATUIN_NO_BUILTIN_PREEXEC-} ]]; then
-        __atuin_update_preexec_backend
-        if [[ $ATUIN_PREEXEC_BACKEND == *:unknown ]]; then
-            __atuin_load_builtin_preexec
-        fi
+        # We can simply load bash-preexec.sh without caring existing
+        # preexec-backend because duplicate detection is already properly
+        # implemented in bash-preexec itself:
+        #
+        # 1. When another instance of bash-preexec.sh has already been loaded,
+        #    the initialization is canceled at the beginning by bash-preexec's
+        #    own detection using the variable "bash_preexec_imported" or
+        #    "__bp_imported".
+        # 2. When ble.sh has already been loaded, we have already requested
+        #    ble.sh's emulation of bash-preexec by "ble-import" in the function
+        #    "__atuin_initialize_blesh", which also sets
+        #    "bash_preexec_imported" and "__bp_imported", so later loading of
+        #    bash-preexec.sh is canceled.
+        __atuin_load_builtin_preexec
     fi
     # Free the function from memory
     unset -f __atuin_load_builtin_preexec


### PR DESCRIPTION
The check is not just redundant, but it's not working as expected...

The present detection using `__atuin_update_preexec_backend` does not work as expected.  First of all, the function
`__atuin_update_preexec_backend` intends to detect the active status of the preexec backend, so it is not suitable for checking the existence of a backend at the session initialization stage.  In particular, the function `__atuin_update_preexec_backend` intentionally does not detect ble.sh even if ble.sh is loaded, because ble.sh is not activated at the initialization stage.

To check whether ble.sh is loaded, one needs to explicitly check the shell variable `$BLE_VERSION`.  However, all the complication is actually unnecessary because bash-preexec.sh already has the necessary duplicate detection for an early return.  See the added code comment for the details of the mechanism.

<!-- Thank you for making a PR! Bug fixes are always welcome, but if you're adding a new feature or changing an existing one, we'd really appreciate if you open an issue, post on the forum, or drop in on Discord -->

## Checks
- [x] I am happy for maintainers to push small adjustments to this PR, to speed up the review cycle
- [x] I have checked that there are no existing pull requests for the same thing
