### PR TITLE
fix: make pty-proxy socket path shorter

### DIFF
--- a/crates/atuin-pty-proxy/src/screen.rs
+++ b/crates/atuin-pty-proxy/src/screen.rs
@@ -19,7 +19,7 @@ pub fn socket_path() -> Result<PathBuf, SecureTempDirError> {
     let uid = atuin_common::os::unix::uid();
     let dir = atuin_common::os::unix::tmp_dir().join(format!("atuin-{uid}"));
     let dir = create_secure_temp_dir(dir)?;
-    Ok(dir.join(format!("atuin-pty-proxy-{}.sock", std::process::id())))
+    Ok(dir.join(format!("pty-proxy-{}.sock", std::process::id())))
 }
 
 pub fn spawn_parser_thread(rows: u16, cols: u16, msg_rx: Receiver<Msg>) {


### PR DESCRIPTION
Socket paths have a limit of 100 characters, so it's better for us to use less of that quota. Prefixing the socket *name* with `atuin` is not necessary because it's now stored in a directory prefixed with `atuin`.

This change is backwards compatible because the socket path is passed in an environment variable.