### PR TITLE
fix: correct documented local_timeout default

### DIFF
--- a/crates/atuin-client/config.toml
+++ b/crates/atuin-client/config.toml
@@ -201,7 +201,7 @@ enter_accept = true
 # extra_headers = { "CF-Access-Client-Id" = "...", "CF-Access-Client-Secret" = "..." }
 
 ## Timeout (in seconds) for acquiring a local database connection (sqlite)
-# local_timeout = 5
+# local_timeout = 2
 
 ## Set this to true and Atuin will minimize motion in the UI - timers will not update live, etc.
 ## Alternatively, set env NO_MOTION=true

--- a/docs/docs/configuration/config.md
+++ b/docs/docs/configuration/config.md
@@ -499,12 +499,12 @@ extra_headers = { "CF-Access-Client-Id" = "...", "CF-Access-Client-Secret" = "..
 
 ### `local_timeout`
 
-Default: `5`
+Default: `2`
 
 Timeout (in seconds) for acquiring a local database connection (SQLite).
 
 ```toml
-local_timeout = 5
+local_timeout = 2
 ```
 
 ### `command_chaining`


### PR DESCRIPTION
`local_timeout` is documented as defaulting to `5`, but `settings.rs` sets it to `2.0`:

```rust
.set_default("local_timeout", 2.0)?
```

Both the shipped `config.toml` and the config docs say `5`. This corrects both to `2`.

Worth fixing because the wrong value is misleading in the direction that matters: someone hitting SQLite lock timeouts reads "default 5", assumes 5 seconds is already in effect, and doesn't realise uncommenting the line actually changes behaviour (2s to 5s) rather than being a no-op.

No code change — the actual default is untouched.

---

AI disclosure: I used Claude (Opus 5) to diff the `set_default(...)` calls in `settings.rs` against the documented defaults in `config.toml` and `docs/docs/configuration/config.md`. I've verified this one by reading both sides; the mismatch is a single value.
