### PR TITLE
refactor(record): name the (host, tag) pair as RecordSeriesKey

### DIFF
--- a/crates/atuin-client/src/api_client.rs
+++ b/crates/atuin-client/src/api_client.rs
@@ -11,7 +11,7 @@ use atuin_domain::api::{
 };
 use atuin_domain::caps::{CapClient, CapMismatch, CapabilitiesExt};
 use atuin_domain::record::{
-    EncryptedData, HostId, Record, RecordId, RecordIdx, RecordStatus, RecordTag,
+    EncryptedData, Record, RecordId, RecordIdx, RecordSeriesKey, RecordStatus,
 };
 use eyre::{Result, bail};
 use reqwest::header::{AUTHORIZATION, HeaderMap, HeaderName, HeaderValue, USER_AGENT};
@@ -422,20 +422,19 @@ impl Client {
         Ok(resp.bytes().await?.to_vec())
     }
 
-    #[instrument(level = "trace", skip_all, fields(host = ?host, tag = ?tag, start = ?start, count), err)]
+    #[instrument(level = "trace", skip_all, fields(host = ?series.host, tag = ?series.tag, start = ?start, count), err)]
     pub async fn next_records(
         &self,
-        host: HostId,
-        tag: RecordTag,
+        series: &RecordSeriesKey,
         start: RecordIdx,
         count: u64,
     ) -> Result<Vec<Record<EncryptedData>>> {
-        debug!("fetching record/s from host {}/{}/{}", host.0, tag, start);
+        debug!("fetching record/s from host {}/{}/{}", series.host.0, series.tag, start);
 
         let mut url = self.sync_addr.append_path("api/v0/record/next")?;
         url.query_pairs_mut()
-            .append_pair("host", &host.0.to_string())
-            .append_pair("tag", tag.as_str())
+            .append_pair("host", &series.host.0.to_string())
+            .append_pair("tag", series.tag.as_str())
             .append_pair("count", &count.to_string())
             .append_pair("start", &start.to_string());
 

--- a/crates/atuin-client/src/history/store.rs
+++ b/crates/atuin-client/src/history/store.rs
@@ -143,7 +143,10 @@ impl HistoryStore {
     async fn push_record(&self, record: HistoryRecord) -> Result<(RecordId, RecordIdx)> {
         let bytes = record.serialize()?;
         let idx =
-            self.store.last(self.host_id, &RecordTag::History).await?.map_or(0, |p| p.idx + 1);
+            self.store
+                .last(&(self.host_id, RecordTag::History).into())
+                .await?
+                .map_or(0, |p| p.idx + 1);
 
         let record = Record::builder()
             .host(Host::new(self.host_id))
@@ -165,7 +168,10 @@ impl HistoryStore {
         let mut ret = Vec::new();
 
         let idx =
-            self.store.last(self.host_id, &RecordTag::History).await?.map_or(0, |p| p.idx + 1);
+            self.store
+                .last(&(self.host_id, RecordTag::History).into())
+                .await?
+                .map_or(0, |p| p.idx + 1);
 
         // Could probably _also_ do this as an iterator, but let's see how this is for now.
         // optimizing for minimal sqlite transactions, this code can be optimised later

--- a/crates/atuin-client/src/history/store.rs
+++ b/crates/atuin-client/src/history/store.rs
@@ -142,11 +142,11 @@ impl HistoryStore {
     #[instrument(level = "trace", skip_all, fields(host = ?self.host_id), err)]
     async fn push_record(&self, record: HistoryRecord) -> Result<(RecordId, RecordIdx)> {
         let bytes = record.serialize()?;
-        let idx =
-            self.store
-                .last(&(self.host_id, RecordTag::History).into())
-                .await?
-                .map_or(0, |p| p.idx + 1);
+        let idx = self
+            .store
+            .last(&(self.host_id, RecordTag::History).into())
+            .await?
+            .map_or(0, |p| p.idx + 1);
 
         let record = Record::builder()
             .host(Host::new(self.host_id))
@@ -167,11 +167,11 @@ impl HistoryStore {
     async fn push_batch(&self, records: impl Iterator<Item = HistoryRecord>) -> Result<()> {
         let mut ret = Vec::new();
 
-        let idx =
-            self.store
-                .last(&(self.host_id, RecordTag::History).into())
-                .await?
-                .map_or(0, |p| p.idx + 1);
+        let idx = self
+            .store
+            .last(&(self.host_id, RecordTag::History).into())
+            .await?
+            .map_or(0, |p| p.idx + 1);
 
         // Could probably _also_ do this as an iterator, but let's see how this is for now.
         // optimizing for minimal sqlite transactions, this code can be optimised later

--- a/crates/atuin-client/src/history/store.rs
+++ b/crates/atuin-client/src/history/store.rs
@@ -7,7 +7,8 @@ use atuin_common::encryption::paseto_v4;
 use atuin_common::futures::stream::chunk_by_bounded;
 use atuin_common::rmp::decode::Bytes;
 use atuin_domain::record::{
-    DecryptedData, Host, HostId, Record, RecordId, RecordIdx, RecordTag, RecordVersion,
+    DecryptedData, Host, HostId, Record, RecordId, RecordIdx, RecordSeriesKey, RecordTag,
+    RecordVersion,
 };
 use eyre::{Result, bail, eyre};
 use futures::{Stream, StreamExt, TryStreamExt, future, stream};
@@ -144,7 +145,7 @@ impl HistoryStore {
         let bytes = record.serialize()?;
         let idx = self
             .store
-            .last(&(self.host_id, RecordTag::History).into())
+            .last(&RecordSeriesKey::new(self.host_id, RecordTag::History))
             .await?
             .map_or(0, |p| p.idx + 1);
 
@@ -169,7 +170,7 @@ impl HistoryStore {
 
         let idx = self
             .store
-            .last(&(self.host_id, RecordTag::History).into())
+            .last(&RecordSeriesKey::new(self.host_id, RecordTag::History))
             .await?
             .map_or(0, |p| p.idx + 1);
 

--- a/crates/atuin-client/src/packfile/packer.rs
+++ b/crates/atuin-client/src/packfile/packer.rs
@@ -36,7 +36,7 @@ pub async fn try_pack(
     };
 
     let last_pack = store
-        .last(&(series.host, RecordTag::Packfile).into())
+        .last(&RecordSeriesKey::new(series.host, RecordTag::Packfile))
         .await
         .map_err(PackingError::Store)?;
 
@@ -138,7 +138,7 @@ mod tests {
     /// The `[start_idx, end_idx]` ranges of the manifest records currently in the store.
     async fn manifest_ranges(store: &SqliteStore, host: HostId) -> Vec<(u64, u64)> {
         store
-            .next(&(host, RecordTag::Packfile).into(), 0, 1000)
+            .next(&RecordSeriesKey::new(host, RecordTag::Packfile), 0, 1000)
             .await
             .unwrap()
             .iter()
@@ -151,7 +151,7 @@ mod tests {
     async fn pack(store: &SqliteStore, host: HostId, count: u64) {
         try_pack(
             store,
-            &(host, RecordTag::History).into(),
+            &RecordSeriesKey::new(host, RecordTag::History),
             Some(PackfileCap {
                 version: 1,
                 record_count: count,

--- a/crates/atuin-client/src/packfile/packer.rs
+++ b/crates/atuin-client/src/packfile/packer.rs
@@ -1,7 +1,7 @@
 //! Turns accumulated history into plaintext `packfile` manifest records.
 
 use atuin_domain::caps::PackfileCap;
-use atuin_domain::record::{Host, HostId, Record, RecordTag, RecordVersion};
+use atuin_domain::record::{Host, Record, RecordSeriesKey, RecordTag, RecordVersion};
 use thiserror::Error;
 use tracing::{instrument, trace};
 
@@ -24,11 +24,10 @@ pub enum PackingError {
 #[instrument(level = "trace", skip(store), err)]
 pub async fn try_pack(
     store: &SqliteStore,
-    host: HostId,
+    series: &RecordSeriesKey,
     cap: Option<PackfileCap>,
-    tag: &RecordTag,
 ) -> Result<(), PackingError> {
-    debug_assert!(*tag != RecordTag::Packfile);
+    debug_assert!(series.tag != RecordTag::Packfile);
 
     // Count is the pack size. Packing waits until at least `count` unpacked records have
     // accumulated and then emits manifests of exactly that many records.
@@ -36,7 +35,10 @@ pub async fn try_pack(
         return Ok(());
     };
 
-    let last_pack = store.last(host, &RecordTag::Packfile).await.map_err(PackingError::Store)?;
+    let last_pack = store
+        .last(&(series.host, RecordTag::Packfile).into())
+        .await
+        .map_err(PackingError::Store)?;
 
     // `start` is the first unpacked source idx; `pack_idx` is the next idx in the *packfile*
     // stream (a separate sequence). Both come from the same latest manifest record.
@@ -47,7 +49,7 @@ pub async fn try_pack(
     let mut pack_idx = last_pack.map_or(0, |record| record.idx + 1);
 
     let Some(ceiling) =
-        store.last(host, tag).await.map_err(PackingError::Store)?.map(|record| record.idx)
+        store.last(series).await.map_err(PackingError::Store)?.map(|record| record.idx)
     else {
         trace!("no history yet; nothing to pack");
         return Ok(());
@@ -61,20 +63,20 @@ pub async fn try_pack(
     let mut cursor = start;
     while cursor <= ceiling && ceiling - cursor + 1 >= count {
         // The loop guard guarantees at least `count` records remain, so each run is exactly `count`.
-        let run = store.next(host, tag, cursor, count).await.map_err(PackingError::Store)?;
+        let run = store.next(series, cursor, count).await.map_err(PackingError::Store)?;
 
         let Some(end) = run.last().map(|record| record.idx) else {
             break;
         };
 
         let manifest = PackManifestDataV1 {
-            host,
-            tag: tag.clone(),
+            host: series.host,
+            tag: series.tag.clone(),
             start_idx: cursor,
             end_idx: end,
         };
         let record = Record::builder()
-            .host(Host::new(host))
+            .host(Host::new(series.host))
             .version(RecordVersion::V1)
             .tag(RecordTag::Packfile)
             .idx(pack_idx)
@@ -94,7 +96,7 @@ pub async fn try_pack(
 #[cfg(test)]
 mod tests {
     use atuin_common::utils::uuid_v7;
-    use atuin_domain::record::EncryptedData;
+    use atuin_domain::record::{EncryptedData, HostId};
     use proptest::prelude::*;
     use rstest::{fixture, rstest};
 
@@ -136,7 +138,7 @@ mod tests {
     /// The `[start_idx, end_idx]` ranges of the manifest records currently in the store.
     async fn manifest_ranges(store: &SqliteStore, host: HostId) -> Vec<(u64, u64)> {
         store
-            .next(host, &RecordTag::Packfile, 0, 1000)
+            .next(&(host, RecordTag::Packfile).into(), 0, 1000)
             .await
             .unwrap()
             .iter()
@@ -149,12 +151,11 @@ mod tests {
     async fn pack(store: &SqliteStore, host: HostId, count: u64) {
         try_pack(
             store,
-            host,
+            &(host, RecordTag::History).into(),
             Some(PackfileCap {
                 version: 1,
                 record_count: count,
             }),
-            &RecordTag::History,
         )
         .await
         .unwrap();

--- a/crates/atuin-client/src/packfile/record.rs
+++ b/crates/atuin-client/src/packfile/record.rs
@@ -290,7 +290,7 @@ impl<'a> PackManifestRecordView<'a> {
         let count = range.end - range.start;
 
         let run = store
-            .next(self.record.host.id, &RecordTag::History, range.start, count)
+            .next(&(self.record.host.id, RecordTag::History).into(), range.start, count)
             .await
             .map_err(RecordLoadingError::StoreError)?;
 

--- a/crates/atuin-client/src/packfile/record.rs
+++ b/crates/atuin-client/src/packfile/record.rs
@@ -6,8 +6,8 @@ use atuin_common::encryption::paseto_v4;
 use atuin_common::rmp::decode::{self, Bytes, DecodeError, RmpRead};
 use atuin_common::rmp::encode::{self, ByteBuf, EncodeError, RmpWrite, TryEncodeError};
 use atuin_domain::record::{
-    DecryptedData, EncryptedData, Host, HostId, Record, RecordId, RecordIdx, RecordTag,
-    RecordVersion,
+    DecryptedData, EncryptedData, Host, HostId, Record, RecordId, RecordIdx, RecordSeriesKey,
+    RecordTag, RecordVersion,
 };
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
@@ -290,7 +290,11 @@ impl<'a> PackManifestRecordView<'a> {
         let count = range.end - range.start;
 
         let run = store
-            .next(&(self.record.host.id, RecordTag::History).into(), range.start, count)
+            .next(
+                &RecordSeriesKey::new(self.record.host.id, RecordTag::History),
+                range.start,
+                count,
+            )
             .await
             .map_err(RecordLoadingError::StoreError)?;
 

--- a/crates/atuin-client/src/packfile/sync.rs
+++ b/crates/atuin-client/src/packfile/sync.rs
@@ -94,8 +94,10 @@ pub async fn download_packed(
     let view = PackManifestRecordView::new(manifest)?;
 
     // Skip if we already have the whole range (history is contiguous, packfiles are prefixes).
-    let head =
-        store.last(view.record.host.id, &RecordTag::History).await.map_err(DownloadError::Store)?;
+    let head = store
+        .last(&(view.record.host.id, RecordTag::History).into())
+        .await
+        .map_err(DownloadError::Store)?;
     if let Some(head) = head
         && head.idx >= view.range().end - 1
     {
@@ -218,17 +220,16 @@ mod tests {
         seed_history(&store, host, &key, 5).await;
         try_pack(
             &store,
-            host,
+            &(host, RecordTag::History).into(),
             Some(PackfileCap {
                 version: 1,
                 record_count: 5,
             }),
-            &RecordTag::History,
         )
         .await
         .unwrap();
         let manifest = store
-            .last(host, &RecordTag::Packfile)
+            .last(&(host, RecordTag::Packfile).into())
             .await
             .unwrap()
             .expect("packer should have written a manifest");
@@ -278,16 +279,15 @@ mod tests {
         seed_history(&up, host, &key, 5).await;
         try_pack(
             &up,
-            host,
+            &(host, RecordTag::History).into(),
             Some(PackfileCap {
                 version: 1,
                 record_count: 5,
             }),
-            &RecordTag::History,
         )
         .await
         .unwrap();
-        let manifest = up.last(host, &RecordTag::Packfile).await.unwrap().unwrap();
+        let manifest = up.last(&(host, RecordTag::Packfile).into()).await.unwrap().unwrap();
         let (blob, _) = PackManifestRecordView::new(&manifest)
             .unwrap()
             .pack_records(&up, key.clone())
@@ -318,7 +318,7 @@ mod tests {
         assert_eq!(ids.len(), 5, "all five history records populated");
 
         // History is present locally and decrypts to the same commands.
-        let got = down.next(host, &RecordTag::History, 0, 5).await.unwrap();
+        let got = down.next(&(host, RecordTag::History).into(), 0, 5).await.unwrap();
         assert_eq!(got.len(), 5);
         let first = got[0].clone().decrypt(&key).unwrap();
         assert_eq!(first.data.0, b"command number 0");
@@ -332,22 +332,21 @@ mod tests {
         seed_history(&up, host, &key, 5).await;
         try_pack(
             &up,
-            host,
+            &(host, RecordTag::History).into(),
             Some(PackfileCap {
                 version: 1,
                 record_count: 5,
             }),
-            &RecordTag::History,
         )
         .await
         .unwrap();
-        let manifest = up.last(host, &RecordTag::Packfile).await.unwrap().unwrap();
+        let manifest = up.last(&(host, RecordTag::Packfile).into()).await.unwrap().unwrap();
 
         // Downloader that already HAS the history the manifest covers.
         let down = memory_store().await;
         seed_history(&down, host, &key, 5).await;
         let expected_ids: Vec<RecordId> = down
-            .next(host, &RecordTag::History, 0, 5)
+            .next(&(host, RecordTag::History).into(), 0, 5)
             .await
             .unwrap()
             .iter()
@@ -412,16 +411,15 @@ mod tests {
         seed_history(&up, host, &key, 3).await;
         try_pack(
             &up,
-            host,
+            &(host, RecordTag::History).into(),
             Some(PackfileCap {
                 version: 1,
                 record_count: 3,
             }),
-            &RecordTag::History,
         )
         .await
         .unwrap();
-        let good = up.last(host, &RecordTag::Packfile).await.unwrap().unwrap();
+        let good = up.last(&(host, RecordTag::Packfile).into()).await.unwrap().unwrap();
         let (blob, _) = PackManifestRecordView::new(&good)
             .unwrap()
             .pack_records(&up, key.clone())
@@ -470,7 +468,7 @@ mod tests {
             .expect("the valid manifest still expands");
         assert_eq!(ids.len(), 3, "the valid manifest's three records expand");
 
-        let got = down.next(host, &RecordTag::History, 0, 3).await.unwrap();
+        let got = down.next(&(host, RecordTag::History).into(), 0, 3).await.unwrap();
         assert_eq!(got.len(), 3, "the valid packfile's history is present locally");
     }
 

--- a/crates/atuin-client/src/packfile/sync.rs
+++ b/crates/atuin-client/src/packfile/sync.rs
@@ -15,7 +15,7 @@
 //! one with the local key, and pushes them into the local record store.
 
 use atuin_common::encryption::paseto_v4;
-use atuin_domain::record::{EncryptedData, Record, RecordId, RecordTag};
+use atuin_domain::record::{EncryptedData, Record, RecordId, RecordSeriesKey, RecordTag};
 use thiserror::Error;
 use tracing::instrument;
 
@@ -95,7 +95,7 @@ pub async fn download_packed(
 
     // Skip if we already have the whole range (history is contiguous, packfiles are prefixes).
     let head = store
-        .last(&(view.record.host.id, RecordTag::History).into())
+        .last(&RecordSeriesKey::new(view.record.host.id, RecordTag::History))
         .await
         .map_err(DownloadError::Store)?;
     if let Some(head) = head
@@ -220,7 +220,7 @@ mod tests {
         seed_history(&store, host, &key, 5).await;
         try_pack(
             &store,
-            &(host, RecordTag::History).into(),
+            &RecordSeriesKey::new(host, RecordTag::History),
             Some(PackfileCap {
                 version: 1,
                 record_count: 5,
@@ -229,7 +229,7 @@ mod tests {
         .await
         .unwrap();
         let manifest = store
-            .last(&(host, RecordTag::Packfile).into())
+            .last(&RecordSeriesKey::new(host, RecordTag::Packfile))
             .await
             .unwrap()
             .expect("packer should have written a manifest");
@@ -279,7 +279,7 @@ mod tests {
         seed_history(&up, host, &key, 5).await;
         try_pack(
             &up,
-            &(host, RecordTag::History).into(),
+            &RecordSeriesKey::new(host, RecordTag::History),
             Some(PackfileCap {
                 version: 1,
                 record_count: 5,
@@ -287,7 +287,8 @@ mod tests {
         )
         .await
         .unwrap();
-        let manifest = up.last(&(host, RecordTag::Packfile).into()).await.unwrap().unwrap();
+        let manifest =
+            up.last(&RecordSeriesKey::new(host, RecordTag::Packfile)).await.unwrap().unwrap();
         let (blob, _) = PackManifestRecordView::new(&manifest)
             .unwrap()
             .pack_records(&up, key.clone())
@@ -318,7 +319,7 @@ mod tests {
         assert_eq!(ids.len(), 5, "all five history records populated");
 
         // History is present locally and decrypts to the same commands.
-        let got = down.next(&(host, RecordTag::History).into(), 0, 5).await.unwrap();
+        let got = down.next(&RecordSeriesKey::new(host, RecordTag::History), 0, 5).await.unwrap();
         assert_eq!(got.len(), 5);
         let first = got[0].clone().decrypt(&key).unwrap();
         assert_eq!(first.data.0, b"command number 0");
@@ -332,7 +333,7 @@ mod tests {
         seed_history(&up, host, &key, 5).await;
         try_pack(
             &up,
-            &(host, RecordTag::History).into(),
+            &RecordSeriesKey::new(host, RecordTag::History),
             Some(PackfileCap {
                 version: 1,
                 record_count: 5,
@@ -340,13 +341,14 @@ mod tests {
         )
         .await
         .unwrap();
-        let manifest = up.last(&(host, RecordTag::Packfile).into()).await.unwrap().unwrap();
+        let manifest =
+            up.last(&RecordSeriesKey::new(host, RecordTag::Packfile)).await.unwrap().unwrap();
 
         // Downloader that already HAS the history the manifest covers.
         let down = memory_store().await;
         seed_history(&down, host, &key, 5).await;
         let expected_ids: Vec<RecordId> = down
-            .next(&(host, RecordTag::History).into(), 0, 5)
+            .next(&RecordSeriesKey::new(host, RecordTag::History), 0, 5)
             .await
             .unwrap()
             .iter()
@@ -411,7 +413,7 @@ mod tests {
         seed_history(&up, host, &key, 3).await;
         try_pack(
             &up,
-            &(host, RecordTag::History).into(),
+            &RecordSeriesKey::new(host, RecordTag::History),
             Some(PackfileCap {
                 version: 1,
                 record_count: 3,
@@ -419,7 +421,8 @@ mod tests {
         )
         .await
         .unwrap();
-        let good = up.last(&(host, RecordTag::Packfile).into()).await.unwrap().unwrap();
+        let good =
+            up.last(&RecordSeriesKey::new(host, RecordTag::Packfile)).await.unwrap().unwrap();
         let (blob, _) = PackManifestRecordView::new(&good)
             .unwrap()
             .pack_records(&up, key.clone())
@@ -468,7 +471,7 @@ mod tests {
             .expect("the valid manifest still expands");
         assert_eq!(ids.len(), 3, "the valid manifest's three records expand");
 
-        let got = down.next(&(host, RecordTag::History).into(), 0, 3).await.unwrap();
+        let got = down.next(&RecordSeriesKey::new(host, RecordTag::History), 0, 3).await.unwrap();
         assert_eq!(got.len(), 3, "the valid packfile's history is present locally");
     }
 

--- a/crates/atuin-client/src/record/sqlite_store.rs
+++ b/crates/atuin-client/src/record/sqlite_store.rs
@@ -438,9 +438,7 @@ impl SqliteStore {
 mod tests {
     use atuin_common::encryption::paseto_v4;
     use atuin_common::utils::uuid_v7;
-    use atuin_domain::record::{
-        DecryptedData, Host, HostId, Record, RecordTag, RecordVersion,
-    };
+    use atuin_domain::record::{DecryptedData, Host, HostId, Record, RecordTag, RecordVersion};
     use rstest::{fixture, rstest};
 
     use super::SqliteStore;
@@ -657,6 +655,9 @@ mod tests {
             assert_eq!(decrypted.data.0, data);
         }
 
-        assert_eq!(store.len(&(host_id, RecordTag::Other("test".to_owned())).into()).await.unwrap(), 10);
+        assert_eq!(
+            store.len(&(host_id, RecordTag::Other("test".to_owned())).into()).await.unwrap(),
+            10
+        );
     }
 }

--- a/crates/atuin-client/src/record/sqlite_store.rs
+++ b/crates/atuin-client/src/record/sqlite_store.rs
@@ -334,7 +334,7 @@ impl SqliteStore {
                 Uuid::from_str(i.0.as_str()).expect("failed to parse uuid for local store status"),
             );
 
-            status.set_raw((host, RecordTag::from(i.1)).into(), i.2 as u64);
+            status.set_raw(RecordSeriesKey::new(host, RecordTag::from(i.1)), i.2 as u64);
         }
 
         Ok(status)
@@ -438,7 +438,9 @@ impl SqliteStore {
 mod tests {
     use atuin_common::encryption::paseto_v4;
     use atuin_common::utils::uuid_v7;
-    use atuin_domain::record::{DecryptedData, Host, HostId, Record, RecordTag, RecordVersion};
+    use atuin_domain::record::{
+        DecryptedData, Host, HostId, Record, RecordSeriesKey, RecordTag, RecordVersion,
+    };
     use rstest::{fixture, rstest};
 
     use super::SqliteStore;
@@ -527,19 +529,19 @@ mod tests {
         };
 
         // Empty stream -> frontier is 0.
-        assert_eq!(store.first_gap(&(host, tag.clone()).into()).await.unwrap(), 0);
+        assert_eq!(store.first_gap(&RecordSeriesKey::new(host, tag.clone())).await.unwrap(), 0);
 
         // Contiguous 0,1,2 -> frontier is the next idx, 3.
         for idx in [0, 1, 2] {
             store.push(&at(idx)).await.unwrap();
         }
-        assert_eq!(store.first_gap(&(host, tag.clone()).into()).await.unwrap(), 3);
+        assert_eq!(store.first_gap(&RecordSeriesKey::new(host, tag.clone())).await.unwrap(), 3);
 
         // Add 4,5 but not 3: the frontier drops back to the hole, not the head + 1.
         for idx in [4, 5] {
             store.push(&at(idx)).await.unwrap();
         }
-        assert_eq!(store.first_gap(&(host, tag.clone()).into()).await.unwrap(), 3);
+        assert_eq!(store.first_gap(&RecordSeriesKey::new(host, tag.clone())).await.unwrap(), 3);
     }
 
     #[rstest]
@@ -656,7 +658,10 @@ mod tests {
         }
 
         assert_eq!(
-            store.len(&(host_id, RecordTag::Other("test".to_owned())).into()).await.unwrap(),
+            store
+                .len(&RecordSeriesKey::new(host_id, RecordTag::Other("test".to_owned())))
+                .await
+                .unwrap(),
             10
         );
     }

--- a/crates/atuin-client/src/record/sqlite_store.rs
+++ b/crates/atuin-client/src/record/sqlite_store.rs
@@ -9,7 +9,8 @@ use std::time::Duration;
 use atuin_common::encryption::paseto_v4;
 use atuin_common::utils;
 use atuin_domain::record::{
-    Host, HostId, Record, RecordId, RecordIdx, RecordStatus, RecordTag, RecordVersion,
+    Host, HostId, Record, RecordId, RecordIdx, RecordSeriesKey, RecordStatus, RecordTag,
+    RecordVersion,
 };
 use eyre::{Result, eyre};
 use fs_err as fs;
@@ -189,17 +190,16 @@ impl SqliteStore {
         Ok(())
     }
 
-    #[instrument(level = "trace", skip_all, fields(host = ?host, tag = ?tag), err)]
+    #[instrument(level = "trace", skip_all, fields(host = ?series.host, tag = ?series.tag), err)]
     pub async fn last(
         &self,
-        host: HostId,
-        tag: &RecordTag,
+        series: &RecordSeriesKey,
     ) -> Result<Option<Record<paseto_v4::EncryptedData>>> {
         let res = sqlx::query_as::<_, DbRecord>(
             "select * from store where host=?1 and tag=?2 order by idx desc limit 1",
         )
-        .bind(host.0.as_hyphenated().to_string())
-        .bind(tag.as_str())
+        .bind(series.host.0.as_hyphenated().to_string())
+        .bind(series.tag.as_str())
         .fetch_one(&self.pool)
         .await;
 
@@ -210,13 +210,12 @@ impl SqliteStore {
         }
     }
 
-    #[instrument(level = "trace", skip_all, fields(host = ?host, tag = ?tag), err)]
+    #[instrument(level = "trace", skip_all, fields(host = ?series.host, tag = ?series.tag), err)]
     pub async fn first(
         &self,
-        host: HostId,
-        tag: &RecordTag,
+        series: &RecordSeriesKey,
     ) -> Result<Option<Record<paseto_v4::EncryptedData>>> {
-        self.idx(host, tag, 0).await
+        self.idx(series, 0).await
     }
 
     #[instrument(level = "trace", skip_all, err)]
@@ -242,9 +241,9 @@ impl SqliteStore {
         }
     }
 
-    #[instrument(level = "trace", skip_all, fields(host = ?host, tag = ?tag), err)]
-    pub async fn len(&self, host: HostId, tag: &RecordTag) -> Result<u64> {
-        let last = self.last(host, tag).await?;
+    #[instrument(level = "trace", skip_all, fields(host = ?series.host, tag = ?series.tag), err)]
+    pub async fn len(&self, series: &RecordSeriesKey) -> Result<u64> {
+        let last = self.last(series).await?;
 
         if let Some(last) = last {
             return Ok(last.idx + 1);
@@ -255,8 +254,8 @@ impl SqliteStore {
 
     /// The smallest `idx >= 0` with no record for `(host, tag)`: Unlike `last().idx + 1`, this
     /// points at an interior hole when one exists.
-    #[instrument(level = "trace", skip_all, fields(host = ?host, tag = ?tag), err)]
-    pub async fn first_gap(&self, host: HostId, tag: &RecordTag) -> Result<RecordIdx> {
+    #[instrument(level = "trace", skip_all, fields(host = ?series.host, tag = ?series.tag), err)]
+    pub async fn first_gap(&self, series: &RecordSeriesKey) -> Result<RecordIdx> {
         let gap: Option<i64> = sqlx::query_scalar(
             "select min(idx) from (
                  select idx + 1 as idx from store where host = ?1 and tag = ?2
@@ -265,19 +264,18 @@ impl SqliteStore {
              ) as candidates
              where idx not in (select idx from store where host = ?1 and tag = ?2)",
         )
-        .bind(host.0.as_hyphenated().to_string())
-        .bind(tag.as_str())
+        .bind(series.host.0.as_hyphenated().to_string())
+        .bind(series.tag.as_str())
         .fetch_one(&self.pool)
         .await?;
 
         Ok(gap.unwrap_or(0) as u64)
     }
 
-    #[instrument(level = "trace", skip_all, fields(host = ?host, tag = ?tag, idx, limit), err)]
+    #[instrument(level = "trace", skip_all, fields(host = ?series.host, tag = ?series.tag, idx, limit), err)]
     pub async fn next(
         &self,
-        host: HostId,
-        tag: &RecordTag,
+        series: &RecordSeriesKey,
         idx: RecordIdx,
         limit: u64,
     ) -> Result<Vec<Record<paseto_v4::EncryptedData>>> {
@@ -286,8 +284,8 @@ impl SqliteStore {
              limit ?4",
         )
         .bind(idx as i64)
-        .bind(host.0.as_hyphenated().to_string())
-        .bind(tag.as_str())
+        .bind(series.host.0.as_hyphenated().to_string())
+        .bind(series.tag.as_str())
         .bind(limit as i64)
         .fetch_all(&self.pool)
         .await?;
@@ -295,19 +293,18 @@ impl SqliteStore {
         Ok(res.into_iter().map(Into::into).collect())
     }
 
-    #[instrument(level = "trace", skip_all, fields(host = ?host, tag = ?tag, idx), err)]
+    #[instrument(level = "trace", skip_all, fields(host = ?series.host, tag = ?series.tag, idx), err)]
     pub async fn idx(
         &self,
-        host: HostId,
-        tag: &RecordTag,
+        series: &RecordSeriesKey,
         idx: RecordIdx,
     ) -> Result<Option<Record<paseto_v4::EncryptedData>>> {
         let res = sqlx::query_as::<_, DbRecord>(
             "select * from store where idx = ?1 and host = ?2 and tag = ?3",
         )
         .bind(idx as i64)
-        .bind(host.0.as_hyphenated().to_string())
-        .bind(tag.as_str())
+        .bind(series.host.0.as_hyphenated().to_string())
+        .bind(series.tag.as_str())
         .fetch_one(&self.pool)
         .await;
 
@@ -337,7 +334,7 @@ impl SqliteStore {
                 Uuid::from_str(i.0.as_str()).expect("failed to parse uuid for local store status"),
             );
 
-            status.set_raw(host, RecordTag::from(i.1), i.2 as u64);
+            status.set_raw((host, RecordTag::from(i.1)).into(), i.2 as u64);
         }
 
         Ok(status)
@@ -441,7 +438,9 @@ impl SqliteStore {
 mod tests {
     use atuin_common::encryption::paseto_v4;
     use atuin_common::utils::uuid_v7;
-    use atuin_domain::record::{DecryptedData, Host, HostId, Record, RecordTag, RecordVersion};
+    use atuin_domain::record::{
+        DecryptedData, Host, HostId, Record, RecordTag, RecordVersion,
+    };
     use rstest::{fixture, rstest};
 
     use super::SqliteStore;
@@ -498,7 +497,7 @@ mod tests {
     #[tokio::test]
     async fn last(#[future(awt)] store: SqliteStore, record: Record<paseto_v4::EncryptedData>) {
         store.push(&record).await.unwrap();
-        let last = store.last(record.host.id, &record.tag).await.unwrap();
+        let last = store.last(&record.series_key()).await.unwrap();
         assert_eq!(last.unwrap().id, record.id, "did not get the inserted record");
     }
 
@@ -506,7 +505,7 @@ mod tests {
     #[tokio::test]
     async fn first(#[future(awt)] store: SqliteStore, record: Record<paseto_v4::EncryptedData>) {
         store.push(&record).await.unwrap();
-        let first = store.first(record.host.id, &record.tag).await.unwrap();
+        let first = store.first(&record.series_key()).await.unwrap();
         assert_eq!(first.unwrap().id, record.id, "did not get the inserted record");
     }
 
@@ -530,26 +529,26 @@ mod tests {
         };
 
         // Empty stream -> frontier is 0.
-        assert_eq!(store.first_gap(host, &tag).await.unwrap(), 0);
+        assert_eq!(store.first_gap(&(host, tag.clone()).into()).await.unwrap(), 0);
 
         // Contiguous 0,1,2 -> frontier is the next idx, 3.
         for idx in [0, 1, 2] {
             store.push(&at(idx)).await.unwrap();
         }
-        assert_eq!(store.first_gap(host, &tag).await.unwrap(), 3);
+        assert_eq!(store.first_gap(&(host, tag.clone()).into()).await.unwrap(), 3);
 
         // Add 4,5 but not 3: the frontier drops back to the hole, not the head + 1.
         for idx in [4, 5] {
             store.push(&at(idx)).await.unwrap();
         }
-        assert_eq!(store.first_gap(host, &tag).await.unwrap(), 3);
+        assert_eq!(store.first_gap(&(host, tag.clone()).into()).await.unwrap(), 3);
     }
 
     #[rstest]
     #[tokio::test]
     async fn len(#[future(awt)] store: SqliteStore, record: Record<paseto_v4::EncryptedData>) {
         store.push(&record).await.unwrap();
-        let len = store.len(record.host.id, &record.tag).await.unwrap();
+        let len = store.len(&record.series_key()).await.unwrap();
         assert_eq!(len, 1, "expected length of 1 after insert");
     }
 
@@ -571,8 +570,8 @@ mod tests {
         store.push(&first).await.unwrap();
         store.push(&second).await.unwrap();
 
-        assert_eq!(store.len(first.host.id, &first.tag).await.unwrap(), 1);
-        assert_eq!(store.len(second.host.id, &second.tag).await.unwrap(), 1);
+        assert_eq!(store.len(&first.series_key()).await.unwrap(), 1);
+        assert_eq!(store.len(&second.series_key()).await.unwrap(), 1);
     }
 
     #[rstest]
@@ -587,7 +586,7 @@ mod tests {
         }
 
         assert_eq!(
-            store.len(tail.host.id, &tail.tag).await.unwrap(),
+            store.len(&tail.series_key()).await.unwrap(),
             100,
             "failed to insert 100 records"
         );
@@ -609,7 +608,7 @@ mod tests {
         store.push_batch(records.iter()).await.unwrap();
 
         assert_eq!(
-            store.len(tail.host.id, &tail.tag).await.unwrap(),
+            store.len(&tail.series_key()).await.unwrap(),
             10000,
             "failed to insert 10k records"
         );
@@ -658,6 +657,6 @@ mod tests {
             assert_eq!(decrypted.data.0, data);
         }
 
-        assert_eq!(store.len(host_id, &RecordTag::Other("test".to_owned())).await.unwrap(), 10);
+        assert_eq!(store.len(&(host_id, RecordTag::Other("test".to_owned())).into()).await.unwrap(), 10);
     }
 }

--- a/crates/atuin-client/src/record/sync.rs
+++ b/crates/atuin-client/src/record/sync.rs
@@ -227,10 +227,8 @@ async fn sync_upload(
     println!("Uploading {} records to {}/{}", expected, series.host.0.as_simple(), series.tag);
 
     while progress < expected {
-        let page = store
-            .next(series, first_missing_remote + progress, page_size)
-            .await
-            .map_err(|e| {
+        let page =
+            store.next(series, first_missing_remote + progress, page_size).await.map_err(|e| {
                 error!("failed to read upload page: {e:?}");
 
                 SyncError::LocalStoreError { msg: e.to_string() }
@@ -413,8 +411,8 @@ pub async fn sync_remote(
             } => {
                 if series.tag == RecordTag::Packfile && !packfiles_enabled {
                     debug!(
-                        "server does not advertise PackfileCap; skipping packfile {} upload \
-                         op, loose history covers it",
+                        "server does not advertise PackfileCap; skipping packfile {} upload op, \
+                         loose history covers it",
                         series.tag
                     );
                     continue;
@@ -426,8 +424,8 @@ pub async fn sync_remote(
             Operation::Download { series, remote } => {
                 if series.tag == RecordTag::Packfile && !packfiles_enabled {
                     debug!(
-                        "server does not advertise PackfileCap; skipping packfile {} download \
-                         op, loose history covers it",
+                        "server does not advertise PackfileCap; skipping packfile {} download op, \
+                         loose history covers it",
                         series.tag
                     );
                     continue;
@@ -453,7 +451,9 @@ pub async fn check_encryption_key(
     let sample = remote_index
         .hosts
         .iter()
-        .flat_map(|(host, tags)| tags.keys().map(move |tag| RecordSeriesKey::new(*host, tag.clone())))
+        .flat_map(|(host, tags)| {
+            tags.keys().map(move |tag| RecordSeriesKey::new(*host, tag.clone()))
+        })
         // Note we have to skip `Packfile`s here because packfiles _aren't_ actually encrypted, so
         // using the default CEK would fail decryption.
         .find(|series| series.tag != RecordTag::Packfile);
@@ -498,9 +498,7 @@ pub async fn sync(
 
 #[cfg(test)]
 mod tests {
-    use atuin_domain::record::{
-        Diff, EncryptedData, HostId, Record, RecordTag,
-    };
+    use atuin_domain::record::{Diff, EncryptedData, HostId, Record, RecordTag};
     use pretty_assertions::assert_eq;
     use rstest::rstest;
 
@@ -963,7 +961,9 @@ mod packfile_download_tests {
         let addr: url::Url = server.uri().parse().unwrap();
         let client = mock_client(&addr);
 
-        sync_download(&down, &client, &(host, RecordTag::Packfile).into(), 1, 100, &key).await.unwrap();
+        sync_download(&down, &client, &(host, RecordTag::Packfile).into(), 1, 100, &key)
+            .await
+            .unwrap();
 
         // The manifest is stored AND the history it covers was populated.
         assert!(down.last(&(host, RecordTag::Packfile).into()).await.unwrap().is_some());
@@ -988,7 +988,9 @@ mod packfile_download_tests {
         let client = mock_client(&addr);
 
         let returned =
-            sync_download(&down, &client, &(host, RecordTag::Packfile).into(), 1, 100, &key).await.unwrap();
+            sync_download(&down, &client, &(host, RecordTag::Packfile).into(), 1, 100, &key)
+                .await
+                .unwrap();
 
         for id in &history_ids {
             assert!(
@@ -1050,8 +1052,12 @@ mod packfile_download_tests {
         let client = mock_client(&addr);
 
         // Packfile op first (populates history 0..=2), then the history op.
-        sync_download(&down, &client, &(host, RecordTag::Packfile).into(), 1, 100, &key).await.unwrap();
-        sync_download(&down, &client, &(host, RecordTag::History).into(), 3, 100, &key).await.unwrap();
+        sync_download(&down, &client, &(host, RecordTag::Packfile).into(), 1, 100, &key)
+            .await
+            .unwrap();
+        sync_download(&down, &client, &(host, RecordTag::History).into(), 3, 100, &key)
+            .await
+            .unwrap();
 
         // The history download must have started AFTER the packed prefix (idx 2), i.e. never
         // requested start=0 for RecordTag::History.
@@ -1089,8 +1095,9 @@ mod packfile_download_tests {
         let client = mock_client(&addr);
 
         // remote (2) is BEHIND the live local head (4) -- must not underflow/panic.
-        let got =
-            sync_download(&down, &client, &(host, RecordTag::History).into(), 2, 100, &key).await.unwrap();
+        let got = sync_download(&down, &client, &(host, RecordTag::History).into(), 2, 100, &key)
+            .await
+            .unwrap();
         assert!(got.is_empty(), "nothing to download when local head already exceeds remote");
     }
 
@@ -1192,7 +1199,9 @@ mod packfile_download_tests {
         let client = mock_client(&addr);
 
         let returned =
-            sync_download(&down, &client, &(host, RecordTag::Packfile).into(), 1, 100, &key).await.unwrap();
+            sync_download(&down, &client, &(host, RecordTag::Packfile).into(), 1, 100, &key)
+                .await
+                .unwrap();
 
         // Every batched packfile's history is populated, whichever download finished first.
         assert_eq!(
@@ -1254,9 +1263,10 @@ mod packfile_download_tests {
         let client = mock_client(&addr);
 
         // The permanent per-manifest failure is logged and skipped; the whole tick still succeeds.
-        let returned = sync_download(&down, &client, &(host, RecordTag::Packfile).into(), 2, 100, &key)
-            .await
-            .expect("a permanent per-manifest failure must not fail the tick");
+        let returned =
+            sync_download(&down, &client, &(host, RecordTag::Packfile).into(), 2, 100, &key)
+                .await
+                .expect("a permanent per-manifest failure must not fail the tick");
 
         // The two valid packfiles in the batch still expand despite the poisoned sibling.
         assert_eq!(
@@ -1278,9 +1288,7 @@ mod packfile_capability_tests {
     use atuin_common::encryption::paseto_v4;
     use atuin_common::utils::uuid_v7;
     use atuin_domain::caps::{CapServer, CapabilitiesCap, PackfileCap};
-    use atuin_domain::record::{
-        EncryptedData, HostId, Record, RecordIdx, RecordTag,
-    };
+    use atuin_domain::record::{EncryptedData, HostId, Record, RecordIdx, RecordTag};
     use rstest::*;
     use wiremock::matchers::{method, path, query_param};
     use wiremock::{Mock, MockServer, ResponseTemplate};

--- a/crates/atuin-client/src/record/sync.rs
+++ b/crates/atuin-client/src/record/sync.rs
@@ -5,7 +5,7 @@ use std::sync::Arc;
 
 use atuin_common::encryption::paseto_v4;
 use atuin_domain::caps::{CapClient, PackfileCap};
-use atuin_domain::record::{Diff, HostId, RecordId, RecordIdx, RecordStatus, RecordTag};
+use atuin_domain::record::{Diff, RecordId, RecordIdx, RecordSeriesKey, RecordStatus, RecordTag};
 use eyre::Result;
 use futures::{StreamExt, stream};
 use indicatif::{ProgressBar, ProgressState, ProgressStyle};
@@ -60,17 +60,14 @@ pub enum Operation {
     Upload {
         local: RecordIdx,
         remote: Option<RecordIdx>,
-        host: HostId,
-        tag: RecordTag,
+        series: RecordSeriesKey,
     },
     Download {
         remote: RecordIdx,
-        host: HostId,
-        tag: RecordTag,
+        series: RecordSeriesKey,
     },
     Noop {
-        host: HostId,
-        tag: RecordTag,
+        series: RecordSeriesKey,
     },
 }
 
@@ -131,35 +128,30 @@ pub fn operations(diffs: Vec<Diff>, _store: &SqliteStore) -> Result<Vec<Operatio
             // We both have it! Could be either. Compare.
             (Some(local), Some(remote)) => match local.cmp(&remote) {
                 Ordering::Equal => Operation::Noop {
-                    host: diff.host,
-                    tag: diff.tag,
+                    series: diff.series,
                 },
                 Ordering::Greater => Operation::Upload {
                     local,
                     remote: Some(remote),
-                    host: diff.host,
-                    tag: diff.tag,
+                    series: diff.series,
                 },
                 Ordering::Less => Operation::Download {
                     remote,
-                    host: diff.host,
-                    tag: diff.tag,
+                    series: diff.series,
                 },
             },
 
             // Remote has it, we don't. Gotta be download
             (None, Some(remote)) => Operation::Download {
                 remote,
-                host: diff.host,
-                tag: diff.tag,
+                series: diff.series,
             },
 
             // We have it, remote doesn't. Gotta be upload.
             (Some(local), None) => Operation::Upload {
                 local,
                 remote: None,
-                host: diff.host,
-                tag: diff.tag,
+                series: diff.series,
             },
 
             // something is pretty fucked.
@@ -181,17 +173,17 @@ pub fn operations(diffs: Vec<Diff>, _store: &SqliteStore) -> Result<Vec<Operatio
     // with the same properties
 
     operations.sort_by_key(|op| match op {
-        Operation::Noop { host, tag } => (0u8, *host, 0u8, tag.clone()),
-        Operation::Upload { host, tag, .. } => (1u8, *host, 0u8, tag.clone()),
-        Operation::Download { host, tag, .. } => {
+        Operation::Noop { series } => (0u8, series.host, 0u8, series.tag.clone()),
+        Operation::Upload { series, .. } => (1u8, series.host, 0u8, series.tag.clone()),
+        Operation::Download { series, .. } => {
             // Packfile manifests must expand before the history download runs, as that
             // `sync_download` will dedupe will have a chance at avoiding unnecessary downloads.
-            let tag_priority = if *tag == RecordTag::Packfile {
+            let tag_priority = if series.tag == RecordTag::Packfile {
                 0u8
             } else {
                 1u8
             };
-            (2u8, *host, tag_priority, tag.clone())
+            (2u8, series.host, tag_priority, series.tag.clone())
         }
     });
 
@@ -199,21 +191,16 @@ pub fn operations(diffs: Vec<Diff>, _store: &SqliteStore) -> Result<Vec<Operatio
 }
 
 // TODO(markovejnovic): Seriously revisit the syncing logic and coupling.
-#[allow(
-    clippy::too_many_arguments,
-    reason = "threading the key for packfile uploads pushes this one param over the limit"
-)]
 #[instrument(
     level = "trace",
     skip_all,
-    fields(host = ?host, tag = ?tag, local, remote = ?remote, page_size),
+    fields(host = ?series.host, tag = ?series.tag, local, remote = ?remote, page_size),
     err
 )]
 async fn sync_upload(
     store: &SqliteStore,
     client: &Client,
-    host: HostId,
-    tag: RecordTag,
+    series: &RecordSeriesKey,
     local: RecordIdx,
     remote: Option<RecordIdx>,
     page_size: u64,
@@ -237,11 +224,11 @@ async fn sync_upload(
         .progress_chars("#>-"),
     );
 
-    println!("Uploading {} records to {}/{}", expected, host.0.as_simple(), tag);
+    println!("Uploading {} records to {}/{}", expected, series.host.0.as_simple(), series.tag);
 
     while progress < expected {
         let page = store
-            .next(host, &tag, first_missing_remote + progress, page_size)
+            .next(series, first_missing_remote + progress, page_size)
             .await
             .map_err(|e| {
                 error!("failed to read upload page: {e:?}");
@@ -253,7 +240,7 @@ async fn sync_upload(
             break;
         }
 
-        if tag == RecordTag::Packfile {
+        if series.tag == RecordTag::Packfile {
             let mut uploads = stream::iter(0..page.len())
                 .map(|i| upload_packed(&page[i], store, key, client))
                 .buffered(MAX_CONCURRENT_PACKFILE_TRANSFERS);
@@ -282,21 +269,16 @@ async fn sync_upload(
 }
 
 // TODO(markovejnovic): Seriously revisit the syncing logic and coupling.
-#[allow(
-    clippy::too_many_arguments,
-    reason = "threading the key for packfile downloads pushes this one param over the limit"
-)]
 #[instrument(
     level = "trace",
     skip_all,
-    fields(host = ?host, tag = ?tag, remote = ?remote, page_size),
+    fields(host = ?series.host, tag = ?series.tag, remote = ?remote, page_size),
     err
 )]
 async fn sync_download(
     store: &SqliteStore,
     client: &Client,
-    host: HostId,
-    tag: RecordTag,
+    series: &RecordSeriesKey,
     remote: RecordIdx,
     page_size: u64,
     key: &paseto_v4::Key,
@@ -307,7 +289,7 @@ async fn sync_download(
     // fetch the hole before it. Start from the actual missing index; records already present above
     // it will be "unnecessarily" redownloaded, but this is a no-op.
     let first_missing_local = store
-        .first_gap(host, &tag)
+        .first_gap(series)
         .await
         .map_err(|e| SyncError::LocalStoreError { msg: e.to_string() })?;
 
@@ -318,7 +300,7 @@ async fn sync_download(
     // TODO: This adds a slight runtime cost, but while the packfile feature is new, let's err on
     // the side of catching potential problems.
     let latest = store
-        .last(host, &tag)
+        .last(series)
         .await
         .map_err(|e| SyncError::LocalStoreError { msg: e.to_string() })?
         .map(|record| record.idx);
@@ -339,7 +321,7 @@ async fn sync_download(
     let mut progress = 0;
     let mut ret = Vec::new();
 
-    println!("Downloading {} records from {}/{}", expected, host.0.as_simple(), tag);
+    println!("Downloading {} records from {}/{}", expected, series.host.0.as_simple(), series.tag);
 
     let pb = ProgressBar::new(expected);
     pb.set_style(
@@ -356,7 +338,7 @@ async fn sync_download(
 
     while progress < expected {
         let page = client
-            .next_records(host, tag.clone(), first_missing_local + progress, page_size)
+            .next_records(series, first_missing_local + progress, page_size)
             .await
             .map_err(|e| SyncError::RemoteRequestError { msg: e.to_string() })?;
 
@@ -366,7 +348,7 @@ async fn sync_download(
 
         // We commit the packfile's history into the local store before we persist the manifests, so
         // a manifest we recorded always has its associated history.
-        if tag == RecordTag::Packfile {
+        if series.tag == RecordTag::Packfile {
             let mut downloads = stream::iter(0..page.len())
                 .map(|i| download_packed(&page[i], store, key, client))
                 .buffered(MAX_CONCURRENT_PACKFILE_TRANSFERS)
@@ -425,33 +407,33 @@ pub async fn sync_remote(
     for i in operations {
         match i {
             Operation::Upload {
-                host,
-                tag,
+                series,
                 local,
                 remote,
             } => {
-                if tag == RecordTag::Packfile && !packfiles_enabled {
+                if series.tag == RecordTag::Packfile && !packfiles_enabled {
                     debug!(
-                        "server does not advertise PackfileCap; skipping packfile {tag} upload \
-                         op, loose history covers it"
+                        "server does not advertise PackfileCap; skipping packfile {} upload \
+                         op, loose history covers it",
+                        series.tag
                     );
                     continue;
                 }
                 uploaded +=
-                    sync_upload(local_store, client, host, tag, local, remote, page_size, key)
-                        .await?
+                    sync_upload(local_store, client, &series, local, remote, page_size, key).await?
             }
 
-            Operation::Download { host, tag, remote } => {
-                if tag == RecordTag::Packfile && !packfiles_enabled {
+            Operation::Download { series, remote } => {
+                if series.tag == RecordTag::Packfile && !packfiles_enabled {
                     debug!(
-                        "server does not advertise PackfileCap; skipping packfile {tag} download \
-                         op, loose history covers it"
+                        "server does not advertise PackfileCap; skipping packfile {} download \
+                         op, loose history covers it",
+                        series.tag
                     );
                     continue;
                 }
                 let mut d =
-                    sync_download(local_store, client, host, tag, remote, page_size, key).await?;
+                    sync_download(local_store, client, &series, remote, page_size, key).await?;
                 downloaded.append(&mut d)
             }
 
@@ -471,17 +453,17 @@ pub async fn check_encryption_key(
     let sample = remote_index
         .hosts
         .iter()
-        .flat_map(|(host, tags)| tags.keys().map(move |tag| (*host, tag.clone())))
+        .flat_map(|(host, tags)| tags.keys().map(move |tag| RecordSeriesKey::new(*host, tag.clone())))
         // Note we have to skip `Packfile`s here because packfiles _aren't_ actually encrypted, so
         // using the default CEK would fail decryption.
-        .find(|(_, tag)| *tag != RecordTag::Packfile);
+        .find(|series| series.tag != RecordTag::Packfile);
 
-    let Some((host, tag)) = sample else {
+    let Some(series) = sample else {
         return Ok(());
     };
 
     let records = client
-        .next_records(host, tag, 0, 1)
+        .next_records(&series, 0, 1)
         .await
         .map_err(|e| SyncError::RemoteRequestError { msg: e.to_string() })?;
 
@@ -516,7 +498,9 @@ pub async fn sync(
 
 #[cfg(test)]
 mod tests {
-    use atuin_domain::record::{Diff, EncryptedData, HostId, Record, RecordTag};
+    use atuin_domain::record::{
+        Diff, EncryptedData, HostId, Record, RecordTag,
+    };
     use pretty_assertions::assert_eq;
     use rstest::rstest;
 
@@ -582,8 +566,7 @@ mod tests {
         assert_eq!(operations.len(), 1);
 
         assert_eq!(operations[0], Operation::Upload {
-            host: record.host.id,
-            tag: record.tag.clone(),
+            series: record.series_key(),
             local: record.idx,
             remote: None,
         });
@@ -613,15 +596,13 @@ mod tests {
         assert_eq!(operations, vec![
             // Or in otherwords, local is ahead by one
             Operation::Upload {
-                host: local_ahead.host.id,
-                tag: local_ahead.tag.clone(),
+                series: local_ahead.series_key(),
                 local: 1,
                 remote: Some(0),
             },
             // Or in other words, remote knows of a record in an entirely new store (tag)
             Operation::Download {
-                host: remote_ahead.host.id,
-                tag: remote_ahead.tag.clone(),
+                series: remote_ahead.series_key(),
                 remote: 0,
             },
         ]);
@@ -712,56 +693,49 @@ mod tests {
             // same store
             Operation::Download {
                 remote: 2,
-                host: second_shared_remote_ahead.host.id,
-                tag: second_shared_remote_ahead.tag.clone(),
+                series: second_shared_remote_ahead.series_key(),
             },
             // We have a shared record, local knows of the first two but not the last
             Operation::Download {
                 remote: 2,
-                host: fourth_shared_remote_ahead2.host.id,
-                tag: fourth_shared_remote_ahead2.tag.clone(),
+                series: fourth_shared_remote_ahead2.series_key(),
             },
             // Remote knows of a store with a single record that local does not have
             Operation::Download {
                 remote: 0,
-                host: remote_only.host.id,
-                tag: remote_only.tag.clone(),
+                series: remote_only.series_key(),
             },
             // Remote knows of a store with a bunch of records that local does not have
             Operation::Download {
                 remote: 4,
-                host: remote_only_20.host.id,
-                tag: remote_only_20.tag.clone(),
+                series: remote_only_20.series_key(),
             },
             // Local knows of a record in a store that remote does not have
             Operation::Upload {
                 local: 0,
                 remote: None,
-                host: local_only.host.id,
-                tag: local_only.tag.clone(),
+                series: local_only.series_key(),
             },
             // Local knows of 4 records in a store that remote does not have
             Operation::Upload {
                 local: 3,
                 remote: None,
-                host: local_only_20.host.id,
-                tag: local_only_20.tag.clone(),
+                series: local_only_20.series_key(),
             },
             // Local knows of 2 more records in a shared store that remote only has one of
             Operation::Upload {
                 local: 2,
                 remote: Some(0),
-                host: third_shared.host.id,
-                tag: third_shared.tag.clone(),
+                series: third_shared.series_key(),
             },
         ];
 
         result_ops.sort_by_key(|op| match op {
-            Operation::Noop { host, tag } => (0, *host, tag.clone()),
+            Operation::Noop { series } => (0, series.host, series.tag.clone()),
 
-            Operation::Upload { host, tag, .. } => (1, *host, tag.clone()),
+            Operation::Upload { series, .. } => (1, series.host, series.tag.clone()),
 
-            Operation::Download { host, tag, .. } => (2, *host, tag.clone()),
+            Operation::Download { series, .. } => (2, series.host, series.tag.clone()),
         });
 
         assert_eq!(result_ops, operations);
@@ -853,16 +827,15 @@ mod packfile_download_tests {
         seed_history(&up, host, key, count).await;
         try_pack(
             &up,
-            host,
+            &(host, RecordTag::History).into(),
             Some(PackfileCap {
                 version: 1,
                 record_count: count,
             }),
-            &RecordTag::History,
         )
         .await
         .unwrap();
-        let manifest = up.last(host, &RecordTag::Packfile).await.unwrap().unwrap();
+        let manifest = up.last(&(host, RecordTag::Packfile).into()).await.unwrap().unwrap();
         let view = PackManifestRecordView::new(&manifest).unwrap();
         let (blob, ids) = view.pack_records(&up, key.clone()).await.unwrap();
         (manifest, blob, ids)
@@ -948,7 +921,7 @@ mod packfile_download_tests {
         let host = HostId(uuid_v7());
         let store = memory_store().await;
         seed_history(&store, host, &key, 1).await;
-        let rec = store.next(host, &RecordTag::History, 0, 1).await.unwrap()[0].clone();
+        let rec = store.next(&(host, RecordTag::History).into(), 0, 1).await.unwrap()[0].clone();
 
         let mut tags = HashMap::new();
         tags.insert(RecordTag::History, rec.idx);
@@ -990,11 +963,11 @@ mod packfile_download_tests {
         let addr: url::Url = server.uri().parse().unwrap();
         let client = mock_client(&addr);
 
-        sync_download(&down, &client, host, RecordTag::Packfile, 1, 100, &key).await.unwrap();
+        sync_download(&down, &client, &(host, RecordTag::Packfile).into(), 1, 100, &key).await.unwrap();
 
         // The manifest is stored AND the history it covers was populated.
-        assert!(down.last(host, &RecordTag::Packfile).await.unwrap().is_some());
-        assert_eq!(down.next(host, &RecordTag::History, 0, 3).await.unwrap().len(), 3);
+        assert!(down.last(&(host, RecordTag::Packfile).into()).await.unwrap().is_some());
+        assert_eq!(down.next(&(host, RecordTag::History).into(), 0, 3).await.unwrap().len(), 3);
     }
 
     #[rstest]
@@ -1015,7 +988,7 @@ mod packfile_download_tests {
         let client = mock_client(&addr);
 
         let returned =
-            sync_download(&down, &client, host, RecordTag::Packfile, 1, 100, &key).await.unwrap();
+            sync_download(&down, &client, &(host, RecordTag::Packfile).into(), 1, 100, &key).await.unwrap();
 
         for id in &history_ids {
             assert!(
@@ -1077,8 +1050,8 @@ mod packfile_download_tests {
         let client = mock_client(&addr);
 
         // Packfile op first (populates history 0..=2), then the history op.
-        sync_download(&down, &client, host, RecordTag::Packfile, 1, 100, &key).await.unwrap();
-        sync_download(&down, &client, host, RecordTag::History, 3, 100, &key).await.unwrap();
+        sync_download(&down, &client, &(host, RecordTag::Packfile).into(), 1, 100, &key).await.unwrap();
+        sync_download(&down, &client, &(host, RecordTag::History).into(), 3, 100, &key).await.unwrap();
 
         // The history download must have started AFTER the packed prefix (idx 2), i.e. never
         // requested start=0 for RecordTag::History.
@@ -1117,7 +1090,7 @@ mod packfile_download_tests {
 
         // remote (2) is BEHIND the live local head (4) -- must not underflow/panic.
         let got =
-            sync_download(&down, &client, host, RecordTag::History, 2, 100, &key).await.unwrap();
+            sync_download(&down, &client, &(host, RecordTag::History).into(), 2, 100, &key).await.unwrap();
         assert!(got.is_empty(), "nothing to download when local head already exceeds remote");
     }
 
@@ -1135,17 +1108,16 @@ mod packfile_download_tests {
         seed_history(&up, host, &key, per * num_packs).await;
         try_pack(
             &up,
-            host,
+            &(host, RecordTag::History).into(),
             Some(PackfileCap {
                 version: 1,
                 record_count: per,
             }),
-            &RecordTag::History,
         )
         .await
         .unwrap();
 
-        let manifests = up.next(host, &RecordTag::Packfile, 0, num_packs).await.unwrap();
+        let manifests = up.next(&(host, RecordTag::Packfile).into(), 0, num_packs).await.unwrap();
         assert_eq!(
             manifests.len() as u64,
             num_packs,
@@ -1160,7 +1132,7 @@ mod packfile_download_tests {
         }
 
         let history_ids: Vec<RecordId> = up
-            .next(host, &RecordTag::History, 0, per * num_packs)
+            .next(&(host, RecordTag::History).into(), 0, per * num_packs)
             .await
             .unwrap()
             .iter()
@@ -1220,11 +1192,11 @@ mod packfile_download_tests {
         let client = mock_client(&addr);
 
         let returned =
-            sync_download(&down, &client, host, RecordTag::Packfile, 1, 100, &key).await.unwrap();
+            sync_download(&down, &client, &(host, RecordTag::Packfile).into(), 1, 100, &key).await.unwrap();
 
         // Every batched packfile's history is populated, whichever download finished first.
         assert_eq!(
-            down.next(host, &RecordTag::History, 0, 6).await.unwrap().len(),
+            down.next(&(host, RecordTag::History).into(), 0, 6).await.unwrap().len(),
             6,
             "all history across the batch must be populated"
         );
@@ -1282,13 +1254,13 @@ mod packfile_download_tests {
         let client = mock_client(&addr);
 
         // The permanent per-manifest failure is logged and skipped; the whole tick still succeeds.
-        let returned = sync_download(&down, &client, host, RecordTag::Packfile, 2, 100, &key)
+        let returned = sync_download(&down, &client, &(host, RecordTag::Packfile).into(), 2, 100, &key)
             .await
             .expect("a permanent per-manifest failure must not fail the tick");
 
         // The two valid packfiles in the batch still expand despite the poisoned sibling.
         assert_eq!(
-            down.next(host, &RecordTag::History, 0, 6).await.unwrap().len(),
+            down.next(&(host, RecordTag::History).into(), 0, 6).await.unwrap().len(),
             6,
             "valid packfiles in the batch must still expand"
         );
@@ -1306,7 +1278,9 @@ mod packfile_capability_tests {
     use atuin_common::encryption::paseto_v4;
     use atuin_common::utils::uuid_v7;
     use atuin_domain::caps::{CapServer, CapabilitiesCap, PackfileCap};
-    use atuin_domain::record::{EncryptedData, HostId, Record, RecordIdx, RecordTag};
+    use atuin_domain::record::{
+        EncryptedData, HostId, Record, RecordIdx, RecordTag,
+    };
     use rstest::*;
     use wiremock::matchers::{method, path, query_param};
     use wiremock::{Mock, MockServer, ResponseTemplate};
@@ -1344,15 +1318,14 @@ mod packfile_capability_tests {
     ) -> Vec<Record<EncryptedData>> {
         let up = memory_store().await;
         seed_history(&up, host, key, count).await;
-        up.next(host, &RecordTag::History, 0, count).await.unwrap()
+        up.next(&(host, RecordTag::History).into(), 0, count).await.unwrap()
     }
 
     /// A single PACKFILE download op covering `remote` manifests from `host`.
     fn packfile_download_op(host: HostId, remote: RecordIdx) -> Operation {
         Operation::Download {
             remote,
-            host,
-            tag: RecordTag::Packfile,
+            series: (host, RecordTag::Packfile).into(),
         }
     }
 
@@ -1385,8 +1358,8 @@ mod packfile_capability_tests {
 
         // Cap advertised -> the whole packfile op ran: the manifest was persisted and its history
         // was expanded into the store.
-        assert!(down.last(host, &RecordTag::Packfile).await.unwrap().is_some());
-        assert_eq!(down.next(host, &RecordTag::History, 0, 3).await.unwrap().len(), 3);
+        assert!(down.last(&(host, RecordTag::Packfile).into()).await.unwrap().is_some());
+        assert_eq!(down.next(&(host, RecordTag::History).into(), 0, 3).await.unwrap().len(), 3);
     }
 
     #[rstest]
@@ -1449,8 +1422,7 @@ mod packfile_capability_tests {
             &client,
             vec![packfile_download_op(host, 3), Operation::Download {
                 remote: 3,
-                host,
-                tag: RecordTag::History,
+                series: (host, RecordTag::History).into(),
             }],
             &down,
             100,
@@ -1460,8 +1432,8 @@ mod packfile_capability_tests {
         .unwrap();
 
         // Packfile op skipped: manifest not persisted. Loose history still synced (no data loss).
-        assert!(down.last(host, &RecordTag::Packfile).await.unwrap().is_none());
-        assert_eq!(down.next(host, &RecordTag::History, 0, 3).await.unwrap().len(), 3);
+        assert!(down.last(&(host, RecordTag::Packfile).into()).await.unwrap().is_none());
+        assert_eq!(down.next(&(host, RecordTag::History).into(), 0, 3).await.unwrap().len(), 3);
     }
 
     #[rstest]
@@ -1480,7 +1452,7 @@ mod packfile_capability_tests {
         sync_remote(&client, vec![packfile_download_op(host, 3)], &down, 100, &key).await.unwrap();
 
         // Skipped: manifest not persisted, and no packfile endpoint was ever hit.
-        assert!(down.last(host, &RecordTag::Packfile).await.unwrap().is_none());
+        assert!(down.last(&(host, RecordTag::Packfile).into()).await.unwrap().is_none());
         let requests = server.received_requests().await.unwrap();
         assert!(
             !requests.iter().any(|r| r.url.path().starts_with("/api/v0/packfiles")),
@@ -1511,6 +1483,6 @@ mod packfile_capability_tests {
 
         sync_remote(&client, vec![packfile_download_op(host, 3)], &down, 100, &key).await.unwrap();
 
-        assert!(down.last(host, &RecordTag::Packfile).await.unwrap().is_none());
+        assert!(down.last(&(host, RecordTag::Packfile).into()).await.unwrap().is_none());
     }
 }

--- a/crates/atuin-client/src/record/sync.rs
+++ b/crates/atuin-client/src/record/sync.rs
@@ -825,7 +825,7 @@ mod packfile_download_tests {
         seed_history(&up, host, key, count).await;
         try_pack(
             &up,
-            &(host, RecordTag::History).into(),
+            &RecordSeriesKey::new(host, RecordTag::History),
             Some(PackfileCap {
                 version: 1,
                 record_count: count,
@@ -833,7 +833,8 @@ mod packfile_download_tests {
         )
         .await
         .unwrap();
-        let manifest = up.last(&(host, RecordTag::Packfile).into()).await.unwrap().unwrap();
+        let manifest =
+            up.last(&RecordSeriesKey::new(host, RecordTag::Packfile)).await.unwrap().unwrap();
         let view = PackManifestRecordView::new(&manifest).unwrap();
         let (blob, ids) = view.pack_records(&up, key.clone()).await.unwrap();
         (manifest, blob, ids)
@@ -919,7 +920,9 @@ mod packfile_download_tests {
         let host = HostId(uuid_v7());
         let store = memory_store().await;
         seed_history(&store, host, &key, 1).await;
-        let rec = store.next(&(host, RecordTag::History).into(), 0, 1).await.unwrap()[0].clone();
+        let rec = store.next(&RecordSeriesKey::new(host, RecordTag::History), 0, 1).await.unwrap()
+            [0]
+        .clone();
 
         let mut tags = HashMap::new();
         tags.insert(RecordTag::History, rec.idx);
@@ -961,13 +964,25 @@ mod packfile_download_tests {
         let addr: url::Url = server.uri().parse().unwrap();
         let client = mock_client(&addr);
 
-        sync_download(&down, &client, &(host, RecordTag::Packfile).into(), 1, 100, &key)
-            .await
-            .unwrap();
+        sync_download(
+            &down,
+            &client,
+            &RecordSeriesKey::new(host, RecordTag::Packfile),
+            1,
+            100,
+            &key,
+        )
+        .await
+        .unwrap();
 
         // The manifest is stored AND the history it covers was populated.
-        assert!(down.last(&(host, RecordTag::Packfile).into()).await.unwrap().is_some());
-        assert_eq!(down.next(&(host, RecordTag::History).into(), 0, 3).await.unwrap().len(), 3);
+        assert!(
+            down.last(&RecordSeriesKey::new(host, RecordTag::Packfile)).await.unwrap().is_some()
+        );
+        assert_eq!(
+            down.next(&RecordSeriesKey::new(host, RecordTag::History), 0, 3).await.unwrap().len(),
+            3
+        );
     }
 
     #[rstest]
@@ -987,10 +1002,16 @@ mod packfile_download_tests {
         let addr: url::Url = server.uri().parse().unwrap();
         let client = mock_client(&addr);
 
-        let returned =
-            sync_download(&down, &client, &(host, RecordTag::Packfile).into(), 1, 100, &key)
-                .await
-                .unwrap();
+        let returned = sync_download(
+            &down,
+            &client,
+            &RecordSeriesKey::new(host, RecordTag::Packfile),
+            1,
+            100,
+            &key,
+        )
+        .await
+        .unwrap();
 
         for id in &history_ids {
             assert!(
@@ -1052,12 +1073,26 @@ mod packfile_download_tests {
         let client = mock_client(&addr);
 
         // Packfile op first (populates history 0..=2), then the history op.
-        sync_download(&down, &client, &(host, RecordTag::Packfile).into(), 1, 100, &key)
-            .await
-            .unwrap();
-        sync_download(&down, &client, &(host, RecordTag::History).into(), 3, 100, &key)
-            .await
-            .unwrap();
+        sync_download(
+            &down,
+            &client,
+            &RecordSeriesKey::new(host, RecordTag::Packfile),
+            1,
+            100,
+            &key,
+        )
+        .await
+        .unwrap();
+        sync_download(
+            &down,
+            &client,
+            &RecordSeriesKey::new(host, RecordTag::History),
+            3,
+            100,
+            &key,
+        )
+        .await
+        .unwrap();
 
         // The history download must have started AFTER the packed prefix (idx 2), i.e. never
         // requested start=0 for RecordTag::History.
@@ -1095,9 +1130,16 @@ mod packfile_download_tests {
         let client = mock_client(&addr);
 
         // remote (2) is BEHIND the live local head (4) -- must not underflow/panic.
-        let got = sync_download(&down, &client, &(host, RecordTag::History).into(), 2, 100, &key)
-            .await
-            .unwrap();
+        let got = sync_download(
+            &down,
+            &client,
+            &RecordSeriesKey::new(host, RecordTag::History),
+            2,
+            100,
+            &key,
+        )
+        .await
+        .unwrap();
         assert!(got.is_empty(), "nothing to download when local head already exceeds remote");
     }
 
@@ -1115,7 +1157,7 @@ mod packfile_download_tests {
         seed_history(&up, host, &key, per * num_packs).await;
         try_pack(
             &up,
-            &(host, RecordTag::History).into(),
+            &RecordSeriesKey::new(host, RecordTag::History),
             Some(PackfileCap {
                 version: 1,
                 record_count: per,
@@ -1124,7 +1166,8 @@ mod packfile_download_tests {
         .await
         .unwrap();
 
-        let manifests = up.next(&(host, RecordTag::Packfile).into(), 0, num_packs).await.unwrap();
+        let manifests =
+            up.next(&RecordSeriesKey::new(host, RecordTag::Packfile), 0, num_packs).await.unwrap();
         assert_eq!(
             manifests.len() as u64,
             num_packs,
@@ -1139,7 +1182,7 @@ mod packfile_download_tests {
         }
 
         let history_ids: Vec<RecordId> = up
-            .next(&(host, RecordTag::History).into(), 0, per * num_packs)
+            .next(&RecordSeriesKey::new(host, RecordTag::History), 0, per * num_packs)
             .await
             .unwrap()
             .iter()
@@ -1198,14 +1241,20 @@ mod packfile_download_tests {
         let addr: url::Url = server.uri().parse().unwrap();
         let client = mock_client(&addr);
 
-        let returned =
-            sync_download(&down, &client, &(host, RecordTag::Packfile).into(), 1, 100, &key)
-                .await
-                .unwrap();
+        let returned = sync_download(
+            &down,
+            &client,
+            &RecordSeriesKey::new(host, RecordTag::Packfile),
+            1,
+            100,
+            &key,
+        )
+        .await
+        .unwrap();
 
         // Every batched packfile's history is populated, whichever download finished first.
         assert_eq!(
-            down.next(&(host, RecordTag::History).into(), 0, 6).await.unwrap().len(),
+            down.next(&RecordSeriesKey::new(host, RecordTag::History), 0, 6).await.unwrap().len(),
             6,
             "all history across the batch must be populated"
         );
@@ -1263,14 +1312,20 @@ mod packfile_download_tests {
         let client = mock_client(&addr);
 
         // The permanent per-manifest failure is logged and skipped; the whole tick still succeeds.
-        let returned =
-            sync_download(&down, &client, &(host, RecordTag::Packfile).into(), 2, 100, &key)
-                .await
-                .expect("a permanent per-manifest failure must not fail the tick");
+        let returned = sync_download(
+            &down,
+            &client,
+            &RecordSeriesKey::new(host, RecordTag::Packfile),
+            2,
+            100,
+            &key,
+        )
+        .await
+        .expect("a permanent per-manifest failure must not fail the tick");
 
         // The two valid packfiles in the batch still expand despite the poisoned sibling.
         assert_eq!(
-            down.next(&(host, RecordTag::History).into(), 0, 6).await.unwrap().len(),
+            down.next(&RecordSeriesKey::new(host, RecordTag::History), 0, 6).await.unwrap().len(),
             6,
             "valid packfiles in the batch must still expand"
         );
@@ -1288,7 +1343,9 @@ mod packfile_capability_tests {
     use atuin_common::encryption::paseto_v4;
     use atuin_common::utils::uuid_v7;
     use atuin_domain::caps::{CapServer, CapabilitiesCap, PackfileCap};
-    use atuin_domain::record::{EncryptedData, HostId, Record, RecordIdx, RecordTag};
+    use atuin_domain::record::{
+        EncryptedData, HostId, Record, RecordIdx, RecordSeriesKey, RecordTag,
+    };
     use rstest::*;
     use wiremock::matchers::{method, path, query_param};
     use wiremock::{Mock, MockServer, ResponseTemplate};
@@ -1326,14 +1383,14 @@ mod packfile_capability_tests {
     ) -> Vec<Record<EncryptedData>> {
         let up = memory_store().await;
         seed_history(&up, host, key, count).await;
-        up.next(&(host, RecordTag::History).into(), 0, count).await.unwrap()
+        up.next(&RecordSeriesKey::new(host, RecordTag::History), 0, count).await.unwrap()
     }
 
     /// A single PACKFILE download op covering `remote` manifests from `host`.
     fn packfile_download_op(host: HostId, remote: RecordIdx) -> Operation {
         Operation::Download {
             remote,
-            series: (host, RecordTag::Packfile).into(),
+            series: RecordSeriesKey::new(host, RecordTag::Packfile),
         }
     }
 
@@ -1366,8 +1423,13 @@ mod packfile_capability_tests {
 
         // Cap advertised -> the whole packfile op ran: the manifest was persisted and its history
         // was expanded into the store.
-        assert!(down.last(&(host, RecordTag::Packfile).into()).await.unwrap().is_some());
-        assert_eq!(down.next(&(host, RecordTag::History).into(), 0, 3).await.unwrap().len(), 3);
+        assert!(
+            down.last(&RecordSeriesKey::new(host, RecordTag::Packfile)).await.unwrap().is_some()
+        );
+        assert_eq!(
+            down.next(&RecordSeriesKey::new(host, RecordTag::History), 0, 3).await.unwrap().len(),
+            3
+        );
     }
 
     #[rstest]
@@ -1430,7 +1492,7 @@ mod packfile_capability_tests {
             &client,
             vec![packfile_download_op(host, 3), Operation::Download {
                 remote: 3,
-                series: (host, RecordTag::History).into(),
+                series: RecordSeriesKey::new(host, RecordTag::History),
             }],
             &down,
             100,
@@ -1440,8 +1502,13 @@ mod packfile_capability_tests {
         .unwrap();
 
         // Packfile op skipped: manifest not persisted. Loose history still synced (no data loss).
-        assert!(down.last(&(host, RecordTag::Packfile).into()).await.unwrap().is_none());
-        assert_eq!(down.next(&(host, RecordTag::History).into(), 0, 3).await.unwrap().len(), 3);
+        assert!(
+            down.last(&RecordSeriesKey::new(host, RecordTag::Packfile)).await.unwrap().is_none()
+        );
+        assert_eq!(
+            down.next(&RecordSeriesKey::new(host, RecordTag::History), 0, 3).await.unwrap().len(),
+            3
+        );
     }
 
     #[rstest]
@@ -1460,7 +1527,9 @@ mod packfile_capability_tests {
         sync_remote(&client, vec![packfile_download_op(host, 3)], &down, 100, &key).await.unwrap();
 
         // Skipped: manifest not persisted, and no packfile endpoint was ever hit.
-        assert!(down.last(&(host, RecordTag::Packfile).into()).await.unwrap().is_none());
+        assert!(
+            down.last(&RecordSeriesKey::new(host, RecordTag::Packfile)).await.unwrap().is_none()
+        );
         let requests = server.received_requests().await.unwrap();
         assert!(
             !requests.iter().any(|r| r.url.path().starts_with("/api/v0/packfiles")),
@@ -1491,6 +1560,8 @@ mod packfile_capability_tests {
 
         sync_remote(&client, vec![packfile_download_op(host, 3)], &down, 100, &key).await.unwrap();
 
-        assert!(down.last(&(host, RecordTag::Packfile).into()).await.unwrap().is_none());
+        assert!(
+            down.last(&RecordSeriesKey::new(host, RecordTag::Packfile)).await.unwrap().is_none()
+        );
     }
 }

--- a/crates/atuin-daemon/src/components/history.rs
+++ b/crates/atuin-daemon/src/components/history.rs
@@ -11,7 +11,7 @@ use atuin_client::packfile;
 use atuin_client::settings::Settings;
 use atuin_common::time::OffsetDateTimeExt;
 use atuin_domain::caps::PackfileCap;
-use atuin_domain::record::{CmdOrigin, RecordTag};
+use atuin_domain::record::{CmdOrigin, RecordSeriesKey, RecordTag};
 use dashmap::DashMap;
 use eyre::Result;
 use time::OffsetDateTime;
@@ -235,7 +235,7 @@ impl HistorySvc for HistoryGrpcService {
 
             if let Err(e) = packfile::try_pack(
                 &history_store.store,
-                &(history_store.host_id, RecordTag::History).into(),
+                &RecordSeriesKey::new(history_store.host_id, RecordTag::History),
                 handle.caps().get_server::<PackfileCap>().await.ok().flatten(),
             )
             .await

--- a/crates/atuin-daemon/src/components/history.rs
+++ b/crates/atuin-daemon/src/components/history.rs
@@ -235,9 +235,8 @@ impl HistorySvc for HistoryGrpcService {
 
             if let Err(e) = packfile::try_pack(
                 &history_store.store,
-                history_store.host_id,
+                &(history_store.host_id, RecordTag::History).into(),
                 handle.caps().get_server::<PackfileCap>().await.ok().flatten(),
-                &RecordTag::History,
             )
             .await
             {

--- a/crates/atuin-domain/src/record/mod.rs
+++ b/crates/atuin-domain/src/record/mod.rs
@@ -84,12 +84,6 @@ impl RecordSeriesKey {
     }
 }
 
-impl From<(HostId, RecordTag)> for RecordSeriesKey {
-    fn from((host, tag): (HostId, RecordTag)) -> Self {
-        Self { host, tag }
-    }
-}
-
 /// A single record stored inside of our local database
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, TypedBuilder)]
 pub struct Record<Data> {
@@ -232,7 +226,7 @@ impl RecordStatus {
 
     /// Insert a new tail record into the store
     pub fn set(&mut self, tail: Record<DecryptedData>) {
-        self.set_raw((tail.host.id, tail.tag).into(), tail.idx)
+        self.set_raw(RecordSeriesKey::new(tail.host.id, tail.tag), tail.idx)
     }
 
     pub fn set_raw(&mut self, series: RecordSeriesKey, tail_id: RecordIdx) {
@@ -263,14 +257,14 @@ impl RecordStatus {
 
                     // The other store does exist, and it is either ahead or behind us. A diff regardless
                     Some(t) => ret.push(Diff {
-                        series: (*host, tag.clone()).into(),
+                        series: RecordSeriesKey::new(*host, tag.clone()),
                         local: Some(*idx),
                         remote: Some(t),
                     }),
 
                     // The other store does not exist :O
                     None => ret.push(Diff {
-                        series: (*host, tag.clone()).into(),
+                        series: RecordSeriesKey::new(*host, tag.clone()),
                         local: Some(*idx),
                         remote: None,
                     }),
@@ -290,7 +284,7 @@ impl RecordStatus {
                 }
 
                 ret.push(Diff {
-                    series: (*host, tag.clone()).into(),
+                    series: RecordSeriesKey::new(*host, tag.clone()),
                     remote: Some(*idx),
                     local: None,
                 });
@@ -712,8 +706,8 @@ mod tests {
     fn record_status_serializes_with_bare_string_tag_keys() {
         let host = HostId(Uuid::from_u128(0xabc));
         let mut status = RecordStatus::new();
-        status.set_raw((host, RecordTag::History).into(), 6);
-        status.set_raw((host, RecordTag::Other("custom".to_owned())).into(), 2);
+        status.set_raw(RecordSeriesKey::new(host, RecordTag::History), 6);
+        status.set_raw(RecordSeriesKey::new(host, RecordTag::Other("custom".to_owned())), 2);
 
         let json = serde_json::to_string(&status).unwrap();
         // Tag keys are bare strings, identical to the pre-refactor String-keyed shape.
@@ -721,8 +715,11 @@ mod tests {
         assert!(json.contains(r#""custom":2"#), "got {json}");
 
         let round: RecordStatus = serde_json::from_str(&json).unwrap();
-        assert_eq!(round.get(&(host, RecordTag::History).into()), Some(6));
-        assert_eq!(round.get(&(host, RecordTag::Other("custom".to_owned())).into()), Some(2));
+        assert_eq!(round.get(&RecordSeriesKey::new(host, RecordTag::History)), Some(6));
+        assert_eq!(
+            round.get(&RecordSeriesKey::new(host, RecordTag::Other("custom".to_owned()))),
+            Some(2)
+        );
     }
 
     /// Do *not* modify this test if it fails! It means the serialization of [`AdditionalData`]

--- a/crates/atuin-domain/src/record/mod.rs
+++ b/crates/atuin-domain/src/record/mod.rs
@@ -70,12 +70,7 @@ new_uuid!(HostId);
 
 pub type RecordIdx = u64;
 
-/// The composite key identifying a single append-only record stream.
-///
-/// Every [`Record`] belongs to exactly one stream, addressed by its owning [`HostId`] and its
-/// [`RecordTag`]; a record's [`RecordIdx`] is only unique *within* one such stream. This pair
-/// travels together through nearly every record-store and sync API, so we give it a name rather
-/// than threading `(HostId, RecordTag)` as two separate arguments everywhere.
+/// The composite key identifying record WAL journal uniqueness.
 #[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub struct RecordSeriesKey {
     pub host: HostId,

--- a/crates/atuin-domain/src/record/mod.rs
+++ b/crates/atuin-domain/src/record/mod.rs
@@ -18,8 +18,7 @@ pub struct DecryptedData(pub Vec<u8>);
 
 #[derive(Debug, PartialEq, PartialOrd, Ord, Eq)]
 pub struct Diff {
-    pub host: HostId,
-    pub tag: RecordTag,
+    pub series: RecordSeriesKey,
     pub local: Option<RecordIdx>,
     pub remote: Option<RecordIdx>,
 }
@@ -71,6 +70,31 @@ new_uuid!(HostId);
 
 pub type RecordIdx = u64;
 
+/// The composite key identifying a single append-only record stream.
+///
+/// Every [`Record`] belongs to exactly one stream, addressed by its owning [`HostId`] and its
+/// [`RecordTag`]; a record's [`RecordIdx`] is only unique *within* one such stream. This pair
+/// travels together through nearly every record-store and sync API, so we give it a name rather
+/// than threading `(HostId, RecordTag)` as two separate arguments everywhere.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub struct RecordSeriesKey {
+    pub host: HostId,
+    pub tag: RecordTag,
+}
+
+impl RecordSeriesKey {
+    #[must_use]
+    pub fn new(host: HostId, tag: RecordTag) -> Self {
+        Self { host, tag }
+    }
+}
+
+impl From<(HostId, RecordTag)> for RecordSeriesKey {
+    fn from((host, tag): (HostId, RecordTag)) -> Self {
+        Self { host, tag }
+    }
+}
+
 /// A single record stored inside of our local database
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, TypedBuilder)]
 pub struct Record<Data> {
@@ -103,6 +127,15 @@ pub struct Record<Data> {
 }
 
 impl<Data> Record<Data> {
+    /// The [`RecordSeriesKey`] of the append-only stream this record belongs to.
+    #[must_use]
+    pub fn series_key(&self) -> RecordSeriesKey {
+        RecordSeriesKey {
+            host: self.host.id,
+            tag: self.tag.clone(),
+        }
+    }
+
     pub fn append(&self, data: Vec<u8>) -> Record<DecryptedData> {
         Record::builder()
             .host(self.host.clone())
@@ -187,10 +220,10 @@ impl Default for RecordStatus {
     }
 }
 
-impl Extend<(HostId, RecordTag, RecordIdx)> for RecordStatus {
-    fn extend<T: IntoIterator<Item = (HostId, RecordTag, RecordIdx)>>(&mut self, iter: T) {
-        for (host, tag, tail_idx) in iter {
-            self.set_raw(host, tag, tail_idx);
+impl Extend<(RecordSeriesKey, RecordIdx)> for RecordStatus {
+    fn extend<T: IntoIterator<Item = (RecordSeriesKey, RecordIdx)>>(&mut self, iter: T) {
+        for (series, tail_idx) in iter {
+            self.set_raw(series, tail_idx);
         }
     }
 }
@@ -204,15 +237,16 @@ impl RecordStatus {
 
     /// Insert a new tail record into the store
     pub fn set(&mut self, tail: Record<DecryptedData>) {
-        self.set_raw(tail.host.id, tail.tag, tail.idx)
+        self.set_raw((tail.host.id, tail.tag).into(), tail.idx)
     }
 
-    pub fn set_raw(&mut self, host: HostId, tag: RecordTag, tail_id: RecordIdx) {
-        self.hosts.entry(host).or_default().insert(tag, tail_id);
+    pub fn set_raw(&mut self, series: RecordSeriesKey, tail_id: RecordIdx) {
+        self.hosts.entry(series.host).or_default().insert(series.tag, tail_id);
     }
 
-    pub fn get(&self, host: HostId, tag: &RecordTag) -> Option<RecordIdx> {
-        self.hosts.get(&host).and_then(|v| v.get(tag)).copied()
+    #[must_use]
+    pub fn get(&self, series: &RecordSeriesKey) -> Option<RecordIdx> {
+        self.hosts.get(&series.host).and_then(|v| v.get(&series.tag)).copied()
     }
 
     /// Diff this index with another, likely remote index.
@@ -228,22 +262,20 @@ impl RecordStatus {
         // First, we check if other has everything that self has
         for (host, tag_map) in &self.hosts {
             for (tag, idx) in tag_map {
-                match other.get(*host, tag) {
+                match other.hosts.get(host).and_then(|m| m.get(tag)).copied() {
                     // The other store is all up to date! No diff.
                     Some(t) if t.eq(idx) => continue,
 
                     // The other store does exist, and it is either ahead or behind us. A diff regardless
                     Some(t) => ret.push(Diff {
-                        host: *host,
-                        tag: tag.clone(),
+                        series: (*host, tag.clone()).into(),
                         local: Some(*idx),
                         remote: Some(t),
                     }),
 
                     // The other store does not exist :O
                     None => ret.push(Diff {
-                        host: *host,
-                        tag: tag.clone(),
+                        series: (*host, tag.clone()).into(),
                         local: Some(*idx),
                         remote: None,
                     }),
@@ -257,17 +289,16 @@ impl RecordStatus {
         // account for that!
         for (host, tag_map) in &other.hosts {
             for (tag, idx) in tag_map {
-                match self.get(*host, tag) {
-                    // If we have this host/tag combo, the comparison and diff will have already happened above
-                    Some(_) => continue,
+                // If we have this host/tag combo, the comparison and diff will have already happened above
+                if self.hosts.get(host).is_some_and(|m| m.contains_key(tag)) {
+                    continue;
+                }
 
-                    None => ret.push(Diff {
-                        host: *host,
-                        tag: tag.clone(),
-                        remote: Some(*idx),
-                        local: None,
-                    }),
-                };
+                ret.push(Diff {
+                    series: (*host, tag.clone()).into(),
+                    remote: Some(*idx),
+                    local: None,
+                });
             }
         }
 
@@ -372,7 +403,7 @@ mod tests {
 
         index.set(record.clone());
 
-        let tail = index.get(record.host.id, &record.tag);
+        let tail = index.get(&record.series_key());
 
         assert_eq!(record.idx, tail.expect("tail not in store"), "tail in store did not match");
     }
@@ -385,7 +416,7 @@ mod tests {
         index.set(record.clone());
         index.set(child.clone());
 
-        let tail = index.get(record.host.id, &record.tag);
+        let tail = index.get(&record.series_key());
 
         assert_eq!(child.idx, tail.expect("tail not in store"), "tail in store did not match");
     }
@@ -421,8 +452,7 @@ mod tests {
 
         assert_eq!(1, diff.len(), "expected single diff");
         assert_eq!(diff[0], Diff {
-            host: record2.host.id,
-            tag: record2.tag,
+            series: record2.series_key(),
             remote: Some(1),
             local: Some(0)
         });
@@ -468,9 +498,9 @@ mod tests {
         // both diffs should be ALMOST the same. They will agree on which hosts and tags
         // require updating, but the "other" value will not be the same.
         let smol_diff_1: Vec<(HostId, RecordTag)> =
-            diff1.iter().map(|v| (v.host, v.tag.clone())).collect();
+            diff1.iter().map(|v| (v.series.host, v.series.tag.clone())).collect();
         let smol_diff_2: Vec<(HostId, RecordTag)> =
-            diff1.iter().map(|v| (v.host, v.tag.clone())).collect();
+            diff1.iter().map(|v| (v.series.host, v.series.tag.clone())).collect();
 
         assert_eq!(smol_diff_1, smol_diff_2);
 
@@ -687,8 +717,8 @@ mod tests {
     fn record_status_serializes_with_bare_string_tag_keys() {
         let host = HostId(Uuid::from_u128(0xabc));
         let mut status = RecordStatus::new();
-        status.set_raw(host, RecordTag::History, 6);
-        status.set_raw(host, RecordTag::Other("custom".to_owned()), 2);
+        status.set_raw((host, RecordTag::History).into(), 6);
+        status.set_raw((host, RecordTag::Other("custom".to_owned())).into(), 2);
 
         let json = serde_json::to_string(&status).unwrap();
         // Tag keys are bare strings, identical to the pre-refactor String-keyed shape.
@@ -696,8 +726,8 @@ mod tests {
         assert!(json.contains(r#""custom":2"#), "got {json}");
 
         let round: RecordStatus = serde_json::from_str(&json).unwrap();
-        assert_eq!(round.get(host, &RecordTag::History), Some(6));
-        assert_eq!(round.get(host, &RecordTag::Other("custom".to_owned())), Some(2));
+        assert_eq!(round.get(&(host, RecordTag::History).into()), Some(6));
+        assert_eq!(round.get(&(host, RecordTag::Other("custom".to_owned())).into()), Some(2));
     }
 
     /// Do *not* modify this test if it fails! It means the serialization of [`AdditionalData`]

--- a/crates/atuin-dotfiles/src/store.rs
+++ b/crates/atuin-dotfiles/src/store.rs
@@ -225,7 +225,7 @@ impl AliasStore {
 
         let idx = self
             .store
-            .last(self.host_id, &RecordTag::ConfigShellAlias)
+            .last(&(self.host_id, RecordTag::ConfigShellAlias).into())
             .await?
             .map_or(0, |entry| entry.idx + 1);
 
@@ -259,7 +259,7 @@ impl AliasStore {
 
         let idx = self
             .store
-            .last(self.host_id, &RecordTag::ConfigShellAlias)
+            .last(&(self.host_id, RecordTag::ConfigShellAlias).into())
             .await?
             .map_or(0, |entry| entry.idx + 1);
 

--- a/crates/atuin-dotfiles/src/store.rs
+++ b/crates/atuin-dotfiles/src/store.rs
@@ -7,7 +7,9 @@ use atuin_common::encryption::paseto_v4;
 // While we will support a range of shell config, I'd rather have a larger number of small records
 // + stores, rather than one mega config store.
 use atuin_common::utils::unquote;
-use atuin_domain::record::{DecryptedData, Host, HostId, RecordTag, RecordVersion};
+use atuin_domain::record::{
+    DecryptedData, Host, HostId, RecordSeriesKey, RecordTag, RecordVersion,
+};
 use eyre::{Result, bail, ensure, eyre};
 
 use crate::shell::Alias;
@@ -225,7 +227,7 @@ impl AliasStore {
 
         let idx = self
             .store
-            .last(&(self.host_id, RecordTag::ConfigShellAlias).into())
+            .last(&RecordSeriesKey::new(self.host_id, RecordTag::ConfigShellAlias))
             .await?
             .map_or(0, |entry| entry.idx + 1);
 
@@ -259,7 +261,7 @@ impl AliasStore {
 
         let idx = self
             .store
-            .last(&(self.host_id, RecordTag::ConfigShellAlias).into())
+            .last(&RecordSeriesKey::new(self.host_id, RecordTag::ConfigShellAlias))
             .await?
             .map_or(0, |entry| entry.idx + 1);
 

--- a/crates/atuin-dotfiles/src/store/var.rs
+++ b/crates/atuin-dotfiles/src/store/var.rs
@@ -6,7 +6,9 @@ use std::collections::BTreeMap;
 
 use atuin_client::record::sqlite_store::SqliteStore;
 use atuin_common::encryption::paseto_v4;
-use atuin_domain::record::{DecryptedData, Host, HostId, RecordTag, RecordVersion};
+use atuin_domain::record::{
+    DecryptedData, Host, HostId, RecordSeriesKey, RecordTag, RecordVersion,
+};
 use eyre::{Result, bail, ensure, eyre};
 
 use crate::shell::Var;
@@ -272,7 +274,7 @@ impl VarStore {
 
         let idx = self
             .store
-            .last(&(self.host_id, RecordTag::DotfilesVar).into())
+            .last(&RecordSeriesKey::new(self.host_id, RecordTag::DotfilesVar))
             .await?
             .map_or(0, |entry| entry.idx + 1);
 
@@ -303,7 +305,7 @@ impl VarStore {
 
         let idx = self
             .store
-            .last(&(self.host_id, RecordTag::DotfilesVar).into())
+            .last(&RecordSeriesKey::new(self.host_id, RecordTag::DotfilesVar))
             .await?
             .map_or(0, |entry| entry.idx + 1);
 

--- a/crates/atuin-dotfiles/src/store/var.rs
+++ b/crates/atuin-dotfiles/src/store/var.rs
@@ -272,7 +272,7 @@ impl VarStore {
 
         let idx = self
             .store
-            .last(self.host_id, &RecordTag::DotfilesVar)
+            .last(&(self.host_id, RecordTag::DotfilesVar).into())
             .await?
             .map_or(0, |entry| entry.idx + 1);
 
@@ -303,7 +303,7 @@ impl VarStore {
 
         let idx = self
             .store
-            .last(self.host_id, &RecordTag::DotfilesVar)
+            .last(&(self.host_id, RecordTag::DotfilesVar).into())
             .await?
             .map_or(0, |entry| entry.idx + 1);
 

--- a/crates/atuin-kv/src/store.rs
+++ b/crates/atuin-kv/src/store.rs
@@ -2,7 +2,9 @@ use std::collections::HashSet;
 
 use atuin_client::record::sqlite_store::SqliteStore;
 use atuin_common::encryption::paseto_v4;
-use atuin_domain::record::{Host, HostId, Record, RecordId, RecordIdx, RecordTag, RecordVersion};
+use atuin_domain::record::{
+    Host, HostId, Record, RecordId, RecordIdx, RecordSeriesKey, RecordTag, RecordVersion,
+};
 use entry::KvEntry;
 use eyre::{Result, eyre};
 use record::KvRecord;
@@ -85,7 +87,7 @@ impl KvStore {
         let bytes = record.serialize()?;
         let idx = self
             .record_store
-            .last(&(self.host_id, RecordTag::Kv).into())
+            .last(&RecordSeriesKey::new(self.host_id, RecordTag::Kv))
             .await?
             .map_or(0, |p| p.idx + 1);
 

--- a/crates/atuin-kv/src/store.rs
+++ b/crates/atuin-kv/src/store.rs
@@ -2,7 +2,9 @@ use std::collections::HashSet;
 
 use atuin_client::record::sqlite_store::SqliteStore;
 use atuin_common::encryption::paseto_v4;
-use atuin_domain::record::{Host, HostId, Record, RecordId, RecordIdx, RecordTag, RecordVersion};
+use atuin_domain::record::{
+    Host, HostId, Record, RecordId, RecordIdx, RecordTag, RecordVersion,
+};
 use entry::KvEntry;
 use eyre::{Result, eyre};
 use record::KvRecord;
@@ -84,7 +86,10 @@ impl KvStore {
     async fn push_record(&self, record: KvRecord) -> Result<(RecordId, RecordIdx)> {
         let bytes = record.serialize()?;
         let idx =
-            self.record_store.last(self.host_id, &RecordTag::Kv).await?.map_or(0, |p| p.idx + 1);
+            self.record_store
+                .last(&(self.host_id, RecordTag::Kv).into())
+                .await?
+                .map_or(0, |p| p.idx + 1);
 
         let record = Record::builder()
             .host(Host::new(self.host_id))

--- a/crates/atuin-kv/src/store.rs
+++ b/crates/atuin-kv/src/store.rs
@@ -2,9 +2,7 @@ use std::collections::HashSet;
 
 use atuin_client::record::sqlite_store::SqliteStore;
 use atuin_common::encryption::paseto_v4;
-use atuin_domain::record::{
-    Host, HostId, Record, RecordId, RecordIdx, RecordTag, RecordVersion,
-};
+use atuin_domain::record::{Host, HostId, Record, RecordId, RecordIdx, RecordTag, RecordVersion};
 use entry::KvEntry;
 use eyre::{Result, eyre};
 use record::KvRecord;
@@ -85,11 +83,11 @@ impl KvStore {
 
     async fn push_record(&self, record: KvRecord) -> Result<(RecordId, RecordIdx)> {
         let bytes = record.serialize()?;
-        let idx =
-            self.record_store
-                .last(&(self.host_id, RecordTag::Kv).into())
-                .await?
-                .map_or(0, |p| p.idx + 1);
+        let idx = self
+            .record_store
+            .last(&(self.host_id, RecordTag::Kv).into())
+            .await?
+            .map_or(0, |p| p.idx + 1);
 
         let record = Record::builder()
             .host(Host::new(self.host_id))

--- a/crates/atuin-scripts/src/store.rs
+++ b/crates/atuin-scripts/src/store.rs
@@ -1,6 +1,8 @@
 use atuin_client::record::sqlite_store::SqliteStore;
 use atuin_common::encryption::paseto_v4;
-use atuin_domain::record::{Host, HostId, Record, RecordId, RecordIdx, RecordTag, RecordVersion};
+use atuin_domain::record::{
+    Host, HostId, Record, RecordId, RecordIdx, RecordTag, RecordVersion,
+};
 use eyre::{Result, eyre};
 use record::ScriptRecord;
 use script::Script;
@@ -28,7 +30,11 @@ impl ScriptStore {
 
     async fn push_record(&self, record: ScriptRecord) -> Result<(RecordId, RecordIdx)> {
         let bytes = record.serialize()?;
-        let idx = self.store.last(self.host_id, &RecordTag::Script).await?.map_or(0, |p| p.idx + 1);
+        let idx = self
+            .store
+            .last(&(self.host_id, RecordTag::Script).into())
+            .await?
+            .map_or(0, |p| p.idx + 1);
 
         let record = Record::builder()
             .host(Host::new(self.host_id))

--- a/crates/atuin-scripts/src/store.rs
+++ b/crates/atuin-scripts/src/store.rs
@@ -1,8 +1,6 @@
 use atuin_client::record::sqlite_store::SqliteStore;
 use atuin_common::encryption::paseto_v4;
-use atuin_domain::record::{
-    Host, HostId, Record, RecordId, RecordIdx, RecordTag, RecordVersion,
-};
+use atuin_domain::record::{Host, HostId, Record, RecordId, RecordIdx, RecordTag, RecordVersion};
 use eyre::{Result, eyre};
 use record::ScriptRecord;
 use script::Script;

--- a/crates/atuin-scripts/src/store.rs
+++ b/crates/atuin-scripts/src/store.rs
@@ -1,6 +1,8 @@
 use atuin_client::record::sqlite_store::SqliteStore;
 use atuin_common::encryption::paseto_v4;
-use atuin_domain::record::{Host, HostId, Record, RecordId, RecordIdx, RecordTag, RecordVersion};
+use atuin_domain::record::{
+    Host, HostId, Record, RecordId, RecordIdx, RecordSeriesKey, RecordTag, RecordVersion,
+};
 use eyre::{Result, eyre};
 use record::ScriptRecord;
 use script::Script;
@@ -30,7 +32,7 @@ impl ScriptStore {
         let bytes = record.serialize()?;
         let idx = self
             .store
-            .last(&(self.host_id, RecordTag::Script).into())
+            .last(&RecordSeriesKey::new(self.host_id, RecordTag::Script))
             .await?
             .map_or(0, |p| p.idx + 1);
 

--- a/crates/atuin-server-database/src/lib.rs
+++ b/crates/atuin-server-database/src/lib.rs
@@ -5,7 +5,7 @@ pub mod models;
 use std::fmt::Debug;
 
 use async_trait::async_trait;
-use atuin_domain::record::{EncryptedData, HostId, Record, RecordIdx, RecordStatus, RecordTag};
+use atuin_domain::record::{EncryptedData, Record, RecordIdx, RecordSeriesKey, RecordStatus};
 use serde::{Deserialize, Serialize};
 
 use self::models::{NewSession, NewUser, Session, User};
@@ -105,8 +105,7 @@ pub trait Database: Sized + Clone + Send + Sync + 'static {
     async fn next_records(
         &self,
         user: &User,
-        host: HostId,
-        tag: RecordTag,
+        series: &RecordSeriesKey,
         start: Option<RecordIdx>,
         count: u64,
     ) -> DbResult<Vec<Record<EncryptedData>>>;

--- a/crates/atuin-server-postgres/src/lib.rs
+++ b/crates/atuin-server-postgres/src/lib.rs
@@ -380,7 +380,10 @@ impl Database for Postgres {
         let mut status = RecordStatus::new();
 
         for i in &res {
-            status.set_raw((HostId(i.0), RecordTag::from(i.1.clone())).into(), i.2 as u64);
+            status.set_raw(
+                RecordSeriesKey::new(HostId(i.0), RecordTag::from(i.1.clone())),
+                i.2 as u64,
+            );
         }
 
         Ok(status)

--- a/crates/atuin-server-postgres/src/lib.rs
+++ b/crates/atuin-server-postgres/src/lib.rs
@@ -1,7 +1,9 @@
 use std::collections::HashMap;
 
 use async_trait::async_trait;
-use atuin_domain::record::{EncryptedData, HostId, Record, RecordIdx, RecordStatus, RecordTag};
+use atuin_domain::record::{
+    EncryptedData, HostId, Record, RecordIdx, RecordSeriesKey, RecordStatus, RecordTag,
+};
 use atuin_server_database::models::{NewSession, NewUser, Session, User};
 use atuin_server_database::{Database, DbError, DbResult, DbSettings};
 use rand::Rng;
@@ -301,12 +303,11 @@ impl Database for Postgres {
     async fn next_records(
         &self,
         user: &User,
-        host: HostId,
-        tag: RecordTag,
+        series: &RecordSeriesKey,
         start: Option<RecordIdx>,
         count: u64,
     ) -> DbResult<Vec<Record<EncryptedData>>> {
-        tracing::debug!("{:?} - {:?} - {:?}", host, tag, start);
+        tracing::debug!("{:?} - {:?} - {:?}", series.host, series.tag, start);
         let start = start.unwrap_or(0);
 
         let records: Result<Vec<DbRecord>, DbError> = sqlx::query_as(
@@ -319,8 +320,8 @@ impl Database for Postgres {
                     limit $5",
         )
         .bind(user.id)
-        .bind(tag.as_str())
-        .bind(host)
+        .bind(series.tag.as_str())
+        .bind(series.host)
         .bind(start as i64)
         .bind(count as i64)
         .fetch_all(self.read_pool())
@@ -340,7 +341,7 @@ impl Database for Postgres {
                 records
             }
             Err(DbError::NotFound) => {
-                tracing::debug!("no records found in store: {:?}/{}", host, tag);
+                tracing::debug!("no records found in store: {:?}/{}", series.host, series.tag);
                 return Ok(vec![]);
             }
             Err(e) => return Err(e),
@@ -379,7 +380,7 @@ impl Database for Postgres {
         let mut status = RecordStatus::new();
 
         for i in &res {
-            status.set_raw(HostId(i.0), RecordTag::from(i.1.clone()), i.2 as u64);
+            status.set_raw((HostId(i.0), RecordTag::from(i.1.clone())).into(), i.2 as u64);
         }
 
         Ok(status)

--- a/crates/atuin-server-sqlite/src/lib.rs
+++ b/crates/atuin-server-sqlite/src/lib.rs
@@ -1,7 +1,9 @@
 use std::str::FromStr;
 
 use async_trait::async_trait;
-use atuin_domain::record::{EncryptedData, HostId, Record, RecordIdx, RecordStatus, RecordTag};
+use atuin_domain::record::{
+    EncryptedData, HostId, Record, RecordIdx, RecordSeriesKey, RecordStatus, RecordTag,
+};
 use atuin_server_database::models::{NewSession, NewUser, Session, User};
 use atuin_server_database::{Database, DbError, DbResult, DbSettings};
 use sqlx::sqlite::{SqliteConnectOptions, SqliteJournalMode, SqlitePoolOptions};
@@ -193,12 +195,11 @@ impl Database for Sqlite {
     async fn next_records(
         &self,
         user: &User,
-        host: HostId,
-        tag: RecordTag,
+        series: &RecordSeriesKey,
         start: Option<RecordIdx>,
         count: u64,
     ) -> DbResult<Vec<Record<EncryptedData>>> {
-        tracing::debug!("{:?} - {:?} - {:?}", host, tag, start);
+        tracing::debug!("{:?} - {:?} - {:?}", series.host, series.tag, start);
         let start = start.unwrap_or(0);
 
         let records: Result<Vec<DbRecord>, DbError> = sqlx::query_as(
@@ -211,8 +212,8 @@ impl Database for Sqlite {
                     limit $5",
         )
         .bind(user.id)
-        .bind(tag.as_str())
-        .bind(host)
+        .bind(series.tag.as_str())
+        .bind(series.host)
         .bind(start as i64)
         .bind(count as i64)
         .fetch_all(&self.pool)
@@ -232,7 +233,7 @@ impl Database for Sqlite {
                 records
             }
             Err(DbError::NotFound) => {
-                tracing::debug!("no records found in store: {:?}/{}", host, tag);
+                tracing::debug!("no records found in store: {:?}/{}", series.host, series.tag);
                 return Ok(vec![]);
             }
             Err(e) => return Err(e),
@@ -251,7 +252,7 @@ impl Database for Sqlite {
         let mut status = RecordStatus::new();
 
         for i in res {
-            status.set_raw(HostId(i.0), RecordTag::from(i.1), i.2 as u64);
+            status.set_raw((HostId(i.0), RecordTag::from(i.1)).into(), i.2 as u64);
         }
 
         Ok(status)

--- a/crates/atuin-server-sqlite/src/lib.rs
+++ b/crates/atuin-server-sqlite/src/lib.rs
@@ -252,7 +252,7 @@ impl Database for Sqlite {
         let mut status = RecordStatus::new();
 
         for i in res {
-            status.set_raw((HostId(i.0), RecordTag::from(i.1)).into(), i.2 as u64);
+            status.set_raw(RecordSeriesKey::new(HostId(i.0), RecordTag::from(i.1)), i.2 as u64);
         }
 
         Ok(status)

--- a/crates/atuin-server/src/handlers/v0/record.rs
+++ b/crates/atuin-server/src/handlers/v0/record.rs
@@ -1,4 +1,6 @@
-use atuin_domain::record::{EncryptedData, HostId, Record, RecordIdx, RecordStatus, RecordTag};
+use atuin_domain::record::{
+    EncryptedData, HostId, Record, RecordIdx, RecordSeriesKey, RecordStatus, RecordTag,
+};
 use atuin_server_database::Database;
 use axum::Json;
 use axum::extract::{Query, State};
@@ -83,9 +85,10 @@ pub async fn next<DB: Database>(
 ) -> Result<Json<Vec<Record<EncryptedData>>>, ErrorResponseStatus<'static>> {
     let State(AppState { database, .. }) = state;
     let params = params.0;
+    let series = RecordSeriesKey::new(params.host, params.tag);
 
     let records = match database
-        .next_records(&user, params.host, params.tag, params.start, params.count)
+        .next_records(&user, &series, params.start, params.count)
         .await
     {
         Ok(records) => records,

--- a/crates/atuin-server/src/handlers/v0/record.rs
+++ b/crates/atuin-server/src/handlers/v0/record.rs
@@ -87,10 +87,7 @@ pub async fn next<DB: Database>(
     let params = params.0;
     let series = RecordSeriesKey::new(params.host, params.tag);
 
-    let records = match database
-        .next_records(&user, &series, params.start, params.count)
-        .await
-    {
+    let records = match database.next_records(&user, &series, params.start, params.count).await {
         Ok(records) => records,
         Err(e) => {
             error!("failed to get record index: {}", e);

--- a/crates/atuin/src/command/client/store.rs
+++ b/crates/atuin/src/command/client/store.rs
@@ -2,6 +2,7 @@ use atuin_client::database::Sqlite;
 use atuin_client::record::sqlite_store::SqliteStore;
 use atuin_client::settings::Settings;
 use atuin_common::time::{OffsetDateTimeExt, UtcOffsetExt};
+use atuin_domain::record::RecordSeriesKey;
 use clap::Subcommand;
 use eyre::Result;
 use itertools::Itertools;
@@ -88,8 +89,9 @@ impl Cmd {
             for (tag, idx) in st.iter().sorted_by_key(|(tag, _)| *tag) {
                 println!("\tstore: {tag}");
 
-                let first = store.first(*host, tag).await?;
-                let last = store.last(*host, tag).await?;
+                let series = RecordSeriesKey::new(*host, tag.clone());
+                let first = store.first(&series).await?;
+                let last = store.last(&series).await?;
 
                 println!("\t\tidx: {idx}");
 

--- a/crates/atuin/src/command/client/store/pull.rs
+++ b/crates/atuin/src/command/client/store/pull.rs
@@ -63,13 +63,13 @@ impl Pull {
                 Operation::Noop { .. } | Operation::Upload { .. } => false,
 
                 // pull, so yes plz to downloads!
-                Operation::Download { tag, .. } => {
+                Operation::Download { series, .. } => {
                     if self.force {
                         return true;
                     }
 
                     if let Some(t) = self.tag.clone()
-                        && t != *tag
+                        && t != series.tag
                     {
                         return false;
                     }

--- a/crates/atuin/src/command/client/store/push.rs
+++ b/crates/atuin/src/command/client/store/push.rs
@@ -86,21 +86,21 @@ impl Push {
                 Operation::Noop { .. } | Operation::Download { .. } => false,
 
                 // push, so yes plz to uploads!
-                Operation::Upload { host, tag, .. } => {
+                Operation::Upload { series, .. } => {
                     if self.force {
                         return true;
                     }
 
                     if let Some(h) = self.host {
-                        if HostId(h) != *host {
+                        if HostId(h) != series.host {
                             return false;
                         }
-                    } else if *host != host_id {
+                    } else if series.host != host_id {
                         return false;
                     }
 
                     if let Some(t) = self.tag.clone()
-                        && t != *tag
+                        && t != series.tag
                     {
                         return false;
                     }

--- a/crates/tests-database/tests/db_story.rs
+++ b/crates/tests-database/tests/db_story.rs
@@ -1,5 +1,7 @@
 use atuin_common::utils::{crypto_random_string, uuid_v7};
-use atuin_domain::record::{EncryptedData, Host, HostId, Record, RecordIdx, RecordTag};
+use atuin_domain::record::{
+    EncryptedData, Host, HostId, Record, RecordIdx, RecordTag,
+};
 use atuin_server_database::models::{NewSession, NewUser, User};
 use atuin_server_database::{Database, DbSettings, DbType};
 use atuin_server_postgres::Postgres;
@@ -110,20 +112,20 @@ async fn run_the_test<DB: Database>(settings: &DbSettings) -> eyre::Result<()> {
     assert_eq!(status.hosts.get(&host_b.id).unwrap().get(&RecordTag::History).unwrap().clone(), 2);
 
     // Get 3 records from the beginning
-    let recs = db.next_records(&user, host_a.id, RecordTag::History, None, 3).await?;
+    let recs = db.next_records(&user, &(host_a.id, RecordTag::History).into(), None, 3).await?;
     assert_eq!(recs.len(), 3);
     assert_eq!(recs[0].idx, 1);
     assert_eq!(recs.last().unwrap().idx, 3);
 
     // Get from the end, for host a. Get more than exists
-    let recs = db.next_records(&user, host_a.id, RecordTag::History, Some(4), 10).await?;
+    let recs = db.next_records(&user, &(host_a.id, RecordTag::History).into(), Some(4), 10).await?;
     assert_eq!(recs.len(), 3);
     assert_eq!(recs[0].idx, 4); // check the head record is idx 4
     assert_eq!(recs.last().unwrap().idx, 6);
 
     // delete_store
     db.delete_store(&user).await?;
-    let recs = db.next_records(&user, host_a.id, RecordTag::History, Some(4), 10).await?;
+    let recs = db.next_records(&user, &(host_a.id, RecordTag::History).into(), Some(4), 10).await?;
     assert_eq!(recs.len(), 0);
 
     Ok(())

--- a/crates/tests-database/tests/db_story.rs
+++ b/crates/tests-database/tests/db_story.rs
@@ -1,7 +1,5 @@
 use atuin_common::utils::{crypto_random_string, uuid_v7};
-use atuin_domain::record::{
-    EncryptedData, Host, HostId, Record, RecordIdx, RecordTag,
-};
+use atuin_domain::record::{EncryptedData, Host, HostId, Record, RecordIdx, RecordTag};
 use atuin_server_database::models::{NewSession, NewUser, User};
 use atuin_server_database::{Database, DbSettings, DbType};
 use atuin_server_postgres::Postgres;

--- a/crates/tests-database/tests/db_story.rs
+++ b/crates/tests-database/tests/db_story.rs
@@ -1,5 +1,7 @@
 use atuin_common::utils::{crypto_random_string, uuid_v7};
-use atuin_domain::record::{EncryptedData, Host, HostId, Record, RecordIdx, RecordTag};
+use atuin_domain::record::{
+    EncryptedData, Host, HostId, Record, RecordIdx, RecordSeriesKey, RecordTag,
+};
 use atuin_server_database::models::{NewSession, NewUser, User};
 use atuin_server_database::{Database, DbSettings, DbType};
 use atuin_server_postgres::Postgres;
@@ -110,20 +112,26 @@ async fn run_the_test<DB: Database>(settings: &DbSettings) -> eyre::Result<()> {
     assert_eq!(status.hosts.get(&host_b.id).unwrap().get(&RecordTag::History).unwrap().clone(), 2);
 
     // Get 3 records from the beginning
-    let recs = db.next_records(&user, &(host_a.id, RecordTag::History).into(), None, 3).await?;
+    let recs = db
+        .next_records(&user, &RecordSeriesKey::new(host_a.id, RecordTag::History), None, 3)
+        .await?;
     assert_eq!(recs.len(), 3);
     assert_eq!(recs[0].idx, 1);
     assert_eq!(recs.last().unwrap().idx, 3);
 
     // Get from the end, for host a. Get more than exists
-    let recs = db.next_records(&user, &(host_a.id, RecordTag::History).into(), Some(4), 10).await?;
+    let recs = db
+        .next_records(&user, &RecordSeriesKey::new(host_a.id, RecordTag::History), Some(4), 10)
+        .await?;
     assert_eq!(recs.len(), 3);
     assert_eq!(recs[0].idx, 4); // check the head record is idx 4
     assert_eq!(recs.last().unwrap().idx, 6);
 
     // delete_store
     db.delete_store(&user).await?;
-    let recs = db.next_records(&user, &(host_a.id, RecordTag::History).into(), Some(4), 10).await?;
+    let recs = db
+        .next_records(&user, &RecordSeriesKey::new(host_a.id, RecordTag::History), Some(4), 10)
+        .await?;
     assert_eq!(recs.len(), 0);
 
     Ok(())


### PR DESCRIPTION
Introduces a `RecordSeriesKey`, which is a struct which uniquely identifies the `(tag, host)` pair we historically had.

This new type semantically conveys what the old loose types did.

Benefits:
- Functions that needed `2` args now only need one.
- Semantic meaning is verbosely conserved.
- Type safety is always good.