### PR TITLE
feat(search): add copy-directory action

### DIFF
--- a/crates/atuin/src/command/client/search/interactive.rs
+++ b/crates/atuin/src/command/client/search/interactive.rs
@@ -2131,6 +2131,10 @@ pub async fn history(
         }
         InputAction::ReturnOriginal => Ok(String::new()),
         InputAction::Copy(index) => {
+            if index >= results.len() {
+                return Ok(String::new());
+            }
+
             let cmd = results.swap_remove(index).command;
             if let Err(e) = set_clipboard(cmd) {
                 tracing::warn!(?e, "failed to copy to clipboard");
@@ -2138,6 +2142,10 @@ pub async fn history(
             Ok(String::new())
         }
         InputAction::CopyDirectory(index) => {
+            if index >= results.len() {
+                return Ok(String::new());
+            }
+
             let cwd = results.swap_remove(index).cwd;
             if let Err(e) = set_clipboard(cwd) {
                 tracing::warn!(?e, "failed to copy directory to clipboard");

--- a/crates/atuin/src/command/client/search/interactive.rs
+++ b/crates/atuin/src/command/client/search/interactive.rs
@@ -49,6 +49,7 @@ pub enum InputAction {
     Accept(usize),
     AcceptInspecting,
     Copy(usize),
+    CopyDirectory(usize),
     Delete(usize),
     DeleteAllMatching(usize),
     ReturnOriginal,
@@ -668,6 +669,7 @@ impl State {
                 InputAction::Accept(self.results_state.selected() + *n as usize)
             }
             Action::Copy => InputAction::Copy(self.results_state.selected()),
+            Action::CopyDirectory => InputAction::CopyDirectory(self.results_state.selected()),
             Action::Delete => InputAction::Delete(self.results_state.selected()),
             Action::DeleteAll => InputAction::DeleteAllMatching(self.results_state.selected()),
             Action::ReturnOriginal => InputAction::ReturnOriginal,
@@ -2132,6 +2134,13 @@ pub async fn history(
             let cmd = results.swap_remove(index).command;
             if let Err(e) = set_clipboard(cmd) {
                 tracing::warn!(?e, "failed to copy to clipboard");
+            }
+            Ok(String::new())
+        }
+        InputAction::CopyDirectory(index) => {
+            let cwd = results.swap_remove(index).cwd;
+            if let Err(e) = set_clipboard(cwd) {
+                tracing::warn!(?e, "failed to copy directory to clipboard");
             }
             Ok(String::new())
         }

--- a/crates/atuin/src/command/client/search/keybindings/actions.rs
+++ b/crates/atuin/src/command/client/search/keybindings/actions.rs
@@ -45,6 +45,7 @@ pub enum Action {
     ReturnSelectionNth(u8),
     // Commands — other
     Copy,
+    CopyDirectory,
     Delete,
     DeleteAll,
     ReturnOriginal,
@@ -125,6 +126,7 @@ impl Action {
             "accept" => Ok(Action::Accept),
             "return-selection" => Ok(Action::ReturnSelection),
             "copy" => Ok(Action::Copy),
+            "copy-directory" => Ok(Action::CopyDirectory),
             "delete" => Ok(Action::Delete),
             "delete-all" => Ok(Action::DeleteAll),
             "return-original" => Ok(Action::ReturnOriginal),
@@ -192,6 +194,7 @@ impl Action {
             Action::ReturnSelection => "return-selection".to_string(),
             Action::ReturnSelectionNth(n) => format!("return-selection-{n}"),
             Action::Copy => "copy".to_string(),
+            Action::CopyDirectory => "copy-directory".to_string(),
             Action::Delete => "delete".to_string(),
             Action::DeleteAll => "delete-all".to_string(),
             Action::ReturnOriginal => "return-original".to_string(),

--- a/docs/docs/configuration/advanced-key-binding.md
+++ b/docs/docs/configuration/advanced-key-binding.md
@@ -200,6 +200,7 @@ Note: `select-next` and `select-previous` respect the `invert` setting. When `in
 | `return-original` | Close the TUI and return the original command line text |
 | `return-query` | Close the TUI and return the current search query |
 | `copy` | Copy the selected entry to the clipboard |
+| `copy-directory` | Copy the selected entry's working directory to the clipboard |
 | `delete` | Delete the selected entry from history |
 | `delete-all` | Delete **all** history entries matching the selected command text |
 | `exit` | Exit the TUI (behavior depends on the `exit_mode` setting) |


### PR DESCRIPTION
Adds a configurable `copy-directory` search action that behaves like the existing `copy` action, but copies the working directory of the selected history entry instead of the command text.

Like `copy`, the action closes the interactive search after copying.

The action uses the existing clipboard handling and can be assigned through the advanced keybinding configuration. No default keybinding is added.

For example:
```toml
[keymap.emacs]
"ctrl-Y" = "copy-directory"
```

Tested with:
- `cargo +nightly fmt --all -- --check`
- `cargo test -p atuin` — 422 passed
- `cargo clippy -p atuin --all-targets --all-features -- -D warnings`
- `vale --no-global --minAlertLevel=error docs/docs/configuration/advanced-key-binding.md`
- Manual testing on macOS

## Checks
- [x] I am happy for maintainers to push small adjustments to this PR, to speed up the review cycle
- [x] I have checked that there are no existing pull requests for the same thing
