### PR TITLE
chore(docker): install the toolchain pinned by rust-toolchain.toml

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,10 @@
-FROM lukemathwalker/cargo-chef:latest-rust-1.97.0-slim-bookworm AS chef
+FROM lukemathwalker/cargo-chef:latest-rust-slim-bookworm@sha256:e406ad0baa7266cee09ca9f62f30d7ed330bdb25be9f337ff8090e7ae215f7fd AS chef
 WORKDIR app
+
+# Build with the toolchain pinned in rust-toolchain.toml, not the image's.
+COPY rust-toolchain.toml .
+RUN rustup toolchain install --profile minimal --no-self-update \
+      "$(sed -n 's/^ *channel *= *"\([^"]*\)".*/\1/p' rust-toolchain.toml)"
 
 FROM chef AS planner
 COPY . .


### PR DESCRIPTION
The base image usually lags behind the actual rust release by a few days. Ensure that the docker image installs whatever version is set inside of rust-toolchain.  

Also now pin the sha :)