### PR TITLE
chore(ai): remove obsolete `atuin ai init` command

### DIFF
--- a/crates/atuin-ai/src/commands.rs
+++ b/crates/atuin-ai/src/commands.rs
@@ -3,7 +3,6 @@ use atuin_client::settings::Settings;
 use atuin_common::logs::{FileConfig, LogConfig, StderrConfig};
 use atuin_common::shell::Shell;
 use clap::{Args, Subcommand};
-pub mod init;
 pub(crate) mod inline;
 
 #[derive(Args, Debug)]
@@ -23,13 +22,6 @@ pub struct AiArgs {
 
 #[derive(Subcommand, Debug)]
 pub enum Command {
-    /// Initialize shell integration
-    Init {
-        /// Shell to generate integration for; defaults to "auto"
-        #[arg(value_name = "SHELL", default_value = "auto")]
-        shell: String,
-    },
-
     /// Inline completion mode with small TUI overlay
     Inline {
         #[command(flatten)]
@@ -52,14 +44,12 @@ impl Command {
                 file: FileConfig::from_settings(&settings.logs, &settings.logs.ai),
                 stderr: args.verbose.then(StderrConfig::default),
             },
-            _ => LogConfig::stderr_only(),
         }
     }
 }
 
 pub async fn run(command: Command, settings: &Settings) -> eyre::Result<()> {
     match command {
-        Command::Init { shell } => init::run(shell).await,
         Command::Inline {
             command,
             hook,

--- a/crates/atuin-ai/src/lib.rs
+++ b/crates/atuin-ai/src/lib.rs
@@ -11,6 +11,7 @@ pub mod mcp;
 pub(crate) mod models;
 pub(crate) mod permissions;
 pub(crate) mod session;
+pub mod shell;
 pub(crate) mod skills;
 pub(crate) mod snapshots;
 pub(crate) mod store;

--- a/crates/atuin-ai/src/shell.rs
+++ b/crates/atuin-ai/src/shell.rs
@@ -1,32 +1,4 @@
-use crate::commands::detect_shell;
-
-pub(crate) async fn run(shell: String) -> eyre::Result<()> {
-    let integration = match shell.as_str() {
-        "zsh" => generate_zsh_integration(),
-        "bash" => generate_bash_integration(),
-        "fish" => generate_fish_integration(),
-        "auto" => generate_auto_integration()?,
-        _ => eyre::bail!("Unsupported shell: {}", shell),
-    };
-
-    println!("{}", integration);
-    Ok(())
-}
-
-fn generate_auto_integration() -> eyre::Result<&'static str> {
-    let shell = detect_shell();
-    match shell.as_deref() {
-        Some("zsh") => Ok(generate_zsh_integration()),
-        Some("bash") => Ok(generate_bash_integration()),
-        Some("fish") => Ok(generate_fish_integration()),
-        Some(s) => eyre::bail!("Unsupported shell: {}", s),
-        None => eyre::bail!("Could not detect shell"),
-    }
-}
-
-/// Generate the zsh integration function - pure function for easy testing
-pub fn generate_zsh_integration() -> &'static str {
-    r#"
+pub const ZSH_INIT: &str = r#"
 _atuin_ai_cleanup() {
     true
 }
@@ -92,12 +64,9 @@ self-atuin-ai-question-mark() {
 zle -N self-atuin-ai-question-mark
 bindkey '?' self-atuin-ai-question-mark # Question mark
 "#
-    .trim()
-}
+.trim_ascii();
 
-/// Generate the bash integration function - pure function for easy testing
-pub fn generate_bash_integration() -> &'static str {
-    r#"
+pub const BASH_INIT: &str = r#"
 # Question mark at start of line - natural language mode
 _atuin_ai_question_mark() {
     # If buffer is empty or just contains '?', trigger natural language mode
@@ -141,12 +110,9 @@ if ((BASH_VERSINFO[0] >= 4)) || [[ ${BLE_VERSION-} ]]; then
     atuin-bind '?' _atuin_ai_question_mark
 fi
 "#
-    .trim()
-}
+.trim_ascii();
 
-/// Generate the fish integration function - pure function for easy testing
-pub fn generate_fish_integration() -> &'static str {
-    r#"
+pub const FISH_INIT: &str = r#"
 # Question mark at start of line - natural language mode
 function _atuin_ai_question_mark
     set -l buf (commandline -b)
@@ -195,8 +161,7 @@ end
 # Set up keybindings
 bind "?" _atuin_ai_question_mark
 "#
-    .trim()
-}
+.trim_ascii();
 
 #[cfg(test)]
 mod tests {
@@ -205,18 +170,18 @@ mod tests {
 
     #[rstest]
     #[case::zsh(
-        generate_zsh_integration(),
+        ZSH_INIT,
         &["self-atuin-ai-question-mark", "bindkey", "zle self-insert"]
     )]
     #[case::bash(
-        generate_bash_integration(),
+        BASH_INIT,
         &["_atuin_ai_question_mark", "bind", "READLINE_LINE", "__atuin_accept_line", "atuin-bind"]
     )]
     #[case::fish(
-        generate_fish_integration(),
+        FISH_INIT,
         &["_atuin_ai_question_mark", "bind", "commandline"]
     )]
-    fn generates_shell_integration(#[case] result: &str, #[case] extras: &[&str]) {
+    fn shell_init(#[case] result: &str, #[case] extras: &[&str]) {
         for t in [
             "atuin ai inline --hook",
             "__atuin_ai_print__",

--- a/crates/atuin/src/command/client/init/bash.rs
+++ b/crates/atuin/src/command/client/init/bash.rs
@@ -42,8 +42,7 @@ fn write_static_init<W: Write>(writer: &mut W, options: &StaticInitOptions<'_>) 
 
     #[cfg(feature = "ai")]
     if options.enable_ai {
-        let bind_ai = atuin_ai::commands::init::generate_bash_integration();
-        writeln!(writer, "{bind_ai}")?;
+        writeln!(writer, "{}", atuin_ai::shell::BASH_INIT)?;
     }
 
     writeln!(writer, "}}") // end include guard

--- a/crates/atuin/src/command/client/init/fish.rs
+++ b/crates/atuin/src/command/client/init/fish.rs
@@ -83,8 +83,7 @@ pub fn init_static(options: &StaticInitOptions<'_>) {
 
         #[cfg(feature = "ai")]
         if options.enable_ai {
-            let bind_ai = atuin_ai::commands::init::generate_fish_integration();
-            println!("{bind_ai}");
+            println!("{}", atuin_ai::shell::FISH_INIT);
         }
     }
 }

--- a/crates/atuin/src/command/client/init/zsh.rs
+++ b/crates/atuin/src/command/client/init/zsh.rs
@@ -38,9 +38,7 @@ bindkey -M vicmd 'k' atuin-up-search-vicmd";
 
         #[cfg(feature = "ai")]
         if options.enable_ai {
-            let bind_ai = atuin_ai::commands::init::generate_zsh_integration();
-
-            println!("{bind_ai}");
+            println!("{}", atuin_ai::shell::ZSH_INIT);
         }
     }
 }


### PR DESCRIPTION
As per discussion with @ellie, the `atuin ai init` command is no longer needed as the initialization for Atuin AI is now included in `atuin init`. This PR removes the obsolete command; its existence was complicating other fixes such as #3928.

As part of this change, the shell init snippets are now exposed as simple constant strings rather than functions.