### PR TITLE
ci: set explicit permissions on workflows missing them

### DIFF
--- a/.github/workflows/installer.yml
+++ b/.github/workflows/installer.yml
@@ -9,6 +9,9 @@ on:
 env:
   CARGO_TERM_COLOR: always
 
+permissions:
+  contents: read
+
 jobs:
   install:
     strategy:

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -12,6 +12,9 @@ on:
     paths-ignore:
       - 'ui/**'
 
+permissions:
+  contents: read
+
 jobs:
   check:
     runs-on: depot-ubuntu-24.04

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -13,6 +13,9 @@ on:
 env:
   CARGO_TERM_COLOR: always
 
+permissions:
+  contents: read
+
 jobs:
   build:
     strategy:

--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ main ]
 
+permissions:
+  contents: read
+
 jobs:
   shellcheck:
     runs-on: depot-ubuntu-24.04

--- a/.github/workflows/update-nix-deps.yml
+++ b/.github/workflows/update-nix-deps.yml
@@ -4,6 +4,10 @@ on:
   schedule:
     - cron: '0 0 1 * *' # runs monthly on the first day of the month at 00:00
 
+permissions:
+  contents: write
+  pull-requests: write
+
 jobs:
   lockfile:
     runs-on: depot-ubuntu-24.04


### PR DESCRIPTION
Five workflows don't declare `permissions:`, so their `GITHUB_TOKEN` falls back to the repository default instead of being scoped. The other eight already declare one (`codespell`, `vale`, `docker`, `release` etc.), so these look like they were just missed.

Scope per workflow, based on what each actually does:

| Workflow | Set to | Why |
| --- | --- | --- |
| `installer.yml` | `contents: read` | checkout + run installer |
| `nix.yml` | `contents: read` | checkout + nix build/check |
| `rust.yml` | `contents: read` | checkout, cache, build, test |
| `shellcheck.yml` | `contents: read` | checkout + shellcheck |
| `update-nix-deps.yml` | `contents: write`, `pull-requests: write` | opens a PR |

`update-nix-deps.yml` is the one to look at. It runs `DeterminateSystems/update-flake-lock` with `pr-title` and `pr-labels`, so it pushes a branch and opens a PR — giving it `contents: read` like the others would break the monthly lockfile update. It gets write on both scopes instead.

This is hardening, not a bug fix: if the repo default is already read-only nothing changes at runtime, it just stops these five depending on that default.

---

AI disclosure: I used Claude (Opus 5) to find the workflows missing a `permissions:` block. I read each one myself to decide the scope, which is how the `update-flake-lock` case got caught rather than being blanket-set to read.
