### PR TITLE
refactor(ai/bash): use existing facility for accept-line

### DIFF
--- a/crates/atuin-ai/src/commands/init.rs
+++ b/crates/atuin-ai/src/commands/init.rs
@@ -100,12 +100,6 @@ pub fn generate_bash_integration() -> &'static str {
     r#"
 # Question mark at start of line - natural language mode
 _atuin_ai_question_mark() {
-    # Reset the chain sequence to a no-op; the execute branch below rebinds
-    # it to accept-line so readline runs the command after this handler
-    # returns.  Without the reset, a stale accept-line binding from a
-    # previous execute would fire on the next '?' press.
-    bind '"\C-x\C-_B0\a": ""'
-
     # If buffer is empty or just contains '?', trigger natural language mode
     if [[ -z "$READLINE_LINE" || "$READLINE_LINE" == "?" ]]; then
         READLINE_LINE=""
@@ -120,26 +114,17 @@ _atuin_ai_question_mark() {
 
         if [[ $output == __atuin_ai_print__:* ]]; then
             echo "${output#__atuin_ai_print__:}"
-            READLINE_LINE=""
-            READLINE_POINT=0
+            __atuin_insert_line ""
         elif [[ $output == __atuin_ai_cancel__ ]]; then
-            READLINE_LINE=""
-            READLINE_POINT=0
+            __atuin_insert_line ""
         elif [[ $output == __atuin_ai_execute__:* ]]; then
-            READLINE_LINE=${output#__atuin_ai_execute__:}
-            READLINE_POINT=${#READLINE_LINE}
-            # Execute by rebinding the chain sequence; accepting the line
-            # also records the command in bash history and fires
-            # bash-preexec, so atuin history captures it too.
-            bind '"\C-x\C-_B0\a": accept-line'
+            __atuin_accept_line "${output#__atuin_ai_execute__:}"
         elif [[ $output == __atuin_ai_insert__:* ]]; then
             # Insert the command for editing
-            READLINE_LINE=${output#__atuin_ai_insert__:}
-            READLINE_POINT=${#READLINE_LINE}
+            __atuin_insert_line "${output#__atuin_ai_insert__:}"
         elif [[ -n $output ]]; then
             # Default: insert for editing
-            READLINE_LINE=$output
-            READLINE_POINT=${#READLINE_LINE}
+            __atuin_insert_line "$output"
         fi
     else
         # Not at empty prompt, just insert the question mark
@@ -153,25 +138,7 @@ _atuin_ai_question_mark() {
 # the contents of the line buffer.  This means that it would make impossible
 # to input "?" in Bash 3.2.
 if ((BASH_VERSINFO[0] >= 4)) || [[ ${BLE_VERSION-} ]]; then
-    # A "bind -x" handler cannot invoke readline bindable functions such as
-    # accept-line, so binding '?' directly to the handler could only ever edit
-    # READLINE_LINE, never execute it.  We use the same two-step macro dispatch
-    # as atuin's main bash integration: '?' expands to two intermediate
-    # sequences, the first runs the handler via "bind -x", and the handler
-    # decides what the second does by rebinding it — accept-line to execute, a
-    # no-op otherwise.  The sequences \C-x\C-_B<n>\a mirror the main
-    # integration's \C-x\C-_A<n>\a chain, with B instead of A to avoid
-    # colliding with it.
-    if ((BASH_VERSINFO[0] >= 5 || BASH_VERSINFO[0] == 4 && BASH_VERSINFO[1] >= 3)); then
-        bind '"\C-x\C-_B0\a": ""'
-        bind -x '"\C-x\C-_B1\a": _atuin_ai_question_mark'
-        bind '"?": "\C-x\C-_B1\a\C-x\C-_B0\a"'
-    else
-        # Bash <= 4.2 cannot "bind -x" a key sequence longer than two bytes,
-        # so bind the handler directly.  Enter in the TUI then inserts the
-        # command instead of executing it.
-        bind -x '"?": _atuin_ai_question_mark'
-    fi
+    atuin-bind '?' _atuin_ai_question_mark
 fi
 "#
     .trim()
@@ -243,7 +210,7 @@ mod tests {
     )]
     #[case::bash(
         generate_bash_integration(),
-        &["_atuin_ai_question_mark", "bind", "READLINE_LINE", "accept-line", r#"\C-x\C-_B0\a"#]
+        &["_atuin_ai_question_mark", "bind", "READLINE_LINE", "__atuin_accept_line", "atuin-bind"]
     )]
     #[case::fish(
         generate_fish_integration(),

--- a/docs/docs/configuration/key-binding.md
+++ b/docs/docs/configuration/key-binding.md
@@ -133,6 +133,7 @@ commands and any arbitrary shell command:
 | `atuin-up-search-emacs` | Search command for <kbd>up</kbd> or similar keys, with the `emacs` keymap mode      |
 | `atuin-up-search-viins` | Search command for <kbd>up</kbd> or similar keys, with the `vim-insert` keymap mode |
 | `atuin-up-search-vicmd` | Search command for <kbd>up</kbd> or similar keys, with the `vim-normal` keymap mode |
+| (other strings)         | The strings are executed as shell commands                                          |
 
 The keymap mode controls the initial keymap in the Atuin search and is
 determined in combination with the config
@@ -161,6 +162,11 @@ keybindings to the <kbd>up</kbd> key or similar keys. For the keybindings in
 the `vi` editing mode, the options `--keymap-mode=vim-insert` and the keymap
 mode `--keymap-mode=vim-normal` (`atuin >= 18.0`) can be additionally specified
 to the shell function `__atuin_history`.
+
+Inside `COMMAND`, `__atuin_accept_line "string"` can be used to execute the
+string as a command. Similarly, `__atuin_insert_line "string"` can be used to
+insert the string into the buffer of the line editor. They're designed to
+work also in Bash 3.2, where `READLINE_LINE` isn't supported.
 
 ## fish
 Edit key bindings in FISH shell by adding the following to ~/.config/fish/config.fish


### PR DESCRIPTION
<!-- Thank you for making a PR! Bug fixes are always welcome, but if you're adding a new feature or changing an existing one, we'd really appreciate if you open an issue, post on the forum, or drop in on Discord -->

The Bash integration by Atuin AI (#3892) seems to try to replicate the macro chaining mechanism implemented in the main Bash integration `atuin.bash`, but we can simply re-use `atuin-bind` implemented in `atuin.bash`. I designed `atuin-bind` to be general enough that it can be used for arbitrary commands wanting to call readline bindable functions.

This is based on #3926 (where `__atuin_insert_line` and `__atuin_accept_line` are made reusable). Making this PR "*a Draft PR*" until #3926 is settled.

**edit**: I also added descriptions into the documentation `configuration/key-binding.md`.

## Checks
- [x] I am happy for maintainers to push small adjustments to this PR, to speed up the review cycle
- [x] I have checked that there are no existing pull requests for the same thing
