### PR TITLE
docs: document settings missing from config.toml

### DIFF
--- a/crates/atuin-client/config.toml
+++ b/crates/atuin-client/config.toml
@@ -185,11 +185,6 @@ enter_accept = true
 ## mode in the Atuin search is forced to be the specified one.
 # keymap_mode = "emacs"
 
-## the keymap mode used when Atuin is invoked from a shell up-key binding.
-## "auto" follows the shell's own keymap; otherwise the accepted values are
-## identical to those of "keymap_mode"
-# keymap_mode_shell = "auto"
-
 ## disable mouse capture in the interactive search TUI, so the terminal keeps
 ## its native selection and scrolling behaviour
 # no_mouse = false

--- a/crates/atuin-client/config.toml
+++ b/crates/atuin-client/config.toml
@@ -185,6 +185,18 @@ enter_accept = true
 ## mode in the Atuin search is forced to be the specified one.
 # keymap_mode = "emacs"
 
+## the keymap mode used when Atuin is invoked from a shell up-key binding.
+## "auto" follows the shell's own keymap; otherwise the accepted values are
+## identical to those of "keymap_mode"
+# keymap_mode_shell = "auto"
+
+## disable mouse capture in the interactive search TUI, so the terminal keeps
+## its native selection and scrolling behaviour
+# no_mouse = false
+
+## enable smart sorting of interactive search results
+# smart_sort = false
+
 ## Cursor style in each keymap mode. If specified, the cursor style is changed
 ## in entering the cursor shape. Available values are "default" and
 ## "{blink,steady}-{block,underline,bar}".
@@ -261,6 +273,9 @@ enter_accept = true
 
 # Defaults to false. The backspace key performs the same functionality as Tab and copies the selected line to the command line to be modified when at the start of the line.
 # accept_with_backspace = false
+
+## the prefix key used for prefix-based keybindings
+# prefix = "a"
 
 [preview]
 ## which preview strategy to use to calculate the preview height (respects max_preview_height).
@@ -343,6 +358,15 @@ enter_accept = true
 ## - array of strings: show commands run by any shell in the array; "" includes
 ##   commands that have no recorded shell
 # shells = "auto"
+
+## weight applied to the recency component when scoring search results
+# recency_score_multiplier = 1.0
+
+## weight applied to the frequency component when scoring search results
+# frequency_score_multiplier = 1.0
+
+## overall multiplier applied to the final frecency score
+# frecency_score_multiplier = 1.0
 
 [tmux]
 ## Enable using atuin with tmux popup (requires tmux >= 3.2)


### PR DESCRIPTION
Seven settings have a `set_default` in `settings.rs` but appear in neither `config.toml` nor the docs site, so the only way to find them is to read the source:

| Setting | Default |
| --- | --- |
| `keymap_mode_shell` | `"auto"` |
| `no_mouse` | `false` |
| `smart_sort` | `false` |
| `keys.prefix` | `"a"` |
| `search.recency_score_multiplier` | `1.0` |
| `search.frequency_score_multiplier` | `1.0` |
| `search.frecency_score_multiplier` | `1.0` |

Added them to `config.toml`, commented out with their real defaults, following the file's existing convention. Descriptions come from the code rather than being invented — the three multipliers use the wording from the `rebuild_frecency` doc comment in `atuin-daemon/src/search/index.rs` ("Weight for recency component", "Weight for frequency component", "Overall multiplier for final score").

I deliberately didn't add the rest of the undocumented `set_default` keys: the `*.db_path` ones are derived from `data_dir` rather than things you'd normally set, and `theme.*`, `logs.*` and `shell_up_key_binding` are already covered on the docs site.

While checking this I noticed something unrelated that I've left alone: `Search::default()` orders filters as global, host, session, **session-preload**, workspace, directory, while `set_default("search.filters", ...)` orders them global, host, session, workspace, directory, **session-preload**. Happy to open a separate issue if that's not intentional.

---

AI disclosure: I used Claude (Opus 5) to diff `set_default` keys against `config.toml` and the docs. I checked each setting's usage in the code myself before writing its description.
