### PR TITLE
fix: drop nonexistent session_path and correct path defaults

### DIFF
--- a/crates/atuin-client/config.toml
+++ b/crates/atuin-client/config.toml
@@ -7,12 +7,12 @@
 ## where to store your database, default is your system data directory
 ## linux/mac: ~/.local/share/atuin/history.db
 ## windows: %USERPROFILE%/.local/share/atuin/history.db
-# db_path = "~/.local/share/atuin/history.db"
+# db_path = "~/.history.db"
 
 ## where to store your encryption key, default is your system data directory
 ## linux/mac: ~/.local/share/atuin/key
 ## windows: %USERPROFILE%/.local/share/atuin/key
-# key_path = "~/.local/share/atuin/key"
+# key_path = "~/.key"
 
 ## date format used, either "us" or "uk"
 # dialect = "us"

--- a/crates/atuin-client/config.toml
+++ b/crates/atuin-client/config.toml
@@ -7,17 +7,12 @@
 ## where to store your database, default is your system data directory
 ## linux/mac: ~/.local/share/atuin/history.db
 ## windows: %USERPROFILE%/.local/share/atuin/history.db
-# db_path = "~/.history.db"
+# db_path = "~/.local/share/atuin/history.db"
 
 ## where to store your encryption key, default is your system data directory
 ## linux/mac: ~/.local/share/atuin/key
 ## windows: %USERPROFILE%/.local/share/atuin/key
-# key_path = "~/.key"
-
-## where to store your auth session token, default is your system data directory
-## linux/mac: ~/.local/share/atuin/session
-## windows: %USERPROFILE%/.local/share/atuin/session
-# session_path = "~/.session"
+# key_path = "~/.local/share/atuin/key"
 
 ## date format used, either "us" or "uk"
 # dialect = "us"

--- a/docs/docs/configuration/config.md
+++ b/docs/docs/configuration/config.md
@@ -27,17 +27,6 @@ The path to the Atuin encryption key.
 key_path = "~/.atuin-key"
 ```
 
-### `session_path`
-
-Default: `~/.local/share/atuin/session`
-
-The path to the Atuin server session file.
-This is essentially just an API token
-
-```toml
-session_path = "~/.atuin-session"
-```
-
 ### `dialect`
 
 Default: `us`


### PR DESCRIPTION
Two problems with the path settings.

**`session_path` isn't a setting.** It's documented in both `config.toml` and the config docs, but there's no `session_path` field on `Settings` and no `set_default` for it. The only occurrence in the codebase is a local variable in `meta.rs`:

```rust
let session_path = data_dir.join(LEGACY_SESSION_FILENAME);
```

So the session file lives at a fixed `data_dir/session` and setting `session_path` does nothing. The two places that document it also disagree on the value (`~/.session` vs `~/.atuin-session`), which is what made me look.

**`db_path` and `key_path` show stale values.** In `config.toml` the commented line is the default — `dialect`, `timezone`, `auto_sync`, `search_mode` and friends all match `set_default` exactly. But `db_path` and `key_path` showed `~/.history.db` and `~/.key`, which contradict both the comment directly above them and the code (`data_dir.join("history.db")`, `data_dir.join("key")`). Looks like leftovers from before the XDG data dir move.

Removed the `session_path` blocks and corrected the two values to match the documented defaults.

I left the docs' `key_path` example (`key_path = "~/.atuin-key"`) alone since that block is illustrating a custom path rather than stating the default, and the Default line above it is already right.

---

AI disclosure: I used Claude (Opus 5) to cross-check `config.toml` and the config docs against `settings.rs`. I verified the `session_path` finding myself by grepping the whole `crates/` tree and reading the `Settings` struct — there's no such field.
