### PR TITLE
fix(docs): correct sync_frequency default

### DIFF
--- a/docs/docs/configuration/config.md
+++ b/docs/docs/configuration/config.md
@@ -92,7 +92,7 @@ sync_address = "https://api.atuin.sh"
 
 ### `sync_frequency`
 
-Default: `1h`
+Default: `5m`
 
 How often to automatically sync with the server. This can be given in a
 "human-readable" format. For example, `10s`, `20m`, `1h`, etc.
@@ -101,7 +101,7 @@ If set to `0`, Atuin will sync after every command. Some servers may rate limit
 frequent syncs, but this won't cause any issues.
 
 ```toml
-sync_frequency = "1h"
+sync_frequency = "5m"
 ```
 
 ### `search_mode`


### PR DESCRIPTION
The docs say `sync_frequency` defaults to `1h`. It's `5m`:

```rust
.set_default("sync_frequency", "5m")?
```

The shipped `crates/atuin-client/config.toml` already says `5m` too, so the docs were the odd one out.

This matters for a sync tool — someone reading "1h" would think auto-sync is hourly and go looking for why their history isn't showing up on another machine sooner, when it's actually syncing every 5 minutes.

I left the `daemon.sync_frequency` entry further down alone; that one is documented as `300` and the code agrees (`.set_default("daemon.sync_frequency", 300)`).

---

AI disclosure: I used Claude (Opus 5) to diff documented defaults against the `set_default(...)` calls in `settings.rs`. I checked this one by hand, including confirming the daemon setting is a separate value and correct as-is.
