### PR TITLE
fix(nu): use unique keybinding names

### DIFF
--- a/crates/atuin/src/command/client/init/nu.rs
+++ b/crates/atuin/src/command/client/init/nu.rs
@@ -47,14 +47,23 @@ pub fn init_static(options: &StaticInitOptions<'_>) {
 
 #[cfg(test)]
 mod tests {
+    use std::collections::HashSet;
+
     use rstest::rstest;
 
-    use super::{BIND_CTRL_R, BIND_UP_ARROW};
+    use super::*;
 
     #[rstest]
-    #[case(BIND_CTRL_R, "atuin")]
-    #[case(BIND_UP_ARROW, "atuin_up_arrow")]
-    fn keybinding_has_unique_name(#[case] binding: &str, #[case] expected_name: &str) {
-        assert!(binding.contains(&format!("name: {expected_name}")));
+    fn keybindings_have_unique_names() {
+        let re = regex::Regex::new(r"\<name:\s*(\w+)").unwrap();
+        let mut names = HashSet::new();
+        for name in [BIND_CTRL_R, BIND_UP_ARROW]
+            .into_iter()
+            .map(|s| re.captures(s).unwrap().get(1).unwrap().as_str().to_owned())
+        {
+            if let Some(existing) = names.replace(name) {
+                panic!("duplicate binding name: {existing}");
+            }
+        }
     }
 }

--- a/crates/atuin/src/command/client/init/nu.rs
+++ b/crates/atuin/src/command/client/init/nu.rs
@@ -17,7 +17,7 @@ const BIND_UP_ARROW: &str = r"$env.config = (
     $env.config | upsert keybindings (
         $env.config.keybindings
         | append {
-            name: atuin
+            name: atuin_up_arrow
             modifier: none
             keycode: up
             mode: [emacs, vi_normal, vi_insert]
@@ -42,5 +42,19 @@ pub fn init_static(options: &StaticInitOptions<'_>) {
         if options.enable_up_arrow {
             println!("{BIND_UP_ARROW}");
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use rstest::rstest;
+
+    use super::{BIND_CTRL_R, BIND_UP_ARROW};
+
+    #[rstest]
+    #[case(BIND_CTRL_R, "atuin")]
+    #[case(BIND_UP_ARROW, "atuin_up_arrow")]
+    fn keybinding_has_unique_name(#[case] binding: &str, #[case] expected_name: &str) {
+        assert!(binding.contains(&format!("name: {expected_name}")));
     }
 }


### PR DESCRIPTION
## Summary

- give the Nushell up-arrow binding its own name instead of reusing `atuin`
- add regression coverage for both generated keybinding names

Fixes #3971.

## Testing

- `cargo test -p atuin keybinding_has_unique_name`
- `cargo +nightly fmt --check`

## Checks

- [x] I am happy for maintainers to push small adjustments to this PR, to speed up the review cycle
- [x] I have checked that there are no existing pull requests for the same thing
