### PR TITLE
refactor(daemon): carry author name and kind as one typed Author message

### DIFF
--- a/crates/atuin-ai/src/history_format.rs
+++ b/crates/atuin-ai/src/history_format.rs
@@ -1,4 +1,4 @@
-use atuin_client::history::{History, is_known_agent};
+use atuin_client::history::History;
 use atuin_common::time::{DurationExt, OffsetDateTimeExt};
 use time::UtcOffset;
 
@@ -37,11 +37,11 @@ fn format_history_metadata(history: &History, local_offset: UtcOffset) -> String
 }
 
 /// Attribution for agent-run commands: which agent, and its stated intent.
-/// A stated intent marks a command as agent-run even when the agent is not in
-/// KNOWN_AGENTS, so its author is still named. User-run commands (no intent,
-/// author not a known agent) get nothing.
+/// A stated intent marks a command as agent-run even when the entry is not
+/// recognised as one, so its author is still named. User-run commands (no
+/// intent, not an agent) get nothing.
 fn format_attribution(history: &History) -> String {
-    match (is_known_agent(&history.author), &history.intent) {
+    match (history.is_agent(), &history.intent) {
         (true, Some(intent)) => format!(" — {}: {intent}", history.author),
         (true, None) => format!(" — {}", history.author),
         (false, Some(intent)) if !history.author.is_empty() => {
@@ -87,6 +87,7 @@ mod tests {
             intent: None,
             deleted_at: None,
             shell: Some("zsh".into()),
+            author_kind: None,
         }
     }
 

--- a/crates/atuin-ai/src/mcp.rs
+++ b/crates/atuin-ai/src/mcp.rs
@@ -136,8 +136,8 @@ fn tool_definitions() -> Vec<Tool> {
                 "description": format!(
                     "Filter by who ran the command: '{AUTHOR_FILTER_ALL_USER}' for \
                      human-run commands, '{AUTHOR_FILTER_ALL_AGENT}' for commands run \
-                     by AI agents, or a literal agent name (one of: {}). Multiple \
-                     entries are OR-ed. Omit for everything.",
+                     by AI agents, or any literal author name (well-known agents: {}). \
+                     Multiple entries are OR-ed. Omit for everything.",
                     KNOWN_AGENTS.join(", ")
                 ),
             },

--- a/crates/atuin-client/migrations/20260818000000_history_author_kind.sql
+++ b/crates/atuin-client/migrations/20260818000000_history_author_kind.sql
@@ -1,0 +1,4 @@
+-- Whether a human or an agent ran the command, when the integration that
+-- captured it said so. Null means it did not, and the author name is all we
+-- have to go on. See `atuin_client::history::AuthorKind`.
+alter table history add column author_kind integer;

--- a/crates/atuin-client/migrations/20260818000000_history_author_kind.sql
+++ b/crates/atuin-client/migrations/20260818000000_history_author_kind.sql
@@ -1,4 +1,3 @@
--- Whether a human or an agent ran the command, when the integration that
--- captured it said so. Null means it did not, and the author name is all we
--- have to go on. See `atuin_client::history::AuthorKind`.
+-- Whether a human or an agent ran the command. If null, we have to go off
+-- the author name.
 alter table history add column author_kind integer;

--- a/crates/atuin-client/src/database.rs
+++ b/crates/atuin-client/src/database.rs
@@ -2071,6 +2071,50 @@ mod test {
         }
     }
 
+    /// A legacy row whose colonless hostname IS a known agent name (e.g. a machine hostnamed
+    /// `pi`, imported before hostnames were `host:user`): the author defaulted to the whole
+    /// hostname, so it tells us nothing — human on both the SQL and [`History::is_agent`] sides.
+    #[tokio::test(flavor = "multi_thread")]
+    #[rstest]
+    async fn author_filter_treats_a_colonless_agent_hostname_as_human() {
+        let db = Sqlite::new("sqlite::memory:", test_local_timeout()).await.unwrap();
+
+        let history: History = History::import()
+            .timestamp(OffsetDateTime::now_utc())
+            .command("echo hello")
+            .cwd("/tmp")
+            .author("pi")
+            .build()
+            .into();
+        db.save(&history).await.unwrap();
+        // `CmdOrigin` cannot represent a colonless hostname (parse_lenient rewrites it), so plant
+        // the legacy shape directly.
+        sqlx::query("update history set hostname = 'pi'").execute(&db.pool).await.unwrap();
+
+        let loaded = db.load(history.id.0.as_str()).await.unwrap().unwrap();
+        assert!(!loaded.is_agent());
+
+        let context = Context {
+            cmd_origin: CmdOrigin::try_from("pi:unknown-user".to_owned()).unwrap(),
+            session: "session".into(),
+            cwd: "/tmp".into(),
+            host_id: "host".into(),
+            git_root: None,
+        };
+        for (pattern, expected) in [(AuthorPattern::AllUser, 1), (AuthorPattern::AllAgent, 0)] {
+            let authors = OrFilter::from_list(vec![pattern]).unwrap();
+            let filters = OptFilters {
+                authors: authors.as_slice_filter(),
+                ..Default::default()
+            };
+            let results = db
+                .search(DbSearchMode::FullText, FilterMode::Global, &context, "echo", filters)
+                .await
+                .unwrap();
+            assert_eq!(results.len(), expected, "{authors:?}");
+        }
+    }
+
     /// A user called `pi` shares a name with the `pi` agent, so on their machine the author name
     /// alone cannot say who ran a command: only an entry that states its kind is an agent's.
     #[tokio::test(flavor = "multi_thread")]

--- a/crates/atuin-client/src/database.rs
+++ b/crates/atuin-client/src/database.rs
@@ -121,7 +121,7 @@ fn apply_author_filter(sql: &mut SqlBuilder, authors: OrFilter<&[AuthorPattern]>
     // Mirrors [`History::is_agent`]: a recorded kind wins, and without one a known agent name means
     // an agent, unless the author is only the username it defaulted to. A kind we don't recognise
     // (written by a newer version) falls through to the name heuristic, exactly like
-    // [`AuthorKind::from_u8`] mapping it to `None` — and so does a NULL kind, because
+    // [`AuthorKind::from_repr`] mapping it to `None` — and so does a NULL kind, because
     // `NULL IN (...)` is not true.
     let is_agent = || {
         format!(
@@ -404,7 +404,7 @@ impl Sqlite {
         let shell: Option<String> = row.try_get("shell").ok().flatten();
         let author_kind: Option<i64> = row.try_get("author_kind").ok().flatten();
         let author_kind =
-            author_kind.and_then(|kind| u8::try_from(kind).ok()).and_then(AuthorKind::from_u8);
+            author_kind.and_then(|kind| u8::try_from(kind).ok()).and_then(AuthorKind::from_repr);
 
         History::from_db()
             .id(row.get("id"))
@@ -2023,7 +2023,7 @@ mod test {
     }
 
     /// An author_kind value this version doesn't recognise (written by a newer one) must fall
-    /// through to the name heuristic in SQL, exactly like [`AuthorKind::from_u8`] returning `None`
+    /// through to the name heuristic in SQL, exactly like [`AuthorKind::from_repr`] returning `None`
     /// does in [`History::is_agent`] — otherwise the two classifiers disagree on the same row.
     #[tokio::test(flavor = "multi_thread")]
     #[rstest]

--- a/crates/atuin-client/src/database.rs
+++ b/crates/atuin-client/src/database.rs
@@ -127,7 +127,7 @@ fn apply_author_filter(sql: &mut SqlBuilder, authors: OrFilter<&[AuthorPattern]>
         format!(
             "CASE WHEN author_kind IN ({kinds}) THEN author_kind = {agent} ELSE {author_expr} IN \
              ({names}) AND {author_expr} <> {user_expr} END",
-            kinds = AuthorKind::VARIANTS.iter().map(|kind| kind.as_u8().to_string()).join(", "),
+            kinds = AuthorKind::VARIANTS.iter().map(|kind| kind.as_u8()).join(", "),
             agent = AuthorKind::Agent.as_u8(),
             names = KNOWN_AGENTS.iter().map(quote).join(", "),
         )

--- a/crates/atuin-client/src/database.rs
+++ b/crates/atuin-client/src/database.rs
@@ -114,8 +114,9 @@ fn apply_author_filter(sql: &mut SqlBuilder, authors: OrFilter<&[AuthorPattern]>
     let user_expr = "CASE WHEN instr(hostname, ':') > 0 THEN substr(hostname, instr(hostname, \
                      ':') + 1) ELSE hostname END";
 
-    let author_expr =
-        format!("CASE WHEN author IS NULL OR trim(author) = '' THEN {user_expr} ELSE author END");
+    let author_expr = std::fmt::from_fn(|f| {
+        write!(f, "CASE WHEN author IS NULL OR trim(author) = '' THEN {user_expr} ELSE author END")
+    });
 
     // Mirrors [`History::is_agent`]: a recorded kind wins, and without one a known agent name means
     // an agent, unless the author is only the username it defaulted to. A kind we don't recognise

--- a/crates/atuin-client/src/database.rs
+++ b/crates/atuin-client/src/database.rs
@@ -118,15 +118,20 @@ fn apply_author_filter(sql: &mut SqlBuilder, authors: OrFilter<&[AuthorPattern]>
         write!(f, "CASE WHEN author IS NULL OR trim(author) = '' THEN {user_expr} ELSE author END")
     });
 
+    let defaulted_expr = "CASE WHEN instr(hostname, ':') = 0 THEN hostname WHEN substr(hostname, \
+                          instr(hostname, ':') + 1) = 'unknown-user' THEN substr(hostname, 1, \
+                          instr(hostname, ':') - 1) ELSE substr(hostname, instr(hostname, ':') + \
+                          1) END";
+
     // Mirrors [`History::is_agent`]: a recorded kind wins, and without one a known agent name means
-    // an agent, unless the author is only the username it defaulted to. A kind we don't recognise
+    // an agent, unless the author is only the name it defaulted to. A kind we don't recognise
     // (written by a newer version) falls through to the name heuristic, exactly like
     // [`AuthorKind::from_repr`] mapping it to `None` — and so does a NULL kind, because
     // `NULL IN (...)` is not true.
     let is_agent = || {
         format!(
             "CASE WHEN author_kind IN ({kinds}) THEN author_kind = {agent} ELSE {author_expr} IN \
-             ({names}) AND {author_expr} <> {user_expr} END",
+             ({names}) AND {author_expr} <> {defaulted_expr} END",
             kinds = AuthorKind::VARIANTS.iter().map(|kind| kind.as_u8()).join(", "),
             agent = AuthorKind::Agent.as_u8(),
             names = KNOWN_AGENTS.iter().map(quote).join(", "),
@@ -2090,6 +2095,45 @@ mod test {
         // `CmdOrigin` cannot represent a colonless hostname (parse_lenient rewrites it), so plant
         // the legacy shape directly.
         sqlx::query("update history set hostname = 'pi'").execute(&db.pool).await.unwrap();
+
+        let loaded = db.load(history.id.0.as_str()).await.unwrap().unwrap();
+        assert!(!loaded.is_agent());
+
+        let context = Context {
+            cmd_origin: CmdOrigin::try_from("pi:unknown-user".to_owned()).unwrap(),
+            session: "session".into(),
+            cwd: "/tmp".into(),
+            host_id: "host".into(),
+            git_root: None,
+        };
+        for (pattern, expected) in [(AuthorPattern::AllUser, 1), (AuthorPattern::AllAgent, 0)] {
+            let authors = OrFilter::from_list(vec![pattern]).unwrap();
+            let filters = OptFilters {
+                authors: authors.as_slice_filter(),
+                ..Default::default()
+            };
+            let results = db
+                .search(DbSearchMode::FullText, FilterMode::Global, &context, "echo", filters)
+                .await
+                .unwrap();
+            assert_eq!(results.len(), expected, "{authors:?}");
+        }
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    #[rstest]
+    async fn author_filter_treats_a_placeholder_user_agent_hostname_as_human() {
+        let db = Sqlite::new("sqlite::memory:", test_local_timeout()).await.unwrap();
+
+        let history: History = History::import()
+            .timestamp(OffsetDateTime::now_utc())
+            .command("echo hello")
+            .cwd("/tmp")
+            .cmd_origin(CmdOrigin::try_from("pi:unknown-user".to_owned()).unwrap())
+            .author("pi")
+            .build()
+            .into();
+        db.save(&history).await.unwrap();
 
         let loaded = db.load(history.id.0.as_str()).await.unwrap().unwrap();
         assert!(!loaded.is_agent());

--- a/crates/atuin-client/src/database.rs
+++ b/crates/atuin-client/src/database.rs
@@ -6,7 +6,7 @@ use std::time::Duration;
 use atuin_common::filter::{self, OrFilter};
 use atuin_common::time::OffsetDateTimeExt;
 use atuin_common::utils;
-use atuin_domain::record::CmdOrigin;
+use atuin_domain::record::{CmdOrigin, UNKNOWN_USER};
 use fs_err as fs;
 use itertools::Itertools;
 use sql_builder::bind::Bind;
@@ -118,20 +118,22 @@ fn apply_author_filter(sql: &mut SqlBuilder, authors: OrFilter<&[AuthorPattern]>
         write!(f, "CASE WHEN author IS NULL OR trim(author) = '' THEN {user_expr} ELSE author END")
     });
 
-    let defaulted_expr = "CASE WHEN instr(hostname, ':') = 0 THEN hostname WHEN substr(hostname, \
-                          instr(hostname, ':') + 1) = 'unknown-user' THEN substr(hostname, 1, \
-                          instr(hostname, ':') - 1) ELSE substr(hostname, instr(hostname, ':') + \
-                          1) END";
+    let defaulted_expr = format!(
+        "CASE WHEN instr(hostname, ':') = 0 THEN hostname WHEN substr(hostname, instr(hostname, \
+         ':') + 1) = {unknown} THEN substr(hostname, 1, instr(hostname, ':') - 1) ELSE \
+         substr(hostname, instr(hostname, ':') + 1) END",
+        unknown = quote(&UNKNOWN_USER),
+    );
 
     // Mirrors [`History::is_agent`]: a recorded kind wins, and without one a known agent name means
-    // an agent, unless the author is only the name it defaulted to. A kind we don't recognise
-    // (written by a newer version) falls through to the name heuristic, exactly like
-    // [`AuthorKind::from_repr`] mapping it to `None` — and so does a NULL kind, because
-    // `NULL IN (...)` is not true.
+    // an agent, unless the author is only the name it defaulted to — a NULL/blank author *is* only
+    // that name, so it is never an agent. A kind we don't recognise (written by a newer version)
+    // falls through to the name heuristic, exactly like [`AuthorKind::from_repr`] mapping it to
+    // `None` — and so does a NULL kind, because `NULL IN (...)` is not true.
     let is_agent = || {
         format!(
-            "CASE WHEN author_kind IN ({kinds}) THEN author_kind = {agent} ELSE {author_expr} IN \
-             ({names}) AND {author_expr} <> {defaulted_expr} END",
+            "CASE WHEN author_kind IN ({kinds}) THEN author_kind = {agent} WHEN author IS NULL OR \
+             trim(author) = '' THEN 0 ELSE author IN ({names}) AND author <> {defaulted_expr} END",
             kinds = AuthorKind::VARIANTS.iter().map(|kind| kind.as_u8()).join(", "),
             agent = AuthorKind::Agent.as_u8(),
             names = KNOWN_AGENTS.iter().map(quote).join(", "),

--- a/crates/atuin-client/src/database.rs
+++ b/crates/atuin-client/src/database.rs
@@ -23,7 +23,7 @@ use uuid::Uuid;
 use super::history::History;
 use super::ordering;
 use super::settings::{FilterMode, SearchMode, Settings};
-use crate::history::{AuthorPattern, HistoryId, HistoryStats, KNOWN_AGENTS};
+use crate::history::{AuthorKind, AuthorPattern, HistoryId, HistoryStats, KNOWN_AGENTS};
 
 #[derive(Clone)]
 pub struct Context {
@@ -102,28 +102,41 @@ impl Context {
     }
 }
 
-/// Each entry is OR'd: [`AuthorPattern::AllUser`] → NOT IN agents, [`AuthorPattern::AllAgent`] →
-/// IN agents, [`AuthorPattern::Name`] → exact match.
+/// Each entry is OR'd: [`AuthorPattern::AllUser`] → not an agent, [`AuthorPattern::AllAgent`] → an
+/// agent, [`AuthorPattern::Name`] → exact match.
 fn apply_author_filter(sql: &mut SqlBuilder, authors: OrFilter<&[AuthorPattern]>) {
     let authors = match authors.items() {
         filter::Items::All => return,
         filter::Items::Some(a) => a,
     };
 
-    let author_expr = "CASE WHEN author IS NULL OR trim(author) = '' THEN CASE WHEN \
-                       instr(hostname, ':') > 0 THEN substr(hostname, instr(hostname, ':') + 1) \
-                       ELSE hostname END ELSE author END";
+    // The username half of `hostname`, which is what `author` falls back to when nothing set it.
+    let user_expr = "CASE \
+        WHEN instr(hostname, ':') > 0 THEN substr(hostname, instr(hostname, ':') + 1) \
+        ELSE hostname \
+    END";
 
-    let mut agent_list: Option<String> = None;
-    let get_agent_list = || KNOWN_AGENTS.iter().map(quote).join(", ");
+    let author_expr =
+        format!("CASE WHEN author IS NULL OR trim(author) = '' THEN {user_expr} ELSE author END");
+
+    // Mirrors [`History::is_agent`]: a recorded kind wins, and without one a known agent name means
+    // an agent, unless the author is only the username it defaulted to. A kind we don't recognise
+    // (written by a newer version) falls through to the name heuristic, exactly like
+    // [`AuthorKind::from_u8`] mapping it to `None` — and so does a NULL kind, because
+    // `NULL IN (...)` is not true.
+    let is_agent = || {
+        format!(
+            "CASE WHEN author_kind IN ({kinds}) THEN author_kind = {agent} \
+             ELSE {author_expr} IN ({names}) AND {author_expr} <> {user_expr} END",
+            kinds = AuthorKind::VARIANTS.iter().map(|kind| kind.as_u8().to_string()).join(", "),
+            agent = AuthorKind::Agent.as_u8(),
+            names = KNOWN_AGENTS.iter().map(quote).join(", "),
+        )
+    };
 
     let mut conditions = authors.iter().map(|author| match author {
-        AuthorPattern::AllUser => {
-            format!("{author_expr} NOT IN ({})", agent_list.get_or_insert_with(get_agent_list))
-        }
-        AuthorPattern::AllAgent => {
-            format!("{author_expr} IN ({})", agent_list.get_or_insert_with(get_agent_list))
-        }
+        AuthorPattern::AllUser => format!("NOT ({})", is_agent()),
+        AuthorPattern::AllAgent => is_agent(),
         AuthorPattern::Name(name) => {
             format!("{author_expr} = {}", quote(name))
         }
@@ -342,10 +355,18 @@ impl Sqlite {
     #[instrument(level = "trace", skip_all, fields(id = ?h.id), err)]
     async fn save_raw(tx: &mut sqlx::Transaction<'_, sqlx::Sqlite>, h: &History) -> Result<()> {
         sqlx::query(
-            "insert or ignore into history(
+            // On an id conflict, adopt the incoming author_kind if the stored row has none: store
+            // rebuilds re-save every record through here, and this is what lets a kind synced from
+            // another machine reach a row that was first written without one (the record store
+            // itself is immutable). The trailing bare ON CONFLICT keeps the old `insert or ignore`
+            // behavior for the (timestamp, cwd, command) uniqueness constraint.
+            "insert into history(
                 id, timestamp, duration, exit, command, cwd, session, hostname, author, intent,
-                deleted_at, shell
-            ) values(?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12)",
+                deleted_at, shell, author_kind
+            ) values(?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13)
+            on conflict(id) do update set author_kind = excluded.author_kind
+                where history.author_kind is null and excluded.author_kind is not null
+            on conflict do nothing",
         )
         .bind(h.id.0.as_str())
         .bind(h.timestamp.unix_timestamp_nanos() as i64)
@@ -359,6 +380,7 @@ impl Sqlite {
         .bind(h.intent.as_deref())
         .bind(h.deleted_at.map(|t| t.unix_timestamp_nanos() as i64))
         .bind(h.shell.as_deref())
+        .bind(h.author_kind.map(|kind| i64::from(kind.as_u8())))
         .execute(&mut **tx)
         .await?;
 
@@ -376,6 +398,39 @@ impl Sqlite {
             .await?;
 
         Ok(())
+    }
+
+    fn row_to_history(row: &SqliteRow) -> History {
+        let deleted_at: Option<i64> = row.get("deleted_at");
+        let hostname: String = row.get("hostname");
+        let author: Option<String> = row.try_get("author").ok().flatten();
+        let author = author.filter(|author| !author.trim().is_empty()).unwrap_or_else(|| {
+            CmdOrigin::try_from(hostname.clone())
+                .map_or_else(|err| err.0, |origin| origin.user().into_inner().to_owned())
+        });
+        let intent: Option<String> = row.try_get("intent").ok().flatten();
+        let intent = intent.filter(|intent| !intent.trim().is_empty());
+        let shell: Option<String> = row.try_get("shell").ok().flatten();
+        let author_kind: Option<i64> = row.try_get("author_kind").ok().flatten();
+        let author_kind =
+            author_kind.and_then(|kind| u8::try_from(kind).ok()).and_then(AuthorKind::from_u8);
+
+        History::from_db()
+            .id(row.get("id"))
+            .timestamp(OffsetDateTime::from_unix_nanos_i64(row.get("timestamp")))
+            .duration(row.get("duration"))
+            .exit(row.get("exit"))
+            .command(row.get("command"))
+            .cwd(row.get("cwd"))
+            .session(row.get("session"))
+            .hostname(hostname)
+            .author(author)
+            .intent(intent)
+            .deleted_at(deleted_at.map(OffsetDateTime::from_unix_nanos_i64))
+            .shell(shell)
+            .author_kind(author_kind)
+            .build()
+            .into()
     }
 
     #[instrument(level = "trace", skip_all, fields(id = ?h.id), err)]
@@ -476,7 +531,7 @@ impl Sqlite {
         sqlx::query(
             "update history
                 set timestamp = ?2, duration = ?3, exit = ?4, command = ?5, cwd = ?6, session = \
-             ?7, hostname = ?8, author = ?9, intent = ?10, deleted_at = ?11
+             ?7, hostname = ?8, author = ?9, intent = ?10, deleted_at = ?11, author_kind = ?12
                 where id = ?1",
         )
         .bind(h.id.0.as_str())
@@ -490,6 +545,7 @@ impl Sqlite {
         .bind(h.author.as_str())
         .bind(h.intent.as_deref())
         .bind(h.deleted_at.map(|t| t.unix_timestamp_nanos() as i64))
+        .bind(h.author_kind.map(|kind| i64::from(kind.as_u8())))
         .execute(&self.pool)
         .await?;
 
@@ -824,6 +880,7 @@ impl Sqlite {
                 "deleted_at",
                 "null as author",
                 "null as intent",
+                "null as author_kind",
                 "group_concat(cwd, ':') as cwd",
                 "group_concat(session) as session",
                 "group_concat(hostname, ',') as hostname",
@@ -1482,12 +1539,18 @@ mod test {
         };
 
         let results = db
-            .search(DbSearchMode::FullText, FilterMode::Global, &context, "", OptFilters {
-                after: after.as_deref(),
-                before: before.as_deref(),
-                include_duplicates: true,
-                ..Default::default()
-            })
+            .search(
+                DbSearchMode::FullText,
+                FilterMode::Global,
+                &context,
+                "",
+                OptFilters {
+                    after: after.as_deref(),
+                    before: before.as_deref(),
+                    include_duplicates: true,
+                    ..Default::default()
+                },
+            )
             .await
             .unwrap();
 
@@ -1510,10 +1573,16 @@ mod test {
         let context = new_context();
 
         let hits = db
-            .search(DbSearchMode::FullText, FilterMode::Global, &context, "", OptFilters {
-                include_duplicates,
-                ..Default::default()
-            })
+            .search(
+                DbSearchMode::FullText,
+                FilterMode::Global,
+                &context,
+                "",
+                OptFilters {
+                    include_duplicates,
+                    ..Default::default()
+                },
+            )
             .await
             .unwrap();
 
@@ -1630,9 +1699,13 @@ mod test {
         new_history_item(&db, "corburl").await.unwrap();
 
         // if fuzzy reordering is on, it should come back in a more sensible order
-        assert_search_commands(&db, DbSearchMode::Fuzzy, FilterMode::Global, "curl", vec![
-            "curl", "corburl",
-        ])
+        assert_search_commands(
+            &db,
+            DbSearchMode::Fuzzy,
+            FilterMode::Global,
+            "curl",
+            vec!["curl", "corburl"],
+        )
         .await;
 
         assert_search_eq(&db, DbSearchMode::Fuzzy, FilterMode::Global, "xxxx", 0).await.unwrap();
@@ -1680,9 +1753,13 @@ mod test {
         new_history_item_at(&db, "curl", Some(now - time::Duration::seconds(10))).await.unwrap();
         new_history_item_at(&db, "corburl", Some(now)).await.unwrap();
 
-        assert_search_commands(&db, mode.closest_db_mode(), FilterMode::Global, "curl", vec![
-            "curl", "corburl",
-        ])
+        assert_search_commands(
+            &db,
+            mode.closest_db_mode(),
+            FilterMode::Global,
+            "curl",
+            vec!["curl", "corburl"],
+        )
         .await;
     }
 
@@ -1745,9 +1822,13 @@ mod test {
         new_history_item_at(&db, close, Some(now - time::Duration::days(5))).await.unwrap();
         new_history_item_at(&db, far, Some(now - time::Duration::hours(1))).await.unwrap();
 
-        assert_search_commands(&db, DbSearchMode::Fuzzy, FilterMode::Global, query, vec![
-            close, far,
-        ])
+        assert_search_commands(
+            &db,
+            DbSearchMode::Fuzzy,
+            FilterMode::Global,
+            query,
+            vec![close, far],
+        )
         .await;
     }
 
@@ -1757,9 +1838,13 @@ mod test {
     async fn test_search_fuzzy_operator() {
         let db = db_with(&["use screen", "screenshot tool"]).await;
 
-        assert_search_commands(&db, DbSearchMode::Fuzzy, FilterMode::Global, "screen$", vec![
-            "use screen",
-        ])
+        assert_search_commands(
+            &db,
+            DbSearchMode::Fuzzy,
+            FilterMode::Global,
+            "screen$",
+            vec!["use screen"],
+        )
         .await;
     }
 
@@ -1972,6 +2057,145 @@ mod test {
             .unwrap();
 
         assert_eq!(results.len(), expected_count, "{results:?}");
+    }
+
+    /// An author_kind value this version doesn't recognise (written by a newer one) must fall
+    /// through to the name heuristic in SQL, exactly like [`AuthorKind::from_u8`] returning `None`
+    /// does in [`History::is_agent`] — otherwise the two classifiers disagree on the same row.
+    #[tokio::test(flavor = "multi_thread")]
+    #[rstest]
+    async fn author_filter_treats_an_unknown_kind_as_unstated() {
+        let db = Sqlite::new("sqlite::memory:", test_local_timeout()).await.unwrap();
+
+        let history: History = History::import()
+            .timestamp(OffsetDateTime::now_utc())
+            .command("echo hello")
+            .cwd("/tmp")
+            .cmd_origin(CmdOrigin::try_from("mac:ellie".to_owned()).unwrap())
+            .author("claude-code")
+            .build()
+            .into();
+        db.save(&history).await.unwrap();
+
+        // A kind from the future: one past the largest value any AuthorKind variant maps to, so
+        // it stays unknown even if more variants are added.
+        let unknown = AuthorKind::VARIANTS.iter().map(|kind| kind.as_u8()).max().unwrap() + 1;
+        sqlx::query("update history set author_kind = ?1")
+            .bind(i64::from(unknown))
+            .execute(&db.pool)
+            .await
+            .unwrap();
+
+        let context = Context {
+            cmd_origin: CmdOrigin::try_from("mac:ellie".to_owned()).unwrap(),
+            session: "session".into(),
+            cwd: "/tmp".into(),
+            host_id: "host".into(),
+            git_root: None,
+        };
+
+        for (pattern, expected) in [(AuthorPattern::AllAgent, 1), (AuthorPattern::AllUser, 0)] {
+            let authors = OrFilter::from_list(vec![pattern]).unwrap();
+            let filters = OptFilters {
+                authors: authors.as_slice_filter(),
+                ..Default::default()
+            };
+            let results = db
+                .search(DbSearchMode::FullText, FilterMode::Global, &context, "echo", filters)
+                .await
+                .unwrap();
+            assert_eq!(results.len(), expected, "{authors:?}");
+        }
+    }
+
+    /// Re-saving an existing row (as a store rebuild does for every record) fills in a missing
+    /// author_kind but never overwrites one that is already set.
+    #[tokio::test(flavor = "multi_thread")]
+    #[rstest]
+    async fn save_backfills_author_kind_on_existing_rows() {
+        let db = Sqlite::new("sqlite::memory:", test_local_timeout()).await.unwrap();
+
+        let kindless: History = History::import()
+            .timestamp(OffsetDateTime::now_utc())
+            .command("echo hello")
+            .cwd("/tmp")
+            .cmd_origin(CmdOrigin::try_from("raspberry:pi".to_owned()).unwrap())
+            .author("pi")
+            .build()
+            .into();
+        db.save(&kindless).await.unwrap();
+
+        // The same entry arrives again, now carrying its kind (e.g. re-synced and rebuilt after
+        // an upgrade).
+        let with_kind = History {
+            author_kind: Some(AuthorKind::Agent),
+            ..kindless.clone()
+        };
+        db.save(&with_kind).await.unwrap();
+        let loaded = db.load(kindless.id.0.as_str()).await.unwrap().unwrap();
+        assert_eq!(loaded.author_kind, Some(AuthorKind::Agent));
+
+        // A later kindless copy does not erase the stored kind.
+        db.save(&kindless).await.unwrap();
+        let loaded = db.load(kindless.id.0.as_str()).await.unwrap().unwrap();
+        assert_eq!(loaded.author_kind, Some(AuthorKind::Agent));
+    }
+
+    /// A user called `pi` shares a name with the `pi` agent, so on their machine the author name
+    /// alone cannot say who ran a command: only an entry that states its kind is an agent's.
+    #[tokio::test(flavor = "multi_thread")]
+    #[rstest]
+    #[case::all_user(["$all-user"], &["echo pi-human"])]
+    #[case::all_agent(["$all-agent"], &["echo pi-agent", "echo claude"])]
+    #[case::by_name(["pi"], &["echo pi-agent", "echo pi-human"])]
+    async fn test_search_authors_when_the_user_is_named_after_an_agent<const N: usize>(
+        #[case] authors: [&str; N],
+        #[case] expected: &[&str],
+    ) {
+        let db = Sqlite::new("sqlite::memory:", test_local_timeout()).await.unwrap();
+
+        for (command, author, author_kind) in [
+            ("echo pi-agent", "pi", Some(AuthorKind::Agent)),
+            ("echo pi-human", "pi", None),
+            ("echo claude", "claude-code", None),
+        ] {
+            let history = History::import()
+                .timestamp(OffsetDateTime::now_utc())
+                .command(command)
+                .cwd("/tmp")
+                .cmd_origin(CmdOrigin::try_from("raspberry:pi".to_owned()).unwrap())
+                .author(author)
+                .author_kind(author_kind)
+                .build()
+                .into();
+            db.save(&history).await.unwrap();
+        }
+
+        let context = Context {
+            cmd_origin: CmdOrigin::try_from("raspberry:pi".to_owned()).unwrap(),
+            session: "session".into(),
+            cwd: "/tmp".into(),
+            host_id: "host".into(),
+            git_root: None,
+        };
+
+        let authors =
+            OrFilter::from_list(authors.map(AuthorPattern::from).to_vec()).unwrap_or_default();
+        let filters = OptFilters {
+            authors: authors.as_slice_filter(),
+            ..Default::default()
+        };
+
+        let results = db
+            .search(DbSearchMode::FullText, FilterMode::Global, &context, "echo", filters)
+            .await
+            .unwrap();
+
+        let mut commands: Vec<&str> = results.iter().map(|h| h.command.as_str()).collect();
+        commands.sort_unstable();
+        let mut expected = expected.to_vec();
+        expected.sort_unstable();
+        assert_eq!(commands, expected);
     }
 
     #[tokio::test(flavor = "multi_thread")]

--- a/crates/atuin-client/src/database.rs
+++ b/crates/atuin-client/src/database.rs
@@ -122,7 +122,7 @@ fn apply_author_filter(sql: &mut SqlBuilder, authors: OrFilter<&[AuthorPattern]>
         "CASE WHEN instr(hostname, ':') = 0 THEN hostname WHEN substr(hostname, instr(hostname, \
          ':') + 1) = {unknown} THEN substr(hostname, 1, instr(hostname, ':') - 1) ELSE \
          substr(hostname, instr(hostname, ':') + 1) END",
-        unknown = quote(&UNKNOWN_USER),
+        unknown = quote(UNKNOWN_USER),
     );
 
     // Mirrors [`History::is_agent`]: a recorded kind wins, and without one a known agent name means
@@ -278,6 +278,9 @@ impl<'r> ::sqlx::FromRow<'r, SqliteRow> for History {
         let intent: Option<String> = row.try_get("intent").ok().flatten();
         let intent = intent.filter(|intent| !intent.trim().is_empty());
         let shell: Option<String> = row.try_get("shell").ok().flatten();
+        let author_kind: Option<i64> = row.try_get("author_kind").ok().flatten();
+        let author_kind =
+            author_kind.and_then(|kind| u8::try_from(kind).ok()).and_then(AuthorKind::from_repr);
 
         Ok(Self::from_db()
             .id(row.try_get("id")?)
@@ -292,6 +295,7 @@ impl<'r> ::sqlx::FromRow<'r, SqliteRow> for History {
             .intent(intent)
             .deleted_at(deleted_at.map(OffsetDateTime::from_unix_nanos_i64))
             .shell(shell)
+            .author_kind(author_kind)
             .build()
             .into())
     }
@@ -396,39 +400,6 @@ impl Sqlite {
             .await?;
 
         Ok(())
-    }
-
-    fn row_to_history(row: &SqliteRow) -> History {
-        let deleted_at: Option<i64> = row.get("deleted_at");
-        let hostname: String = row.get("hostname");
-        let author: Option<String> = row.try_get("author").ok().flatten();
-        let author = author.filter(|author| !author.trim().is_empty()).unwrap_or_else(|| {
-            CmdOrigin::try_from(hostname.clone())
-                .map_or_else(|err| err.0, |origin| origin.user().into_inner().to_owned())
-        });
-        let intent: Option<String> = row.try_get("intent").ok().flatten();
-        let intent = intent.filter(|intent| !intent.trim().is_empty());
-        let shell: Option<String> = row.try_get("shell").ok().flatten();
-        let author_kind: Option<i64> = row.try_get("author_kind").ok().flatten();
-        let author_kind =
-            author_kind.and_then(|kind| u8::try_from(kind).ok()).and_then(AuthorKind::from_repr);
-
-        History::from_db()
-            .id(row.get("id"))
-            .timestamp(OffsetDateTime::from_unix_nanos_i64(row.get("timestamp")))
-            .duration(row.get("duration"))
-            .exit(row.get("exit"))
-            .command(row.get("command"))
-            .cwd(row.get("cwd"))
-            .session(row.get("session"))
-            .hostname(hostname)
-            .author(author)
-            .intent(intent)
-            .deleted_at(deleted_at.map(OffsetDateTime::from_unix_nanos_i64))
-            .shell(shell)
-            .author_kind(author_kind)
-            .build()
-            .into()
     }
 
     #[instrument(level = "trace", skip_all, fields(id = ?h.id), err)]

--- a/crates/atuin-client/src/database.rs
+++ b/crates/atuin-client/src/database.rs
@@ -355,18 +355,10 @@ impl Sqlite {
     #[instrument(level = "trace", skip_all, fields(id = ?h.id), err)]
     async fn save_raw(tx: &mut sqlx::Transaction<'_, sqlx::Sqlite>, h: &History) -> Result<()> {
         sqlx::query(
-            // On an id conflict, adopt the incoming author_kind if the stored row has none: store
-            // rebuilds re-save every record through here, and this is what lets a kind synced from
-            // another machine reach a row that was first written without one (the record store
-            // itself is immutable). The trailing bare ON CONFLICT keeps the old `insert or ignore`
-            // behavior for the (timestamp, cwd, command) uniqueness constraint.
-            "insert into history(
+            "insert or ignore into history(
                 id, timestamp, duration, exit, command, cwd, session, hostname, author, intent,
                 deleted_at, shell, author_kind
-            ) values(?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13)
-            on conflict(id) do update set author_kind = excluded.author_kind
-                where history.author_kind is null and excluded.author_kind is not null
-            on conflict do nothing",
+            ) values(?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13)",
         )
         .bind(h.id.0.as_str())
         .bind(h.timestamp.unix_timestamp_nanos() as i64)
@@ -2106,39 +2098,6 @@ mod test {
                 .unwrap();
             assert_eq!(results.len(), expected, "{authors:?}");
         }
-    }
-
-    /// Re-saving an existing row (as a store rebuild does for every record) fills in a missing
-    /// author_kind but never overwrites one that is already set.
-    #[tokio::test(flavor = "multi_thread")]
-    #[rstest]
-    async fn save_backfills_author_kind_on_existing_rows() {
-        let db = Sqlite::new("sqlite::memory:", test_local_timeout()).await.unwrap();
-
-        let kindless: History = History::import()
-            .timestamp(OffsetDateTime::now_utc())
-            .command("echo hello")
-            .cwd("/tmp")
-            .cmd_origin(CmdOrigin::try_from("raspberry:pi".to_owned()).unwrap())
-            .author("pi")
-            .build()
-            .into();
-        db.save(&kindless).await.unwrap();
-
-        // The same entry arrives again, now carrying its kind (e.g. re-synced and rebuilt after
-        // an upgrade).
-        let with_kind = History {
-            author_kind: Some(AuthorKind::Agent),
-            ..kindless.clone()
-        };
-        db.save(&with_kind).await.unwrap();
-        let loaded = db.load(kindless.id.0.as_str()).await.unwrap().unwrap();
-        assert_eq!(loaded.author_kind, Some(AuthorKind::Agent));
-
-        // A later kindless copy does not erase the stored kind.
-        db.save(&kindless).await.unwrap();
-        let loaded = db.load(kindless.id.0.as_str()).await.unwrap().unwrap();
-        assert_eq!(loaded.author_kind, Some(AuthorKind::Agent));
     }
 
     /// A user called `pi` shares a name with the `pi` agent, so on their machine the author name

--- a/crates/atuin-client/src/database.rs
+++ b/crates/atuin-client/src/database.rs
@@ -111,10 +111,8 @@ fn apply_author_filter(sql: &mut SqlBuilder, authors: OrFilter<&[AuthorPattern]>
     };
 
     // The username half of `hostname`, which is what `author` falls back to when nothing set it.
-    let user_expr = "CASE \
-        WHEN instr(hostname, ':') > 0 THEN substr(hostname, instr(hostname, ':') + 1) \
-        ELSE hostname \
-    END";
+    let user_expr = "CASE WHEN instr(hostname, ':') > 0 THEN substr(hostname, instr(hostname, \
+                     ':') + 1) ELSE hostname END";
 
     let author_expr =
         format!("CASE WHEN author IS NULL OR trim(author) = '' THEN {user_expr} ELSE author END");
@@ -126,8 +124,8 @@ fn apply_author_filter(sql: &mut SqlBuilder, authors: OrFilter<&[AuthorPattern]>
     // `NULL IN (...)` is not true.
     let is_agent = || {
         format!(
-            "CASE WHEN author_kind IN ({kinds}) THEN author_kind = {agent} \
-             ELSE {author_expr} IN ({names}) AND {author_expr} <> {user_expr} END",
+            "CASE WHEN author_kind IN ({kinds}) THEN author_kind = {agent} ELSE {author_expr} IN \
+             ({names}) AND {author_expr} <> {user_expr} END",
             kinds = AuthorKind::VARIANTS.iter().map(|kind| kind.as_u8().to_string()).join(", "),
             agent = AuthorKind::Agent.as_u8(),
             names = KNOWN_AGENTS.iter().map(quote).join(", "),
@@ -1531,18 +1529,12 @@ mod test {
         };
 
         let results = db
-            .search(
-                DbSearchMode::FullText,
-                FilterMode::Global,
-                &context,
-                "",
-                OptFilters {
-                    after: after.as_deref(),
-                    before: before.as_deref(),
-                    include_duplicates: true,
-                    ..Default::default()
-                },
-            )
+            .search(DbSearchMode::FullText, FilterMode::Global, &context, "", OptFilters {
+                after: after.as_deref(),
+                before: before.as_deref(),
+                include_duplicates: true,
+                ..Default::default()
+            })
             .await
             .unwrap();
 
@@ -1565,16 +1557,10 @@ mod test {
         let context = new_context();
 
         let hits = db
-            .search(
-                DbSearchMode::FullText,
-                FilterMode::Global,
-                &context,
-                "",
-                OptFilters {
-                    include_duplicates,
-                    ..Default::default()
-                },
-            )
+            .search(DbSearchMode::FullText, FilterMode::Global, &context, "", OptFilters {
+                include_duplicates,
+                ..Default::default()
+            })
             .await
             .unwrap();
 
@@ -1691,13 +1677,9 @@ mod test {
         new_history_item(&db, "corburl").await.unwrap();
 
         // if fuzzy reordering is on, it should come back in a more sensible order
-        assert_search_commands(
-            &db,
-            DbSearchMode::Fuzzy,
-            FilterMode::Global,
-            "curl",
-            vec!["curl", "corburl"],
-        )
+        assert_search_commands(&db, DbSearchMode::Fuzzy, FilterMode::Global, "curl", vec![
+            "curl", "corburl",
+        ])
         .await;
 
         assert_search_eq(&db, DbSearchMode::Fuzzy, FilterMode::Global, "xxxx", 0).await.unwrap();
@@ -1745,13 +1727,9 @@ mod test {
         new_history_item_at(&db, "curl", Some(now - time::Duration::seconds(10))).await.unwrap();
         new_history_item_at(&db, "corburl", Some(now)).await.unwrap();
 
-        assert_search_commands(
-            &db,
-            mode.closest_db_mode(),
-            FilterMode::Global,
-            "curl",
-            vec!["curl", "corburl"],
-        )
+        assert_search_commands(&db, mode.closest_db_mode(), FilterMode::Global, "curl", vec![
+            "curl", "corburl",
+        ])
         .await;
     }
 
@@ -1814,13 +1792,9 @@ mod test {
         new_history_item_at(&db, close, Some(now - time::Duration::days(5))).await.unwrap();
         new_history_item_at(&db, far, Some(now - time::Duration::hours(1))).await.unwrap();
 
-        assert_search_commands(
-            &db,
-            DbSearchMode::Fuzzy,
-            FilterMode::Global,
-            query,
-            vec![close, far],
-        )
+        assert_search_commands(&db, DbSearchMode::Fuzzy, FilterMode::Global, query, vec![
+            close, far,
+        ])
         .await;
     }
 
@@ -1830,13 +1804,9 @@ mod test {
     async fn test_search_fuzzy_operator() {
         let db = db_with(&["use screen", "screenshot tool"]).await;
 
-        assert_search_commands(
-            &db,
-            DbSearchMode::Fuzzy,
-            FilterMode::Global,
-            "screen$",
-            vec!["use screen"],
-        )
+        assert_search_commands(&db, DbSearchMode::Fuzzy, FilterMode::Global, "screen$", vec![
+            "use screen",
+        ])
         .await;
     }
 

--- a/crates/atuin-client/src/history.rs
+++ b/crates/atuin-client/src/history.rs
@@ -51,9 +51,6 @@ impl AuthorKind {
     pub const VARIANTS: [Self; 2] = [Self::User, Self::Agent];
 
     /// Decode the representation written by [`Self::as_u8`].
-    ///
-    /// Unknown values are treated as "not stated" rather than an error, so that entries written by
-    /// a future version with more kinds still decode.
     pub const fn from_u8(value: u8) -> Option<Self> {
         match value {
             1 => Some(Self::User),

--- a/crates/atuin-client/src/history.rs
+++ b/crates/atuin-client/src/history.rs
@@ -6,7 +6,7 @@ use atuin_common::rmp::decode::{self, Bytes, DecodeError};
 use atuin_common::rmp::encode::{self, ByteBuf, EncodeError};
 use atuin_common::time::OffsetDateTimeExt;
 use atuin_common::utils::{normalize_optional_string, uuid_v7};
-use atuin_domain::record::{CmdOrigin, DecryptedData};
+use atuin_domain::record::{CmdOrigin, DecryptedData, UNKNOWN_USER};
 use eyre::{Result, bail};
 use time::OffsetDateTime;
 
@@ -311,7 +311,7 @@ impl History {
                 // old writers defaulted the author to the whole hostname there — as does the SQL
                 // author filter's user expression — so compare against the host in that case.
                 let user = self.cmd_origin.user();
-                let defaulted = if user.as_ref() == "unknown-user" {
+                let defaulted = if user.as_ref() == UNKNOWN_USER {
                     self.cmd_origin.host().into_inner()
                 } else {
                     user.into_inner()
@@ -689,14 +689,22 @@ mod tests {
     }
 
     /// The capture path treats an explicitly stated author as an authorship claim: a known agent
-    /// name there marks the entry as an agent's even where the hostname fallback would have
-    /// produced the same string. An explicit kind still wins over the inference.
+    /// name there marks the entry as an agent's — unless it is also the current username, which
+    /// is what a human's author defaults to and so says nothing (the same exception
+    /// [`History::is_agent`] applies). An explicit kind still wins over the inference.
     #[rstest]
-    #[case::known_agent_name("pi", None, Some(AuthorKind::Agent))]
-    #[case::human_name("ellie", None, None)]
-    #[case::explicit_kind_wins("pi", Some(AuthorKind::User), Some(AuthorKind::User))]
+    #[case::known_agent_name("pi", "raspberry:ellie", None, Some(AuthorKind::Agent))]
+    #[case::agent_name_is_the_username("pi", "raspberry:pi", None, None)]
+    #[case::human_name("ellie", "raspberry:ellie", None, None)]
+    #[case::explicit_kind_wins(
+        "pi",
+        "raspberry:pi",
+        Some(AuthorKind::Agent),
+        Some(AuthorKind::Agent)
+    )]
     fn capture_infers_agent_kind_from_an_explicit_author(
         #[case] author: &str,
+        #[case] origin: &str,
         #[case] stated_kind: Option<AuthorKind>,
         #[case] expected: Option<AuthorKind>,
     ) {
@@ -705,6 +713,7 @@ mod tests {
             .command("git status")
             .cwd("/")
             .author(author)
+            .cmd_origin(CmdOrigin::try_from(origin.to_owned()).unwrap())
             .author_kind_opt(stated_kind)
             .build()
             .into();

--- a/crates/atuin-client/src/history.rs
+++ b/crates/atuin-client/src/history.rs
@@ -49,7 +49,7 @@ pub enum AuthorKind {
 
 impl AuthorKind {
     /// Every recognised kind. The SQL author filter derives its recognised-value list from this,
-    /// so it stays in lockstep with [`Self::from_u8`] (a test pins the two together).
+    /// so it stays in lockstep with [`Self::from_repr`] (a test pins the two together).
     pub const VARIANTS: [Self; 2] = [Self::User, Self::Agent];
 
     pub const fn as_u8(self) -> u8 {
@@ -271,9 +271,6 @@ impl History {
             .or_else(|| env::var("ATUIN_SESSION").ok())
             .unwrap_or_else(|| uuid_v7().as_simple().to_string());
         let cmd_origin = cmd_origin.unwrap_or_else(CmdOrigin::probe_current);
-        // `From<HistoryCaptured>` pre-resolves the same flag -> env chain to infer `author_kind`;
-        // a precedence change here must be mirrored there, or the stored kind can disagree with
-        // the stored author.
         let author = normalize_optional_string(author)
             .or_else(|| normalize_optional_string(env::var(HISTORY_AUTHOR_ENV).ok()))
             .unwrap_or_else(|| cmd_origin.user().to_string());

--- a/crates/atuin-client/src/history.rs
+++ b/crates/atuin-client/src/history.rs
@@ -65,6 +65,12 @@ impl AuthorKind {
     pub const fn as_u8(self) -> u8 {
         self as u8
     }
+
+    /// The kind stated by the invoking integration's environment (`ATUIN_HISTORY_AUTHOR_KIND`).
+    pub fn probe_current() -> Option<Self> {
+        let value = env::var(HISTORY_AUTHOR_KIND_ENV).ok()?;
+        clap::ValueEnum::from_str(&value, true).ok()
+    }
 }
 
 /// An element of an author filter.
@@ -111,9 +117,14 @@ pub fn all_user_author_filter() -> OrFilter<&'static [AuthorPattern]> {
     FILTER.as_slice_filter()
 }
 
-pub(crate) const HISTORY_AUTHOR_ENV: &str = "ATUIN_HISTORY_AUTHOR";
-pub(crate) const HISTORY_AUTHOR_KIND_ENV: &str = "ATUIN_HISTORY_AUTHOR_KIND";
+const HISTORY_AUTHOR_ENV: &str = "ATUIN_HISTORY_AUTHOR";
+const HISTORY_AUTHOR_KIND_ENV: &str = "ATUIN_HISTORY_AUTHOR_KIND";
 const HISTORY_INTENT_ENV: &str = "ATUIN_HISTORY_INTENT";
+
+/// The author identity exported by the invoking integration (`ATUIN_HISTORY_AUTHOR`).
+pub fn probe_author() -> Option<String> {
+    normalize_optional_string(env::var(HISTORY_AUTHOR_ENV).ok())
+}
 
 #[derive(Clone, Copy, Eq, PartialEq, Ord, PartialOrd, derive_more::Display)]
 #[display("{}", self.name())]

--- a/crates/atuin-client/src/history.rs
+++ b/crates/atuin-client/src/history.rs
@@ -16,7 +16,8 @@ use crate::settings::Settings;
 pub(crate) mod builder;
 pub mod store;
 
-/// Known AI agent author values. Used when matching against [`AuthorPattern::AllAgent`] and
+/// Known AI agent author values. Used by [`History::is_agent`] to guess who ran a command when the
+/// entry does not state it, and so when matching against [`AuthorPattern::AllAgent`] and
 /// [`AuthorPattern::AllUser`].
 pub const KNOWN_AGENTS: &[&str] = &["claude-code", "codex", "copilot", "opencode", "pi"];
 
@@ -30,15 +31,51 @@ pub fn is_known_agent(author: &str) -> bool {
     KNOWN_AGENTS.contains(&author)
 }
 
+/// Who wrote a history entry, as declared by whatever captured it.
+///
+/// This is stored as a small integer, both on the wire and in the database, and is optional: an
+/// entry captured before this field existed, or by an integration that does not set it, has no
+/// kind, and [`History::is_agent`] falls back to inspecting the author name.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Hash, clap::ValueEnum)]
+#[repr(u8)]
+pub enum AuthorKind {
+    /// A human ran this command.
+    User = 1,
+    /// An AI agent ran this command.
+    Agent = 2,
+}
+
+impl AuthorKind {
+    /// Every recognised kind. The SQL author filter derives its recognised-value list from this,
+    /// so it stays in lockstep with [`Self::from_u8`] (a test pins the two together).
+    pub const VARIANTS: [Self; 2] = [Self::User, Self::Agent];
+
+    /// Decode the representation written by [`Self::as_u8`].
+    ///
+    /// Unknown values are treated as "not stated" rather than an error, so that entries written by
+    /// a future version with more kinds still decode.
+    pub const fn from_u8(value: u8) -> Option<Self> {
+        match value {
+            1 => Some(Self::User),
+            2 => Some(Self::Agent),
+            _ => None,
+        }
+    }
+
+    pub const fn as_u8(self) -> u8 {
+        self as u8
+    }
+}
+
 /// An element of an author filter.
 ///
 /// In addition to a plain string, this type can also be the special pattern `AllUser` or
-/// `AllAgent`, which matches known agents or all authors than are not a known agent.
+/// `AllAgent`, which matches agent-run commands or everything that is not one.
 #[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
 pub enum AuthorPattern {
-    /// Matches every author that is not a known agent.
+    /// Matches every entry that is not an agent's (see [`History::is_agent`]).
     AllUser,
-    /// Matches every author that is a known agent (see [`KNOWN_AGENTS`]).
+    /// Matches every entry that is an agent's (see [`History::is_agent`]).
     AllAgent,
     /// Matches exactly one author name.
     Name(String),
@@ -74,7 +111,8 @@ pub fn all_user_author_filter() -> OrFilter<&'static [AuthorPattern]> {
     FILTER.as_slice_filter()
 }
 
-const HISTORY_AUTHOR_ENV: &str = "ATUIN_HISTORY_AUTHOR";
+pub(crate) const HISTORY_AUTHOR_ENV: &str = "ATUIN_HISTORY_AUTHOR";
+pub(crate) const HISTORY_AUTHOR_KIND_ENV: &str = "ATUIN_HISTORY_AUTHOR_KIND";
 const HISTORY_INTENT_ENV: &str = "ATUIN_HISTORY_INTENT";
 
 #[derive(Clone, Copy, Eq, PartialEq, Ord, PartialOrd, derive_more::Display)]
@@ -128,6 +166,24 @@ impl Version {
     }
 }
 
+/// Number of fields [`History::serialize`] writes.
+///
+/// This is deliberately not [`Version::min_fields`]: fields appended to V2 grow this count, while
+/// `min_fields` stays at the 12 fields V2 launched with so that entries written before the new
+/// fields existed still decode.
+///
+/// This count must never gate reading a field back. Each appended field gets its own frozen
+/// threshold constant (its position in the array, like [`V2_FIELDS_THROUGH_AUTHOR_KIND`]) —
+/// gating on this growing total would make records written before the *next* field silently lose
+/// this one.
+const V2_SERIALIZED_FIELDS: u32 = 13;
+
+/// A V2 record contains `author_kind` iff it has at least this many fields.
+///
+/// Frozen forever at the position `author_kind` was appended at; do not grow it alongside
+/// [`V2_SERIALIZED_FIELDS`].
+const V2_FIELDS_THROUGH_AUTHOR_KIND: u32 = 13;
+
 #[derive(Clone, Debug, Eq, PartialEq, Hash, derive_more::Display, derive_more::From)]
 #[display("{_0}")]
 pub struct HistoryId(pub String);
@@ -173,6 +229,10 @@ pub struct History {
     pub deleted_at: Option<OffsetDateTime>,
     /// The shell used to run the command.
     pub shell: Option<String>,
+    /// Whether a human or an agent wrote this command, if whatever captured it said so.
+    ///
+    /// When this is `None`, [`History::is_agent`] guesses from the author name.
+    pub author_kind: Option<AuthorKind>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -209,11 +269,15 @@ impl History {
         intent: Option<String>,
         deleted_at: Option<OffsetDateTime>,
         shell: Option<String>,
+        author_kind: Option<AuthorKind>,
     ) -> Self {
         let session = session
             .or_else(|| env::var("ATUIN_SESSION").ok())
             .unwrap_or_else(|| uuid_v7().as_simple().to_string());
         let cmd_origin = cmd_origin.unwrap_or_else(CmdOrigin::probe_current);
+        // `From<HistoryCaptured>` pre-resolves the same flag -> env chain to infer `author_kind`;
+        // a precedence change here must be mirrored there, or the stored kind can disagree with
+        // the stored author.
         let author = normalize_optional_string(author)
             .or_else(|| normalize_optional_string(env::var(HISTORY_AUTHOR_ENV).ok()))
             .unwrap_or_else(|| cmd_origin.user().to_string());
@@ -234,6 +298,21 @@ impl History {
             intent,
             deleted_at,
             shell,
+            author_kind,
+        }
+    }
+
+    /// Whether an AI agent, rather than a human, ran this command.
+    ///
+    /// [`Self::author_kind`] is authoritative when the integration that captured the entry set it.
+    /// Otherwise we guess: a known agent name identifies an agent, unless it is also the username
+    /// recorded in the entry's origin, in which case the author is just the default it fell back
+    /// to and tells us nothing. That exception is what stops a user called `pi` from looking like
+    /// the `pi` agent.
+    pub fn is_agent(&self) -> bool {
+        match self.author_kind {
+            Some(kind) => kind == AuthorKind::Agent,
+            None => is_known_agent(&self.author) && self.author != self.cmd_origin.user().as_ref(),
         }
     }
 
@@ -244,6 +323,10 @@ impl History {
     /// * `intent` is always written; if `None`, nil is written to the output.
     /// * Added new field `shell`.
     ///
+    /// Fields appended after V2 shipped (see [`V2_SERIALIZED_FIELDS`]) are read back only if the
+    /// encoded array is long enough to contain them, so older clients ignore them and newer clients
+    /// can still read older entries.
+    ///
     /// V2 is designed to allow new fields to be added without incrementing the version. V1 cannot
     /// accommodate this because its deserialization routine errors if more than 11 fields are
     /// provided.
@@ -252,7 +335,7 @@ impl History {
 
         // write the version
         encode::write_u16(&mut output, Version::LATEST.as_int())?;
-        encode::write_array_len(&mut output, Version::LATEST.min_fields())?;
+        encode::write_array_len(&mut output, V2_SERIALIZED_FIELDS)?;
 
         encode::write_str(&mut output, &self.id.0)?;
         encode::write_u64(&mut output, self.timestamp.unix_timestamp_nanos() as u64)?;
@@ -271,6 +354,11 @@ impl History {
         encode::write_str(&mut output, self.author.as_str())?;
         encode::write_optional(&mut output, self.intent.as_deref(), encode::write_str)?;
         encode::write_optional(&mut output, self.shell.as_deref(), encode::write_str)?;
+        encode::write_optional(
+            &mut output,
+            self.author_kind.map(AuthorKind::as_u8),
+            |output, kind| encode::write_uint8(output, kind).map(|_marker| ()),
+        )?;
         Ok(DecryptedData(output.into_vec()))
     }
 
@@ -326,6 +414,13 @@ impl History {
             None
         };
 
+        let author_kind = if version >= Version::Two && nfields >= V2_FIELDS_THROUGH_AUTHOR_KIND {
+            decode::read_optional(&mut bytes, decode::read_int::<u8, _>)?
+                .and_then(AuthorKind::from_u8)
+        } else {
+            None
+        };
+
         if version < Version::Two && !bytes.remaining_slice().is_empty() {
             bail!("trailing bytes in encoded history. malformed");
         }
@@ -343,6 +438,7 @@ impl History {
             intent,
             deleted_at: deleted_at.map(OffsetDateTime::from_unix_nanos_u64),
             shell,
+            author_kind,
         })
     }
 
@@ -515,22 +611,34 @@ mod tests {
     use rstest::*;
     use time::macros::datetime;
 
-    use super::{AuthorPattern, History, all_user_author_filter, is_known_agent};
+    use super::{AuthorKind, AuthorPattern, History, all_user_author_filter, is_known_agent};
     use crate::history::Version;
     use crate::settings::Settings;
 
-    /// Whether an author filter permits `author`, mirroring the SQL that
+    /// Whether an author filter permits `history`, mirroring the SQL that
     /// [`apply_author_filter`](crate::database::OptFilters::authors) builds.
     ///
     /// There are only three ways a filter can admit an author, so each is one binary search rather
     /// than a scan that reinterprets every element in turn. No guard against an author *named*
     /// `$all-agent` is needed: such an author is an [`AuthorPattern::Name`], a different value from
     /// [`AuthorPattern::AllAgent`].
-    fn author_matches_filters(author: &str, filters: OrFilter<&[AuthorPattern]>) -> bool {
+    fn author_matches_filters(history: &History, filters: OrFilter<&[AuthorPattern]>) -> bool {
         // `contains` is true for an "all" filter, so that case needs no separate check.
-        filters.contains(&AuthorPattern::Name(author.to_owned()))
-            || (filters.contains(&AuthorPattern::AllUser) && !is_known_agent(author))
-            || (filters.contains(&AuthorPattern::AllAgent) && is_known_agent(author))
+        filters.contains(&AuthorPattern::Name(history.author.clone()))
+            || (filters.contains(&AuthorPattern::AllUser) && !history.is_agent())
+            || (filters.contains(&AuthorPattern::AllAgent) && history.is_agent())
+    }
+
+    fn entry(author: &str, origin: &str, author_kind: Option<AuthorKind>) -> History {
+        #[allow(deprecated, reason = "the bare-hostname test case has no `:` separator")]
+        History::import()
+            .timestamp(time::OffsetDateTime::now_utc())
+            .command("git status")
+            .cmd_origin(CmdOrigin::parse_lenient(origin))
+            .author(author)
+            .author_kind(author_kind)
+            .build()
+            .into()
     }
 
     #[fixture]
@@ -565,29 +673,95 @@ mod tests {
         assert_eq!(history.should_save(&settings), expected);
     }
 
+    /// The SQL author filter derives its recognised-kind list from [`AuthorKind::VARIANTS`] while
+    /// Rust decoding goes through [`AuthorKind::from_u8`]; a value present in one but not the
+    /// other would split the two classifiers, so pin them to agree over the whole u8 range.
+    #[test]
+    fn author_kind_variants_and_from_u8_agree() {
+        for value in 0..=u8::MAX {
+            assert_eq!(
+                AuthorKind::from_u8(value),
+                AuthorKind::VARIANTS.iter().copied().find(|kind| kind.as_u8() == value),
+                "{value}"
+            );
+        }
+    }
+
+    /// The capture path treats an explicitly stated author as an authorship claim: a known agent
+    /// name there marks the entry as an agent's even where the hostname fallback would have
+    /// produced the same string. An explicit kind still wins over the inference.
+    #[rstest]
+    #[case::known_agent_name("pi", None, Some(AuthorKind::Agent))]
+    #[case::human_name("ellie", None, None)]
+    #[case::explicit_kind_wins("pi", Some(AuthorKind::User), Some(AuthorKind::User))]
+    fn capture_infers_agent_kind_from_an_explicit_author(
+        #[case] author: &str,
+        #[case] stated_kind: Option<AuthorKind>,
+        #[case] expected: Option<AuthorKind>,
+    ) {
+        let history: History = History::capture()
+            .timestamp(time::OffsetDateTime::now_utc())
+            .command("git status")
+            .cwd("/")
+            .author(author)
+            .author_kind_opt(stated_kind)
+            .build()
+            .into();
+        assert_eq!(history.author_kind, expected);
+    }
+
     #[rstest]
     fn known_agents_include_pi() {
         let agents = OrFilter::from_list(vec![AuthorPattern::AllAgent]).unwrap();
         let users = OrFilter::from_list(vec![AuthorPattern::AllUser]).unwrap();
+        let pi = entry("pi", "raspberry:ellie", None);
+        let ellie = entry("ellie", "raspberry:ellie", None);
 
         assert!(is_known_agent("pi"));
-        assert!(author_matches_filters("pi", agents.as_slice_filter()));
-        assert!(!author_matches_filters("pi", users.as_slice_filter()));
-        assert!(!author_matches_filters("ellie", agents.as_slice_filter()));
-        assert!(author_matches_filters("ellie", users.as_slice_filter()));
+        assert!(author_matches_filters(&pi, agents.as_slice_filter()));
+        assert!(!author_matches_filters(&pi, users.as_slice_filter()));
+        assert!(!author_matches_filters(&ellie, agents.as_slice_filter()));
+        assert!(author_matches_filters(&ellie, users.as_slice_filter()));
     }
 
     #[test]
     fn an_all_author_filter_matches_everyone() {
         let all = OrFilter::all();
-        assert!(author_matches_filters("pi", all));
-        assert!(author_matches_filters("ellie", all));
+        assert!(author_matches_filters(&entry("pi", "raspberry:ellie", None), all));
+        assert!(author_matches_filters(&entry("ellie", "raspberry:ellie", None), all));
     }
 
     #[test]
     fn the_all_user_filter_excludes_agents() {
-        assert!(!author_matches_filters("pi", all_user_author_filter()));
-        assert!(author_matches_filters("ellie", all_user_author_filter()));
+        let filter = all_user_author_filter();
+        assert!(!author_matches_filters(&entry("pi", "raspberry:ellie", None), filter));
+        assert!(author_matches_filters(&entry("ellie", "raspberry:ellie", None), filter));
+    }
+
+    /// An agent name is only evidence of an agent when it is not also the username: a user called
+    /// `pi` gets `pi` as their author by default, and is not the `pi` agent.
+    #[rstest]
+    #[case::agent_name_on_another_users_machine("pi", "raspberry:ellie", None, true)]
+    #[case::agent_name_is_the_username("pi", "raspberry:pi", None, false)]
+    #[case::plain_user("ellie", "raspberry:ellie", None, false)]
+    #[case::hostname_without_a_username("pi", "raspberry", None, true)]
+    // A stated kind is authoritative, which is the only way to tell the `pi` agent apart from the
+    // `pi` user on their own machine.
+    #[case::stated_agent("pi", "raspberry:pi", Some(AuthorKind::Agent), true)]
+    #[case::stated_user("pi", "raspberry:ellie", Some(AuthorKind::User), false)]
+    #[case::stated_agent_with_a_human_name(
+        "ellie",
+        "raspberry:ellie",
+        Some(AuthorKind::Agent),
+        true
+    )]
+    fn is_agent_uses_the_username_when_no_kind_was_stated(
+        #[case] author: &str,
+        #[case] origin: &str,
+        #[case] author_kind: Option<AuthorKind>,
+        #[case] expected: bool,
+    ) {
+        assert_eq!(entry(author, origin, author_kind).is_agent(), expected);
     }
 
     #[rstest]
@@ -621,6 +795,7 @@ mod tests {
         intent: None,
         deleted_at: None,
         shell: None,
+        author_kind: None,
     })]
     #[case::deleted(History {
         id: "66d16cbee7cd47538e5c5b8b44e9006e".to_owned().into(),
@@ -635,6 +810,7 @@ mod tests {
         intent: None,
         deleted_at: Some(datetime!(2023-11-19 20:18 +00:00)),
         shell: Some("bash".into()),
+        author_kind: Some(AuthorKind::User),
     })]
     #[case::with_author_and_intent(History {
         id: "66d16cbee7cd47538e5c5b8b44e9006e".to_owned().into(),
@@ -649,6 +825,7 @@ mod tests {
         intent: Some("check repository status".to_owned()),
         deleted_at: None,
         shell: Some("fish".into()),
+        author_kind: Some(AuthorKind::Agent),
     })]
     fn serialize_deserialize_roundtrip(#[case] history: History) {
         let serialized = history.serialize().expect("failed to serialize history");
@@ -699,6 +876,7 @@ mod tests {
             intent: Some("sample intent".to_owned()),
             deleted_at: Some(time::OffsetDateTime::from_unix_timestamp(1784080673).unwrap()),
             shell: Some("zsh".into()),
+            author_kind: None,
         }
     }
 
@@ -715,6 +893,30 @@ mod tests {
             deleted_at: None,
             ..expected_v1()
         }
+    }
+
+    /// A V2 record from before `author_kind` was appended: same version, one field short. New
+    /// fields are only read when the encoded array is long enough to hold them, so this must still
+    /// decode rather than error or misread the missing field.
+    #[test]
+    fn deserialize_v2_written_without_author_kind() {
+        let history = History {
+            author_kind: Some(AuthorKind::Agent),
+            ..expected_v2()
+        };
+        let mut bytes = history.serialize().unwrap().0;
+
+        assert_eq!(bytes[3], 0x90 | 13, "v2 should encode 13 fields");
+        bytes[3] = 0x90 | 12;
+        bytes.pop();
+
+        assert_eq!(
+            History::deserialize(&bytes, Version::Two.name()).unwrap(),
+            History {
+                author_kind: None,
+                ..history
+            }
+        );
     }
 
     #[rstest]

--- a/crates/atuin-client/src/history.rs
+++ b/crates/atuin-client/src/history.rs
@@ -35,8 +35,10 @@ pub fn is_known_agent(author: &str) -> bool {
 ///
 /// This is stored as a small integer, both on the wire and in the database, and is optional: an
 /// entry captured before this field existed, or by an integration that does not set it, has no
-/// kind, and [`History::is_agent`] falls back to inspecting the author name.
-#[derive(Clone, Copy, Debug, Eq, PartialEq, Hash, clap::ValueEnum)]
+/// kind, and [`History::is_agent`] falls back to inspecting the author name. A stored value we
+/// don't recognise (written by a future version with more kinds) decodes as "not stated" too:
+/// [`Self::from_repr`] returns `None` rather than an error.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Hash, clap::ValueEnum, strum_macros::FromRepr)]
 #[repr(u8)]
 pub enum AuthorKind {
     /// A human ran this command.
@@ -49,15 +51,6 @@ impl AuthorKind {
     /// Every recognised kind. The SQL author filter derives its recognised-value list from this,
     /// so it stays in lockstep with [`Self::from_u8`] (a test pins the two together).
     pub const VARIANTS: [Self; 2] = [Self::User, Self::Agent];
-
-    /// Decode the representation written by [`Self::as_u8`].
-    pub const fn from_u8(value: u8) -> Option<Self> {
-        match value {
-            1 => Some(Self::User),
-            2 => Some(Self::Agent),
-            _ => None,
-        }
-    }
 
     pub const fn as_u8(self) -> u8 {
         self as u8
@@ -179,11 +172,6 @@ impl Version {
 /// This is deliberately not [`Version::min_fields`]: fields appended to V2 grow this count, while
 /// `min_fields` stays at the 12 fields V2 launched with so that entries written before the new
 /// fields existed still decode.
-///
-/// This count must never gate reading a field back. Each appended field gets its own frozen
-/// threshold constant (its position in the array, like [`V2_FIELDS_THROUGH_AUTHOR_KIND`]) —
-/// gating on this growing total would make records written before the *next* field silently lose
-/// this one.
 const V2_SERIALIZED_FIELDS: u32 = 13;
 
 /// A V2 record contains `author_kind` iff it has at least this many fields.
@@ -432,7 +420,7 @@ impl History {
 
         let author_kind = if version >= Version::Two && nfields >= V2_FIELDS_THROUGH_AUTHOR_KIND {
             decode::read_optional(&mut bytes, decode::read_int::<u8, _>)?
-                .and_then(AuthorKind::from_u8)
+                .and_then(AuthorKind::from_repr)
         } else {
             None
         };
@@ -690,13 +678,13 @@ mod tests {
     }
 
     /// The SQL author filter derives its recognised-kind list from [`AuthorKind::VARIANTS`] while
-    /// Rust decoding goes through [`AuthorKind::from_u8`]; a value present in one but not the
+    /// Rust decoding goes through [`AuthorKind::from_repr`]; a value present in one but not the
     /// other would split the two classifiers, so pin them to agree over the whole u8 range.
     #[test]
-    fn author_kind_variants_and_from_u8_agree() {
+    fn author_kind_variants_and_from_repr_agree() {
         for value in 0..=u8::MAX {
             assert_eq!(
-                AuthorKind::from_u8(value),
+                AuthorKind::from_repr(value),
                 AuthorKind::VARIANTS.iter().copied().find(|kind| kind.as_u8() == value),
                 "{value}"
             );

--- a/crates/atuin-client/src/history.rs
+++ b/crates/atuin-client/src/history.rs
@@ -910,13 +910,10 @@ mod tests {
         bytes[3] = 0x90 | 12;
         bytes.pop();
 
-        assert_eq!(
-            History::deserialize(&bytes, Version::Two.name()).unwrap(),
-            History {
-                author_kind: None,
-                ..history
-            }
-        );
+        assert_eq!(History::deserialize(&bytes, Version::Two.name()).unwrap(), History {
+            author_kind: None,
+            ..history
+        });
     }
 
     #[rstest]

--- a/crates/atuin-client/src/history.rs
+++ b/crates/atuin-client/src/history.rs
@@ -169,16 +169,16 @@ impl Version {
 
 /// Number of fields [`History::serialize`] writes.
 ///
-/// This is deliberately not [`Version::min_fields`]: fields appended to V2 grow this count, while
-/// `min_fields` stays at the 12 fields V2 launched with so that entries written before the new
-/// fields existed still decode.
-const V2_SERIALIZED_FIELDS: u32 = 13;
+/// This is deliberately not [`Version::min_fields`]: fields appended to the latest version grow
+/// this count, while `min_fields` stays at the 12 fields V2 launched with so that entries written
+/// before the new fields existed still decode.
+const LATEST_SERIALIZED_FIELDS: u32 = 13;
 
 /// A V2 record contains `author_kind` iff it has at least this many fields.
 ///
 /// Frozen forever at the position `author_kind` was appended at; do not grow it alongside
-/// [`V2_SERIALIZED_FIELDS`].
-const V2_FIELDS_THROUGH_AUTHOR_KIND: u32 = 13;
+/// [`LATEST_SERIALIZED_FIELDS`].
+const V2_AUTHOR_KIND_FIELD_NUMBER: u32 = 13;
 
 #[derive(Clone, Debug, Eq, PartialEq, Hash, derive_more::Display, derive_more::From)]
 #[display("{_0}")]
@@ -336,7 +336,7 @@ impl History {
 
         // write the version
         encode::write_u16(&mut output, Version::LATEST.as_int())?;
-        encode::write_array_len(&mut output, V2_SERIALIZED_FIELDS)?;
+        encode::write_array_len(&mut output, LATEST_SERIALIZED_FIELDS)?;
 
         encode::write_str(&mut output, &self.id.0)?;
         encode::write_u64(&mut output, self.timestamp.unix_timestamp_nanos() as u64)?;
@@ -415,7 +415,7 @@ impl History {
             None
         };
 
-        let author_kind = if version >= Version::Two && nfields >= V2_FIELDS_THROUGH_AUTHOR_KIND {
+        let author_kind = if version >= Version::Two && nfields >= V2_AUTHOR_KIND_FIELD_NUMBER {
             decode::read_optional(&mut bytes, decode::read_int::<u8, _>)?
                 .and_then(AuthorKind::from_repr)
         } else {

--- a/crates/atuin-client/src/history.rs
+++ b/crates/atuin-client/src/history.rs
@@ -346,10 +346,6 @@ impl History {
     /// * `intent` is always written; if `None`, nil is written to the output.
     /// * Added new field `shell`.
     ///
-    /// Fields appended after V2 shipped (see [`V2_SERIALIZED_FIELDS`]) are read back only if the
-    /// encoded array is long enough to contain them, so older clients ignore them and newer clients
-    /// can still read older entries.
-    ///
     /// V2 is designed to allow new fields to be added without incrementing the version. V1 cannot
     /// accommodate this because its deserialization routine errors if more than 11 fields are
     /// provided.

--- a/crates/atuin-client/src/history.rs
+++ b/crates/atuin-client/src/history.rs
@@ -312,7 +312,19 @@ impl History {
     pub fn is_agent(&self) -> bool {
         match self.author_kind {
             Some(kind) => kind == AuthorKind::Agent,
-            None => is_known_agent(&self.author) && self.author != self.cmd_origin.user().as_ref(),
+            None => {
+                // The username the author would have defaulted to. `CmdOrigin::parse_lenient`
+                // maps a legacy colonless hostname to a placeholder user ("unknown-user"), but
+                // old writers defaulted the author to the whole hostname there — as does the SQL
+                // author filter's user expression — so compare against the host in that case.
+                let user = self.cmd_origin.user();
+                let defaulted = if user.as_ref() == "unknown-user" {
+                    self.cmd_origin.host().into_inner()
+                } else {
+                    user.into_inner()
+                };
+                is_known_agent(&self.author) && self.author != defaulted
+            }
         }
     }
 
@@ -745,6 +757,7 @@ mod tests {
     #[case::agent_name_is_the_username("pi", "raspberry:pi", None, false)]
     #[case::plain_user("ellie", "raspberry:ellie", None, false)]
     #[case::hostname_without_a_username("pi", "raspberry", None, true)]
+    #[case::colonless_hostname_is_the_agent_name("pi", "pi", None, false)]
     // A stated kind is authoritative, which is the only way to tell the `pi` agent apart from the
     // `pi` user on their own machine.
     #[case::stated_agent("pi", "raspberry:pi", Some(AuthorKind::Agent), true)]

--- a/crates/atuin-client/src/history/builder.rs
+++ b/crates/atuin-client/src/history/builder.rs
@@ -2,7 +2,7 @@ use atuin_common::utils::normalize_optional_string;
 use atuin_domain::record::CmdOrigin;
 use typed_builder::TypedBuilder;
 
-use super::{AuthorKind, HISTORY_AUTHOR_ENV, HISTORY_AUTHOR_KIND_ENV, History, is_known_agent};
+use super::{AuthorKind, History, is_known_agent};
 
 /// Builder for a history entry that is imported from shell history.
 ///
@@ -81,22 +81,12 @@ pub struct HistoryCaptured {
 
 impl From<HistoryCaptured> for History {
     fn from(captured: HistoryCaptured) -> Self {
-        // An author stated by the caller (`--author` or `ATUIN_HISTORY_AUTHOR`), unlike the
-        // hostname-derived default, is an authorship claim: a known agent name there identifies
-        // the agent even on a machine whose username matches it. This is what classifies entries
-        // from integrations that predate `--author-kind`. An explicit kind, from the builder or
-        // `ATUIN_HISTORY_AUTHOR_KIND` (`user`/`agent`), still wins.
-        let author = normalize_optional_string(captured.author)
-            .or_else(|| normalize_optional_string(std::env::var(HISTORY_AUTHOR_ENV).ok()));
+        // Only agent integrations state an author; humans never do. That makes a stated
+        // known-agent name a far stronger signal that an agent ran this than anything we can
+        // infer after the fact. An explicit kind still wins.
+        let author = normalize_optional_string(captured.author);
         let author_kind = captured
             .author_kind
-            .or_else(|| {
-                // Parsed like the `--author-kind` flag, so the two channels can't drift —
-                // case-insensitively, since a bad env value is silently ignored rather than
-                // rejected loudly the way a bad flag is.
-                let value = std::env::var(HISTORY_AUTHOR_KIND_ENV).ok()?;
-                clap::ValueEnum::from_str(&value, true).ok()
-            })
             .or_else(|| author.as_deref().is_some_and(is_known_agent).then_some(AuthorKind::Agent));
 
         Self::new(

--- a/crates/atuin-client/src/history/builder.rs
+++ b/crates/atuin-client/src/history/builder.rs
@@ -1,7 +1,8 @@
+use atuin_common::utils::normalize_optional_string;
 use atuin_domain::record::CmdOrigin;
 use typed_builder::TypedBuilder;
 
-use super::History;
+use super::{AuthorKind, HISTORY_AUTHOR_ENV, HISTORY_AUTHOR_KIND_ENV, History, is_known_agent};
 
 /// Builder for a history entry that is imported from shell history.
 ///
@@ -27,6 +28,8 @@ pub struct HistoryImported {
     intent: Option<String>,
     #[builder(default, setter(strip_option, into))]
     shell: Option<String>,
+    #[builder(default)]
+    author_kind: Option<AuthorKind>,
 }
 
 impl HistoryImported {
@@ -48,6 +51,7 @@ impl From<HistoryImported> for History {
             imported.intent,
             None,
             imported.shell,
+            imported.author_kind,
         )
     }
 }
@@ -71,10 +75,28 @@ pub struct HistoryCaptured {
     intent: Option<String>,
     #[builder(default, setter(into))]
     shell: Option<String>,
+    #[builder(default)]
+    author_kind: Option<AuthorKind>,
 }
 
 impl From<HistoryCaptured> for History {
     fn from(captured: HistoryCaptured) -> Self {
+        // An author stated by the caller (`--author` or `ATUIN_HISTORY_AUTHOR`), unlike the
+        // hostname-derived default, is an authorship claim: a known agent name there identifies
+        // the agent even on a machine whose username matches it. This is what classifies entries
+        // from integrations that predate `--author-kind`. An explicit kind, from the builder or
+        // `ATUIN_HISTORY_AUTHOR_KIND` (`user`/`agent`), still wins.
+        let author = normalize_optional_string(captured.author)
+            .or_else(|| normalize_optional_string(std::env::var(HISTORY_AUTHOR_ENV).ok()));
+        let author_kind = captured
+            .author_kind
+            .or_else(|| {
+                // Parsed exactly like the `--author-kind` flag, so the two channels can't drift.
+                let value = std::env::var(HISTORY_AUTHOR_KIND_ENV).ok()?;
+                clap::ValueEnum::from_str(&value, false).ok()
+            })
+            .or_else(|| author.as_deref().is_some_and(is_known_agent).then_some(AuthorKind::Agent));
+
         Self::new(
             captured.timestamp,
             captured.command,
@@ -83,10 +105,11 @@ impl From<HistoryCaptured> for History {
             -1,
             None,
             None,
-            captured.author,
+            author,
             captured.intent,
             None,
             captured.shell,
+            author_kind,
         )
     }
 }
@@ -108,6 +131,7 @@ pub struct HistoryFromDb {
     intent: Option<String>,
     deleted_at: Option<time::OffsetDateTime>,
     shell: Option<String>,
+    author_kind: Option<AuthorKind>,
 }
 
 impl From<HistoryFromDb> for History {
@@ -127,6 +151,7 @@ impl From<HistoryFromDb> for History {
             intent: from_db.intent,
             deleted_at: from_db.deleted_at,
             shell: from_db.shell,
+            author_kind: from_db.author_kind,
         }
     }
 }
@@ -153,6 +178,8 @@ pub struct HistoryDaemonCapture {
     intent: Option<String>,
     #[builder(default, setter(strip_option, into))]
     shell: Option<String>,
+    #[builder(default)]
+    author_kind: Option<AuthorKind>,
 }
 
 impl From<HistoryDaemonCapture> for History {
@@ -169,6 +196,7 @@ impl From<HistoryDaemonCapture> for History {
             captured.intent,
             None,
             captured.shell,
+            captured.author_kind,
         )
     }
 }

--- a/crates/atuin-client/src/history/builder.rs
+++ b/crates/atuin-client/src/history/builder.rs
@@ -91,9 +91,11 @@ impl From<HistoryCaptured> for History {
         let author_kind = captured
             .author_kind
             .or_else(|| {
-                // Parsed exactly like the `--author-kind` flag, so the two channels can't drift.
+                // Parsed like the `--author-kind` flag, so the two channels can't drift —
+                // case-insensitively, since a bad env value is silently ignored rather than
+                // rejected loudly the way a bad flag is.
                 let value = std::env::var(HISTORY_AUTHOR_KIND_ENV).ok()?;
-                clap::ValueEnum::from_str(&value, false).ok()
+                clap::ValueEnum::from_str(&value, true).ok()
             })
             .or_else(|| author.as_deref().is_some_and(is_known_agent).then_some(AuthorKind::Agent));
 

--- a/crates/atuin-client/src/history/builder.rs
+++ b/crates/atuin-client/src/history/builder.rs
@@ -72,6 +72,8 @@ pub struct HistoryCaptured {
     #[builder(default, setter(into))]
     author: Option<String>,
     #[builder(default, setter(into))]
+    cmd_origin: Option<CmdOrigin>,
+    #[builder(default, setter(into))]
     intent: Option<String>,
     #[builder(default, setter(into))]
     shell: Option<String>,
@@ -83,11 +85,18 @@ impl From<HistoryCaptured> for History {
     fn from(captured: HistoryCaptured) -> Self {
         // Only agent integrations state an author; humans never do. That makes a stated
         // known-agent name a far stronger signal that an agent ran this than anything we can
-        // infer after the fact. An explicit kind still wins.
+        // infer after the fact — unless it is also the current username, which says nothing
+        // (see [`History::is_agent`]). An explicit kind still wins.
         let author = normalize_optional_string(captured.author);
-        let author_kind = captured
-            .author_kind
-            .or_else(|| author.as_deref().is_some_and(is_known_agent).then_some(AuthorKind::Agent));
+        let cmd_origin = captured.cmd_origin.unwrap_or_else(CmdOrigin::probe_current);
+        let author_kind = captured.author_kind.or_else(|| {
+            author
+                .as_deref()
+                .is_some_and(|author| {
+                    is_known_agent(author) && author != cmd_origin.user().into_inner()
+                })
+                .then_some(AuthorKind::Agent)
+        });
 
         Self::new(
             captured.timestamp,
@@ -96,7 +105,7 @@ impl From<HistoryCaptured> for History {
             -1,
             -1,
             None,
-            None,
+            Some(cmd_origin),
             author,
             captured.intent,
             None,

--- a/crates/atuin-client/src/history/store.rs
+++ b/crates/atuin-client/src/history/store.rs
@@ -489,6 +489,7 @@ mod tests {
             intent: None,
             deleted_at: None,
             shell: None,
+            author_kind: None,
         }
     }
 
@@ -536,9 +537,10 @@ mod tests {
             intent: None,
             deleted_at: None,
             shell: Some("bash".to_owned()),
+            author_kind: None,
         }),
         vec![
-            204, 0, 196, 153, 205, 0, 2, 156, 217, 32, 48, 49, 56, 99, 100, 52, 102, 101, 56, 49,
+            204, 0, 196, 154, 205, 0, 2, 157, 217, 32, 48, 49, 56, 99, 100, 52, 102, 101, 56, 49,
             55, 53, 55, 99, 100, 50, 97, 101, 101, 54, 53, 99, 100, 55, 56, 54, 49, 102, 57, 99,
             56, 49, 207, 23, 166, 251, 212, 181, 82, 0, 0, 100, 0, 162, 108, 115, 217, 41, 47, 85,
             115, 101, 114, 115, 47, 101, 108, 108, 105, 101, 47, 115, 114, 99, 47, 103, 105, 116,
@@ -546,7 +548,7 @@ mod tests {
             105, 110, 217, 32, 48, 49, 56, 99, 100, 52, 102, 101, 97, 100, 56, 57, 55, 53, 57, 55,
             56, 53, 50, 53, 50, 55, 97, 51, 49, 99, 57, 57, 56, 48, 53, 57, 170, 98, 111, 111, 112,
             58, 101, 108, 108, 105, 101, 192, 165, 101, 108, 108, 105, 101, 192, 164, 98, 97, 115,
-            104,
+            104, 192,
         ]
     )]
     #[case::delete(
@@ -694,9 +696,10 @@ mod tests {
 
         // Had the delete been applied before the create, `first` would still be present.
         let stored = db.list([], &context(), None, false, true, None).await.unwrap();
-        assert_eq!(stored.iter().map(|h| h.command.as_str()).collect::<Vec<_>>(), vec![
-            "command 2"
-        ]);
+        assert_eq!(
+            stored.iter().map(|h| h.command.as_str()).collect::<Vec<_>>(),
+            vec!["command 2"]
+        );
     }
 
     #[rstest]

--- a/crates/atuin-client/src/history/store.rs
+++ b/crates/atuin-client/src/history/store.rs
@@ -696,10 +696,9 @@ mod tests {
 
         // Had the delete been applied before the create, `first` would still be present.
         let stored = db.list([], &context(), None, false, true, None).await.unwrap();
-        assert_eq!(
-            stored.iter().map(|h| h.command.as_str()).collect::<Vec<_>>(),
-            vec!["command 2"]
-        );
+        assert_eq!(stored.iter().map(|h| h.command.as_str()).collect::<Vec<_>>(), vec![
+            "command 2"
+        ]);
     }
 
     #[rstest]

--- a/crates/atuin-daemon/proto/history.proto
+++ b/crates/atuin-daemon/proto/history.proto
@@ -1,6 +1,14 @@
 syntax = "proto3";
 package history;
 
+// Whether a human or an agent ran a command. Unspecified means the caller did
+// not say, and the author name is all the receiver has to go on.
+enum AuthorKind {
+  AUTHOR_KIND_UNSPECIFIED = 0;
+  AUTHOR_KIND_USER = 1;
+  AUTHOR_KIND_AGENT = 2;
+}
+
 message StartHistoryRequest {
   // If people are still using my software in ~530 years, they can figure out a u128 migration
   uint64 timestamp = 1; // nanosecond unix epoch
@@ -11,6 +19,7 @@ message StartHistoryRequest {
   string author = 6;
   string intent = 7;
   string shell = 8;
+  AuthorKind author_kind = 9;
 }
 
 message EndHistoryRequest {
@@ -77,6 +86,7 @@ message HistoryEntry {
   int64 exit = 9;
   int64 duration = 10;
   string shell = 11;
+  AuthorKind author_kind = 12;
 }
 
 message TailHistoryReply {

--- a/crates/atuin-daemon/proto/history.proto
+++ b/crates/atuin-daemon/proto/history.proto
@@ -11,17 +11,32 @@ enum AuthorKind {
   AUTHOR_KIND_AGENT = 2;
 }
 
+// Who ran a command. `name` is the author identity as stated by the
+// integration; `kind` says whether that is a human or an agent.
+message Author {
+  AuthorKind kind = 1;
+  string name = 2;
+}
+
 message StartHistoryRequest {
+  // Briefly held a flat `AuthorKind author_kind` while that feature was in
+  // review; it was never in a release, but reserve it anyway.
+  reserved 9;
+
   // If people are still using my software in ~530 years, they can figure out a u128 migration
   uint64 timestamp = 1; // nanosecond unix epoch
   string command = 2;
   string cwd = 3;
   string session = 4;
   string hostname = 5;
-  string author = 6;
+  // The author name alone, readable by daemons from before `Author` existed.
+  // Writers must keep setting this to `author.name`; readers only look at it
+  // when `author` is absent. This is the released `author` field renamed:
+  // field names are not part of the wire format, only the number is.
+  string legacy_author = 6;
   string intent = 7;
   string shell = 8;
-  AuthorKind author_kind = 9;
+  Author author = 10;
 }
 
 message EndHistoryRequest {
@@ -77,18 +92,24 @@ enum HistoryEventKind {
 }
 
 message HistoryEntry {
+  // Briefly held a flat `AuthorKind author_kind` while that feature was in
+  // review; it was never in a release, but reserve it anyway.
+  reserved 12;
+
   uint64 timestamp = 1; // nanosecond unix epoch
   string id = 2;
   string command = 3;
   string cwd = 4;
   string session = 5;
   string hostname = 6;
-  string author = 7;
+  // The author name alone, readable by clients from before `Author` existed.
+  // Same contract as `StartHistoryRequest.legacy_author`.
+  string legacy_author = 7;
   string intent = 8;
   int64 exit = 9;
   int64 duration = 10;
   string shell = 11;
-  AuthorKind author_kind = 12;
+  Author author = 13;
 }
 
 message TailHistoryReply {

--- a/crates/atuin-daemon/proto/history.proto
+++ b/crates/atuin-daemon/proto/history.proto
@@ -2,7 +2,9 @@ syntax = "proto3";
 package history;
 
 // Whether a human or an agent ran a command. Unspecified means the caller did
-// not say, and the author name is all the receiver has to go on.
+// not say, and the author name is all the receiver has to go on. Unspecified is
+// also what keeps this backwards compatible: it is proto3's zero value, so a
+// peer from before this field existed reads and writes it implicitly.
 enum AuthorKind {
   AUTHOR_KIND_UNSPECIFIED = 0;
   AUTHOR_KIND_USER = 1;

--- a/crates/atuin-daemon/src/client.rs
+++ b/crates/atuin-daemon/src/client.rs
@@ -24,9 +24,9 @@ use crate::control::{
 use crate::events::DaemonEvent;
 use crate::history::history_client::HistoryClient as HistoryServiceClient;
 use crate::history::{
-    CancelHistoryReply, CancelHistoryRequest, EndHistoryReply, EndHistoryRequest, ShutdownRequest,
-    StartHistoryReply, StartHistoryRequest, StatusReply, StatusRequest, TailHistoryReply,
-    TailHistoryRequest,
+    AuthorKind, CancelHistoryReply, CancelHistoryRequest, EndHistoryReply, EndHistoryRequest,
+    ShutdownRequest, StartHistoryReply, StartHistoryRequest, StatusReply, StatusRequest,
+    TailHistoryReply, TailHistoryRequest,
 };
 use crate::search::search_client::SearchClient as SearchServiceClient;
 use crate::search::{
@@ -131,6 +131,7 @@ impl HistoryClient {
             author: h.author,
             intent: h.intent.unwrap_or_default(),
             shell: h.shell.unwrap_or_default(),
+            author_kind: AuthorKind::from(h.author_kind) as i32,
         };
 
         Ok(self.client.start_history(req).await?.into_inner())

--- a/crates/atuin-daemon/src/client.rs
+++ b/crates/atuin-daemon/src/client.rs
@@ -24,9 +24,9 @@ use crate::control::{
 use crate::events::DaemonEvent;
 use crate::history::history_client::HistoryClient as HistoryServiceClient;
 use crate::history::{
-    AuthorKind, CancelHistoryReply, CancelHistoryRequest, EndHistoryReply, EndHistoryRequest,
-    ShutdownRequest, StartHistoryReply, StartHistoryRequest, StatusReply, StatusRequest,
-    TailHistoryReply, TailHistoryRequest,
+    Author, AuthorKind, CancelHistoryReply, CancelHistoryRequest, EndHistoryReply,
+    EndHistoryRequest, ShutdownRequest, StartHistoryReply, StartHistoryRequest, StatusReply,
+    StatusRequest, TailHistoryReply, TailHistoryRequest,
 };
 use crate::search::search_client::SearchClient as SearchServiceClient;
 use crate::search::{
@@ -128,10 +128,13 @@ impl HistoryClient {
             hostname: h.cmd_origin.into_string(),
             session: h.session,
             timestamp: h.timestamp.unix_timestamp_nanos() as u64,
-            author: h.author,
+            legacy_author: h.author.clone(),
             intent: h.intent.unwrap_or_default(),
             shell: h.shell.unwrap_or_default(),
-            author_kind: AuthorKind::from(h.author_kind) as i32,
+            author: Some(Author {
+                kind: AuthorKind::from(h.author_kind) as i32,
+                name: h.author,
+            }),
         };
 
         Ok(self.client.start_history(req).await?.into_inner())

--- a/crates/atuin-daemon/src/components/history.rs
+++ b/crates/atuin-daemon/src/components/history.rs
@@ -23,9 +23,9 @@ use crate::daemon::{Component, DaemonHandle};
 use crate::events::DaemonEvent;
 use crate::history::history_server::{History as HistorySvc, HistoryServer};
 use crate::history::{
-    CancelHistoryReply, CancelHistoryRequest, EndHistoryReply, EndHistoryRequest, HistoryEntry,
-    HistoryEventKind, ShutdownReply, ShutdownRequest, StartHistoryReply, StartHistoryRequest,
-    StatusReply, StatusRequest, TailHistoryReply, TailHistoryRequest,
+    AuthorKind, CancelHistoryReply, CancelHistoryRequest, EndHistoryReply, EndHistoryRequest,
+    HistoryEntry, HistoryEventKind, ShutdownReply, ShutdownRequest, StartHistoryReply,
+    StartHistoryRequest, StatusReply, StatusRequest, TailHistoryReply, TailHistoryRequest,
 };
 
 const DAEMON_PROTOCOL_VERSION: u32 = 1;
@@ -131,6 +131,7 @@ fn history_to_tail_reply(kind: HistoryEventKind, history: History) -> TailHistor
             exit: history.exit,
             duration: history.duration,
             shell: history.shell.unwrap_or_default(),
+            author_kind: AuthorKind::from(history.author_kind) as i32,
         }),
     }
 }
@@ -147,6 +148,7 @@ impl HistorySvc for HistoryGrpcService {
         let req = request.into_inner();
 
         let timestamp = OffsetDateTime::from_unix_nanos_u64(req.timestamp);
+        let author_kind = req.author_kind();
 
         let cmd_origin = CmdOrigin::try_from(req.hostname)
             .map_err(|e| Status::invalid_argument(e.to_string()))?;
@@ -159,6 +161,7 @@ impl HistorySvc for HistoryGrpcService {
             .author(req.author)
             .intent(req.intent)
             .shell(req.shell)
+            .author_kind(author_kind.into())
             .build()
             .into();
 

--- a/crates/atuin-daemon/src/components/history.rs
+++ b/crates/atuin-daemon/src/components/history.rs
@@ -23,9 +23,10 @@ use crate::daemon::{Component, DaemonHandle};
 use crate::events::DaemonEvent;
 use crate::history::history_server::{History as HistorySvc, HistoryServer};
 use crate::history::{
-    AuthorKind, CancelHistoryReply, CancelHistoryRequest, EndHistoryReply, EndHistoryRequest,
-    HistoryEntry, HistoryEventKind, ShutdownReply, ShutdownRequest, StartHistoryReply,
-    StartHistoryRequest, StatusReply, StatusRequest, TailHistoryReply, TailHistoryRequest,
+    Author, AuthorKind, CancelHistoryReply, CancelHistoryRequest, EndHistoryReply,
+    EndHistoryRequest, HistoryEntry, HistoryEventKind, ShutdownReply, ShutdownRequest,
+    StartHistoryReply, StartHistoryRequest, StatusReply, StatusRequest, TailHistoryReply,
+    TailHistoryRequest,
 };
 
 const DAEMON_PROTOCOL_VERSION: u32 = 1;
@@ -126,12 +127,15 @@ fn history_to_tail_reply(kind: HistoryEventKind, history: History) -> TailHistor
             cwd: history.cwd,
             session: history.session,
             hostname: history.cmd_origin.into_string(),
-            author: history.author,
+            legacy_author: history.author.clone(),
             intent: history.intent.unwrap_or_default(),
             exit: history.exit,
             duration: history.duration,
             shell: history.shell.unwrap_or_default(),
-            author_kind: AuthorKind::from(history.author_kind) as i32,
+            author: Some(Author {
+                kind: AuthorKind::from(history.author_kind) as i32,
+                name: history.author,
+            }),
         }),
     }
 }
@@ -148,7 +152,15 @@ impl HistorySvc for HistoryGrpcService {
         let req = request.into_inner();
 
         let timestamp = OffsetDateTime::from_unix_nanos_u64(req.timestamp);
-        let author_kind = req.author_kind();
+        // Clients from before `Author` existed only send `legacy_author`, and
+        // never stated a kind.
+        let (author, author_kind) = match req.author {
+            Some(author) => {
+                let kind = author.kind();
+                (author.name, kind.into())
+            }
+            None => (req.legacy_author, None),
+        };
 
         let cmd_origin = CmdOrigin::try_from(req.hostname)
             .map_err(|e| Status::invalid_argument(e.to_string()))?;
@@ -158,10 +170,10 @@ impl HistorySvc for HistoryGrpcService {
             .cwd(req.cwd)
             .session(req.session)
             .cmd_origin(cmd_origin)
-            .author(req.author)
+            .author(author)
             .intent(req.intent)
             .shell(req.shell)
-            .author_kind(author_kind.into())
+            .author_kind(author_kind)
             .build()
             .into();
 

--- a/crates/atuin-daemon/src/components/semantic.rs
+++ b/crates/atuin-daemon/src/components/semantic.rs
@@ -597,6 +597,7 @@ mod tests {
             intent: None,
             deleted_at: None,
             shell: Some("bash".into()),
+            author_kind: None,
         }
     }
 

--- a/crates/atuin-daemon/src/history/mod.rs
+++ b/crates/atuin-daemon/src/history/mod.rs
@@ -5,6 +5,26 @@
 // Include the generated proto code
 tonic::include_proto!("history");
 
+impl From<Option<atuin_client::history::AuthorKind>> for AuthorKind {
+    fn from(kind: Option<atuin_client::history::AuthorKind>) -> Self {
+        match kind {
+            None => Self::Unspecified,
+            Some(atuin_client::history::AuthorKind::User) => Self::User,
+            Some(atuin_client::history::AuthorKind::Agent) => Self::Agent,
+        }
+    }
+}
+
+impl From<AuthorKind> for Option<atuin_client::history::AuthorKind> {
+    fn from(kind: AuthorKind) -> Self {
+        match kind {
+            AuthorKind::Unspecified => None,
+            AuthorKind::User => Some(atuin_client::history::AuthorKind::User),
+            AuthorKind::Agent => Some(atuin_client::history::AuthorKind::Agent),
+        }
+    }
+}
+
 /// Trait for reply types that include the daemon version and protocol version.
 pub trait VersionedReply {
     fn version(&self) -> &str;

--- a/crates/atuin-daemon/src/history/mod.rs
+++ b/crates/atuin-daemon/src/history/mod.rs
@@ -5,6 +5,8 @@
 // Include the generated proto code
 tonic::include_proto!("history");
 
+// Translate between the client's `Option<AuthorKind>` (where "not stated" is `None`) and the
+// proto enum (where proto3 forces a zero variant, `Unspecified`, to mean the same thing).
 impl From<Option<atuin_client::history::AuthorKind>> for AuthorKind {
     fn from(kind: Option<atuin_client::history::AuthorKind>) -> Self {
         match kind {

--- a/crates/atuin-daemon/src/history/mod.rs
+++ b/crates/atuin-daemon/src/history/mod.rs
@@ -5,8 +5,6 @@
 // Include the generated proto code
 tonic::include_proto!("history");
 
-// Translate between the client's `Option<AuthorKind>` (where "not stated" is `None`) and the
-// proto enum (where proto3 forces a zero variant, `Unspecified`, to mean the same thing).
 impl From<Option<atuin_client::history::AuthorKind>> for AuthorKind {
     fn from(kind: Option<atuin_client::history::AuthorKind>) -> Self {
         match kind {

--- a/crates/atuin-daemon/src/search/index.rs
+++ b/crates/atuin-daemon/src/search/index.rs
@@ -12,7 +12,7 @@ use std::cmp::Ordering;
 use std::collections::HashSet;
 use std::sync::{Arc, RwLock};
 
-use atuin_client::history::{History, is_known_agent};
+use atuin_client::history::History;
 use atuin_client::settings::Search;
 use atuin_common::filter::OrFilter;
 use atuin_common::path::DisplayRichExt;
@@ -369,7 +369,7 @@ impl SearchIndex {
     /// If the command already exists, updates its invocation data.
     /// If it's a new command, adds it to both the map and Nucleo.
     pub fn add_history(&self, history: &History) {
-        if is_known_agent(&history.author) {
+        if history.is_agent() {
             return;
         }
         if !self.shells.contains(history.shell.as_deref().unwrap_or_default()) {

--- a/crates/atuin-daemon/tests/lifecycle.rs
+++ b/crates/atuin-daemon/tests/lifecycle.rs
@@ -178,7 +178,9 @@ mod unix {
         assert_eq!(started_history.command, "git status");
         assert_eq!(started_history.cwd, "/tmp/repo");
         assert_eq!(started_history.hostname, "test-host:ellie");
-        assert_eq!(started_history.author, "claude");
+        let started_author = started_history.author.as_ref().unwrap();
+        assert_eq!(started_author.name, "claude");
+        assert_eq!(started_history.legacy_author, "claude");
         assert_eq!(started_history.intent, "inspect repository state");
 
         client.end_history(start_reply.id.clone(), 1_000_000, 0).await.unwrap();

--- a/crates/atuin-domain/src/record/cmd_origin.rs
+++ b/crates/atuin-domain/src/record/cmd_origin.rs
@@ -1,3 +1,6 @@
+/// The placeholder username [`CmdOrigin::parse_lenient`] assigns to a legacy value with no `:`.
+pub const UNKNOWN_USER: &str = "unknown-user";
+
 /// A hostname, generic over its backing storage so it can be an owned
 /// `CmdHost<String>` or a zero-copy `CmdHost<&str>` view into a [`CmdOrigin`].
 #[derive(
@@ -73,7 +76,7 @@ impl<T> CmdUser<T> {
 
 impl Default for CmdUser<String> {
     fn default() -> Self {
-        Self(String::from("unknown-user"))
+        Self(String::from(UNKNOWN_USER))
     }
 }
 

--- a/crates/atuin-domain/src/record/mod.rs
+++ b/crates/atuin-domain/src/record/mod.rs
@@ -11,7 +11,7 @@ pub use tag::RecordTag;
 mod version;
 pub use version::RecordVersion;
 mod cmd_origin;
-pub use cmd_origin::{CmdHost, CmdOrigin, CmdUser};
+pub use cmd_origin::{CmdHost, CmdOrigin, CmdUser, UNKNOWN_USER};
 
 #[derive(Clone, Debug, PartialEq, derive_more::Deref, derive_more::From)]
 pub struct DecryptedData(pub Vec<u8>);

--- a/crates/atuin/contrib/opencode/atuin.ts
+++ b/crates/atuin/contrib/opencode/atuin.ts
@@ -93,7 +93,14 @@ async function startHistory(
 	cwd: string,
 	proposal: Proposal,
 ): Promise<string | undefined> {
-	const args = ["history", "start", "--author", ATUIN_AUTHOR];
+	const args = [
+		"history",
+		"start",
+		"--author",
+		ATUIN_AUTHOR,
+		"--author-kind",
+		"agent",
+	];
 	if (proposal.intent) args.push("--intent", proposal.intent);
 	args.push("--", proposal.command);
 

--- a/crates/atuin/contrib/pi/atuin.ts
+++ b/crates/atuin/contrib/pi/atuin.ts
@@ -22,7 +22,16 @@ async function startHistory(
 	try {
 		const result = await pi.exec(
 			"atuin",
-			["history", "start", "--author", ATUIN_AUTHOR, "--", command],
+			[
+				"history",
+				"start",
+				"--author",
+				ATUIN_AUTHOR,
+				"--author-kind",
+				"agent",
+				"--",
+				command,
+			],
 			{ cwd, timeout: ATUIN_TIMEOUT_MS },
 		);
 

--- a/crates/atuin/src/command/client/history.rs
+++ b/crates/atuin/src/command/client/history.rs
@@ -51,9 +51,7 @@ pub enum Cmd {
 
         /// Whether a human or an AI agent ran this command
         ///
-        /// When omitted, an explicitly passed author that is a known agent name counts as an
-        /// agent; anything else is left unstated and later classified by the author name, which
-        /// cannot tell an agent apart from a user who shares its name.
+        /// [`Option::None`] will cause us to perform a best-guess effort.
         #[arg(long, value_enum)]
         author_kind: Option<AuthorKind>,
 

--- a/crates/atuin/src/command/client/history.rs
+++ b/crates/atuin/src/command/client/history.rs
@@ -15,7 +15,6 @@ use atuin_common::logs::LogConfig;
 use atuin_common::string::{EscapeNonPrintablePosixExt as _, NonNulStr};
 use atuin_common::time::{DurationExt, OffsetDateTimeExt, UtcOffsetSpec};
 use atuin_common::utils;
-#[cfg(feature = "daemon")]
 use atuin_common::utils::normalize_optional_string;
 #[cfg(feature = "daemon")]
 use atuin_daemon::history::{HistoryEventKind, TailHistoryReply};

--- a/crates/atuin/src/command/client/history.rs
+++ b/crates/atuin/src/command/client/history.rs
@@ -671,7 +671,15 @@ impl TailEvent {
             .history
             .ok_or_else(|| eyre::eyre!("daemon sent a history tail event without history"))?;
         let timestamp = OffsetDateTime::from_unix_nanos_u64(history.timestamp);
-        let author_kind = history.author_kind();
+        // Daemons from before `Author` existed only send `legacy_author`, and
+        // never stated a kind.
+        let (author, author_kind) = match history.author {
+            Some(author) => {
+                let kind = author.kind();
+                (author.name, kind.into())
+            }
+            None => (history.legacy_author, None),
+        };
         let kind = match HistoryEventKind::try_from(reply.kind)
             .unwrap_or(HistoryEventKind::Unspecified)
         {
@@ -692,11 +700,11 @@ impl TailEvent {
                 session: history.session,
                 #[allow(deprecated)]
                 cmd_origin: CmdOrigin::parse_lenient(history.hostname),
-                author: history.author,
+                author,
                 intent: normalize_optional_string(history.intent),
                 shell: normalize_optional_string(history.shell),
                 deleted_at: None,
-                author_kind: author_kind.into(),
+                author_kind,
             },
         })
     }

--- a/crates/atuin/src/command/client/history.rs
+++ b/crates/atuin/src/command/client/history.rs
@@ -4,7 +4,7 @@ use std::time::Duration;
 
 use atuin_client::database::{Sqlite, current_context};
 use atuin_client::history::store::HistoryStore;
-use atuin_client::history::{AuthorKind, History};
+use atuin_client::history::{AuthorKind, History, probe_author};
 #[cfg(feature = "sync")]
 use atuin_client::record;
 use atuin_client::record::sqlite_store::SqliteStore;
@@ -417,11 +417,16 @@ fn make_starting_history(
         return None;
     }
 
+    // When the flags didn't state an identity, fall back to the one the invoking integration
+    // exported to the environment.
+    let author = normalize_optional_string(author.map(String::from)).or_else(probe_author);
+    let author_kind = author_kind.or_else(AuthorKind::probe_current);
+
     let h: History = History::capture()
         .timestamp(OffsetDateTime::now_utc())
         .command(command)
         .cwd(cwd)
-        .author_opt(author.map(String::from))
+        .author_opt(author)
         .author_kind_opt(author_kind)
         .intent_opt(intent.map(String::from))
         .shell_opt(std::env::var("ATUIN_SHELL").ok())

--- a/crates/atuin/src/command/client/history.rs
+++ b/crates/atuin/src/command/client/history.rs
@@ -416,9 +416,12 @@ fn make_starting_history(
     }
 
     // When the flags didn't state an identity, fall back to the one the invoking integration
-    // exported to the environment.
+    // exported to the environment. The env kind only qualifies a stated author: a stray
+    // ATUIN_HISTORY_AUTHOR_KIND inherited by a nested interactive shell must not stamp the
+    // human's own commands.
     let author = normalize_optional_string(author.map(String::from)).or_else(probe_author);
-    let author_kind = author_kind.or_else(AuthorKind::probe_current);
+    let author_kind =
+        author_kind.or_else(|| author.is_some().then(AuthorKind::probe_current).flatten());
 
     let h: History = History::capture()
         .timestamp(OffsetDateTime::now_utc())

--- a/crates/atuin/src/command/client/history.rs
+++ b/crates/atuin/src/command/client/history.rs
@@ -3,8 +3,8 @@ use std::io::{self, IsTerminal, Write};
 use std::time::Duration;
 
 use atuin_client::database::{Sqlite, current_context};
-use atuin_client::history::History;
 use atuin_client::history::store::HistoryStore;
+use atuin_client::history::{AuthorKind, History};
 #[cfg(feature = "sync")]
 use atuin_client::record;
 use atuin_client::record::sqlite_store::SqliteStore;
@@ -48,6 +48,14 @@ pub enum Cmd {
         /// Author of this command, eg `ellie`, `claude`, or `copilot`
         #[arg(long)]
         author: Option<String>,
+
+        /// Whether a human or an AI agent ran this command
+        ///
+        /// When omitted, an explicitly passed author that is a known agent name counts as an
+        /// agent; anything else is left unstated and later classified by the author name, which
+        /// cannot tell an agent apart from a user who shares its name.
+        #[arg(long, value_enum)]
+        author_kind: Option<AuthorKind>,
 
         /// Optional intent/rationale for running this command
         #[arg(long)]
@@ -393,6 +401,7 @@ fn make_starting_history(
     settings: &Settings,
     command: &str,
     author: Option<&str>,
+    author_kind: Option<AuthorKind>,
     intent: Option<&str>,
 ) -> Option<History> {
     // It's better for atuin to silently fail here and attempt to
@@ -413,6 +422,7 @@ fn make_starting_history(
         .command(command)
         .cwd(cwd)
         .author_opt(author.map(String::from))
+        .author_kind_opt(author_kind)
         .intent_opt(intent.map(String::from))
         .shell_opt(std::env::var("ATUIN_SHELL").ok())
         .build()
@@ -427,9 +437,10 @@ async fn handle_start(
     settings: &Settings,
     command: &str,
     author: Option<&str>,
+    author_kind: Option<AuthorKind>,
     intent: Option<&str>,
 ) -> Result<Option<String>> {
-    let Some(h) = make_starting_history(settings, command, author, intent) else {
+    let Some(h) = make_starting_history(settings, command, author, author_kind, intent) else {
         return Ok(None);
     };
 
@@ -448,9 +459,10 @@ async fn handle_daemon_start(
     settings: &Settings,
     command: &str,
     author: Option<&str>,
+    author_kind: Option<AuthorKind>,
     intent: Option<&str>,
 ) -> Result<Option<String>> {
-    let Some(h) = make_starting_history(settings, command, author, intent) else {
+    let Some(h) = make_starting_history(settings, command, author, author_kind, intent) else {
         return Ok(None);
     };
 
@@ -560,16 +572,17 @@ pub(super) async fn start_history_entry(
     settings: &Settings,
     command: &str,
     author: Option<&str>,
+    author_kind: Option<AuthorKind>,
     intent: Option<&str>,
 ) -> Result<Option<String>> {
     #[cfg(feature = "daemon")]
     if settings.daemon.enabled {
-        return handle_daemon_start(settings, command, author, intent).await;
+        return handle_daemon_start(settings, command, author, author_kind, intent).await;
     }
 
     let db_path = &settings.db_path;
     let db = Sqlite::new(db_path, settings.local_timeout).await?;
-    handle_start(&db, settings, command, author, intent).await
+    handle_start(&db, settings, command, author, author_kind, intent).await
 }
 
 #[instrument(level = "trace", skip_all, fields(id = %id, exit, duration = ?duration), err)]
@@ -653,6 +666,7 @@ impl TailEvent {
             .history
             .ok_or_else(|| eyre::eyre!("daemon sent a history tail event without history"))?;
         let timestamp = OffsetDateTime::from_unix_nanos_u64(history.timestamp);
+        let author_kind = history.author_kind();
         let kind = match HistoryEventKind::try_from(reply.kind)
             .unwrap_or(HistoryEventKind::Unspecified)
         {
@@ -677,6 +691,7 @@ impl TailEvent {
                 intent: normalize_optional_string(history.intent),
                 shell: normalize_optional_string(history.shell),
                 deleted_at: None,
+                author_kind: author_kind.into(),
             },
         })
     }
@@ -1052,6 +1067,7 @@ impl Cmd {
             Self::Start {
                 cmd_env,
                 author,
+                author_kind,
                 intent,
                 command,
                 ..
@@ -1062,9 +1078,14 @@ impl Cmd {
                     command.join(" ")
                 };
 
-                if let Some(id) =
-                    start_history_entry(settings, &command, author.as_deref(), intent.as_deref())
-                        .await?
+                if let Some(id) = start_history_entry(
+                    settings,
+                    &command,
+                    author.as_deref(),
+                    author_kind,
+                    intent.as_deref(),
+                )
+                .await?
                 {
                     println!("{id}");
                 }
@@ -1229,7 +1250,7 @@ mod tests {
             ..Settings::utc()
         };
 
-        handle_start(&db, &settings, "ls   \t", None, None).await.unwrap();
+        handle_start(&db, &settings, "ls   \t", None, None, None).await.unwrap();
 
         let history = db
             .before(OffsetDateTime::now_utc() + time::Duration::SECOND, 1)
@@ -1247,7 +1268,7 @@ mod tests {
 
         // A command containing a NUL byte can never have been executed by a shell;
         // it should be dropped rather than committed to history.
-        let id = handle_start(&db, &settings, "hello\0world", None, None).await.unwrap();
+        let id = handle_start(&db, &settings, "hello\0world", None, None, None).await.unwrap();
         assert!(id.is_none());
 
         let stored =
@@ -1282,6 +1303,7 @@ mod tests {
                 intent: Some("inspect repository state".to_owned()),
                 deleted_at: None,
                 shell: Some("zsh".into()),
+                author_kind: Some(AuthorKind::Agent),
             },
         }
     }

--- a/crates/atuin/src/command/client/hook.rs
+++ b/crates/atuin/src/command/client/hook.rs
@@ -2,6 +2,7 @@ use std::ffi::OsString;
 use std::io::Read;
 use std::path::PathBuf;
 
+use atuin_client::history::AuthorKind;
 use atuin_client::settings::Settings;
 use atuin_common::utils::home_dir;
 use clap::{Parser, Subcommand};
@@ -202,6 +203,7 @@ async fn handle(agent_name: &str, settings: &Settings) -> Result<()> {
                 settings,
                 &command,
                 Some(agent.actor_name()),
+                Some(AuthorKind::Agent),
                 intent.as_deref(),
             )
             .await?

--- a/crates/atuin/src/command/client/search/inspector.rs
+++ b/crates/atuin/src/command/client/search/inspector.rs
@@ -337,6 +337,7 @@ mod tests {
             intent: None,
             deleted_at: None,
             shell: None,
+            author_kind: None,
         };
         let next = History {
             id: HistoryId::from("test2".to_string()),
@@ -352,6 +353,7 @@ mod tests {
             intent: None,
             deleted_at: None,
             shell: Some("bash".into()),
+            author_kind: None,
         };
         let prev = History {
             id: HistoryId::from("test3".to_string()),
@@ -367,6 +369,7 @@ mod tests {
             intent: None,
             deleted_at: None,
             shell: Some("nu".into()),
+            author_kind: None,
         };
         let stats = HistoryStats {
             next: Some(next),

--- a/docs/docs/guide/agent-hooks.md
+++ b/docs/docs/guide/agent-hooks.md
@@ -50,14 +50,14 @@ By default, Atuin's interactive search shows only your own commands. Agent-run c
 
 Today this default is built into the search UI rather than configurable via `config.toml`. Interactive search uses the equivalent of:
 
-- `$all-user` — any author that's **not** a known AI agent
+- `$all-user` — any entry that is **not** agent-run
 
 For explicit author filtering, use the CLI `atuin search --author ...` flag. Special values:
 
 | Value | Meaning |
 |-------|---------|
-| `$all-user` | Any author that's **not** a known AI agent |
-| `$all-agent` | Any known AI agent author |
+| `$all-user` | Any entry that is **not** agent-run |
+| `$all-agent` | Any agent-run entry (see [how entries are classified](#filtering-by-author)) |
 
 You can also use literal author names:
 
@@ -77,6 +77,21 @@ atuin search --author '$all-agent' -- ''
 ```
 
 Currently recognized agent names are: `claude-code`, `codex`, `copilot`, `opencode`, and `pi`.
+
+Whether an entry counts as agent-run is decided when it is captured, not by its author name alone:
+
+- An author stated explicitly — `atuin history start --author <name>` or the `ATUIN_HISTORY_AUTHOR`
+  environment variable — that matches a known agent name marks the entry as agent-run. This is how
+  all of the integrations above are classified.
+- An author that was merely defaulted from your username never does. That is what keeps a user
+  called `pi` out of `$all-agent`: their own commands are theirs, while commands the `pi` agent
+  runs on their machine are still recorded as the agent's.
+- `--author-kind <user|agent>` (or `ATUIN_HISTORY_AUTHOR_KIND`) overrides both — use it if you
+  really do want to claim an agent's name for your own commands, or to mark an agent whose name is
+  not in the list.
+
+For entries recorded by older versions, where no kind was stored, the same rule is approximated
+after the fact: an agent-named author counts as an agent unless it is also your username.
 
 ## Supported Agents
 

--- a/docs/docs/guide/agent-hooks.md
+++ b/docs/docs/guide/agent-hooks.md
@@ -57,7 +57,7 @@ For explicit author filtering, use the CLI `atuin search --author ...` flag. Spe
 | Value | Meaning |
 |-------|---------|
 | `$all-user` | Any entry that is **not** agent-run |
-| `$all-agent` | Any agent-run entry (see [how entries are classified](#filtering-by-author)) |
+| `$all-agent` | Any agent-run entry |
 
 You can also use literal author names:
 
@@ -77,21 +77,6 @@ atuin search --author '$all-agent' -- ''
 ```
 
 Currently recognized agent names are: `claude-code`, `codex`, `copilot`, `opencode`, and `pi`.
-
-Whether an entry counts as agent-run is decided when it is captured, not by its author name alone:
-
-- An author stated explicitly — `atuin history start --author <name>` or the `ATUIN_HISTORY_AUTHOR`
-  environment variable — that matches a known agent name marks the entry as agent-run. This is how
-  all of the integrations above are classified.
-- An author that was merely defaulted from your username never does. That is what keeps a user
-  called `pi` out of `$all-agent`: their own commands are theirs, while commands the `pi` agent
-  runs on their machine are still recorded as the agent's.
-- `--author-kind <user|agent>` (or `ATUIN_HISTORY_AUTHOR_KIND`) overrides both — use it if you
-  really do want to claim an agent's name for your own commands, or to mark an agent whose name is
-  not in the list.
-
-For entries recorded by older versions, where no kind was stored, the same rule is approximated
-after the fact: an agent-named author counts as an agent unless it is also your username.
 
 ## Supported Agents
 

--- a/docs/docs/guide/agent-hooks.md
+++ b/docs/docs/guide/agent-hooks.md
@@ -50,13 +50,13 @@ By default, Atuin's interactive search shows only your own commands. Agent-run c
 
 Today this default is built into the search UI rather than configurable via `config.toml`. Interactive search uses the equivalent of:
 
-- `$all-user` — any entry that is **not** agent-run
+- `$all-user` — any entry that's **not** agent-run
 
 For explicit author filtering, use the CLI `atuin search --author ...` flag. Special values:
 
 | Value | Meaning |
 |-------|---------|
-| `$all-user` | Any entry that is **not** agent-run |
+| `$all-user` | Any entry that's **not** agent-run |
 | `$all-agent` | Any agent-run entry |
 
 You can also use literal author names:

--- a/docs/docs/guide/shell-integration.md
+++ b/docs/docs/guide/shell-integration.md
@@ -28,8 +28,8 @@ When Atuin initializes, it sets several environment variables:
 | `ATUIN_SESSION` | Unique identifier for this shell session |
 | `ATUIN_SHLVL` | Tracks shell nesting level |
 | `ATUIN_HISTORY_ID` | Temporary ID for the currently executing command |
-| `ATUIN_HISTORY_AUTHOR` | Optional command author identity (for example `ellie`, `claude`, `copilot`). A known agent name here marks entries as agent-run |
-| `ATUIN_HISTORY_AUTHOR_KIND` | Optional: `user` or `agent`, overriding the classification inferred from the author name |
+| `ATUIN_HISTORY_AUTHOR` | Optional command author identity (for example `ellie`, `claude`, `copilot`). A known agent name here marks entries as agent-run, unless it is also the local username |
+| `ATUIN_HISTORY_AUTHOR_KIND` | Optional: `user` or `agent`, overriding the classification inferred from the author name. Only applies when an author is stated |
 | `ATUIN_HISTORY_INTENT` | Optional command intent/rationale text |
 
 Atuin uses these variables internally to track command execution and associate commands with sessions.

--- a/docs/docs/guide/shell-integration.md
+++ b/docs/docs/guide/shell-integration.md
@@ -28,7 +28,8 @@ When Atuin initializes, it sets several environment variables:
 | `ATUIN_SESSION` | Unique identifier for this shell session |
 | `ATUIN_SHLVL` | Tracks shell nesting level |
 | `ATUIN_HISTORY_ID` | Temporary ID for the currently executing command |
-| `ATUIN_HISTORY_AUTHOR` | Optional command author identity (for example `ellie`, `claude`, `copilot`) |
+| `ATUIN_HISTORY_AUTHOR` | Optional command author identity (for example `ellie`, `claude`, `copilot`). A known agent name here marks entries as agent-run |
+| `ATUIN_HISTORY_AUTHOR_KIND` | Optional: `user` or `agent`, overriding the classification inferred from the author name |
 | `ATUIN_HISTORY_INTENT` | Optional command intent/rationale text |
 
 Atuin uses these variables internally to track command execution and associate commands with sessions.

--- a/docs/docs/guide/shell-integration.md
+++ b/docs/docs/guide/shell-integration.md
@@ -28,7 +28,7 @@ When Atuin initializes, it sets several environment variables:
 | `ATUIN_SESSION` | Unique identifier for this shell session |
 | `ATUIN_SHLVL` | Tracks shell nesting level |
 | `ATUIN_HISTORY_ID` | Temporary ID for the currently executing command |
-| `ATUIN_HISTORY_AUTHOR` | Optional command author identity (for example `ellie`, `claude`, `copilot`). A known agent name here marks entries as agent-run, unless it is also the local username |
+| `ATUIN_HISTORY_AUTHOR` | Optional command author identity (for example `ellie`, `claude`, `copilot`). A known agent name here marks entries as agent-run, unless it's also the local username |
 | `ATUIN_HISTORY_AUTHOR_KIND` | Optional: `user` or `agent`, overriding the classification inferred from the author name. Only applies when an author is stated |
 | `ATUIN_HISTORY_INTENT` | Optional command intent/rationale text |
 


### PR DESCRIPTION
Stacked on #3951. Addresses https://github.com/atuinsh/atuin/pull/3951#discussion_r3818014936 directly instead of tracking it as a ticket.

The daemon RPCs now carry the author as one typed message:

```protobuf
message Author {
  AuthorKind kind = 1;
  string name = 2;
}
```

Wire compatibility:

- The released `string author` field (v18.13.0) cannot change type on the wire, so it keeps its field number under the name `legacy_author` — field names are not part of the wire format, only numbers are. Writers keep setting it to `author.name`; readers only consult it when the `Author` message is absent, so both directions of version skew against released peers keep working.
- The flat `AuthorKind author_kind` fields added in #3951 never shipped in a release, so they are dropped outright, with their field numbers reserved in case a beta cuts between the two PRs landing.

`cargo test -p atuin-daemon --test lifecycle` passes; the tail test now asserts both the typed message and the legacy field.