### PR TITLE
refactor(sync): introduce SyncEngine to hold shared sync state

### DIFF
--- a/crates/atuin-client/src/api_client.rs
+++ b/crates/atuin-client/src/api_client.rs
@@ -48,6 +48,7 @@ impl AuthToken {
     }
 }
 
+#[derive(Clone)]
 pub struct Client {
     sync_addr: Arc<Url>,
     client: ClientWithMiddleware,

--- a/crates/atuin-client/src/packfile/mod.rs
+++ b/crates/atuin-client/src/packfile/mod.rs
@@ -86,9 +86,8 @@
 //!
 //! ### Uploading
 //!
-//! During the uploading loop in [`crate::record::sync`], when we find the packed record, we invoke
-//! the [`sync::upload_packed`] procedure, which is responsible for performing the actual packing
-//! and uploading payload.
+//! During the uploading loop in [`crate::record::sync`], when we find the packed record, the sync
+//! engine performs the actual packing and uploading of the payload.
 //!
 //! This operation will open up the manifest in the packfile, read the `"start"` and `"end"` values,
 //! and scan the record table for these entries. For each of these entries, it will decrypt them,
@@ -98,18 +97,15 @@
 //! ### Downloading
 //!
 //! During the downloading loop in [`crate::record::sync`], when we find a remote `packfile`
-//! manifest record, we invoke [`sync::download_packed`], which is responsible for turning that
-//! manifest back into local `history` records.
+//! manifest record, the sync engine turns that manifest back into local `history` records.
 //!
 //! This operation asks the server for the packfile's presigned download URL, fetches the packfile,
 //! unpacks it (via `PackManifestRecordView::unpack_records`) back into the individual history
 //! records for the manifest's `"start".."end"` range, re-encrypts each one with the local key, and
 //! pushes them into the local record store.
 mod packer;
-mod record;
-mod sync;
+pub(crate) mod record;
 
 pub use packer::{PackingError, try_pack};
 #[cfg(test)]
 pub(crate) use record::PackManifestRecordView;
-pub use sync::{DownloadError, UploadError, download_packed, upload_packed};

--- a/crates/atuin-client/src/packfile/record.rs
+++ b/crates/atuin-client/src/packfile/record.rs
@@ -191,6 +191,8 @@ pub enum PackError {
     Decrypt(eyre::Report),
     #[error("failed to serialize the records: {0}")]
     Serialize(#[from] EncodeError),
+    // Never constructed today; kept as a documented guard for the record-count invariant.
+    #[allow(dead_code)]
     #[error("the record run yielded a different number of records than it reported")]
     BadLength,
     #[error("failed to compress the packfile: {0}")]

--- a/crates/atuin-client/src/packfile/record.rs
+++ b/crates/atuin-client/src/packfile/record.rs
@@ -191,10 +191,6 @@ pub enum PackError {
     Decrypt(eyre::Report),
     #[error("failed to serialize the records: {0}")]
     Serialize(#[from] EncodeError),
-    // Never constructed today; kept as a documented guard for the record-count invariant.
-    #[allow(dead_code)]
-    #[error("the record run yielded a different number of records than it reported")]
-    BadLength,
     #[error("failed to compress the packfile: {0}")]
     Compress(#[from] std::io::Error),
     #[error("failed to encrypt the packfile: {0}")]

--- a/crates/atuin-client/src/record/sync.rs
+++ b/crates/atuin-client/src/record/sync.rs
@@ -74,444 +74,460 @@ pub enum Operation {
     },
 }
 
-#[instrument(level = "trace", skip_all, err)]
-pub async fn build_client_with_caps(
-    settings: &Settings,
-    caps: Arc<CapClient>,
-) -> Result<Client, SyncError> {
-    Client::new(
-        settings.sync_address.clone(),
-        &settings
-            .sync_auth_token()
-            .await
-            .map_err(|e| SyncError::RemoteRequestError { msg: e.to_string() })?,
-        settings.network_connect_timeout,
-        settings.network_timeout,
-        &settings.extra_headers,
-        caps,
-    )
-    .map_err(|e| SyncError::OperationalError { msg: e.to_string() })
+/// Stateful driver for a sync session.
+///
+/// Historically the sync logic was a bag of free functions that threaded the same trio of values
+/// -- the API `client`, the local `store`, and the encryption `key` -- through every call. The
+/// engine owns that shared state so the individual steps (`diff`, `operations`, `sync_remote`,
+/// `check_encryption_key`, ...) become methods that no longer have to pass it around.
+///
+/// The `client` is owned; `store` and `key` are borrowed for the lifetime of the session so the
+/// signatures line up with the borrow-based callers that build them.
+pub struct SyncEngine<'a> {
+    client: Client,
+    store: &'a SqliteStore,
+    key: &'a paseto_v4::Key,
 }
 
-#[instrument(level = "trace", skip_all, err)]
-pub async fn build_client(settings: &Settings) -> Result<Client, SyncError> {
-    let caps = caps_client(&settings.sync_address, &settings.extra_headers)
+impl<'a> SyncEngine<'a> {
+    /// Build an engine using an explicitly-supplied capability client.
+    #[instrument(level = "trace", skip_all, err)]
+    pub async fn new(
+        settings: &Settings,
+        store: &'a SqliteStore,
+        key: &'a paseto_v4::Key,
+        caps: Arc<CapClient>,
+    ) -> Result<Self, SyncError> {
+        let client = Client::new(
+            settings.sync_address.clone(),
+            &settings
+                .sync_auth_token()
+                .await
+                .map_err(|e| SyncError::RemoteRequestError { msg: e.to_string() })?,
+            settings.network_connect_timeout,
+            settings.network_timeout,
+            &settings.extra_headers,
+            caps,
+        )
         .map_err(|e| SyncError::OperationalError { msg: e.to_string() })?;
-    build_client_with_caps(settings, caps).await
-}
 
-#[instrument(level = "trace", skip_all, err)]
-pub async fn diff(
-    client: &Client,
-    store: &SqliteStore,
-) -> Result<(Vec<Diff>, RecordStatus), SyncError> {
-    let local_index =
-        store.status().await.map_err(|e| SyncError::LocalStoreError { msg: e.to_string() })?;
+        Ok(Self::with_client(client, store, key))
+    }
 
-    let remote_index = client
-        .record_status()
-        .await
-        .map_err(|e| SyncError::RemoteRequestError { msg: e.to_string() })?;
+    /// Build an engine, fetching the server capabilities as part of construction.
+    #[instrument(level = "trace", skip_all, err)]
+    pub async fn connect(
+        settings: &Settings,
+        store: &'a SqliteStore,
+        key: &'a paseto_v4::Key,
+    ) -> Result<Self, SyncError> {
+        let caps = caps_client(&settings.sync_address, &settings.extra_headers)
+            .map_err(|e| SyncError::OperationalError { msg: e.to_string() })?;
+        Self::new(settings, store, key, caps).await
+    }
 
-    let diff = local_index.diff(&remote_index);
+    /// Wrap an already-constructed client (e.g. in tests, or where the client is built directly).
+    pub fn with_client(client: Client, store: &'a SqliteStore, key: &'a paseto_v4::Key) -> Self {
+        Self { client, store, key }
+    }
 
-    Ok((diff, remote_index))
-}
+    /// The underlying API client, for callers that need to talk to the remote directly.
+    pub fn client(&self) -> &Client {
+        &self.client
+    }
 
-// Take a diff, along with a local store, and resolve it into a set of operations.
-// With the store as context, we can determine if a tail exists locally or not and therefore if it needs uploading or download.
-// In theory this could be done as a part of the diffing stage, but it's easier to reason
-// about and test this way
-#[instrument(level = "trace", skip_all, fields(n_diffs = diffs.len()), err)]
-pub fn operations(diffs: Vec<Diff>, _store: &SqliteStore) -> Result<Vec<Operation>, SyncError> {
-    let mut operations = Vec::with_capacity(diffs.len());
+    #[instrument(level = "trace", skip_all, err)]
+    pub async fn diff(&self) -> Result<(Vec<Diff>, RecordStatus), SyncError> {
+        let local_index = self
+            .store
+            .status()
+            .await
+            .map_err(|e| SyncError::LocalStoreError { msg: e.to_string() })?;
 
-    for diff in diffs {
-        let op = match (diff.local, diff.remote) {
-            // We both have it! Could be either. Compare.
-            (Some(local), Some(remote)) => match local.cmp(&remote) {
-                Ordering::Equal => Operation::Noop {
-                    host: diff.host,
-                    tag: diff.tag,
+        let remote_index = self
+            .client
+            .record_status()
+            .await
+            .map_err(|e| SyncError::RemoteRequestError { msg: e.to_string() })?;
+
+        let diff = local_index.diff(&remote_index);
+
+        Ok((diff, remote_index))
+    }
+
+    // Take a diff and resolve it into a set of operations. In theory this could be done as a part of
+    // the diffing stage, but it's easier to reason about and test this way. It needs none of the
+    // engine's state, so it's an associated function rather than a method.
+    #[instrument(level = "trace", skip_all, fields(n_diffs = diffs.len()), err)]
+    pub fn operations(diffs: Vec<Diff>) -> Result<Vec<Operation>, SyncError> {
+        let mut operations = Vec::with_capacity(diffs.len());
+
+        for diff in diffs {
+            let op = match (diff.local, diff.remote) {
+                // We both have it! Could be either. Compare.
+                (Some(local), Some(remote)) => match local.cmp(&remote) {
+                    Ordering::Equal => Operation::Noop {
+                        host: diff.host,
+                        tag: diff.tag,
+                    },
+                    Ordering::Greater => Operation::Upload {
+                        local,
+                        remote: Some(remote),
+                        host: diff.host,
+                        tag: diff.tag,
+                    },
+                    Ordering::Less => Operation::Download {
+                        remote,
+                        host: diff.host,
+                        tag: diff.tag,
+                    },
                 },
-                Ordering::Greater => Operation::Upload {
-                    local,
-                    remote: Some(remote),
-                    host: diff.host,
-                    tag: diff.tag,
-                },
-                Ordering::Less => Operation::Download {
+
+                // Remote has it, we don't. Gotta be download
+                (None, Some(remote)) => Operation::Download {
                     remote,
                     host: diff.host,
                     tag: diff.tag,
                 },
-            },
 
-            // Remote has it, we don't. Gotta be download
-            (None, Some(remote)) => Operation::Download {
-                remote,
-                host: diff.host,
-                tag: diff.tag,
-            },
+                // We have it, remote doesn't. Gotta be upload.
+                (Some(local), None) => Operation::Upload {
+                    local,
+                    remote: None,
+                    host: diff.host,
+                    tag: diff.tag,
+                },
 
-            // We have it, remote doesn't. Gotta be upload.
-            (Some(local), None) => Operation::Upload {
-                local,
-                remote: None,
-                host: diff.host,
-                tag: diff.tag,
-            },
+                // something is pretty fucked.
+                (None, None) => {
+                    return Err(SyncError::SyncLogicError {
+                        msg: String::from(
+                            "diff has nothing for local or remote - (host, tag) does not exist",
+                        ),
+                    });
+                }
+            };
 
-            // something is pretty fucked.
-            (None, None) => {
-                return Err(SyncError::SyncLogicError {
-                    msg: String::from(
-                        "diff has nothing for local or remote - (host, tag) does not exist",
-                    ),
-                });
+            operations.push(op);
+        }
+
+        // sort them - purely so we have a stable testing order, and can rely on
+        // same input = same output
+        // We can sort by ID so long as we continue to use UUIDv7 or something
+        // with the same properties
+
+        operations.sort_by_key(|op| match op {
+            Operation::Noop { host, tag } => (0u8, *host, 0u8, tag.clone()),
+            Operation::Upload { host, tag, .. } => (1u8, *host, 0u8, tag.clone()),
+            Operation::Download { host, tag, .. } => {
+                // Packfile manifests must expand before the history download runs, as that
+                // `sync_download` will dedupe will have a chance at avoiding unnecessary downloads.
+                let tag_priority = if *tag == RecordTag::Packfile {
+                    0u8
+                } else {
+                    1u8
+                };
+                (2u8, *host, tag_priority, tag.clone())
             }
-        };
+        });
 
-        operations.push(op);
+        Ok(operations)
     }
 
-    // sort them - purely so we have a stable testing order, and can rely on
-    // same input = same output
-    // We can sort by ID so long as we continue to use UUIDv7 or something
-    // with the same properties
+    // TODO(markovejnovic): Seriously revisit the syncing logic and coupling.
+    #[instrument(
+        level = "trace",
+        skip_all,
+        fields(host = ?host, tag = ?tag, local, remote = ?remote, page_size),
+        err
+    )]
+    async fn sync_upload(
+        &self,
+        host: HostId,
+        tag: RecordTag,
+        local: RecordIdx,
+        remote: Option<RecordIdx>,
+        page_size: u64,
+    ) -> Result<u64, SyncError> {
+        let store = self.store;
+        let client = &self.client;
+        let key = self.key;
+        // The first record the remote *doesn't* have.
+        let first_missing_remote = remote.map_or(0, |n| n + 1);
+        let expected = local + 1 - first_missing_remote;
+        let mut progress = 0;
 
-    operations.sort_by_key(|op| match op {
-        Operation::Noop { host, tag } => (0u8, *host, 0u8, tag.clone()),
-        Operation::Upload { host, tag, .. } => (1u8, *host, 0u8, tag.clone()),
-        Operation::Download { host, tag, .. } => {
-            // Packfile manifests must expand before the history download runs, as that
-            // `sync_download` will dedupe will have a chance at avoiding unnecessary downloads.
-            let tag_priority = if *tag == RecordTag::Packfile {
-                0u8
-            } else {
-                1u8
-            };
-            (2u8, *host, tag_priority, tag.clone())
-        }
-    });
+        let pb = ProgressBar::new(expected);
+        pb.set_style(
+            ProgressStyle::with_template(
+                "{spinner:.green} [{elapsed_precise}] [{wide_bar:.cyan/blue}] \
+                 {human_pos}/{human_len} ({eta})",
+            )
+            .unwrap()
+            .with_key("eta", |state: &ProgressState, w: &mut dyn Write| {
+                write!(w, "{:.1}s", state.eta().as_secs_f64()).unwrap()
+            })
+            .progress_chars("#>-"),
+        );
 
-    Ok(operations)
-}
+        println!("Uploading {} records to {}/{}", expected, host.0.as_simple(), tag);
 
-// TODO(markovejnovic): Seriously revisit the syncing logic and coupling.
-#[allow(
-    clippy::too_many_arguments,
-    reason = "threading the key for packfile uploads pushes this one param over the limit"
-)]
-#[instrument(
-    level = "trace",
-    skip_all,
-    fields(host = ?host, tag = ?tag, local, remote = ?remote, page_size),
-    err
-)]
-async fn sync_upload(
-    store: &SqliteStore,
-    client: &Client,
-    host: HostId,
-    tag: RecordTag,
-    local: RecordIdx,
-    remote: Option<RecordIdx>,
-    page_size: u64,
-    key: &paseto_v4::Key,
-) -> Result<u64, SyncError> {
-    // The first record the remote *doesn't* have.
-    let first_missing_remote = remote.map_or(0, |n| n + 1);
-    let expected = local + 1 - first_missing_remote;
-    let mut progress = 0;
+        while progress < expected {
+            let page = store
+                .next(host, &tag, first_missing_remote + progress, page_size)
+                .await
+                .map_err(|e| {
+                    error!("failed to read upload page: {e:?}");
 
-    let pb = ProgressBar::new(expected);
-    pb.set_style(
-        ProgressStyle::with_template(
-            "{spinner:.green} [{elapsed_precise}] [{wide_bar:.cyan/blue}] {human_pos}/{human_len} \
-             ({eta})",
-        )
-        .unwrap()
-        .with_key("eta", |state: &ProgressState, w: &mut dyn Write| {
-            write!(w, "{:.1}s", state.eta().as_secs_f64()).unwrap()
-        })
-        .progress_chars("#>-"),
-    );
+                    SyncError::LocalStoreError { msg: e.to_string() }
+                })?;
 
-    println!("Uploading {} records to {}/{}", expected, host.0.as_simple(), tag);
+            if page.is_empty() {
+                break;
+            }
 
-    while progress < expected {
-        let page = store
-            .next(host, &tag, first_missing_remote + progress, page_size)
-            .await
-            .map_err(|e| {
-                error!("failed to read upload page: {e:?}");
+            if tag == RecordTag::Packfile {
+                let mut uploads = stream::iter(0..page.len())
+                    .map(|i| upload_packed(&page[i], store, key, client))
+                    .buffered(MAX_CONCURRENT_PACKFILE_TRANSFERS);
 
-                SyncError::LocalStoreError { msg: e.to_string() }
+                while let Some(result) = uploads.next().await {
+                    result.map_err(|e| {
+                        error!("failed to upload packfile: {e}");
+                        SyncError::RemoteRequestError { msg: e.to_string() }
+                    })?;
+                }
+            }
+
+            client.post_records(&page).await.map_err(|e| {
+                error!("failed to post records: {e:?}");
+
+                SyncError::RemoteRequestError { msg: e.to_string() }
             })?;
 
-        if page.is_empty() {
-            break;
+            progress += page.len() as u64;
+            pb.set_position(progress);
         }
 
-        if tag == RecordTag::Packfile {
-            let mut uploads = stream::iter(0..page.len())
-                .map(|i| upload_packed(&page[i], store, key, client))
-                .buffered(MAX_CONCURRENT_PACKFILE_TRANSFERS);
+        pb.finish_with_message("Uploaded records");
 
-            while let Some(result) = uploads.next().await {
-                result.map_err(|e| {
-                    error!("failed to upload packfile: {e}");
-                    SyncError::RemoteRequestError { msg: e.to_string() }
-                })?;
-            }
-        }
-
-        client.post_records(&page).await.map_err(|e| {
-            error!("failed to post records: {e:?}");
-
-            SyncError::RemoteRequestError { msg: e.to_string() }
-        })?;
-
-        progress += page.len() as u64;
-        pb.set_position(progress);
+        Ok(progress)
     }
 
-    pb.finish_with_message("Uploaded records");
-
-    Ok(progress)
-}
-
-// TODO(markovejnovic): Seriously revisit the syncing logic and coupling.
-#[allow(
-    clippy::too_many_arguments,
-    reason = "threading the key for packfile downloads pushes this one param over the limit"
-)]
-#[instrument(
-    level = "trace",
-    skip_all,
-    fields(host = ?host, tag = ?tag, remote = ?remote, page_size),
-    err
-)]
-async fn sync_download(
-    store: &SqliteStore,
-    client: &Client,
-    host: HostId,
-    tag: RecordTag,
-    remote: RecordIdx,
-    page_size: u64,
-    key: &paseto_v4::Key,
-) -> Result<Vec<RecordId>, SyncError> {
-    // Scan the database to find the first missing local index, rather than assuming it's one more
-    // than the highest local index. A prior packfile op for this host may have expanded a pack
-    // whose history landed ABOVE a still-missing index; keying off the highest index would never
-    // fetch the hole before it. Start from the actual missing index; records already present above
-    // it will be "unnecessarily" redownloaded, but this is a no-op.
-    let first_missing_local = store
-        .first_gap(host, &tag)
-        .await
-        .map_err(|e| SyncError::LocalStoreError { msg: e.to_string() })?;
-
-    // One higher than the latest record index we have locally. The case described above where we
-    // have a hole in the sequence of record indices should not happen in practice; this variable is
-    // used to detect that situation so we can print a warning.
-    //
-    // TODO: This adds a slight runtime cost, but while the packfile feature is new, let's err on
-    // the side of catching potential problems.
-    let latest = store
-        .last(host, &tag)
-        .await
-        .map_err(|e| SyncError::LocalStoreError { msg: e.to_string() })?
-        .map(|record| record.idx);
-
-    if first_missing_local != latest.map_or(0, |n| n + 1) {
-        tracing::warn!(
-            "first missing record index is {first_missing_local}, but latest record is {}",
-            std::fmt::from_fn(|f| {
-                match latest {
-                    Some(n) => write!(f, "{n}"),
-                    None => write!(f, "(none)"),
-                }
-            }),
-        );
-    }
-
-    let expected = (remote + 1).saturating_sub(first_missing_local);
-    let mut progress = 0;
-    let mut ret = Vec::new();
-
-    println!("Downloading {} records from {}/{}", expected, host.0.as_simple(), tag);
-
-    let pb = ProgressBar::new(expected);
-    pb.set_style(
-        ProgressStyle::with_template(
-            "{spinner:.green} [{elapsed_precise}] [{wide_bar:.cyan/blue}] {human_pos}/{human_len} \
-             ({eta})",
-        )
-        .unwrap()
-        .with_key("eta", |state: &ProgressState, w: &mut dyn Write| {
-            write!(w, "{:.1}s", state.eta().as_secs_f64()).unwrap()
-        })
-        .progress_chars("#>-"),
-    );
-
-    while progress < expected {
-        let page = client
-            .next_records(host, tag.clone(), first_missing_local + progress, page_size)
-            .await
-            .map_err(|e| SyncError::RemoteRequestError { msg: e.to_string() })?;
-
-        if page.is_empty() {
-            break;
-        }
-
-        // We commit the packfile's history into the local store before we persist the manifests, so
-        // a manifest we recorded always has its associated history.
-        if tag == RecordTag::Packfile {
-            let mut downloads = stream::iter(0..page.len())
-                .map(|i| download_packed(&page[i], store, key, client))
-                .buffered(MAX_CONCURRENT_PACKFILE_TRANSFERS)
-                .enumerate();
-
-            while let Some((i, result)) = downloads.next().await {
-                match result {
-                    Ok(expanded) => ret.extend(expanded),
-                    Err(e) if e.is_permanent() => error!(
-                        manifest_id = %page[i].id,
-                        host = %page[i].host.id,
-                        idx = page[i].idx,
-                        "skipping unexpandable packfile manifest: {e}. you have lost data."
-                    ),
-                    Err(e) => {
-                        error!("failed to download packfile: {e:?}");
-                        return Err(SyncError::RemoteRequestError { msg: e.to_string() });
-                    }
-                }
-            }
-        }
-
-        store
-            .push_batch(page.iter())
+    // TODO(markovejnovic): Seriously revisit the syncing logic and coupling.
+    #[instrument(
+        level = "trace",
+        skip_all,
+        fields(host = ?host, tag = ?tag, remote = ?remote, page_size),
+        err
+    )]
+    async fn sync_download(
+        &self,
+        host: HostId,
+        tag: RecordTag,
+        remote: RecordIdx,
+        page_size: u64,
+    ) -> Result<Vec<RecordId>, SyncError> {
+        let store = self.store;
+        let client = &self.client;
+        let key = self.key;
+        // Scan the database to find the first missing local index, rather than assuming it's one more
+        // than the highest local index. A prior packfile op for this host may have expanded a pack
+        // whose history landed ABOVE a still-missing index; keying off the highest index would never
+        // fetch the hole before it. Start from the actual missing index; records already present above
+        // it will be "unnecessarily" redownloaded, but this is a no-op.
+        let first_missing_local = store
+            .first_gap(host, &tag)
             .await
             .map_err(|e| SyncError::LocalStoreError { msg: e.to_string() })?;
 
-        ret.extend(page.iter().map(|f| f.id));
+        // One higher than the latest record index we have locally. The case described above where we
+        // have a hole in the sequence of record indices should not happen in practice; this variable is
+        // used to detect that situation so we can print a warning.
+        //
+        // TODO: This adds a slight runtime cost, but while the packfile feature is new, let's err on
+        // the side of catching potential problems.
+        let latest = store
+            .last(host, &tag)
+            .await
+            .map_err(|e| SyncError::LocalStoreError { msg: e.to_string() })?
+            .map(|record| record.idx);
 
-        progress += page.len() as u64;
-        pb.set_position(progress);
-    }
-
-    pb.finish_with_message("Downloaded records");
-
-    Ok(ret)
-}
-
-#[instrument(level = "trace", skip_all, fields(page_size), err)]
-pub async fn sync_remote(
-    client: &Client,
-    operations: Vec<Operation>,
-    local_store: &SqliteStore,
-    page_size: u64,
-    key: &paseto_v4::Key,
-) -> Result<(u64, Vec<RecordId>), SyncError> {
-    let mut uploaded = 0;
-    let mut downloaded = Vec::new();
-
-    let packfiles_enabled = matches!(
-        client.caps().get_server::<PackfileCap>().await,
-        Ok(Some(cap)) if cap.record_count > 0
-    );
-
-    // this can totally run in parallel, but lets get it working first
-    for i in operations {
-        match i {
-            Operation::Upload {
-                host,
-                tag,
-                local,
-                remote,
-            } => {
-                if tag == RecordTag::Packfile && !packfiles_enabled {
-                    debug!(
-                        "server does not advertise PackfileCap; skipping packfile {tag} upload \
-                         op, loose history covers it"
-                    );
-                    continue;
-                }
-                uploaded +=
-                    sync_upload(local_store, client, host, tag, local, remote, page_size, key)
-                        .await?
-            }
-
-            Operation::Download { host, tag, remote } => {
-                if tag == RecordTag::Packfile && !packfiles_enabled {
-                    debug!(
-                        "server does not advertise PackfileCap; skipping packfile {tag} download \
-                         op, loose history covers it"
-                    );
-                    continue;
-                }
-                let mut d =
-                    sync_download(local_store, client, host, tag, remote, page_size, key).await?;
-                downloaded.append(&mut d)
-            }
-
-            Operation::Noop { .. } => continue,
+        if first_missing_local != latest.map_or(0, |n| n + 1) {
+            tracing::warn!(
+                "first missing record index is {first_missing_local}, but latest record is {}",
+                std::fmt::from_fn(|f| {
+                    match latest {
+                        Some(n) => write!(f, "{n}"),
+                        None => write!(f, "(none)"),
+                    }
+                }),
+            );
         }
+
+        let expected = (remote + 1).saturating_sub(first_missing_local);
+        let mut progress = 0;
+        let mut ret = Vec::new();
+
+        println!("Downloading {} records from {}/{}", expected, host.0.as_simple(), tag);
+
+        let pb = ProgressBar::new(expected);
+        pb.set_style(
+            ProgressStyle::with_template(
+                "{spinner:.green} [{elapsed_precise}] [{wide_bar:.cyan/blue}] \
+                 {human_pos}/{human_len} ({eta})",
+            )
+            .unwrap()
+            .with_key("eta", |state: &ProgressState, w: &mut dyn Write| {
+                write!(w, "{:.1}s", state.eta().as_secs_f64()).unwrap()
+            })
+            .progress_chars("#>-"),
+        );
+
+        while progress < expected {
+            let page = client
+                .next_records(host, tag.clone(), first_missing_local + progress, page_size)
+                .await
+                .map_err(|e| SyncError::RemoteRequestError { msg: e.to_string() })?;
+
+            if page.is_empty() {
+                break;
+            }
+
+            // We commit the packfile's history into the local store before we persist the manifests, so
+            // a manifest we recorded always has its associated history.
+            if tag == RecordTag::Packfile {
+                let mut downloads = stream::iter(0..page.len())
+                    .map(|i| download_packed(&page[i], store, key, client))
+                    .buffered(MAX_CONCURRENT_PACKFILE_TRANSFERS)
+                    .enumerate();
+
+                while let Some((i, result)) = downloads.next().await {
+                    match result {
+                        Ok(expanded) => ret.extend(expanded),
+                        Err(e) if e.is_permanent() => error!(
+                            manifest_id = %page[i].id,
+                            host = %page[i].host.id,
+                            idx = page[i].idx,
+                            "skipping unexpandable packfile manifest: {e}. you have lost data."
+                        ),
+                        Err(e) => {
+                            error!("failed to download packfile: {e:?}");
+                            return Err(SyncError::RemoteRequestError { msg: e.to_string() });
+                        }
+                    }
+                }
+            }
+
+            store
+                .push_batch(page.iter())
+                .await
+                .map_err(|e| SyncError::LocalStoreError { msg: e.to_string() })?;
+
+            ret.extend(page.iter().map(|f| f.id));
+
+            progress += page.len() as u64;
+            pb.set_position(progress);
+        }
+
+        pb.finish_with_message("Downloaded records");
+
+        Ok(ret)
     }
 
-    Ok((uploaded, downloaded))
-}
+    #[instrument(level = "trace", skip_all, fields(page_size), err)]
+    pub async fn sync_remote(
+        &self,
+        operations: Vec<Operation>,
+        page_size: u64,
+    ) -> Result<(u64, Vec<RecordId>), SyncError> {
+        let mut uploaded = 0;
+        let mut downloaded = Vec::new();
 
-#[instrument(level = "trace", skip_all, err)]
-pub async fn check_encryption_key(
-    client: &Client,
-    remote_index: &RecordStatus,
-    encryption_key: &paseto_v4::Key,
-) -> Result<(), SyncError> {
-    let sample = remote_index
-        .hosts
-        .iter()
-        .flat_map(|(host, tags)| tags.keys().map(move |tag| (*host, tag.clone())))
-        // Note we have to skip `Packfile`s here because packfiles _aren't_ actually encrypted, so
-        // using the default CEK would fail decryption.
-        .find(|(_, tag)| *tag != RecordTag::Packfile);
+        let packfiles_enabled = matches!(
+            self.client.caps().get_server::<PackfileCap>().await,
+            Ok(Some(cap)) if cap.record_count > 0
+        );
 
-    let Some((host, tag)) = sample else {
-        return Ok(());
-    };
+        // this can totally run in parallel, but lets get it working first
+        for i in operations {
+            match i {
+                Operation::Upload {
+                    host,
+                    tag,
+                    local,
+                    remote,
+                } => {
+                    if tag == RecordTag::Packfile && !packfiles_enabled {
+                        debug!(
+                            "server does not advertise PackfileCap; skipping packfile {tag} \
+                             upload op, loose history covers it"
+                        );
+                        continue;
+                    }
+                    uploaded += self.sync_upload(host, tag, local, remote, page_size).await?
+                }
 
-    let records = client
-        .next_records(host, tag, 0, 1)
-        .await
-        .map_err(|e| SyncError::RemoteRequestError { msg: e.to_string() })?;
+                Operation::Download { host, tag, remote } => {
+                    if tag == RecordTag::Packfile && !packfiles_enabled {
+                        debug!(
+                            "server does not advertise PackfileCap; skipping packfile {tag} \
+                             download op, loose history covers it"
+                        );
+                        continue;
+                    }
+                    let mut d = self.sync_download(host, tag, remote, page_size).await?;
+                    downloaded.append(&mut d)
+                }
 
-    let Some(record) = records.into_iter().next() else {
-        return Ok(());
-    };
+                Operation::Noop { .. } => continue,
+            }
+        }
 
-    record.decrypt(encryption_key).map_err(|_| SyncError::WrongKey)?;
+        Ok((uploaded, downloaded))
+    }
 
-    Ok(())
-}
+    #[instrument(level = "trace", skip_all, err)]
+    pub async fn check_encryption_key(&self, remote_index: &RecordStatus) -> Result<(), SyncError> {
+        let sample = remote_index
+            .hosts
+            .iter()
+            .flat_map(|(host, tags)| tags.keys().map(move |tag| (*host, tag.clone())))
+            // Note we have to skip `Packfile`s here because packfiles _aren't_ actually encrypted,
+            // so using the default CEK would fail decryption.
+            .find(|(_, tag)| *tag != RecordTag::Packfile);
 
-#[instrument(level = "trace", skip_all, err)]
-pub async fn sync(
-    settings: &Settings,
-    store: &SqliteStore,
-    encryption_key: &paseto_v4::Key,
-    caps: Arc<CapClient>,
-) -> Result<(u64, Vec<RecordId>), SyncError> {
-    let client = build_client_with_caps(settings, caps).await?;
-    let (diff, remote_index) = diff(&client, store).await?;
+        let Some((host, tag)) = sample else {
+            return Ok(());
+        };
 
-    // Bail before mutating either side if the local key can't read the remote.
-    check_encryption_key(&client, &remote_index, encryption_key).await?;
+        let records = self
+            .client
+            .next_records(host, tag, 0, 1)
+            .await
+            .map_err(|e| SyncError::RemoteRequestError { msg: e.to_string() })?;
 
-    let operations = operations(diff, store)?;
-    let (uploaded, downloaded) =
-        sync_remote(&client, operations, store, 100, encryption_key).await?;
+        let Some(record) = records.into_iter().next() else {
+            return Ok(());
+        };
 
-    Ok((uploaded, downloaded))
+        record.decrypt(self.key).map_err(|_| SyncError::WrongKey)?;
+
+        Ok(())
+    }
+
+    /// Run a full sync: diff local against remote, verify the key can read the remote, resolve the
+    /// diff into operations, then apply them.
+    #[instrument(level = "trace", skip_all, err)]
+    pub async fn sync(&self) -> Result<(u64, Vec<RecordId>), SyncError> {
+        let (diff, remote_index) = self.diff().await?;
+
+        // Bail before mutating either side if the local key can't read the remote.
+        self.check_encryption_key(&remote_index).await?;
+
+        let operations = Self::operations(diff)?;
+        self.sync_remote(operations, 100).await
+    }
 }
 
 #[cfg(test)]
@@ -521,7 +537,7 @@ mod tests {
     use rstest::rstest;
 
     use crate::record::sqlite_store::SqliteStore;
-    use crate::record::sync::{self, Operation};
+    use crate::record::sync::{Operation, SyncEngine};
     use crate::settings::test_local_timeout;
 
     fn test_record() -> Record<EncryptedData> {
@@ -573,11 +589,11 @@ mod tests {
         // a diff where local is ahead of remote. nothing else.
 
         let record = test_record();
-        let (store, diff) = build_test_diff(vec![record.clone()], vec![]).await;
+        let (_store, diff) = build_test_diff(vec![record.clone()], vec![]).await;
 
         assert_eq!(diff.len(), 1);
 
-        let operations = sync::operations(diff, &store).unwrap();
+        let operations = SyncEngine::operations(diff).unwrap();
 
         assert_eq!(operations.len(), 1);
 
@@ -605,8 +621,8 @@ mod tests {
         let local = vec![shared_record.clone(), local_ahead.clone()]; // local knows about the already synced, and something newer in the same store
         let remote = vec![shared_record.clone(), remote_ahead.clone()]; // remote knows about the already-synced, and one new record in a new store
 
-        let (store, diff) = build_test_diff(local, remote).await;
-        let operations = sync::operations(diff, &store).unwrap();
+        let (_store, diff) = build_test_diff(local, remote).await;
+        let operations = SyncEngine::operations(diff).unwrap();
 
         assert_eq!(operations.len(), 2);
 
@@ -702,8 +718,8 @@ mod tests {
             fourth_shared_remote_ahead2.clone(),
         ]; // remote knows about the already-synced, and one new record in a new store
 
-        let (store, diff) = build_test_diff(local, remote).await;
-        let operations = sync::operations(diff, &store).unwrap();
+        let (_store, diff) = build_test_diff(local, remote).await;
+        let operations = SyncEngine::operations(diff).unwrap();
 
         assert_eq!(operations.len(), 7);
 
@@ -931,8 +947,10 @@ mod packfile_download_tests {
             .await;
         let addr: url::Url = server.uri().parse().unwrap();
         let client = mock_client(&addr);
+        let store = memory_store().await;
 
-        check_encryption_key(&client, &remote_index, &key)
+        SyncEngine::with_client(client, &store, &key)
+            .check_encryption_key(&remote_index)
             .await
             .expect("a plaintext packfile manifest must not be treated as a wrong key");
     }
@@ -966,7 +984,8 @@ mod packfile_download_tests {
         let client = mock_client(&addr);
 
         let wrong = paseto_v4::Key::from([9u8; 32]);
-        let err = check_encryption_key(&client, &remote_index, &wrong)
+        let err = SyncEngine::with_client(client, &store, &wrong)
+            .check_encryption_key(&remote_index)
             .await
             .expect_err("a wrong key on an encrypted record must still be detected");
         assert!(matches!(err, SyncError::WrongKey), "expected WrongKey, got {err:?}");
@@ -990,7 +1009,10 @@ mod packfile_download_tests {
         let addr: url::Url = server.uri().parse().unwrap();
         let client = mock_client(&addr);
 
-        sync_download(&down, &client, host, RecordTag::Packfile, 1, 100, &key).await.unwrap();
+        SyncEngine::with_client(client, &down, &key)
+            .sync_download(host, RecordTag::Packfile, 1, 100)
+            .await
+            .unwrap();
 
         // The manifest is stored AND the history it covers was populated.
         assert!(down.last(host, &RecordTag::Packfile).await.unwrap().is_some());
@@ -1014,8 +1036,10 @@ mod packfile_download_tests {
         let addr: url::Url = server.uri().parse().unwrap();
         let client = mock_client(&addr);
 
-        let returned =
-            sync_download(&down, &client, host, RecordTag::Packfile, 1, 100, &key).await.unwrap();
+        let returned = SyncEngine::with_client(client, &down, &key)
+            .sync_download(host, RecordTag::Packfile, 1, 100)
+            .await
+            .unwrap();
 
         for id in &history_ids {
             assert!(
@@ -1075,10 +1099,11 @@ mod packfile_download_tests {
         let down = memory_store().await;
         let addr: url::Url = server.uri().parse().unwrap();
         let client = mock_client(&addr);
+        let engine = SyncEngine::with_client(client, &down, &key);
 
         // Packfile op first (populates history 0..=2), then the history op.
-        sync_download(&down, &client, host, RecordTag::Packfile, 1, 100, &key).await.unwrap();
-        sync_download(&down, &client, host, RecordTag::History, 3, 100, &key).await.unwrap();
+        engine.sync_download(host, RecordTag::Packfile, 1, 100).await.unwrap();
+        engine.sync_download(host, RecordTag::History, 3, 100).await.unwrap();
 
         // The history download must have started AFTER the packed prefix (idx 2), i.e. never
         // requested start=0 for RecordTag::History.
@@ -1116,8 +1141,10 @@ mod packfile_download_tests {
         let client = mock_client(&addr);
 
         // remote (2) is BEHIND the live local head (4) -- must not underflow/panic.
-        let got =
-            sync_download(&down, &client, host, RecordTag::History, 2, 100, &key).await.unwrap();
+        let got = SyncEngine::with_client(client, &down, &key)
+            .sync_download(host, RecordTag::History, 2, 100)
+            .await
+            .unwrap();
         assert!(got.is_empty(), "nothing to download when local head already exceeds remote");
     }
 
@@ -1219,8 +1246,10 @@ mod packfile_download_tests {
         let addr: url::Url = server.uri().parse().unwrap();
         let client = mock_client(&addr);
 
-        let returned =
-            sync_download(&down, &client, host, RecordTag::Packfile, 1, 100, &key).await.unwrap();
+        let returned = SyncEngine::with_client(client, &down, &key)
+            .sync_download(host, RecordTag::Packfile, 1, 100)
+            .await
+            .unwrap();
 
         // Every batched packfile's history is populated, whichever download finished first.
         assert_eq!(
@@ -1282,7 +1311,8 @@ mod packfile_download_tests {
         let client = mock_client(&addr);
 
         // The permanent per-manifest failure is logged and skipped; the whole tick still succeeds.
-        let returned = sync_download(&down, &client, host, RecordTag::Packfile, 2, 100, &key)
+        let returned = SyncEngine::with_client(client, &down, &key)
+            .sync_download(host, RecordTag::Packfile, 2, 100)
             .await
             .expect("a permanent per-manifest failure must not fail the tick");
 
@@ -1314,7 +1344,7 @@ mod packfile_capability_tests {
     use super::packfile_download_tests::{
         memory_store, mock_client, mount_packfile, packed_packfile, seed_history,
     };
-    use super::{Operation, sync_remote};
+    use super::{Operation, SyncEngine};
 
     /// A single fixed encryption key, matching the sibling packfile tests.
     #[fixture]
@@ -1381,7 +1411,10 @@ mod packfile_capability_tests {
         let addr: url::Url = server.uri().parse().unwrap();
         let client = mock_client(&addr);
 
-        sync_remote(&client, vec![packfile_download_op(host, 3)], &down, 100, &key).await.unwrap();
+        SyncEngine::with_client(client, &down, &key)
+            .sync_remote(vec![packfile_download_op(host, 3)], 100)
+            .await
+            .unwrap();
 
         // Cap advertised -> the whole packfile op ran: the manifest was persisted and its history
         // was expanded into the store.
@@ -1445,19 +1478,17 @@ mod packfile_capability_tests {
         let addr: url::Url = server.uri().parse().unwrap();
         let client = mock_client(&addr);
 
-        sync_remote(
-            &client,
-            vec![packfile_download_op(host, 3), Operation::Download {
-                remote: 3,
-                host,
-                tag: RecordTag::History,
-            }],
-            &down,
-            100,
-            &key,
-        )
-        .await
-        .unwrap();
+        SyncEngine::with_client(client, &down, &key)
+            .sync_remote(
+                vec![packfile_download_op(host, 3), Operation::Download {
+                    remote: 3,
+                    host,
+                    tag: RecordTag::History,
+                }],
+                100,
+            )
+            .await
+            .unwrap();
 
         // Packfile op skipped: manifest not persisted. Loose history still synced (no data loss).
         assert!(down.last(host, &RecordTag::Packfile).await.unwrap().is_none());
@@ -1477,7 +1508,10 @@ mod packfile_capability_tests {
         let addr: url::Url = server.uri().parse().unwrap();
         let client = mock_client(&addr);
 
-        sync_remote(&client, vec![packfile_download_op(host, 3)], &down, 100, &key).await.unwrap();
+        SyncEngine::with_client(client, &down, &key)
+            .sync_remote(vec![packfile_download_op(host, 3)], 100)
+            .await
+            .unwrap();
 
         // Skipped: manifest not persisted, and no packfile endpoint was ever hit.
         assert!(down.last(host, &RecordTag::Packfile).await.unwrap().is_none());
@@ -1509,7 +1543,10 @@ mod packfile_capability_tests {
         let addr: url::Url = server.uri().parse().unwrap();
         let client = mock_client(&addr);
 
-        sync_remote(&client, vec![packfile_download_op(host, 3)], &down, 100, &key).await.unwrap();
+        SyncEngine::with_client(client, &down, &key)
+            .sync_remote(vec![packfile_download_op(host, 3)], 100)
+            .await
+            .unwrap();
 
         assert!(down.last(host, &RecordTag::Packfile).await.unwrap().is_none());
     }

--- a/crates/atuin-client/src/record/sync/builder.rs
+++ b/crates/atuin-client/src/record/sync/builder.rs
@@ -12,20 +12,16 @@ use crate::settings::Settings;
 
 /// Where a [`SyncEngine`]'s API client comes from.
 pub enum ClientSource<'a> {
-    /// Wrap an already-built [`Client`] (tests, login).
+    /// Wrap an already-built [`Client`].
     FromClient(Client),
-    /// Build the client from settings, fetching the server capabilities during `connect` unless
-    /// they are supplied here.
+    /// Build from settings, fetching capabilities during `connect`, unless supplied here.
     FromSettings {
         settings: &'a Settings,
         caps: Option<Arc<CapClient>>,
     },
 }
 
-/// Inputs for constructing a [`SyncEngine`].
-///
-/// Obtain one with [`SyncEngine::builder`], set the [`ClientSource`], then finish with
-/// [`connect`](Self::connect).
+/// Inputs for constructing a [`SyncEngine`]. See [`SyncEngine::builder`].
 #[derive(TypedBuilder)]
 #[builder(builder_type(name = SyncEngineBuilder), builder_method(vis = "pub(crate)"))]
 pub struct SyncEngineInit<'a> {
@@ -35,9 +31,6 @@ pub struct SyncEngineInit<'a> {
 
 impl SyncEngineInit<'_> {
     /// Resolve the configured inputs into a live [`SyncEngine`].
-    ///
-    /// A directly-supplied client is wrapped as-is; otherwise the client is built from the
-    /// settings, fetching the server capabilities when they were not supplied.
     #[instrument(level = "trace", skip_all, err)]
     pub async fn connect(self) -> Result<SyncEngine, SyncError> {
         let client = match self.client_source {

--- a/crates/atuin-client/src/record/sync/builder.rs
+++ b/crates/atuin-client/src/record/sync/builder.rs
@@ -1,0 +1,82 @@
+use std::sync::Arc;
+
+use atuin_common::encryption::paseto_v4;
+use atuin_domain::caps::CapClient;
+use eyre::Result;
+use tracing::instrument;
+use typed_builder::TypedBuilder;
+
+use super::{SyncEngine, SyncError};
+use crate::api_client::{Client, caps_client};
+use crate::record::sqlite_store::SqliteStore;
+use crate::settings::Settings;
+
+/// Where a [`SyncEngine`]'s API client comes from.
+pub enum ClientSource<'a> {
+    /// Wrap an already-built [`Client`] (tests, login).
+    FromClient(Client),
+    /// Build the client from settings, fetching the server capabilities during `connect` unless
+    /// they are supplied here.
+    FromSettings {
+        settings: &'a Settings,
+        caps: Option<Arc<CapClient>>,
+    },
+}
+
+/// Inputs for constructing a [`SyncEngine`].
+///
+/// Obtain one with [`SyncEngine::builder`], set the [`ClientSource`], then finish with
+/// [`connect`](Self::connect).
+#[derive(TypedBuilder)]
+#[builder(builder_type(name = SyncEngineBuilder), builder_method(vis = "pub(crate)"))]
+pub struct SyncEngineInit<'a> {
+    store: SqliteStore,
+    key: &'a paseto_v4::Key,
+    client_source: ClientSource<'a>,
+}
+
+impl<'a> SyncEngineInit<'a> {
+    /// Resolve the configured inputs into a live [`SyncEngine`].
+    ///
+    /// A directly-supplied client is wrapped as-is; otherwise the client is built from the
+    /// settings, fetching the server capabilities when they were not supplied.
+    #[instrument(level = "trace", skip_all, err)]
+    pub async fn connect(self) -> Result<SyncEngine<'a>, SyncError> {
+        let client = match self.client_source {
+            ClientSource::FromClient(client) => client,
+            ClientSource::FromSettings { settings, caps } => {
+                let caps = match caps {
+                    Some(caps) => caps,
+                    None => caps_client(&settings.sync_address, &settings.extra_headers)
+                        .map_err(|e| SyncError::OperationalError { msg: e.to_string() })?,
+                };
+
+                Client::new(
+                    settings.sync_address.clone(),
+                    &settings
+                        .sync_auth_token()
+                        .await
+                        .map_err(|e| SyncError::RemoteRequestError { msg: e.to_string() })?,
+                    settings.network_connect_timeout,
+                    settings.network_timeout,
+                    &settings.extra_headers,
+                    caps,
+                )
+                .map_err(|e| SyncError::OperationalError { msg: e.to_string() })?
+            }
+        };
+
+        Ok(SyncEngine {
+            client,
+            store: self.store,
+            key: self.key,
+        })
+    }
+}
+
+impl<'a> SyncEngine<'a> {
+    /// Start building a [`SyncEngine`]. See [`SyncEngineInit`] for the construction paths.
+    pub fn builder() -> SyncEngineBuilder<'a, ((), (), ())> {
+        SyncEngineInit::builder()
+    }
+}

--- a/crates/atuin-client/src/record/sync/builder.rs
+++ b/crates/atuin-client/src/record/sync/builder.rs
@@ -1,6 +1,5 @@
 use std::sync::Arc;
 
-use atuin_common::encryption::paseto_v4;
 use atuin_domain::caps::CapClient;
 use eyre::Result;
 use tracing::instrument;
@@ -31,17 +30,16 @@ pub enum ClientSource<'a> {
 #[builder(builder_type(name = SyncEngineBuilder), builder_method(vis = "pub(crate)"))]
 pub struct SyncEngineInit<'a> {
     store: SqliteStore,
-    key: &'a paseto_v4::Key,
     client_source: ClientSource<'a>,
 }
 
-impl<'a> SyncEngineInit<'a> {
+impl SyncEngineInit<'_> {
     /// Resolve the configured inputs into a live [`SyncEngine`].
     ///
     /// A directly-supplied client is wrapped as-is; otherwise the client is built from the
     /// settings, fetching the server capabilities when they were not supplied.
     #[instrument(level = "trace", skip_all, err)]
-    pub async fn connect(self) -> Result<SyncEngine<'a>, SyncError> {
+    pub async fn connect(self) -> Result<SyncEngine, SyncError> {
         let client = match self.client_source {
             ClientSource::FromClient(client) => client,
             ClientSource::FromSettings { settings, caps } => {
@@ -69,14 +67,13 @@ impl<'a> SyncEngineInit<'a> {
         Ok(SyncEngine {
             client,
             store: self.store,
-            key: self.key,
         })
     }
 }
 
-impl<'a> SyncEngine<'a> {
+impl SyncEngine {
     /// Start building a [`SyncEngine`]. See [`SyncEngineInit`] for the construction paths.
-    pub fn builder() -> SyncEngineBuilder<'a, ((), (), ())> {
+    pub fn builder<'a>() -> SyncEngineBuilder<'a, ((), ())> {
         SyncEngineInit::builder()
     }
 }

--- a/crates/atuin-client/src/record/sync/mod.rs
+++ b/crates/atuin-client/src/record/sync/mod.rs
@@ -82,18 +82,13 @@ pub enum Operation {
 /// Drives atuin's sync.
 ///
 /// The intended way to use this is to build one with the [`SyncEngine::builder()`] method.
-///
-/// Operations that touch the encryption key live on [`Keyed`], obtained via [`SyncEngine::keyed`],
-/// so the key is never long-lived engine state.
 pub struct SyncEngine {
     client: Client,
     store: SqliteStore,
 }
 
 /// A [`SyncEngine`] paired with an encryption key, for the operations that encrypt or decrypt.
-///
-/// Obtained from [`SyncEngine::keyed`]; it borrows both the engine and the key only for the
-/// duration of the operations called on it, so the key stays out of the engine's own state.
+/// Obtained from [`SyncEngine::keyed`].
 pub struct Keyed<'k> {
     engine: &'k SyncEngine,
     key: &'k paseto_v4::Key,

--- a/crates/atuin-client/src/record/sync/mod.rs
+++ b/crates/atuin-client/src/record/sync/mod.rs
@@ -1,4 +1,11 @@
-// do a sync :O
+//! The core sync engine that Atuin uses.
+//!
+//! This is the library that handles syncing records between a client and a server.
+//!
+//! TODO(markovejnovic): Migrate this outside of `record/`, since it handles a lot more than just
+//!                      records.
+//!
+//! > do a sync :O
 use std::cmp::Ordering;
 use std::fmt::Write;
 
@@ -13,9 +20,9 @@ use tracing::instrument;
 
 use super::sqlite_store::SqliteStore;
 use crate::api_client::Client;
-use crate::packfile::{download_packed, upload_packed};
 
 mod builder;
+mod packfile;
 pub use builder::{ClientSource, SyncEngineBuilder, SyncEngineInit};
 
 /// How many packfile blobs to transfer (upload or download) concurrently within a single page.
@@ -78,16 +85,36 @@ pub enum Operation {
 /// Drives atuin's sync.
 ///
 /// The intended way to use this is to build one with the [`SyncEngine::builder()`] method.
-pub struct SyncEngine<'a> {
+///
+/// Operations that touch the encryption key live on [`Keyed`], obtained via [`SyncEngine::keyed`],
+/// so the key is never long-lived engine state.
+pub struct SyncEngine {
     client: Client,
     store: SqliteStore,
-    key: &'a paseto_v4::Key,
 }
 
-impl SyncEngine<'_> {
-    /// The underlying API client, for callers that need to talk to the remote directly.
-    pub fn client(&self) -> &Client {
-        &self.client
+/// A [`SyncEngine`] paired with an encryption key, for the operations that encrypt or decrypt.
+///
+/// Obtained from [`SyncEngine::keyed`]; it borrows both the engine and the key only for the
+/// duration of the operations called on it, so the key stays out of the engine's own state.
+pub struct Keyed<'k> {
+    engine: &'k SyncEngine,
+    key: &'k paseto_v4::Key,
+}
+
+impl SyncEngine {
+    /// Pair this engine with an encryption `key` to run the crypto-touching sync operations.
+    pub fn keyed<'k>(&'k self, key: &'k paseto_v4::Key) -> Keyed<'k> {
+        Keyed { engine: self, key }
+    }
+
+    /// Fetch the remote's record status index.
+    #[instrument(level = "trace", skip_all, err)]
+    pub async fn record_status(&self) -> Result<RecordStatus, SyncError> {
+        self.client
+            .record_status()
+            .await
+            .map_err(|e| SyncError::RemoteRequestError { msg: e.to_string() })
     }
 
     #[instrument(level = "trace", skip_all, err)]
@@ -181,7 +208,9 @@ impl SyncEngine<'_> {
 
         Ok(operations)
     }
+}
 
+impl Keyed<'_> {
     // TODO(markovejnovic): Seriously revisit the syncing logic and coupling.
     #[instrument(
         level = "trace",
@@ -197,9 +226,8 @@ impl SyncEngine<'_> {
         remote: Option<RecordIdx>,
         page_size: u64,
     ) -> Result<u64, SyncError> {
-        let store = &self.store;
-        let client = &self.client;
-        let key = self.key;
+        let store = &self.engine.store;
+        let client = &self.engine.client;
         // The first record the remote *doesn't* have.
         let first_missing_remote = remote.map_or(0, |n| n + 1);
         let expected = local + 1 - first_missing_remote;
@@ -236,7 +264,7 @@ impl SyncEngine<'_> {
 
             if tag == RecordTag::Packfile {
                 let mut uploads = stream::iter(0..page.len())
-                    .map(|i| upload_packed(&page[i], store, key, client))
+                    .map(|i| self.upload_packed(&page[i]))
                     .buffered(MAX_CONCURRENT_PACKFILE_TRANSFERS);
 
                 while let Some(result) = uploads.next().await {
@@ -276,9 +304,8 @@ impl SyncEngine<'_> {
         remote: RecordIdx,
         page_size: u64,
     ) -> Result<Vec<RecordId>, SyncError> {
-        let store = &self.store;
-        let client = &self.client;
-        let key = self.key;
+        let store = &self.engine.store;
+        let client = &self.engine.client;
         // Scan the database to find the first missing local index, rather than assuming it's one more
         // than the highest local index. A prior packfile op for this host may have expanded a pack
         // whose history landed ABOVE a still-missing index; keying off the highest index would never
@@ -346,7 +373,7 @@ impl SyncEngine<'_> {
             // a manifest we recorded always has its associated history.
             if tag == RecordTag::Packfile {
                 let mut downloads = stream::iter(0..page.len())
-                    .map(|i| download_packed(&page[i], store, key, client))
+                    .map(|i| self.download_packed(&page[i]))
                     .buffered(MAX_CONCURRENT_PACKFILE_TRANSFERS)
                     .enumerate();
 
@@ -393,7 +420,7 @@ impl SyncEngine<'_> {
         let mut downloaded = Vec::new();
 
         let packfiles_enabled = matches!(
-            self.client.caps().get_server::<PackfileCap>().await,
+            self.engine.client.caps().get_server::<PackfileCap>().await,
             Ok(Some(cap)) if cap.record_count > 0
         );
 
@@ -450,6 +477,7 @@ impl SyncEngine<'_> {
         };
 
         let records = self
+            .engine
             .client
             .next_records(host, tag, 0, 1)
             .await
@@ -468,12 +496,12 @@ impl SyncEngine<'_> {
     /// diff into operations, then apply them.
     #[instrument(level = "trace", skip_all, err)]
     pub async fn sync(&self) -> Result<(u64, Vec<RecordId>), SyncError> {
-        let (diff, remote_index) = self.diff().await?;
+        let (diff, remote_index) = self.engine.diff().await?;
 
         // Bail before mutating either side if the local key can't read the remote.
         self.check_encryption_key(&remote_index).await?;
 
-        let operations = Self::operations(diff)?;
+        let operations = SyncEngine::operations(diff)?;
         self.sync_remote(operations, 100).await
     }
 }
@@ -776,14 +804,9 @@ mod packfile_download_tests {
     }
 
     /// Wrap a prebuilt client in a [`SyncEngine`] for tests.
-    pub(super) async fn build_engine(
-        client: Client,
-        store: SqliteStore,
-        key: &paseto_v4::Key,
-    ) -> SyncEngine<'_> {
+    pub(super) async fn build_engine(client: Client, store: SqliteStore) -> SyncEngine {
         SyncEngine::builder()
             .store(store)
-            .key(key)
             .client_source(ClientSource::FromClient(client))
             .build()
             .connect()
@@ -913,8 +936,9 @@ mod packfile_download_tests {
         let client = mock_client(&addr);
         let store = memory_store().await;
 
-        build_engine(client, store, &key)
+        build_engine(client, store)
             .await
+            .keyed(&key)
             .check_encryption_key(&remote_index)
             .await
             .expect("a plaintext packfile manifest must not be treated as a wrong key");
@@ -949,8 +973,9 @@ mod packfile_download_tests {
         let client = mock_client(&addr);
 
         let wrong = paseto_v4::Key::from([9u8; 32]);
-        let err = build_engine(client, store, &wrong)
+        let err = build_engine(client, store)
             .await
+            .keyed(&wrong)
             .check_encryption_key(&remote_index)
             .await
             .expect_err("a wrong key on an encrypted record must still be detected");
@@ -975,8 +1000,9 @@ mod packfile_download_tests {
         let addr: url::Url = server.uri().parse().unwrap();
         let client = mock_client(&addr);
 
-        build_engine(client, down.clone(), &key)
+        build_engine(client, down.clone())
             .await
+            .keyed(&key)
             .sync_download(host, RecordTag::Packfile, 1, 100)
             .await
             .unwrap();
@@ -1003,8 +1029,9 @@ mod packfile_download_tests {
         let addr: url::Url = server.uri().parse().unwrap();
         let client = mock_client(&addr);
 
-        let returned = build_engine(client, down, &key)
+        let returned = build_engine(client, down)
             .await
+            .keyed(&key)
             .sync_download(host, RecordTag::Packfile, 1, 100)
             .await
             .unwrap();
@@ -1067,11 +1094,11 @@ mod packfile_download_tests {
         let down = memory_store().await;
         let addr: url::Url = server.uri().parse().unwrap();
         let client = mock_client(&addr);
-        let engine = build_engine(client, down, &key).await;
+        let engine = build_engine(client, down).await;
 
         // Packfile op first (populates history 0..=2), then the history op.
-        engine.sync_download(host, RecordTag::Packfile, 1, 100).await.unwrap();
-        engine.sync_download(host, RecordTag::History, 3, 100).await.unwrap();
+        engine.keyed(&key).sync_download(host, RecordTag::Packfile, 1, 100).await.unwrap();
+        engine.keyed(&key).sync_download(host, RecordTag::History, 3, 100).await.unwrap();
 
         // The history download must have started AFTER the packed prefix (idx 2), i.e. never
         // requested start=0 for RecordTag::History.
@@ -1109,8 +1136,9 @@ mod packfile_download_tests {
         let client = mock_client(&addr);
 
         // remote (2) is BEHIND the live local head (4) -- must not underflow/panic.
-        let got = build_engine(client, down, &key)
+        let got = build_engine(client, down)
             .await
+            .keyed(&key)
             .sync_download(host, RecordTag::History, 2, 100)
             .await
             .unwrap();
@@ -1215,8 +1243,9 @@ mod packfile_download_tests {
         let addr: url::Url = server.uri().parse().unwrap();
         let client = mock_client(&addr);
 
-        let returned = build_engine(client, down.clone(), &key)
+        let returned = build_engine(client, down.clone())
             .await
+            .keyed(&key)
             .sync_download(host, RecordTag::Packfile, 1, 100)
             .await
             .unwrap();
@@ -1281,8 +1310,9 @@ mod packfile_download_tests {
         let client = mock_client(&addr);
 
         // The permanent per-manifest failure is logged and skipped; the whole tick still succeeds.
-        let returned = build_engine(client, down.clone(), &key)
+        let returned = build_engine(client, down.clone())
             .await
+            .keyed(&key)
             .sync_download(host, RecordTag::Packfile, 2, 100)
             .await
             .expect("a permanent per-manifest failure must not fail the tick");
@@ -1382,8 +1412,9 @@ mod packfile_capability_tests {
         let addr: url::Url = server.uri().parse().unwrap();
         let client = mock_client(&addr);
 
-        build_engine(client, down.clone(), &key)
+        build_engine(client, down.clone())
             .await
+            .keyed(&key)
             .sync_remote(vec![packfile_download_op(host, 3)], 100)
             .await
             .unwrap();
@@ -1450,8 +1481,9 @@ mod packfile_capability_tests {
         let addr: url::Url = server.uri().parse().unwrap();
         let client = mock_client(&addr);
 
-        build_engine(client, down.clone(), &key)
+        build_engine(client, down.clone())
             .await
+            .keyed(&key)
             .sync_remote(
                 vec![packfile_download_op(host, 3), Operation::Download {
                     remote: 3,
@@ -1481,8 +1513,9 @@ mod packfile_capability_tests {
         let addr: url::Url = server.uri().parse().unwrap();
         let client = mock_client(&addr);
 
-        build_engine(client, down.clone(), &key)
+        build_engine(client, down.clone())
             .await
+            .keyed(&key)
             .sync_remote(vec![packfile_download_op(host, 3)], 100)
             .await
             .unwrap();
@@ -1517,8 +1550,9 @@ mod packfile_capability_tests {
         let addr: url::Url = server.uri().parse().unwrap();
         let client = mock_client(&addr);
 
-        build_engine(client, down.clone(), &key)
+        build_engine(client, down.clone())
             .await
+            .keyed(&key)
             .sync_remote(vec![packfile_download_op(host, 3)], 100)
             .await
             .unwrap();

--- a/crates/atuin-client/src/record/sync/mod.rs
+++ b/crates/atuin-client/src/record/sync/mod.rs
@@ -1,10 +1,9 @@
 // do a sync :O
 use std::cmp::Ordering;
 use std::fmt::Write;
-use std::sync::Arc;
 
 use atuin_common::encryption::paseto_v4;
-use atuin_domain::caps::{CapClient, PackfileCap};
+use atuin_domain::caps::PackfileCap;
 use atuin_domain::record::{Diff, HostId, RecordId, RecordIdx, RecordStatus, RecordTag};
 use eyre::Result;
 use futures::{StreamExt, stream};
@@ -13,9 +12,11 @@ use thiserror::Error;
 use tracing::instrument;
 
 use super::sqlite_store::SqliteStore;
-use crate::api_client::{Client, caps_client};
+use crate::api_client::Client;
 use crate::packfile::{download_packed, upload_packed};
-use crate::settings::Settings;
+
+mod builder;
+pub use builder::{ClientSource, SyncEngineBuilder, SyncEngineInit};
 
 /// How many packfile blobs to transfer (upload or download) concurrently within a single page.
 const MAX_CONCURRENT_PACKFILE_TRANSFERS: usize = 16;
@@ -74,63 +75,16 @@ pub enum Operation {
     },
 }
 
-/// Stateful driver for a sync session.
+/// Drives atuin's sync.
 ///
-/// Historically the sync logic was a bag of free functions that threaded the same trio of values
-/// -- the API `client`, the local `store`, and the encryption `key` -- through every call. The
-/// engine owns that shared state so the individual steps (`diff`, `operations`, `sync_remote`,
-/// `check_encryption_key`, ...) become methods that no longer have to pass it around.
-///
-/// The `client` is owned; `store` and `key` are borrowed for the lifetime of the session so the
-/// signatures line up with the borrow-based callers that build them.
+/// The intended way to use this is to build one with the [`SyncEngine::builder()`] method.
 pub struct SyncEngine<'a> {
     client: Client,
-    store: &'a SqliteStore,
+    store: SqliteStore,
     key: &'a paseto_v4::Key,
 }
 
-impl<'a> SyncEngine<'a> {
-    /// Build an engine using an explicitly-supplied capability client.
-    #[instrument(level = "trace", skip_all, err)]
-    pub async fn new(
-        settings: &Settings,
-        store: &'a SqliteStore,
-        key: &'a paseto_v4::Key,
-        caps: Arc<CapClient>,
-    ) -> Result<Self, SyncError> {
-        let client = Client::new(
-            settings.sync_address.clone(),
-            &settings
-                .sync_auth_token()
-                .await
-                .map_err(|e| SyncError::RemoteRequestError { msg: e.to_string() })?,
-            settings.network_connect_timeout,
-            settings.network_timeout,
-            &settings.extra_headers,
-            caps,
-        )
-        .map_err(|e| SyncError::OperationalError { msg: e.to_string() })?;
-
-        Ok(Self::with_client(client, store, key))
-    }
-
-    /// Build an engine, fetching the server capabilities as part of construction.
-    #[instrument(level = "trace", skip_all, err)]
-    pub async fn connect(
-        settings: &Settings,
-        store: &'a SqliteStore,
-        key: &'a paseto_v4::Key,
-    ) -> Result<Self, SyncError> {
-        let caps = caps_client(&settings.sync_address, &settings.extra_headers)
-            .map_err(|e| SyncError::OperationalError { msg: e.to_string() })?;
-        Self::new(settings, store, key, caps).await
-    }
-
-    /// Wrap an already-constructed client (e.g. in tests, or where the client is built directly).
-    pub fn with_client(client: Client, store: &'a SqliteStore, key: &'a paseto_v4::Key) -> Self {
-        Self { client, store, key }
-    }
-
+impl SyncEngine<'_> {
     /// The underlying API client, for callers that need to talk to the remote directly.
     pub fn client(&self) -> &Client {
         &self.client
@@ -160,12 +114,11 @@ impl<'a> SyncEngine<'a> {
     // engine's state, so it's an associated function rather than a method.
     #[instrument(level = "trace", skip_all, fields(n_diffs = diffs.len()), err)]
     pub fn operations(diffs: Vec<Diff>) -> Result<Vec<Operation>, SyncError> {
-        let mut operations = Vec::with_capacity(diffs.len());
-
-        for diff in diffs {
-            let op = match (diff.local, diff.remote) {
+        let mut operations = diffs
+            .into_iter()
+            .map(|diff| match (diff.local, diff.remote) {
                 // We both have it! Could be either. Compare.
-                (Some(local), Some(remote)) => match local.cmp(&remote) {
+                (Some(local), Some(remote)) => Ok(match local.cmp(&remote) {
                     Ordering::Equal => Operation::Noop {
                         host: diff.host,
                         tag: diff.tag,
@@ -181,41 +134,36 @@ impl<'a> SyncEngine<'a> {
                         host: diff.host,
                         tag: diff.tag,
                     },
-                },
+                }),
 
                 // Remote has it, we don't. Gotta be download
-                (None, Some(remote)) => Operation::Download {
+                (None, Some(remote)) => Ok(Operation::Download {
                     remote,
                     host: diff.host,
                     tag: diff.tag,
-                },
+                }),
 
                 // We have it, remote doesn't. Gotta be upload.
-                (Some(local), None) => Operation::Upload {
+                (Some(local), None) => Ok(Operation::Upload {
                     local,
                     remote: None,
                     host: diff.host,
                     tag: diff.tag,
-                },
+                }),
 
                 // something is pretty fucked.
-                (None, None) => {
-                    return Err(SyncError::SyncLogicError {
-                        msg: String::from(
-                            "diff has nothing for local or remote - (host, tag) does not exist",
-                        ),
-                    });
-                }
-            };
-
-            operations.push(op);
-        }
+                (None, None) => Err(SyncError::SyncLogicError {
+                    msg: String::from(
+                        "diff has nothing for local or remote - (host, tag) does not exist",
+                    ),
+                }),
+            })
+            .collect::<Result<Vec<_>, _>>()?;
 
         // sort them - purely so we have a stable testing order, and can rely on
         // same input = same output
         // We can sort by ID so long as we continue to use UUIDv7 or something
         // with the same properties
-
         operations.sort_by_key(|op| match op {
             Operation::Noop { host, tag } => (0u8, *host, 0u8, tag.clone()),
             Operation::Upload { host, tag, .. } => (1u8, *host, 0u8, tag.clone()),
@@ -249,7 +197,7 @@ impl<'a> SyncEngine<'a> {
         remote: Option<RecordIdx>,
         page_size: u64,
     ) -> Result<u64, SyncError> {
-        let store = self.store;
+        let store = &self.store;
         let client = &self.client;
         let key = self.key;
         // The first record the remote *doesn't* have.
@@ -328,7 +276,7 @@ impl<'a> SyncEngine<'a> {
         remote: RecordIdx,
         page_size: u64,
     ) -> Result<Vec<RecordId>, SyncError> {
-        let store = self.store;
+        let store = &self.store;
         let client = &self.client;
         let key = self.key;
         // Scan the database to find the first missing local index, rather than assuming it's one more
@@ -827,6 +775,22 @@ mod packfile_download_tests {
         SqliteStore::new(":memory:", test_local_timeout()).await.unwrap()
     }
 
+    /// Wrap a prebuilt client in a [`SyncEngine`] for tests.
+    pub(super) async fn build_engine(
+        client: Client,
+        store: SqliteStore,
+        key: &paseto_v4::Key,
+    ) -> SyncEngine<'_> {
+        SyncEngine::builder()
+            .store(store)
+            .key(key)
+            .client_source(ClientSource::FromClient(client))
+            .build()
+            .connect()
+            .await
+            .unwrap()
+    }
+
     /// Push a contiguous run of `count` encrypted HISTORY records (idx `0..count`).
     pub(super) async fn seed_history(
         store: &SqliteStore,
@@ -949,7 +913,8 @@ mod packfile_download_tests {
         let client = mock_client(&addr);
         let store = memory_store().await;
 
-        SyncEngine::with_client(client, &store, &key)
+        build_engine(client, store, &key)
+            .await
             .check_encryption_key(&remote_index)
             .await
             .expect("a plaintext packfile manifest must not be treated as a wrong key");
@@ -984,7 +949,8 @@ mod packfile_download_tests {
         let client = mock_client(&addr);
 
         let wrong = paseto_v4::Key::from([9u8; 32]);
-        let err = SyncEngine::with_client(client, &store, &wrong)
+        let err = build_engine(client, store, &wrong)
+            .await
             .check_encryption_key(&remote_index)
             .await
             .expect_err("a wrong key on an encrypted record must still be detected");
@@ -1009,7 +975,8 @@ mod packfile_download_tests {
         let addr: url::Url = server.uri().parse().unwrap();
         let client = mock_client(&addr);
 
-        SyncEngine::with_client(client, &down, &key)
+        build_engine(client, down.clone(), &key)
+            .await
             .sync_download(host, RecordTag::Packfile, 1, 100)
             .await
             .unwrap();
@@ -1036,7 +1003,8 @@ mod packfile_download_tests {
         let addr: url::Url = server.uri().parse().unwrap();
         let client = mock_client(&addr);
 
-        let returned = SyncEngine::with_client(client, &down, &key)
+        let returned = build_engine(client, down, &key)
+            .await
             .sync_download(host, RecordTag::Packfile, 1, 100)
             .await
             .unwrap();
@@ -1099,7 +1067,7 @@ mod packfile_download_tests {
         let down = memory_store().await;
         let addr: url::Url = server.uri().parse().unwrap();
         let client = mock_client(&addr);
-        let engine = SyncEngine::with_client(client, &down, &key);
+        let engine = build_engine(client, down, &key).await;
 
         // Packfile op first (populates history 0..=2), then the history op.
         engine.sync_download(host, RecordTag::Packfile, 1, 100).await.unwrap();
@@ -1141,7 +1109,8 @@ mod packfile_download_tests {
         let client = mock_client(&addr);
 
         // remote (2) is BEHIND the live local head (4) -- must not underflow/panic.
-        let got = SyncEngine::with_client(client, &down, &key)
+        let got = build_engine(client, down, &key)
+            .await
             .sync_download(host, RecordTag::History, 2, 100)
             .await
             .unwrap();
@@ -1246,7 +1215,8 @@ mod packfile_download_tests {
         let addr: url::Url = server.uri().parse().unwrap();
         let client = mock_client(&addr);
 
-        let returned = SyncEngine::with_client(client, &down, &key)
+        let returned = build_engine(client, down.clone(), &key)
+            .await
             .sync_download(host, RecordTag::Packfile, 1, 100)
             .await
             .unwrap();
@@ -1311,7 +1281,8 @@ mod packfile_download_tests {
         let client = mock_client(&addr);
 
         // The permanent per-manifest failure is logged and skipped; the whole tick still succeeds.
-        let returned = SyncEngine::with_client(client, &down, &key)
+        let returned = build_engine(client, down.clone(), &key)
+            .await
             .sync_download(host, RecordTag::Packfile, 2, 100)
             .await
             .expect("a permanent per-manifest failure must not fail the tick");
@@ -1341,10 +1312,10 @@ mod packfile_capability_tests {
     use wiremock::matchers::{method, path, query_param};
     use wiremock::{Mock, MockServer, ResponseTemplate};
 
+    use super::Operation;
     use super::packfile_download_tests::{
-        memory_store, mock_client, mount_packfile, packed_packfile, seed_history,
+        build_engine, memory_store, mock_client, mount_packfile, packed_packfile, seed_history,
     };
-    use super::{Operation, SyncEngine};
 
     /// A single fixed encryption key, matching the sibling packfile tests.
     #[fixture]
@@ -1411,7 +1382,8 @@ mod packfile_capability_tests {
         let addr: url::Url = server.uri().parse().unwrap();
         let client = mock_client(&addr);
 
-        SyncEngine::with_client(client, &down, &key)
+        build_engine(client, down.clone(), &key)
+            .await
             .sync_remote(vec![packfile_download_op(host, 3)], 100)
             .await
             .unwrap();
@@ -1478,7 +1450,8 @@ mod packfile_capability_tests {
         let addr: url::Url = server.uri().parse().unwrap();
         let client = mock_client(&addr);
 
-        SyncEngine::with_client(client, &down, &key)
+        build_engine(client, down.clone(), &key)
+            .await
             .sync_remote(
                 vec![packfile_download_op(host, 3), Operation::Download {
                     remote: 3,
@@ -1508,7 +1481,8 @@ mod packfile_capability_tests {
         let addr: url::Url = server.uri().parse().unwrap();
         let client = mock_client(&addr);
 
-        SyncEngine::with_client(client, &down, &key)
+        build_engine(client, down.clone(), &key)
+            .await
             .sync_remote(vec![packfile_download_op(host, 3)], 100)
             .await
             .unwrap();
@@ -1543,7 +1517,8 @@ mod packfile_capability_tests {
         let addr: url::Url = server.uri().parse().unwrap();
         let client = mock_client(&addr);
 
-        SyncEngine::with_client(client, &down, &key)
+        build_engine(client, down.clone(), &key)
+            .await
             .sync_remote(vec![packfile_download_op(host, 3)], 100)
             .await
             .unwrap();

--- a/crates/atuin-client/src/record/sync/packfile.rs
+++ b/crates/atuin-client/src/record/sync/packfile.rs
@@ -1,61 +1,31 @@
 //! Syncs a packed history range in both directions: ship a manifest's blob to the remote, and
 //! expand a remote manifest back into the local store.
 //!
-//! # Uploading
-//!
-//! [`upload_packed`] takes a `packfile` manifest record, reads the history run it covers,
-//! compresses + encrypts it with the pack codec (bound to the manifest's identity), and PUTs
-//! the blob to the presigned URL the server hands back. The manifest record itself is authored by
-//! the packer and synced separately; this only ships the bytes.
-//!
-//! # Downloading
-//!
-//! [`download_packed`] takes a remote `packfile` manifest, fetches its packfile blob, unpacks it back
-//! into the individual history records for the manifest's `"start".."end"` range, re-encrypts each
-//! one with the local key, and pushes them into the local record store.
+//! These live on [`Keyed`] rather than [`SyncEngine`](super::SyncEngine) because they encrypt and
+//! decrypt with the session key. The lower-level packing machinery stays in [`crate::packfile`];
+//! this is only the sync integration (fetch/store/upload through the engine's client and store).
 
-use atuin_common::encryption::paseto_v4;
 use atuin_domain::record::{EncryptedData, Record, RecordId, RecordTag};
 use thiserror::Error;
 use tracing::instrument;
 
-use super::record::{PackManifestRecordView, PackingError, UnpackError};
-use crate::api_client::Client;
-use crate::packfile::record::ParsingError;
-use crate::record::sqlite_store::SqliteStore;
+use super::Keyed;
+use crate::packfile::record::{PackManifestRecordView, PackingError, ParsingError, UnpackError};
 
 #[derive(Debug, Error)]
-pub enum UploadError {
+pub(super) enum UploadError {
     #[error("failed to load the packfile manifest: {0}")]
     PackManifest(#[from] ParsingError),
 
     #[error(transparent)]
     Pack(#[from] PackingError),
 
-    #[error("failed to load the packed history from the store: {0}")]
-    Load(eyre::Report),
-
     #[error("packfile upload failed: {0}")]
     Api(eyre::Report),
 }
 
-/// Build and upload the packfile blob for a single `packfile` manifest record.
-#[instrument(level = "trace", skip_all, fields(id = ?manifest.id), err)]
-pub async fn upload_packed(
-    manifest: &Record<EncryptedData>,
-    store: &SqliteStore,
-    key: &paseto_v4::Key,
-    client: &Client,
-) -> Result<(), UploadError> {
-    let view = PackManifestRecordView::new(manifest)?;
-
-    let (blob, ids) = view.pack_records(store, key.clone()).await?;
-
-    client.upload_packfile(view.record.id, &ids, blob).await.map_err(UploadError::Api)
-}
-
 #[derive(Debug, Error)]
-pub enum DownloadError {
+pub(super) enum DownloadError {
     #[error("failed to load the packfile manifest: {0}")]
     PackManifest(#[from] ParsingError),
 
@@ -71,7 +41,7 @@ pub enum DownloadError {
 
 impl DownloadError {
     /// Whether repeating the same download operation would definitively fail.
-    pub fn is_permanent(&self) -> bool {
+    pub(super) fn is_permanent(&self) -> bool {
         match self {
             Self::PackManifest(_) => true,
             Self::Unpack(_) => true,
@@ -80,41 +50,66 @@ impl DownloadError {
     }
 }
 
-/// Fetch, unpack, and locally store the history covered by a single `packfile` manifest.
-///
-/// Returns the ids of the history records the manifest's range covers, whether they were just
-/// inserted or were already present locally.
-#[instrument(level = "trace", skip_all, fields(id = ?manifest.id), err)]
-pub async fn download_packed(
-    manifest: &Record<EncryptedData>,
-    store: &SqliteStore,
-    key: &paseto_v4::Key,
-    client: &Client,
-) -> Result<Vec<RecordId>, DownloadError> {
-    let view = PackManifestRecordView::new(manifest)?;
+impl Keyed<'_> {
+    /// Build and upload the packfile blob for a single `packfile` manifest record.
+    #[instrument(level = "trace", skip_all, fields(id = ?manifest.id), err)]
+    pub(super) async fn upload_packed(
+        &self,
+        manifest: &Record<EncryptedData>,
+    ) -> Result<(), UploadError> {
+        let view = PackManifestRecordView::new(manifest)?;
 
-    // Skip if we already have the whole range (history is contiguous, packfiles are prefixes).
-    let head =
-        store.last(view.record.host.id, &RecordTag::History).await.map_err(DownloadError::Store)?;
-    if let Some(head) = head
-        && head.idx >= view.range().end - 1
-    {
-        // Range already available locally. Return the IDs.
-        let existing = view
-            .load_encrypted_packed_records(store)
+        let (blob, ids) = view.pack_records(&self.engine.store, self.key.clone()).await?;
+
+        self.engine
+            .client
+            .upload_packfile(view.record.id, &ids, blob)
             .await
-            .map_err(|e| DownloadError::Store(e.into()))?;
-        return Ok(existing.iter().map(|r| r.id).collect());
+            .map_err(UploadError::Api)
     }
 
-    let blob = client.download_packfile(view.record.id).await.map_err(DownloadError::Api)?;
+    /// Fetch, unpack, and locally store the history covered by a single `packfile` manifest.
+    ///
+    /// Returns the ids of the history records the manifest's range covers, whether they were just
+    /// inserted or were already present locally.
+    #[instrument(level = "trace", skip_all, fields(id = ?manifest.id), err)]
+    pub(super) async fn download_packed(
+        &self,
+        manifest: &Record<EncryptedData>,
+    ) -> Result<Vec<RecordId>, DownloadError> {
+        let view = PackManifestRecordView::new(manifest)?;
+        let store = &self.engine.store;
 
-    let records = view.unpack_records(blob, key.clone()).await?;
-    let ids: Vec<RecordId> = records.iter().map(|record| record.id).collect();
+        // Skip if we already have the whole range (history is contiguous, packfiles are prefixes).
+        let head = store
+            .last(view.record.host.id, &RecordTag::History)
+            .await
+            .map_err(DownloadError::Store)?;
+        if let Some(head) = head
+            && head.idx >= view.range().end - 1
+        {
+            // Range already available locally. Return the IDs.
+            let existing = view
+                .load_encrypted_packed_records(store)
+                .await
+                .map_err(|e| DownloadError::Store(e.into()))?;
+            return Ok(existing.iter().map(|r| r.id).collect());
+        }
 
-    store.push_batch(records.iter()).await.map_err(DownloadError::Store)?;
+        let blob = self
+            .engine
+            .client
+            .download_packfile(view.record.id)
+            .await
+            .map_err(DownloadError::Api)?;
 
-    Ok(ids)
+        let records = view.unpack_records(blob, self.key.clone()).await?;
+        let ids: Vec<RecordId> = records.iter().map(|record| record.id).collect();
+
+        store.push_batch(records.iter()).await.map_err(DownloadError::Store)?;
+
+        Ok(ids)
+    }
 }
 
 #[cfg(test)]
@@ -131,8 +126,10 @@ mod tests {
 
     use super::*;
     use crate::api_client::{AuthToken, Client, caps_client};
+    use crate::packfile::record::{PackManifestDataV1, PackManifestRecordView};
     use crate::packfile::try_pack;
     use crate::record::sqlite_store::SqliteStore;
+    use crate::record::sync::{ClientSource, SyncEngine};
     use crate::settings::test_local_timeout;
 
     /// A single fixed encryption key. The specific bytes are arbitrary in these tests -- each one
@@ -152,6 +149,17 @@ mod tests {
     /// A fresh in-memory record store.
     async fn memory_store() -> SqliteStore {
         SqliteStore::new(":memory:", test_local_timeout()).await.unwrap()
+    }
+
+    /// A [`SyncEngine`] wrapping a prebuilt client and store, for calling the packfile methods.
+    async fn build_engine(client: Client, store: SqliteStore) -> SyncEngine {
+        SyncEngine::builder()
+            .store(store)
+            .client_source(ClientSource::FromClient(client))
+            .build()
+            .connect()
+            .await
+            .unwrap()
     }
 
     /// Push a contiguous run of `count` encrypted HISTORY records (idx `0..count`).
@@ -180,8 +188,6 @@ mod tests {
         #[case] start_idx: u64,
         #[case] end_idx: u64,
     ) {
-        use crate::packfile::record::PackManifestDataV1;
-
         let host = HostId(uuid_v7());
 
         // A corrupt/tampered manifest whose plaintext range is inverted (start_idx > end_idx). The
@@ -265,7 +271,7 @@ mod tests {
 
         // `.expect(1)` on all three mocks verifies create_packfile + put_packfile +
         // confirm_packfile each fired exactly once.
-        upload_packed(&manifest, &store, &key, &client).await.unwrap();
+        build_engine(client, store).await.keyed(&key).upload_packed(&manifest).await.unwrap();
     }
 
     #[rstest]
@@ -314,7 +320,12 @@ mod tests {
         let addr: url::Url = server.uri().parse().unwrap();
         let client = mock_client(&addr);
 
-        let ids = download_packed(&manifest, &down, &key, &client).await.unwrap();
+        let ids = build_engine(client, down.clone())
+            .await
+            .keyed(&key)
+            .download_packed(&manifest)
+            .await
+            .unwrap();
         assert_eq!(ids.len(), 5, "all five history records populated");
 
         // History is present locally and decrypts to the same commands.
@@ -368,7 +379,8 @@ mod tests {
         )
         .unwrap();
 
-        let ids = download_packed(&manifest, &down, &key, &client).await.unwrap();
+        let ids =
+            build_engine(client, down).await.keyed(&key).download_packed(&manifest).await.unwrap();
 
         // Range already present -> no fetch, but the covered ids are still returned so the
         // id-driven history.db rebuild can re-index them (see download_packed's doc comment).
@@ -391,7 +403,7 @@ mod tests {
         cek: String::new(),
     })]
     #[case::inverted_range(|host| {
-        crate::packfile::record::PackManifestDataV1 {
+        PackManifestDataV1 {
             tag: RecordTag::History,
             host,
             start_idx: 100,
@@ -456,8 +468,11 @@ mod tests {
         let down = memory_store().await;
         let addr: url::Url = server.uri().parse().unwrap();
         let client = mock_client(&addr);
+        let engine = build_engine(client, down.clone()).await;
 
-        let err = download_packed(&bad, &down, &key, &client)
+        let err = engine
+            .keyed(&key)
+            .download_packed(&bad)
             .await
             .expect_err("a malformed manifest must not expand");
         assert!(
@@ -465,7 +480,9 @@ mod tests {
             "the caller must be told to skip this manifest, not fail the tick: {err:?}"
         );
 
-        let ids = download_packed(&good, &down, &key, &client)
+        let ids = engine
+            .keyed(&key)
+            .download_packed(&good)
             .await
             .expect("the valid manifest still expands");
         assert_eq!(ids.len(), 3, "the valid manifest's three records expand");
@@ -488,7 +505,7 @@ mod tests {
             .tag(RecordTag::Packfile)
             .idx(0)
             .data(
-                crate::packfile::record::PackManifestDataV1 {
+                PackManifestDataV1 {
                     host,
                     tag: RecordTag::History,
                     start_idx: 0,
@@ -516,7 +533,7 @@ mod tests {
         )
         .unwrap();
 
-        let result = download_packed(&manifest, &down, &key, &client).await;
+        let result = build_engine(client, down).await.keyed(&key).download_packed(&manifest).await;
         assert!(
             matches!(result, Err(DownloadError::Api(_))),
             "a transient transport fault must surface as Api: {result:?}"

--- a/crates/atuin-daemon/src/components/sync.rs
+++ b/crates/atuin-daemon/src/components/sync.rs
@@ -7,7 +7,7 @@ use std::time::Duration;
 
 use atuin_client::history::HistoryId;
 use atuin_client::history::store::HistoryStore;
-use atuin_client::record::sync::SyncEngine;
+use atuin_client::record::sync::{ClientSource, SyncEngine};
 use atuin_client::settings::Settings;
 use atuin_dotfiles::store::AliasStore;
 use atuin_dotfiles::store::var::VarStore;
@@ -217,7 +217,15 @@ async fn do_sync_tick(
 
     // Perform the sync
     let res = async {
-        SyncEngine::new(settings, handle.store(), handle.encryption_key(), handle.caps().clone())
+        SyncEngine::builder()
+            .store(handle.store().clone())
+            .key(handle.encryption_key())
+            .client_source(ClientSource::FromSettings {
+                settings,
+                caps: Some(handle.caps().clone()),
+            })
+            .build()
+            .connect()
             .await?
             .sync()
             .await

--- a/crates/atuin-daemon/src/components/sync.rs
+++ b/crates/atuin-daemon/src/components/sync.rs
@@ -7,7 +7,7 @@ use std::time::Duration;
 
 use atuin_client::history::HistoryId;
 use atuin_client::history::store::HistoryStore;
-use atuin_client::record::sync;
+use atuin_client::record::sync::SyncEngine;
 use atuin_client::settings::Settings;
 use atuin_dotfiles::store::AliasStore;
 use atuin_dotfiles::store::var::VarStore;
@@ -216,8 +216,13 @@ async fn do_sync_tick(
     }
 
     // Perform the sync
-    let res =
-        sync::sync(settings, handle.store(), handle.encryption_key(), handle.caps().clone()).await;
+    let res = async {
+        SyncEngine::new(settings, handle.store(), handle.encryption_key(), handle.caps().clone())
+            .await?
+            .sync()
+            .await
+    }
+    .await;
 
     match res {
         Err(e) => {

--- a/crates/atuin-daemon/src/components/sync.rs
+++ b/crates/atuin-daemon/src/components/sync.rs
@@ -217,18 +217,16 @@ async fn do_sync_tick(
 
     // Perform the sync
     let res = async {
-        SyncEngine::builder()
+        let engine = SyncEngine::builder()
             .store(handle.store().clone())
-            .key(handle.encryption_key())
             .client_source(ClientSource::FromSettings {
                 settings,
                 caps: Some(handle.caps().clone()),
             })
             .build()
             .connect()
-            .await?
-            .sync()
-            .await
+            .await?;
+        engine.keyed(handle.encryption_key()).sync().await
     }
     .await;
 

--- a/crates/atuin-server/tests/sync.rs
+++ b/crates/atuin-server/tests/sync.rs
@@ -157,7 +157,6 @@ async fn download(
     let key = key();
     let engine = SyncEngine::builder()
         .store(store.clone())
-        .key(&key)
         .client_source(ClientSource::FromClient(client))
         .build()
         .connect()
@@ -165,7 +164,7 @@ async fn download(
         .unwrap();
     let (diff, _) = engine.diff().await.unwrap();
     let operations = SyncEngine::operations(diff).unwrap();
-    let (_, downloaded) = engine.sync_remote(operations, page_size).await.unwrap();
+    let (_, downloaded) = engine.keyed(&key).sync_remote(operations, page_size).await.unwrap();
 
     let status = store.status().await.unwrap();
     let local_idx = *status.hosts.get(&host).unwrap().get(&tag).unwrap();
@@ -224,7 +223,6 @@ async fn upload(
     let key = key();
     let engine = SyncEngine::builder()
         .store(store)
-        .key(&key)
         .client_source(ClientSource::FromClient(client))
         .build()
         .connect()
@@ -232,9 +230,9 @@ async fn upload(
         .unwrap();
     let (diff, _) = engine.diff().await.unwrap();
     let operations = SyncEngine::operations(diff).unwrap();
-    let (uploaded, _) = engine.sync_remote(operations, page_size).await.unwrap();
+    let (uploaded, _) = engine.keyed(&key).sync_remote(operations, page_size).await.unwrap();
 
-    let status = engine.client().record_status().await.unwrap();
+    let status = engine.record_status().await.unwrap();
     let remote_idx = *status.hosts.get(&host).unwrap().get(&tag).unwrap();
 
     // The PR that added these tests also changed the type of `uploaded` from `i64` to `u64`; the

--- a/crates/atuin-server/tests/sync.rs
+++ b/crates/atuin-server/tests/sync.rs
@@ -3,7 +3,7 @@ use std::time::Duration;
 
 use atuin_client::api_client;
 use atuin_client::record::sqlite_store::SqliteStore;
-use atuin_client::record::sync;
+use atuin_client::record::sync::SyncEngine;
 use atuin_common::encryption::paseto_v4;
 use atuin_common::utils::uuid_v7;
 use atuin_domain::record::{EncryptedData, Host, HostId, Record, RecordId, RecordIdx, RecordTag};
@@ -154,10 +154,11 @@ async fn download(
         store.push_batch(records.iter().take(local_max as usize + 1)).await.unwrap();
     }
 
-    let (diff, _) = sync::diff(&client, &store).await.unwrap();
-    let operations = sync::operations(diff, &store).unwrap();
-    let (_, downloaded) =
-        sync::sync_remote(&client, operations, &store, page_size, &key()).await.unwrap();
+    let key = key();
+    let engine = SyncEngine::with_client(client, &store, &key);
+    let (diff, _) = engine.diff().await.unwrap();
+    let operations = SyncEngine::operations(diff).unwrap();
+    let (_, downloaded) = engine.sync_remote(operations, page_size).await.unwrap();
 
     let status = store.status().await.unwrap();
     let local_idx = *status.hosts.get(&host).unwrap().get(&tag).unwrap();
@@ -213,12 +214,13 @@ async fn upload(
         client.post_records(&records[..=remote_max as usize]).await.unwrap();
     }
 
-    let (diff, _) = sync::diff(&client, &store).await.unwrap();
-    let operations = sync::operations(diff, &store).unwrap();
-    let (uploaded, _) =
-        sync::sync_remote(&client, operations, &store, page_size, &key()).await.unwrap();
+    let key = key();
+    let engine = SyncEngine::with_client(client, &store, &key);
+    let (diff, _) = engine.diff().await.unwrap();
+    let operations = SyncEngine::operations(diff).unwrap();
+    let (uploaded, _) = engine.sync_remote(operations, page_size).await.unwrap();
 
-    let status = client.record_status().await.unwrap();
+    let status = engine.client().record_status().await.unwrap();
     let remote_idx = *status.hosts.get(&host).unwrap().get(&tag).unwrap();
 
     // The PR that added these tests also changed the type of `uploaded` from `i64` to `u64`; the

--- a/crates/atuin-server/tests/sync.rs
+++ b/crates/atuin-server/tests/sync.rs
@@ -3,7 +3,7 @@ use std::time::Duration;
 
 use atuin_client::api_client;
 use atuin_client::record::sqlite_store::SqliteStore;
-use atuin_client::record::sync::SyncEngine;
+use atuin_client::record::sync::{ClientSource, SyncEngine};
 use atuin_common::encryption::paseto_v4;
 use atuin_common::utils::uuid_v7;
 use atuin_domain::record::{EncryptedData, Host, HostId, Record, RecordId, RecordIdx, RecordTag};
@@ -155,7 +155,14 @@ async fn download(
     }
 
     let key = key();
-    let engine = SyncEngine::with_client(client, &store, &key);
+    let engine = SyncEngine::builder()
+        .store(store.clone())
+        .key(&key)
+        .client_source(ClientSource::FromClient(client))
+        .build()
+        .connect()
+        .await
+        .unwrap();
     let (diff, _) = engine.diff().await.unwrap();
     let operations = SyncEngine::operations(diff).unwrap();
     let (_, downloaded) = engine.sync_remote(operations, page_size).await.unwrap();
@@ -215,7 +222,14 @@ async fn upload(
     }
 
     let key = key();
-    let engine = SyncEngine::with_client(client, &store, &key);
+    let engine = SyncEngine::builder()
+        .store(store)
+        .key(&key)
+        .client_source(ClientSource::FromClient(client))
+        .build()
+        .connect()
+        .await
+        .unwrap();
     let (diff, _) = engine.diff().await.unwrap();
     let operations = SyncEngine::operations(diff).unwrap();
     let (uploaded, _) = engine.sync_remote(operations, page_size).await.unwrap();

--- a/crates/atuin/src/command/client/account/login.rs
+++ b/crates/atuin/src/command/client/account/login.rs
@@ -2,7 +2,7 @@ use std::io::{self, IsTerminal};
 
 use atuin_client::auth::{self, AuthClient, AuthResponse};
 use atuin_client::record::sqlite_store::SqliteStore;
-use atuin_client::record::sync::{SyncEngine, SyncError};
+use atuin_client::record::sync::{ClientSource, SyncEngine, SyncError};
 use atuin_client::settings::{Settings, SyncAuth};
 use atuin_common::encryption::paseto_v4;
 use clap::Parser;
@@ -273,7 +273,18 @@ async fn verify_key_against_remote(
 
     // Build the client once (this hits the network). The key can change between retries below, so
     // each iteration wraps a cheap clone of the client in a fresh engine rather than re-connecting.
-    let client = SyncEngine::connect(settings, store, &key).await?.client().clone();
+    let client = SyncEngine::builder()
+        .store(store.clone())
+        .key(&key)
+        .client_source(ClientSource::FromSettings {
+            settings,
+            caps: None,
+        })
+        .build()
+        .connect()
+        .await?
+        .client()
+        .clone();
     let remote_index = match client.record_status().await {
         Ok(idx) => idx,
         Err(e) => {
@@ -283,7 +294,13 @@ async fn verify_key_against_remote(
     };
 
     loop {
-        let check = SyncEngine::with_client(client.clone(), store, &key)
+        let check = SyncEngine::builder()
+            .store(store.clone())
+            .key(&key)
+            .client_source(ClientSource::FromClient(client.clone()))
+            .build()
+            .connect()
+            .await?
             .check_encryption_key(&remote_index)
             .await;
         match check {

--- a/crates/atuin/src/command/client/account/login.rs
+++ b/crates/atuin/src/command/client/account/login.rs
@@ -2,7 +2,7 @@ use std::io::{self, IsTerminal};
 
 use atuin_client::auth::{self, AuthClient, AuthResponse};
 use atuin_client::record::sqlite_store::SqliteStore;
-use atuin_client::record::sync::{self, SyncError};
+use atuin_client::record::sync::{SyncEngine, SyncError};
 use atuin_client::settings::{Settings, SyncAuth};
 use atuin_common::encryption::paseto_v4;
 use clap::Parser;
@@ -271,7 +271,9 @@ async fn verify_key_against_remote(
     let mut key = paseto_v4::Key::try_load_from_path(&settings.key_path)
         .context("could not load encryption key for verification")?;
 
-    let client = sync::build_client(settings).await?;
+    // Build the client once (this hits the network). The key can change between retries below, so
+    // each iteration wraps a cheap clone of the client in a fresh engine rather than re-connecting.
+    let client = SyncEngine::connect(settings, store, &key).await?.client().clone();
     let remote_index = match client.record_status().await {
         Ok(idx) => idx,
         Err(e) => {
@@ -281,7 +283,10 @@ async fn verify_key_against_remote(
     };
 
     loop {
-        match sync::check_encryption_key(&client, &remote_index, &key).await {
+        let check = SyncEngine::with_client(client.clone(), store, &key)
+            .check_encryption_key(&remote_index)
+            .await;
+        match check {
             // Only persist a key the server has confirmed can read the data, so
             // that cancelling out of a retry leaves the local store as it was.
             Ok(()) => return store_key(settings, store, &key).await,

--- a/crates/atuin/src/command/client/account/login.rs
+++ b/crates/atuin/src/command/client/account/login.rs
@@ -271,21 +271,18 @@ async fn verify_key_against_remote(
     let mut key = paseto_v4::Key::try_load_from_path(&settings.key_path)
         .context("could not load encryption key for verification")?;
 
-    // Build the client once (this hits the network). The key can change between retries below, so
-    // each iteration wraps a cheap clone of the client in a fresh engine rather than re-connecting.
-    let client = SyncEngine::builder()
+    // Build the engine once (this hits the network). The key can change between retries below, so
+    // each iteration re-keys the shared engine rather than reconnecting.
+    let engine = SyncEngine::builder()
         .store(store.clone())
-        .key(&key)
         .client_source(ClientSource::FromSettings {
             settings,
             caps: None,
         })
         .build()
         .connect()
-        .await?
-        .client()
-        .clone();
-    let remote_index = match client.record_status().await {
+        .await?;
+    let remote_index = match engine.record_status().await {
         Ok(idx) => idx,
         Err(e) => {
             tracing::warn!("could not fetch remote status to verify key: {e}");
@@ -294,15 +291,7 @@ async fn verify_key_against_remote(
     };
 
     loop {
-        let check = SyncEngine::builder()
-            .store(store.clone())
-            .key(&key)
-            .client_source(ClientSource::FromClient(client.clone()))
-            .build()
-            .connect()
-            .await?
-            .check_encryption_key(&remote_index)
-            .await;
+        let check = engine.keyed(&key).check_encryption_key(&remote_index).await;
         match check {
             // Only persist a key the server has confirmed can read the data, so
             // that cancelling out of a retry leaves the local store as it was.

--- a/crates/atuin/src/command/client/history.rs
+++ b/crates/atuin/src/command/client/history.rs
@@ -522,18 +522,16 @@ async fn handle_end(
                 &settings.sync_address,
                 &settings.extra_headers,
             )?;
-            let (_, downloaded) = record::sync::SyncEngine::builder()
+            let engine = record::sync::SyncEngine::builder()
                 .store(store.clone())
-                .key(&history_store.encryption_key)
                 .client_source(record::sync::ClientSource::FromSettings {
                     settings,
                     caps: Some(caps),
                 })
                 .build()
                 .connect()
-                .await?
-                .sync()
                 .await?;
+            let (_, downloaded) = engine.keyed(&history_store.encryption_key).sync().await?;
             Settings::save_sync_time().await?;
 
             crate::sync::build(settings, &store, db, Some(&downloaded)).await?;

--- a/crates/atuin/src/command/client/history.rs
+++ b/crates/atuin/src/command/client/history.rs
@@ -522,8 +522,15 @@ async fn handle_end(
                 &settings.sync_address,
                 &settings.extra_headers,
             )?;
-            let (_, downloaded) =
-                record::sync::sync(settings, &store, &history_store.encryption_key, caps).await?;
+            let (_, downloaded) = record::sync::SyncEngine::new(
+                settings,
+                &store,
+                &history_store.encryption_key,
+                caps,
+            )
+            .await?
+            .sync()
+            .await?;
             Settings::save_sync_time().await?;
 
             crate::sync::build(settings, &store, db, Some(&downloaded)).await?;

--- a/crates/atuin/src/command/client/history.rs
+++ b/crates/atuin/src/command/client/history.rs
@@ -522,15 +522,18 @@ async fn handle_end(
                 &settings.sync_address,
                 &settings.extra_headers,
             )?;
-            let (_, downloaded) = record::sync::SyncEngine::new(
-                settings,
-                &store,
-                &history_store.encryption_key,
-                caps,
-            )
-            .await?
-            .sync()
-            .await?;
+            let (_, downloaded) = record::sync::SyncEngine::builder()
+                .store(store.clone())
+                .key(&history_store.encryption_key)
+                .client_source(record::sync::ClientSource::FromSettings {
+                    settings,
+                    caps: Some(caps),
+                })
+                .build()
+                .connect()
+                .await?
+                .sync()
+                .await?;
             Settings::save_sync_time().await?;
 
             crate::sync::build(settings, &store, db, Some(&downloaded)).await?;

--- a/crates/atuin/src/command/client/store/pull.rs
+++ b/crates/atuin/src/command/client/store/pull.rs
@@ -1,7 +1,6 @@
 use atuin_client::database::Sqlite;
 use atuin_client::record::sqlite_store::SqliteStore;
-use atuin_client::record::sync;
-use atuin_client::record::sync::Operation;
+use atuin_client::record::sync::{Operation, SyncEngine};
 use atuin_client::settings::Settings;
 use atuin_common::encryption::paseto_v4;
 use atuin_domain::record::RecordTag;
@@ -42,19 +41,20 @@ impl Pull {
         // 3. Filter operations by
         //  a) are they a download op?
         //  b) are they for the host/tag we are pushing here?
-        let client = sync::build_client(settings).await?;
-        let (diff, remote_index) = sync::diff(&client, &store).await?;
-
         let key = paseto_v4::Key::try_load_from_path(&settings.key_path)?;
+        let engine = SyncEngine::connect(settings, &store, &key).await?;
+
+        let (diff, remote_index) = engine.diff().await?;
 
         // Skip on --force: local was already wiped above, mismatch is the user's call.
         if !self.force {
-            sync::check_encryption_key(&client, &remote_index, &key)
+            engine
+                .check_encryption_key(&remote_index)
                 .await
                 .map_err(crate::print_error::format_sync_error)?;
         }
 
-        let operations = sync::operations(diff, &store)?;
+        let operations = SyncEngine::operations(diff)?;
 
         let operations = operations
             .into_iter()
@@ -79,8 +79,7 @@ impl Pull {
             })
             .collect();
 
-        let (_, downloaded) =
-            sync::sync_remote(&client, operations, &store, self.page, &key).await?;
+        let (_, downloaded) = engine.sync_remote(operations, self.page).await?;
 
         println!("Downloaded {} records", downloaded.len());
 

--- a/crates/atuin/src/command/client/store/pull.rs
+++ b/crates/atuin/src/command/client/store/pull.rs
@@ -44,7 +44,6 @@ impl Pull {
         let key = paseto_v4::Key::try_load_from_path(&settings.key_path)?;
         let engine = SyncEngine::builder()
             .store(store.clone())
-            .key(&key)
             .client_source(ClientSource::FromSettings {
                 settings,
                 caps: None,
@@ -58,6 +57,7 @@ impl Pull {
         // Skip on --force: local was already wiped above, mismatch is the user's call.
         if !self.force {
             engine
+                .keyed(&key)
                 .check_encryption_key(&remote_index)
                 .await
                 .map_err(crate::print_error::format_sync_error)?;
@@ -88,7 +88,7 @@ impl Pull {
             })
             .collect();
 
-        let (_, downloaded) = engine.sync_remote(operations, self.page).await?;
+        let (_, downloaded) = engine.keyed(&key).sync_remote(operations, self.page).await?;
 
         println!("Downloaded {} records", downloaded.len());
 

--- a/crates/atuin/src/command/client/store/pull.rs
+++ b/crates/atuin/src/command/client/store/pull.rs
@@ -1,6 +1,6 @@
 use atuin_client::database::Sqlite;
 use atuin_client::record::sqlite_store::SqliteStore;
-use atuin_client::record::sync::{Operation, SyncEngine};
+use atuin_client::record::sync::{ClientSource, Operation, SyncEngine};
 use atuin_client::settings::Settings;
 use atuin_common::encryption::paseto_v4;
 use atuin_domain::record::RecordTag;
@@ -42,7 +42,16 @@ impl Pull {
         //  a) are they a download op?
         //  b) are they for the host/tag we are pushing here?
         let key = paseto_v4::Key::try_load_from_path(&settings.key_path)?;
-        let engine = SyncEngine::connect(settings, &store, &key).await?;
+        let engine = SyncEngine::builder()
+            .store(store.clone())
+            .key(&key)
+            .client_source(ClientSource::FromSettings {
+                settings,
+                caps: None,
+            })
+            .build()
+            .connect()
+            .await?;
 
         let (diff, remote_index) = engine.diff().await?;
 

--- a/crates/atuin/src/command/client/store/push.rs
+++ b/crates/atuin/src/command/client/store/push.rs
@@ -1,7 +1,6 @@
 use atuin_client::api_client::Client;
 use atuin_client::record::sqlite_store::SqliteStore;
-use atuin_client::record::sync;
-use atuin_client::record::sync::Operation;
+use atuin_client::record::sync::{Operation, SyncEngine};
 use atuin_client::settings::Settings;
 use atuin_common::encryption::paseto_v4;
 use atuin_domain::record::{HostId, RecordTag};
@@ -65,19 +64,20 @@ impl Push {
         // 3. Filter operations by
         //  a) are they an upload op?
         //  b) are they for the host/tag we are pushing here?
-        let client = sync::build_client(settings).await?;
-        let (diff, remote_index) = sync::diff(&client, &store).await?;
-
         let key = paseto_v4::Key::try_load_from_path(&settings.key_path)?;
+        let engine = SyncEngine::connect(settings, &store, &key).await?;
+
+        let (diff, remote_index) = engine.diff().await?;
 
         // Skip on --force: that path intentionally replaces remote with local.
         if !self.force {
-            sync::check_encryption_key(&client, &remote_index, &key)
+            engine
+                .check_encryption_key(&remote_index)
                 .await
                 .map_err(crate::print_error::format_sync_error)?;
         }
 
-        let operations = sync::operations(diff, &store)?;
+        let operations = SyncEngine::operations(diff)?;
 
         let operations = operations
             .into_iter()
@@ -110,7 +110,7 @@ impl Push {
             })
             .collect();
 
-        let (uploaded, _) = sync::sync_remote(&client, operations, &store, self.page, &key).await?;
+        let (uploaded, _) = engine.sync_remote(operations, self.page).await?;
 
         println!("Uploaded {uploaded} records");
 

--- a/crates/atuin/src/command/client/store/push.rs
+++ b/crates/atuin/src/command/client/store/push.rs
@@ -1,6 +1,6 @@
 use atuin_client::api_client::Client;
 use atuin_client::record::sqlite_store::SqliteStore;
-use atuin_client::record::sync::{Operation, SyncEngine};
+use atuin_client::record::sync::{ClientSource, Operation, SyncEngine};
 use atuin_client::settings::Settings;
 use atuin_common::encryption::paseto_v4;
 use atuin_domain::record::{HostId, RecordTag};
@@ -65,7 +65,16 @@ impl Push {
         //  a) are they an upload op?
         //  b) are they for the host/tag we are pushing here?
         let key = paseto_v4::Key::try_load_from_path(&settings.key_path)?;
-        let engine = SyncEngine::connect(settings, &store, &key).await?;
+        let engine = SyncEngine::builder()
+            .store(store)
+            .key(&key)
+            .client_source(ClientSource::FromSettings {
+                settings,
+                caps: None,
+            })
+            .build()
+            .connect()
+            .await?;
 
         let (diff, remote_index) = engine.diff().await?;
 

--- a/crates/atuin/src/command/client/store/push.rs
+++ b/crates/atuin/src/command/client/store/push.rs
@@ -67,7 +67,6 @@ impl Push {
         let key = paseto_v4::Key::try_load_from_path(&settings.key_path)?;
         let engine = SyncEngine::builder()
             .store(store)
-            .key(&key)
             .client_source(ClientSource::FromSettings {
                 settings,
                 caps: None,
@@ -81,6 +80,7 @@ impl Push {
         // Skip on --force: that path intentionally replaces remote with local.
         if !self.force {
             engine
+                .keyed(&key)
                 .check_encryption_key(&remote_index)
                 .await
                 .map_err(crate::print_error::format_sync_error)?;
@@ -119,7 +119,7 @@ impl Push {
             })
             .collect();
 
-        let (uploaded, _) = engine.sync_remote(operations, self.page).await?;
+        let (uploaded, _) = engine.keyed(&key).sync_remote(operations, self.page).await?;
 
         println!("Uploaded {uploaded} records");
 

--- a/crates/atuin/src/command/client/sync.rs
+++ b/crates/atuin/src/command/client/sync.rs
@@ -1,7 +1,7 @@
 use atuin_client::database::Sqlite;
 use atuin_client::history::store::HistoryStore;
 use atuin_client::record::sqlite_store::SqliteStore;
-use atuin_client::record::sync::SyncEngine;
+use atuin_client::record::sync::{ClientSource, SyncEngine};
 use atuin_client::settings::Settings;
 use atuin_common::encryption::paseto_v4;
 use atuin_domain::record::RecordTag;
@@ -79,7 +79,18 @@ async fn run(settings: &Settings, force: bool, db: &Sqlite, store: SqliteStore) 
         atuin_client::api_client::caps_client(&settings.sync_address, &settings.extra_headers)?;
 
     let (uploaded, downloaded) = async {
-        SyncEngine::new(settings, &store, &encryption_key, caps.clone()).await?.sync().await
+        SyncEngine::builder()
+            .store(store.clone())
+            .key(&encryption_key)
+            .client_source(ClientSource::FromSettings {
+                settings,
+                caps: Some(caps.clone()),
+            })
+            .build()
+            .connect()
+            .await?
+            .sync()
+            .await
     }
     .await
     .map_err(crate::print_error::format_sync_error)?;
@@ -104,7 +115,18 @@ async fn run(settings: &Settings, force: bool, db: &Sqlite, store: SqliteStore) 
 
         // we'll want to run sync once more, as there will now be stuff to upload
         let (uploaded, downloaded) = async {
-            SyncEngine::new(settings, &store, &encryption_key, caps.clone()).await?.sync().await
+            SyncEngine::builder()
+                .store(store.clone())
+                .key(&encryption_key)
+                .client_source(ClientSource::FromSettings {
+                    settings,
+                    caps: Some(caps.clone()),
+                })
+                .build()
+                .connect()
+                .await?
+                .sync()
+                .await
         }
         .await
         .map_err(crate::print_error::format_sync_error)?;

--- a/crates/atuin/src/command/client/sync.rs
+++ b/crates/atuin/src/command/client/sync.rs
@@ -1,7 +1,7 @@
 use atuin_client::database::Sqlite;
 use atuin_client::history::store::HistoryStore;
 use atuin_client::record::sqlite_store::SqliteStore;
-use atuin_client::record::sync;
+use atuin_client::record::sync::SyncEngine;
 use atuin_client::settings::Settings;
 use atuin_common::encryption::paseto_v4;
 use atuin_domain::record::RecordTag;
@@ -78,9 +78,11 @@ async fn run(settings: &Settings, force: bool, db: &Sqlite, store: SqliteStore) 
     let caps =
         atuin_client::api_client::caps_client(&settings.sync_address, &settings.extra_headers)?;
 
-    let (uploaded, downloaded) = sync::sync(settings, &store, &encryption_key, caps.clone())
-        .await
-        .map_err(crate::print_error::format_sync_error)?;
+    let (uploaded, downloaded) = async {
+        SyncEngine::new(settings, &store, &encryption_key, caps.clone()).await?.sync().await
+    }
+    .await
+    .map_err(crate::print_error::format_sync_error)?;
 
     crate::sync::build(settings, &store, db, Some(&downloaded)).await?;
 
@@ -101,9 +103,11 @@ async fn run(settings: &Settings, force: bool, db: &Sqlite, store: SqliteStore) 
         println!("Re-running sync due to new records locally");
 
         // we'll want to run sync once more, as there will now be stuff to upload
-        let (uploaded, downloaded) = sync::sync(settings, &store, &encryption_key, caps.clone())
-            .await
-            .map_err(crate::print_error::format_sync_error)?;
+        let (uploaded, downloaded) = async {
+            SyncEngine::new(settings, &store, &encryption_key, caps.clone()).await?.sync().await
+        }
+        .await
+        .map_err(crate::print_error::format_sync_error)?;
 
         crate::sync::build(settings, &store, db, Some(&downloaded)).await?;
 

--- a/crates/atuin/src/command/client/sync.rs
+++ b/crates/atuin/src/command/client/sync.rs
@@ -79,18 +79,16 @@ async fn run(settings: &Settings, force: bool, db: &Sqlite, store: SqliteStore) 
         atuin_client::api_client::caps_client(&settings.sync_address, &settings.extra_headers)?;
 
     let (uploaded, downloaded) = async {
-        SyncEngine::builder()
+        let engine = SyncEngine::builder()
             .store(store.clone())
-            .key(&encryption_key)
             .client_source(ClientSource::FromSettings {
                 settings,
                 caps: Some(caps.clone()),
             })
             .build()
             .connect()
-            .await?
-            .sync()
-            .await
+            .await?;
+        engine.keyed(&encryption_key).sync().await
     }
     .await
     .map_err(crate::print_error::format_sync_error)?;
@@ -115,18 +113,16 @@ async fn run(settings: &Settings, force: bool, db: &Sqlite, store: SqliteStore) 
 
         // we'll want to run sync once more, as there will now be stuff to upload
         let (uploaded, downloaded) = async {
-            SyncEngine::builder()
+            let engine = SyncEngine::builder()
                 .store(store.clone())
-                .key(&encryption_key)
                 .client_source(ClientSource::FromSettings {
                     settings,
                     caps: Some(caps.clone()),
                 })
                 .build()
                 .connect()
-                .await?
-                .sync()
-                .await
+                .await?;
+            engine.keyed(&encryption_key).sync().await
         }
         .await
         .map_err(crate::print_error::format_sync_error)?;

--- a/crates/atuin/src/command/client/sync.rs
+++ b/crates/atuin/src/command/client/sync.rs
@@ -78,20 +78,24 @@ async fn run(settings: &Settings, force: bool, db: &Sqlite, store: SqliteStore) 
     let caps =
         atuin_client::api_client::caps_client(&settings.sync_address, &settings.extra_headers)?;
 
-    let (uploaded, downloaded) = async {
-        let engine = SyncEngine::builder()
-            .store(store.clone())
-            .client_source(ClientSource::FromSettings {
-                settings,
-                caps: Some(caps.clone()),
-            })
-            .build()
-            .connect()
-            .await?;
-        engine.keyed(&encryption_key).sync().await
-    }
-    .await
-    .map_err(crate::print_error::format_sync_error)?;
+    // Build the engine once and reuse it for both sync passes below. It owns a clone of the store
+    // (a shared pool), so the second pass sees whatever the store-init writes locally.
+    let engine = SyncEngine::builder()
+        .store(store.clone())
+        .client_source(ClientSource::FromSettings {
+            settings,
+            caps: Some(caps),
+        })
+        .build()
+        .connect()
+        .await
+        .map_err(crate::print_error::format_sync_error)?;
+
+    let (uploaded, downloaded) = engine
+        .keyed(&encryption_key)
+        .sync()
+        .await
+        .map_err(crate::print_error::format_sync_error)?;
 
     crate::sync::build(settings, &store, db, Some(&downloaded)).await?;
 
@@ -111,21 +115,13 @@ async fn run(settings: &Settings, force: bool, db: &Sqlite, store: SqliteStore) 
 
         println!("Re-running sync due to new records locally");
 
-        // we'll want to run sync once more, as there will now be stuff to upload
-        let (uploaded, downloaded) = async {
-            let engine = SyncEngine::builder()
-                .store(store.clone())
-                .client_source(ClientSource::FromSettings {
-                    settings,
-                    caps: Some(caps.clone()),
-                })
-                .build()
-                .connect()
-                .await?;
-            engine.keyed(&encryption_key).sync().await
-        }
-        .await
-        .map_err(crate::print_error::format_sync_error)?;
+        // we'll want to run sync once more, as there will now be stuff to upload -- re-key the same
+        // engine rather than reconnecting.
+        let (uploaded, downloaded) = engine
+            .keyed(&encryption_key)
+            .sync()
+            .await
+            .map_err(crate::print_error::format_sync_error)?;
 
         crate::sync::build(settings, &store, db, Some(&downloaded)).await?;
 


### PR DESCRIPTION
- Wraps our `sync` utilities in a `SyncEngine` structure which helps remove some of the repeated manual threading of arguments.
- Migrates the `packfiles/sync.rs` into `SyncEngine` since that makes more sense.