### PR TITLE
bug: avoid rare race condition in sync

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -452,6 +452,7 @@ dependencies = [
  "futures",
  "getrandom 0.4.3",
  "itertools 0.15.0",
+ "parking_lot",
  "pretty_assertions",
  "proptest",
  "rmp",

--- a/crates/atuin-client/src/record/sync/mod.rs
+++ b/crates/atuin-client/src/record/sync/mod.rs
@@ -516,7 +516,7 @@ impl Keyed<'_> {
     /// new `remote_index`.
     pub async fn key_valid_against(&self, remote_index: &RecordStatus) -> Option<SyncError> {
         let verdict = self.engine.check_key_against_index(self.key, remote_index).await;
-        self.key_check.emplace_cancelling(verdict.clone());
+        self.key_check.overwrite(verdict.clone());
         verdict
     }
 

--- a/crates/atuin-client/src/record/sync/mod.rs
+++ b/crates/atuin-client/src/record/sync/mod.rs
@@ -10,7 +10,7 @@ use std::cmp::Ordering;
 use std::fmt::Write;
 
 use atuin_common::encryption::paseto_v4;
-use atuin_common::sync::EagerFutureCell;
+use atuin_common::sync::MutEagerFutureCell;
 use atuin_domain::caps::PackfileCap;
 use atuin_domain::record::{Diff, RecordId, RecordIdx, RecordSeriesKey, RecordStatus, RecordTag};
 use eyre::Result;
@@ -93,8 +93,9 @@ pub struct SyncEngine {
 pub struct Keyed<'k> {
     engine: &'k SyncEngine,
     key: &'k paseto_v4::Key,
-    /// The result of verifying `key` against the remote. Read via [`Self::key_valid`].
-    key_check: EagerFutureCell<Option<SyncError>>,
+    /// The result of verifying `key` against the remote. Read via [`Self::key_valid`], or replaced
+    /// with a snapshot-consistent verdict via [`Self::key_valid_against`].
+    key_check: MutEagerFutureCell<Option<SyncError>>,
 }
 
 impl SyncEngine {
@@ -102,7 +103,7 @@ impl SyncEngine {
     pub fn keyed<'k>(&'k self, key: &'k paseto_v4::Key) -> Keyed<'k> {
         let engine = self.clone();
         let key_for_check = key.clone();
-        let key_check = EagerFutureCell::new(
+        let key_check = MutEagerFutureCell::new(
             async move { engine.check_encryption_key(&key_for_check).await },
             &Handle::current(),
         );
@@ -505,18 +506,34 @@ impl Keyed<'_> {
         Ok((uploaded, downloaded))
     }
 
-    /// The verdict of verifying this `Keyed`'s key against the remote.
+    /// The verdict of verifying this `Keyed`'s key against the remote, from the eager check kicked
+    /// off at [`SyncEngine::keyed`] time.
     pub async fn key_valid(&self) -> Option<SyncError> {
-        self.key_check.get().await.clone()
+        self.key_check.get().await
+    }
+
+    /// Verify the key against an already-fetched `remote_index` (e.g. the one `diff` just fetched),
+    /// caching that verdict and cancelling the eager check.
+    ///
+    /// The eager [`key_valid`](Self::key_valid) verdict is from the snapshot taken at `keyed()`
+    /// time, which predates `diff`. Using it to authorize a `diff`-derived download risks waving
+    /// through a record the remote gained in between. Re-checking against `diff`'s own snapshot
+    /// keeps the verdict and the operations consistent.
+    pub async fn key_valid_against(&self, remote_index: &RecordStatus) -> Option<SyncError> {
+        let verdict = self.engine.check_key_against_index(self.key, remote_index).await;
+        self.key_check.emplace_cancelling(verdict.clone());
+        verdict
     }
 
     /// Run a full sync: diff local against remote, verify the key can read the remote, resolve the
     /// diff into operations, then apply them.
     #[instrument(level = "trace", skip_all, err)]
     pub async fn sync(&self) -> Result<(u64, Vec<RecordId>), SyncError> {
-        let (diff, _remote_index) = self.engine.diff().await?;
+        let (diff, remote_index) = self.engine.diff().await?;
 
-        if let Some(err) = self.key_valid().await {
+        // Verify against diff's own snapshot -- not the eager verdict, which predates it -- so the
+        // key check and the operations we're about to apply describe the same remote state.
+        if let Some(err) = self.key_valid_against(&remote_index).await {
             return Err(err);
         }
 

--- a/crates/atuin-client/src/record/sync/mod.rs
+++ b/crates/atuin-client/src/record/sync/mod.rs
@@ -93,8 +93,7 @@ pub struct SyncEngine {
 pub struct Keyed<'k> {
     engine: &'k SyncEngine,
     key: &'k paseto_v4::Key,
-    /// The result of verifying `key` against the remote. Read via [`Self::key_valid`], or replaced
-    /// with a snapshot-consistent verdict via [`Self::key_valid_against`].
+    /// The result of verifying `key` against the remote.
     key_check: MutEagerFutureCell<Option<SyncError>>,
 }
 
@@ -506,19 +505,15 @@ impl Keyed<'_> {
         Ok((uploaded, downloaded))
     }
 
-    /// The verdict of verifying this `Keyed`'s key against the remote, from the eager check kicked
-    /// off at [`SyncEngine::keyed`] time.
+    /// Check whether the key can decrypt the synced data.
     pub async fn key_valid(&self) -> Option<SyncError> {
         self.key_check.get().await
     }
 
-    /// Verify the key against an already-fetched `remote_index` (e.g. the one `diff` just fetched),
-    /// caching that verdict and cancelling the eager check.
+    /// Verify the key against an already-fetched `remote_index`.
     ///
-    /// The eager [`key_valid`](Self::key_valid) verdict is from the snapshot taken at `keyed()`
-    /// time, which predates `diff`. Using it to authorize a `diff`-derived download risks waving
-    /// through a record the remote gained in between. Re-checking against `diff`'s own snapshot
-    /// keeps the verdict and the operations consistent.
+    /// Subsequent calls to [`Self::key_valid`] will return whether the key is valid against this
+    /// new `remote_index`.
     pub async fn key_valid_against(&self, remote_index: &RecordStatus) -> Option<SyncError> {
         let verdict = self.engine.check_key_against_index(self.key, remote_index).await;
         self.key_check.emplace_cancelling(verdict.clone());
@@ -531,8 +526,6 @@ impl Keyed<'_> {
     pub async fn sync(&self) -> Result<(u64, Vec<RecordId>), SyncError> {
         let (diff, remote_index) = self.engine.diff().await?;
 
-        // Verify against diff's own snapshot -- not the eager verdict, which predates it -- so the
-        // key check and the operations we're about to apply describe the same remote state.
         if let Some(err) = self.key_valid_against(&remote_index).await {
             return Err(err);
         }

--- a/crates/atuin-common/Cargo.toml
+++ b/crates/atuin-common/Cargo.toml
@@ -49,6 +49,7 @@ itertools = { workspace = true }
 rusty_paseto = { workspace = true }
 rusty_paserk = { workspace = true }
 tokio = { workspace = true }
+parking_lot = { workspace = true }
 futures = "0.3"
 serde_json = { workspace = true }
 zeroize = { workspace = true }

--- a/crates/atuin-common/src/sync/eager_future_cell.rs
+++ b/crates/atuin-common/src/sync/eager_future_cell.rs
@@ -1,6 +1,7 @@
 use std::future::Future;
-use std::sync::{Arc, Mutex};
+use std::sync::Arc;
 
+use parking_lot::Mutex;
 use tokio::runtime::Handle;
 use tokio::sync::{Notify, OnceCell};
 use tokio::task::AbortHandle;
@@ -23,12 +24,12 @@ impl<T: Clone + Send + Sync + 'static> MutEagerFutureCell<T> {
     /// discarded. Any current or future [`get`](EagerFuture::get) observes `value`.
     pub fn emplace_cancelling(&self, value: T) {
         self.abort.abort();
-        *self.inner.cell.lock().unwrap() = Some(value);
+        *self.inner.cell.lock() = Some(value);
         self.inner.ready.notify_waiters();
     }
 }
 
-#[doc(hidden)]
+/// Internal detail to the [`EagerFutureCell`].
 pub trait ResultCell: Default + Send + Sync + 'static {
     type Value: Clone + Send + Sync + 'static;
 
@@ -52,7 +53,7 @@ impl<T: Default + Clone + Send + Sync + 'static> ResultCell for Mutex<Option<T>>
     type Value = T;
 
     fn fill(&self, value: T) {
-        let mut slot = self.lock().unwrap();
+        let mut slot = self.lock();
         // Keep an existing value: an `emplace_cancelling` may have already won.
         if slot.is_none() {
             *slot = Some(value);
@@ -60,7 +61,7 @@ impl<T: Default + Clone + Send + Sync + 'static> ResultCell for Mutex<Option<T>>
     }
 
     fn peek(&self) -> Option<T> {
-        self.lock().unwrap().clone()
+        self.lock().clone()
     }
 }
 

--- a/crates/atuin-common/src/sync/eager_future_cell.rs
+++ b/crates/atuin-common/src/sync/eager_future_cell.rs
@@ -67,7 +67,7 @@ impl<T: Default + Clone + Send + Sync + 'static> ResultCell for Mutex<Option<T>>
     }
 }
 
-#[doc(hidden)]
+/// Data stored under the [`EagerFuture`].
 #[derive(Debug)]
 struct Inner<C> {
     cell: C,
@@ -77,7 +77,7 @@ struct Inner<C> {
 /// A cell whose value is seeded with a task scheduled at [`EagerFutureCell::new`], in the
 /// background.
 ///
-/// Use [`EagerFutureCell`] or [`MutEagerFutureCell`].
+/// Use [`EagerFutureCell`] or [`MutEagerFutureCell`], directly.
 pub struct EagerFuture<C> {
     inner: Arc<Inner<C>>,
     abort: AbortHandle,

--- a/crates/atuin-common/src/sync/eager_future_cell.rs
+++ b/crates/atuin-common/src/sync/eager_future_cell.rs
@@ -1,53 +1,134 @@
 use std::future::Future;
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 
 use tokio::runtime::Handle;
 use tokio::sync::{Notify, OnceCell};
+use tokio::task::AbortHandle;
+
+/// The storage backing an [`EagerFuture`]: a slot that starts empty and later holds the future's
+/// output. Implemented for [`OnceCell<T>`] (write-once) and [`Mutex<Option<T>>`] (overwritable).
+pub trait ResultCell: Send + Sync + 'static {
+    /// The value the cell holds.
+    type Value: Clone + Send + Sync + 'static;
+
+    /// A fresh, empty slot.
+    fn empty() -> Self;
+
+    /// Store the value produced by the eager future. A slot that already holds a value keeps it --
+    /// that is what lets [`EagerFuture::emplace_cancelling`] win the race against a finishing future.
+    fn fill(&self, value: Self::Value);
+
+    /// A clone of the stored value, if the slot has been filled.
+    fn peek(&self) -> Option<Self::Value>;
+}
+
+impl<T: Clone + Send + Sync + 'static> ResultCell for OnceCell<T> {
+    type Value = T;
+
+    fn empty() -> Self {
+        Self::new()
+    }
+
+    fn fill(&self, value: T) {
+        let _ = self.set(value);
+    }
+
+    fn peek(&self) -> Option<T> {
+        self.get().cloned()
+    }
+}
+
+impl<T: Clone + Send + Sync + 'static> ResultCell for Mutex<Option<T>> {
+    type Value = T;
+
+    fn empty() -> Self {
+        Self::new(None)
+    }
+
+    fn fill(&self, value: T) {
+        let mut slot = self.lock().unwrap();
+        // Keep an existing value: an `emplace_cancelling` may have already won.
+        if slot.is_none() {
+            *slot = Some(value);
+        }
+    }
+
+    fn peek(&self) -> Option<T> {
+        self.lock().unwrap().clone()
+    }
+}
 
 #[derive(Debug)]
-struct Inner<T> {
+struct Inner<C> {
     /// The computed value, once it is ready.
-    cell: OnceCell<T>,
-    /// Notified once [`Self::cell`] is ready, waking anything waiting in [`EagerFutureCell::get`].
+    cell: C,
+    /// Notified once [`Self::cell`] is ready, waking anything waiting in [`EagerFuture::get`].
     ready: Notify,
 }
 
-/// A cell whose value is produced exactly once, eagerly, in the background.
+/// A cell whose value is produced exactly once, eagerly, in the background, over pluggable storage
+/// `C` (see [`ResultCell`]).
 ///
-/// [`EagerFutureCell::new`] accepts a future which will be executed in the background. Fetching the
-/// value with [`EagerFutureCell::get`] will either wait for the future to produce the value, or
-/// return the already-stored value as computed by the given future.
-#[derive(Debug, Clone)]
-pub struct EagerFutureCell<T> {
-    inner: Arc<Inner<T>>,
+/// [`EagerFuture::new`] accepts a future which is executed in the background. [`EagerFuture::get`]
+/// either waits for the future to produce the value, or returns the already-stored value.
+///
+/// Use the [`EagerFutureCell`] alias for a write-once slot, or [`MutEagerFutureCell`] for one that
+/// additionally supports [`EagerFuture::emplace_cancelling`].
+pub struct EagerFuture<C> {
+    inner: Arc<Inner<C>>,
+    /// Aborts the background task, used by [`EagerFuture::emplace_cancelling`].
+    abort: AbortHandle,
 }
 
-impl<T: Send + Sync + 'static> EagerFutureCell<T> {
-    /// Initialize the cell with the given `work` future, starting the work immediately if a tokio
-    /// runtime is available.
+/// A write-once [`EagerFuture`]: the background future's value is the only value it ever holds.
+pub type EagerFutureCell<T> = EagerFuture<OnceCell<T>>;
+
+/// An [`EagerFuture`] whose value can be overwritten via [`EagerFuture::emplace_cancelling`].
+pub type MutEagerFutureCell<T> = EagerFuture<Mutex<Option<T>>>;
+
+impl<C> Clone for EagerFuture<C> {
+    fn clone(&self) -> Self {
+        Self {
+            inner: Arc::clone(&self.inner),
+            abort: self.abort.clone(),
+        }
+    }
+}
+
+impl<C> std::fmt::Debug for EagerFuture<C> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("EagerFuture").finish_non_exhaustive()
+    }
+}
+
+impl<C: ResultCell> EagerFuture<C> {
+    /// Initialize the cell with the given `work` future, starting the work immediately on `handle`.
     pub fn new<Fut>(work: Fut, handle: &Handle) -> Self
     where
-        Fut: Future<Output = T> + Send + 'static,
+        Fut: Future<Output = C::Value> + Send + 'static,
     {
         let inner = Arc::new(Inner {
-            cell: OnceCell::new(),
+            cell: C::empty(),
             ready: Notify::new(),
         });
 
         // Drive on a spawned task, so a `get` cancelled while waiting cannot strand the work.
         let driver = Arc::clone(&inner);
-        handle.spawn(async move {
+        let task = handle.spawn(async move {
             let value = work.await;
-            let _ = driver.cell.set(value);
+            driver.cell.fill(value);
             driver.ready.notify_waiters();
         });
 
-        Self { inner }
+        Self {
+            inner,
+            abort: task.abort_handle(),
+        }
     }
 
-    /// Fetch the value, awaiting the work if necessary.
-    pub async fn get(&self) -> &T {
-        if let Some(value) = self.inner.cell.get() {
+    /// Fetch a clone of the value, awaiting the work if necessary.
+    pub async fn get(&self) -> C::Value {
+        if let Some(value) = self.inner.cell.peek() {
             return value;
         }
 
@@ -56,7 +137,7 @@ impl<T: Send + Sync + 'static> EagerFutureCell<T> {
             tokio::pin!(notified);
             notified.as_mut().enable();
 
-            if let Some(value) = self.inner.cell.get() {
+            if let Some(value) = self.inner.cell.peek() {
                 return value;
             }
 
@@ -65,14 +146,27 @@ impl<T: Send + Sync + 'static> EagerFutureCell<T> {
     }
 }
 
+impl<T: Clone + Send + Sync + 'static> MutEagerFutureCell<T> {
+    /// Force `value` into the cell, aborting the background future so its (now-superseded) result is
+    /// discarded. Any current or future [`get`](EagerFuture::get) observes `value`.
+    pub fn emplace_cancelling(&self, value: T) {
+        // Abort first so a task sitting between `work.await` and `fill` cannot re-fill afterwards;
+        // even if it does slip in, `fill` keeps our value because the slot is already `Some`.
+        self.abort.abort();
+        *self.inner.cell.lock().unwrap() = Some(value);
+        self.inner.ready.notify_waiters();
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use std::sync::Arc;
     use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::time::Duration;
 
     use rstest::rstest;
 
-    use super::EagerFutureCell;
+    use super::{EagerFutureCell, MutEagerFutureCell};
 
     #[rstest]
     #[case(42)]
@@ -81,7 +175,7 @@ mod tests {
     async fn computes_once_and_caches(#[case] value: usize) {
         let calls = Arc::new(AtomicUsize::new(0));
         let counter = calls.clone();
-        let cell = EagerFutureCell::new(
+        let cell: EagerFutureCell<usize> = EagerFutureCell::new(
             async move {
                 counter.fetch_add(1, Ordering::SeqCst);
                 value
@@ -91,8 +185,8 @@ mod tests {
 
         // Repeated gets return the cached value, and the work runs exactly once even though the
         // eager background kick and these gets can race.
-        assert_eq!(*cell.get().await, value);
-        assert_eq!(*cell.get().await, value);
+        assert_eq!(cell.get().await, value);
+        assert_eq!(cell.get().await, value);
         assert_eq!(calls.load(Ordering::SeqCst), 1);
     }
 
@@ -103,7 +197,7 @@ mod tests {
         let calls = Arc::new(AtomicUsize::new(0));
         let counter = calls.clone();
         let rt = tokio::runtime::Runtime::new().unwrap();
-        let cell = EagerFutureCell::new(
+        let cell: EagerFutureCell<usize> = EagerFutureCell::new(
             async move {
                 counter.fetch_add(1, Ordering::SeqCst);
                 7usize
@@ -111,7 +205,41 @@ mod tests {
             rt.handle(),
         );
 
-        assert_eq!(*rt.block_on(cell.get()), 7);
+        assert_eq!(rt.block_on(cell.get()), 7);
         assert_eq!(calls.load(Ordering::SeqCst), 1);
+    }
+
+    #[rstest]
+    #[tokio::test]
+    async fn emplace_cancelling_supersedes_a_slow_future() {
+        let ran = Arc::new(AtomicUsize::new(0));
+        let counter = ran.clone();
+        let cell: MutEagerFutureCell<usize> = MutEagerFutureCell::new(
+            async move {
+                // Long enough that `emplace_cancelling` below wins the race.
+                tokio::time::sleep(Duration::from_secs(30)).await;
+                counter.fetch_add(1, Ordering::SeqCst);
+                1
+            },
+            &tokio::runtime::Handle::current(),
+        );
+
+        cell.emplace_cancelling(2);
+
+        // The emplaced value is observed, and the aborted future never ran to completion.
+        assert_eq!(cell.get().await, 2);
+        assert_eq!(ran.load(Ordering::SeqCst), 0);
+    }
+
+    #[rstest]
+    #[tokio::test]
+    async fn emplace_cancelling_overrides_an_already_completed_future() {
+        let cell: MutEagerFutureCell<usize> =
+            MutEagerFutureCell::new(async move { 1 }, &tokio::runtime::Handle::current());
+
+        // Let the eager future resolve first, then overwrite it.
+        assert_eq!(cell.get().await, 1);
+        cell.emplace_cancelling(2);
+        assert_eq!(cell.get().await, 2);
     }
 }

--- a/crates/atuin-common/src/sync/eager_future_cell.rs
+++ b/crates/atuin-common/src/sync/eager_future_cell.rs
@@ -15,25 +15,27 @@ pub type EagerFutureCell<T> = EagerFuture<OnceCell<T>>;
 
 /// A cell whose value is seeded with a task scheduled at [`MutEagerFutureCell::new`], in the
 /// background. Unlike the [`EagerFutureCell`] one-shot dual, [`MutEagerFutureCell`] allows you to
-/// emplace any arbitrary value into the cell, via the [`MutEagerFutureCell::emplace_cancelling`]
-/// call.
+/// emplace any arbitrary value into the cell, via the `overwrite` call.
 pub type MutEagerFutureCell<T> = EagerFuture<Mutex<Option<T>>>;
 
 impl<T: Clone + Send + Sync + 'static> MutEagerFutureCell<T> {
     /// Force `value` into the cell, aborting the background future so its (now-superseded) result is
     /// discarded. Any current or future [`get`](EagerFuture::get) observes `value`.
-    pub fn emplace_cancelling(&self, value: T) {
+    pub fn overwrite(&self, value: T) {
         self.abort.abort();
         *self.inner.cell.lock() = Some(value);
         self.inner.ready.notify_waiters();
     }
 }
 
-/// Internal detail to the [`EagerFutureCell`].
+/// Acts as a storage backend to [`EagerFutureCell`].
 pub trait ResultCell: Default + Send + Sync + 'static {
     type Value: Clone + Send + Sync + 'static;
 
+    /// Place the value into the cell.
     fn fill(&self, value: Self::Value);
+
+    /// Read the value from the cell.
     fn peek(&self) -> Option<Self::Value>;
 }
 
@@ -54,7 +56,7 @@ impl<T: Default + Clone + Send + Sync + 'static> ResultCell for Mutex<Option<T>>
 
     fn fill(&self, value: T) {
         let mut slot = self.lock();
-        // Keep an existing value: an `emplace_cancelling` may have already won.
+        // Keep an existing value: an `overwrite` may have already won.
         if slot.is_none() {
             *slot = Some(value);
         }
@@ -72,7 +74,10 @@ struct Inner<C> {
     ready: Notify,
 }
 
-#[doc(hidden)]
+/// A cell whose value is seeded with a task scheduled at [`EagerFutureCell::new`], in the
+/// background.
+///
+/// Use [`EagerFutureCell`] or [`MutEagerFutureCell`].
 pub struct EagerFuture<C> {
     inner: Arc<Inner<C>>,
     abort: AbortHandle,
@@ -191,12 +196,12 @@ mod tests {
 
     #[rstest]
     #[tokio::test]
-    async fn emplace_cancelling_supersedes_a_slow_future() {
+    async fn overwrite_supersedes_a_slow_future() {
         let ran = Arc::new(AtomicUsize::new(0));
         let counter = ran.clone();
         let cell: MutEagerFutureCell<usize> = MutEagerFutureCell::new(
             async move {
-                // Long enough that `emplace_cancelling` below wins the race.
+                // Long enough that the `overwrite` below wins the race.
                 tokio::time::sleep(Duration::from_secs(30)).await;
                 counter.fetch_add(1, Ordering::SeqCst);
                 1
@@ -204,7 +209,7 @@ mod tests {
             &tokio::runtime::Handle::current(),
         );
 
-        cell.emplace_cancelling(2);
+        cell.overwrite(2);
 
         // The emplaced value is observed, and the aborted future never ran to completion.
         assert_eq!(cell.get().await, 2);
@@ -213,13 +218,13 @@ mod tests {
 
     #[rstest]
     #[tokio::test]
-    async fn emplace_cancelling_overrides_an_already_completed_future() {
+    async fn overwrite_replaces_an_already_completed_future() {
         let cell: MutEagerFutureCell<usize> =
             MutEagerFutureCell::new(async move { 1 }, &tokio::runtime::Handle::current());
 
         // Let the eager future resolve first, then overwrite it.
         assert_eq!(cell.get().await, 1);
-        cell.emplace_cancelling(2);
+        cell.overwrite(2);
         assert_eq!(cell.get().await, 2);
     }
 }

--- a/crates/atuin-common/src/sync/eager_future_cell.rs
+++ b/crates/atuin-common/src/sync/eager_future_cell.rs
@@ -99,7 +99,7 @@ impl<C: ResultCell> EagerFuture<C> {
         Fut: Future<Output = C::Value> + Send + 'static,
     {
         let inner = Arc::new(Inner {
-            cell: C::empty(),
+            cell: C::default(),
             ready: Notify::new(),
         });
 

--- a/crates/atuin-common/src/sync/eager_future_cell.rs
+++ b/crates/atuin-common/src/sync/eager_future_cell.rs
@@ -5,29 +5,39 @@ use tokio::runtime::Handle;
 use tokio::sync::{Notify, OnceCell};
 use tokio::task::AbortHandle;
 
-/// The storage backing an [`EagerFuture`]: a slot that starts empty and later holds the future's
-/// output. Implemented for [`OnceCell<T>`] (write-once) and [`Mutex<Option<T>>`] (overwritable).
-pub trait ResultCell: Send + Sync + 'static {
-    /// The value the cell holds.
+/// A cell whose value is seeded with a task scheduled at [`EagerFutureCell::new`], in the
+/// background.
+///
+/// [`EagerFuture::new`] accepts a future which is executed in the background. [`EagerFuture::get`]
+/// either waits for the future to produce the value, or returns the already-stored value.
+pub type EagerFutureCell<T> = EagerFuture<OnceCell<T>>;
+
+/// A cell whose value is seeded with a task scheduled at [`MutEagerFutureCell::new`], in the
+/// background. Unlike the [`EagerFutureCell`] one-shot dual, [`MutEagerFutureCell`] allows you to
+/// emplace any arbitrary value into the cell, via the [`MutEagerFutureCell::emplace_cancelling`]
+/// call.
+pub type MutEagerFutureCell<T> = EagerFuture<Mutex<Option<T>>>;
+
+impl<T: Clone + Send + Sync + 'static> MutEagerFutureCell<T> {
+    /// Force `value` into the cell, aborting the background future so its (now-superseded) result is
+    /// discarded. Any current or future [`get`](EagerFuture::get) observes `value`.
+    pub fn emplace_cancelling(&self, value: T) {
+        self.abort.abort();
+        *self.inner.cell.lock().unwrap() = Some(value);
+        self.inner.ready.notify_waiters();
+    }
+}
+
+#[doc(hidden)]
+pub trait ResultCell: Default + Send + Sync + 'static {
     type Value: Clone + Send + Sync + 'static;
 
-    /// A fresh, empty slot.
-    fn empty() -> Self;
-
-    /// Store the value produced by the eager future. A slot that already holds a value keeps it --
-    /// that is what lets [`EagerFuture::emplace_cancelling`] win the race against a finishing future.
     fn fill(&self, value: Self::Value);
-
-    /// A clone of the stored value, if the slot has been filled.
     fn peek(&self) -> Option<Self::Value>;
 }
 
-impl<T: Clone + Send + Sync + 'static> ResultCell for OnceCell<T> {
+impl<T: Default + Clone + Send + Sync + 'static> ResultCell for OnceCell<T> {
     type Value = T;
-
-    fn empty() -> Self {
-        Self::new()
-    }
 
     fn fill(&self, value: T) {
         let _ = self.set(value);
@@ -38,12 +48,8 @@ impl<T: Clone + Send + Sync + 'static> ResultCell for OnceCell<T> {
     }
 }
 
-impl<T: Clone + Send + Sync + 'static> ResultCell for Mutex<Option<T>> {
+impl<T: Default + Clone + Send + Sync + 'static> ResultCell for Mutex<Option<T>> {
     type Value = T;
-
-    fn empty() -> Self {
-        Self::new(None)
-    }
 
     fn fill(&self, value: T) {
         let mut slot = self.lock().unwrap();
@@ -58,33 +64,18 @@ impl<T: Clone + Send + Sync + 'static> ResultCell for Mutex<Option<T>> {
     }
 }
 
+#[doc(hidden)]
 #[derive(Debug)]
 struct Inner<C> {
-    /// The computed value, once it is ready.
     cell: C,
-    /// Notified once [`Self::cell`] is ready, waking anything waiting in [`EagerFuture::get`].
     ready: Notify,
 }
 
-/// A cell whose value is produced exactly once, eagerly, in the background, over pluggable storage
-/// `C` (see [`ResultCell`]).
-///
-/// [`EagerFuture::new`] accepts a future which is executed in the background. [`EagerFuture::get`]
-/// either waits for the future to produce the value, or returns the already-stored value.
-///
-/// Use the [`EagerFutureCell`] alias for a write-once slot, or [`MutEagerFutureCell`] for one that
-/// additionally supports [`EagerFuture::emplace_cancelling`].
+#[doc(hidden)]
 pub struct EagerFuture<C> {
     inner: Arc<Inner<C>>,
-    /// Aborts the background task, used by [`EagerFuture::emplace_cancelling`].
     abort: AbortHandle,
 }
-
-/// A write-once [`EagerFuture`]: the background future's value is the only value it ever holds.
-pub type EagerFutureCell<T> = EagerFuture<OnceCell<T>>;
-
-/// An [`EagerFuture`] whose value can be overwritten via [`EagerFuture::emplace_cancelling`].
-pub type MutEagerFutureCell<T> = EagerFuture<Mutex<Option<T>>>;
 
 impl<C> Clone for EagerFuture<C> {
     fn clone(&self) -> Self {
@@ -143,18 +134,6 @@ impl<C: ResultCell> EagerFuture<C> {
 
             notified.await;
         }
-    }
-}
-
-impl<T: Clone + Send + Sync + 'static> MutEagerFutureCell<T> {
-    /// Force `value` into the cell, aborting the background future so its (now-superseded) result is
-    /// discarded. Any current or future [`get`](EagerFuture::get) observes `value`.
-    pub fn emplace_cancelling(&self, value: T) {
-        // Abort first so a task sitting between `work.await` and `fill` cannot re-fill afterwards;
-        // even if it does slip in, `fill` keeps our value because the slot is already `Some`.
-        self.abort.abort();
-        *self.inner.cell.lock().unwrap() = Some(value);
-        self.inner.ready.notify_waiters();
     }
 }
 

--- a/crates/atuin-common/src/sync/mod.rs
+++ b/crates/atuin-common/src/sync/mod.rs
@@ -2,4 +2,4 @@
 
 mod eager_future_cell;
 
-pub use eager_future_cell::EagerFutureCell;
+pub use eager_future_cell::{EagerFuture, EagerFutureCell, MutEagerFutureCell, ResultCell};

--- a/crates/atuin-search-bench/benches/search.rs
+++ b/crates/atuin-search-bench/benches/search.rs
@@ -189,11 +189,11 @@ fn index(scale: usize) -> Arc<SearchIndex> {
     eprintln!("index ready: {} unique commands", index.command_count());
 
     for query in QUERIES {
-        let n = index.search(query, IndexFilterMode::Global, LIMIT).count();
+        let n = index.search(query, &IndexFilterMode::Global, LIMIT).count();
         eprintln!("  {query:?}: {n} results (limit {LIMIT})");
     }
     let dir = filter_dir();
-    let n = index.search("git", IndexFilterMode::Directory(dir.clone()), LIMIT).count();
+    let n = index.search("git", &IndexFilterMode::Directory(dir.clone()), LIMIT).count();
     eprintln!("  \"git\" in {dir:?}: {n} results (limit {LIMIT})");
     assert!(n > 0, "directory filter matched nothing; filter is broken");
 
@@ -210,5 +210,5 @@ fn daemon_search(bencher: divan::Bencher, case: &Case) {
     } else {
         IndexFilterMode::Global
     };
-    bencher.bench(|| index.search(case.query, filter.clone(), LIMIT).count());
+    bencher.bench(|| index.search(case.query, &filter, LIMIT).count());
 }

--- a/crates/atuin/src/command/client/store/pull.rs
+++ b/crates/atuin/src/command/client/store/pull.rs
@@ -53,11 +53,11 @@ impl Pull {
             .await?;
 
         let keyed = engine.keyed(&key);
-        let (diff, _remote_index) = engine.diff().await?;
+        let (diff, remote_index) = engine.diff().await?;
 
         // Skip on --force: local was already wiped above, mismatch is the user's call.
         if !self.force
-            && let Some(err) = keyed.key_valid().await
+            && let Some(err) = keyed.key_valid_against(&remote_index).await
         {
             return Err(crate::print_error::format_sync_error(err));
         }

--- a/crates/atuin/src/command/client/store/push.rs
+++ b/crates/atuin/src/command/client/store/push.rs
@@ -76,11 +76,11 @@ impl Push {
             .await?;
 
         let keyed = engine.keyed(&key);
-        let (diff, _remote_index) = engine.diff().await?;
+        let (diff, remote_index) = engine.diff().await?;
 
         // Skip on --force: that path intentionally replaces remote with local.
         if !self.force
-            && let Some(err) = keyed.key_valid().await
+            && let Some(err) = keyed.key_valid_against(&remote_index).await
         {
             return Err(crate::print_error::format_sync_error(err));
         }


### PR DESCRIPTION
#3968 merged a mechanism wherein we would **eagerly** query the key validity. Greptile mentioned there was a race condition with respect to using a stale validity status in `diff`. We have a new `RecordStatus`, but we never checked it for validity. Here's a slop mermaid diagram illustrating the race:

```mermaid
  sequenceDiagram
      autonumber
      participant C as Client (key B)
      participant E as Eager key check
      participant S as Sync server
      participant O as Other machine (key A)

      Note over C: keyed(&B) called
      C->>E: spawn eager check
      E->>S: record_status()  (snapshot T0)
      S-->>E: index @ T0
      E->>S: next_records(sample, idx 0)
      S-->>E: a key-B record
      E->>E: decrypt OK
      Note over E: verdict = "key OK" (cached at T0)

      O->>S: upload record R (encrypted with key A)
      Note over S: remote now has a record<br/>Client's key B cannot decrypt

      Note over C: sync()
      C->>S: diff() → record_status()  (snapshot T1 > T0)
      S-->>C: index @ T1 (includes R)
      C->>E: key_valid()  (reads cached T0 verdict)
      E-->>C: "key OK"  ← stale: predates R
      Note over C: operations from T1 include downloading R,<br/>authorized by a verdict from T0

      C->>S: sync_remote → fetch R
      S-->>C: encrypted R
      C->>C: commit R to record store (still encrypted)
      C->>C: materialize → decrypt R fails → skip

      Note over C: later sync: R present in store → never re-fetched<br/>💥 history entry for R permanently missing
```

This fixes it up.