### PR TITLE
chore(release): prepare for release 18.20.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,21 +2,103 @@
 
 All notable changes to this project will be documented in this file.
 
-## [unreleased]
+## 18.20.0
 
 ### Bug Fixes
 
+- *(ai)* Execute commands from enter in the bash integration ([#3892](https://github.com/atuinsh/atuin/issues/3892))
+- *(ai)* Answer unrecognized tool calls with an error result ([#3893](https://github.com/atuinsh/atuin/issues/3893))
+- *(bash)* Localize "READLINE_{LINE,POINT}" in Bash <= 3.2 ([#3926](https://github.com/atuinsh/atuin/issues/3926))
+- *(common)* Survive wide characters on a one-column screen ([#3876](https://github.com/atuinsh/atuin/issues/3876))
 - *(docs)* Don't say `enter_accept` defaults to true in example config.toml ([#3865](https://github.com/atuinsh/atuin/issues/3865))
+- *(history)* Don't misclassify users named after an agent as agents ([#3951](https://github.com/atuinsh/atuin/issues/3951))
+- *(install)* Atuin init for bash ([#3919](https://github.com/atuinsh/atuin/issues/3919))
+- *(nix)* Add an RPATH for OpenSSL so the built binary runs ([#3852](https://github.com/atuinsh/atuin/issues/3852))
 - *(search)* Prepare daemon search index in shell init scripts ([#3864](https://github.com/atuinsh/atuin/issues/3864))
+- *(search)* Fall back when daemon-fuzzy fails ([#3895](https://github.com/atuinsh/atuin/issues/3895))
+- *(search)* Don't overflow on a session id with an out-of-range uuid timestamp ([#3965](https://github.com/atuinsh/atuin/issues/3965))
+- *(sync)* Fix off-by-one bugs in sync ([#3913](https://github.com/atuinsh/atuin/issues/3913))
+- *(wrapped)* Panic when every command is in stats.ignored_commands ([#3925](https://github.com/atuinsh/atuin/issues/3925))
 - *(zsh)* Don't clobber RPS1 when wrapping the prompt for OSC 133 ([#3861](https://github.com/atuinsh/atuin/issues/3861))
+- 'atuin login' prints 401 failures until authorized ([#3916](https://github.com/atuinsh/atuin/issues/3916))
+- Silence hub 401 log spam during installer login ([#3918](https://github.com/atuinsh/atuin/issues/3918))
+- Fix panics from `vt100::Parser::new` ([#3933](https://github.com/atuinsh/atuin/issues/3933))
+- Make pty-proxy socket path shorter ([#3991](https://github.com/atuinsh/atuin/issues/3991))
+
+
+### Documentation
+
+- Document rstest/proptest testing conventions in AGENTS.md ([#3942](https://github.com/atuinsh/atuin/issues/3942))
+
+
+### Features
+
+- *(common)* Add rmp::serde iterator-to-MessagePack helper ([#3897](https://github.com/atuinsh/atuin/issues/3897))
+- *(daemon)* Change default daemon socket path ([#3910](https://github.com/atuinsh/atuin/issues/3910))
+- *(domain)* Add RecordTag string enum ([#3899](https://github.com/atuinsh/atuin/issues/3899))
+- *(sync)* Send the auth token on the capabilities fetch when logged in ([#3974](https://github.com/atuinsh/atuin/issues/3974))
+- Add agent hooks for opencode ([#3844](https://github.com/atuinsh/atuin/issues/3844))
+- Add devcontainers ([#3871](https://github.com/atuinsh/atuin/issues/3871))
+- Setup claude in devcontainers ([#3878](https://github.com/atuinsh/atuin/issues/3878))
+- Add windows/powershell highlighting ([#3883](https://github.com/atuinsh/atuin/issues/3883))
+- Add turn time and tips to Atuin AI ([#3870](https://github.com/atuinsh/atuin/issues/3870))
+- Enable syntax highlighting on illumos ([#3879](https://github.com/atuinsh/atuin/issues/3879))
+- Offer account login during install setup ([#3849](https://github.com/atuinsh/atuin/issues/3849))
+- Client-side history packfiles ([#3737](https://github.com/atuinsh/atuin/issues/3737))
+- Parallel packfile upload/download ([#3944](https://github.com/atuinsh/atuin/issues/3944))
+- Eager Key Query ([#3968](https://github.com/atuinsh/atuin/issues/3968))
+- Capabilities-driven sync page size ([#3979](https://github.com/atuinsh/atuin/issues/3979))
+- Improve powershell highlighting ([#3917](https://github.com/atuinsh/atuin/issues/3917))
+- Enable gzip and zstd for reqwest ([#3980](https://github.com/atuinsh/atuin/issues/3980))
+
+
+### Miscellaneous Tasks
+
+- *(ai)* Remove obsolete `atuin ai init` command ([#3936](https://github.com/atuinsh/atuin/issues/3936))
+- *(docker)* Install the toolchain pinned by rust-toolchain.toml ([#3963](https://github.com/atuinsh/atuin/issues/3963))
+- *(lints)* Use workspace lints instead of overriding lints in GHA workflow ([#3949](https://github.com/atuinsh/atuin/issues/3949))
+- *(rustfmt)* Update Rustfmt config ([#3945](https://github.com/atuinsh/atuin/issues/3945))
+- *(tests)* Fix flaky pty-proxy test ([#3874](https://github.com/atuinsh/atuin/issues/3874))
+- Add profiling to the app ([#3853](https://github.com/atuinsh/atuin/issues/3853))
+- Temporarily drop tailscale and atuin ([#3873](https://github.com/atuinsh/atuin/issues/3873))
+- Instruct agents to use `rstest` in AGENTS.md ([#3912](https://github.com/atuinsh/atuin/issues/3912))
+- More xdg compliance ([#3932](https://github.com/atuinsh/atuin/issues/3932))
+- Remove atuin-nucleo ([#3950](https://github.com/atuinsh/atuin/issues/3950))
+- Enable more Clippy lints ([#3953](https://github.com/atuinsh/atuin/issues/3953))
+- Update to rust 1.98 ([#3964](https://github.com/atuinsh/atuin/issues/3964))
+- Revert changes to `atuin-pty-proxy` from `lab share` PR / feat: store pty-proxy sockets in `/tmp/atuin-$UID` ([#3988](https://github.com/atuinsh/atuin/issues/3988))
+
+
+### Performance
+
+- *(sql)* Chunked bulk inserts + shared sqlite wrapper ([#3981](https://github.com/atuinsh/atuin/issues/3981))
+- *(sync)* Batch post-sync history indexing into bulk transactions ([#3947](https://github.com/atuinsh/atuin/issues/3947))
+- *(sync)* Parallel record downloads ([#3955](https://github.com/atuinsh/atuin/issues/3955))
+- *(tracing)* OTel export + instrumentation coverage ([#3952](https://github.com/atuinsh/atuin/issues/3952))
 
 
 ### Refactor
 
+- *(ai/bash)* Use existing facility for accept-line ([#3928](https://github.com/atuinsh/atuin/issues/3928))
+- *(bash)* Remove redundant check of existing preexec-backend ([#3927](https://github.com/atuinsh/atuin/issues/3927))
+- *(caps)* CapClient owns its client and warms on construction ([#3898](https://github.com/atuinsh/atuin/issues/3898))
+- *(client)* Own sync_addr via Arc<Url>, drop Client lifetime ([#3896](https://github.com/atuinsh/atuin/issues/3896))
+- *(client)* Remove the Database trait in favor of Sqlite ([#3946](https://github.com/atuinsh/atuin/issues/3946))
+- *(deps)* Bump pymdown-extensions from 11.0 to 11.0.1 in /docs in the uv group across 1 directory ([#3875](https://github.com/atuinsh/atuin/issues/3875))
+- *(domain)* Make Record::with_data consume self, add with_data_clone ([#3900](https://github.com/atuinsh/atuin/issues/3900))
+- *(domain)* Make Record.version a RecordVersion enum ([#3903](https://github.com/atuinsh/atuin/issues/3903))
+- *(domain)* Drop the vestigial Host.name field ([#3941](https://github.com/atuinsh/atuin/issues/3941))
 - *(encryption)* Introduce PasetoV4Key newtype for the encryption key ([#3860](https://github.com/atuinsh/atuin/issues/3860))
 - *(encryption)* Move encryption into atuin-common. ([#3863](https://github.com/atuinsh/atuin/issues/3863))
+- *(record)* Name the (host, tag) pair as RecordSeriesKey ([#3961](https://github.com/atuinsh/atuin/issues/3961))
+- *(sqlx)* Use FromRow instead of manual row mapping ([#3958](https://github.com/atuinsh/atuin/issues/3958))
+- *(sync)* Introduce SyncEngine to hold shared sync state ([#3962](https://github.com/atuinsh/atuin/issues/3962))
+- Add a `CmdOrigin` Type ([#3943](https://github.com/atuinsh/atuin/issues/3943))
 
 
+### Bug
+
+- Avoid rare race condition in sync ([#3972](https://github.com/atuinsh/atuin/issues/3972))
 
 ## 18.19.0
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -267,7 +267,7 @@ checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "atuin"
-version = "18.20.0-beta.3"
+version = "18.20.0"
 dependencies = [
  "arboard",
  "async-trait",
@@ -337,7 +337,7 @@ dependencies = [
 
 [[package]]
 name = "atuin-ai"
-version = "18.20.0-beta.3"
+version = "18.20.0"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -397,7 +397,7 @@ dependencies = [
 
 [[package]]
 name = "atuin-client"
-version = "18.20.0-beta.3"
+version = "18.20.0"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -462,7 +462,7 @@ dependencies = [
 
 [[package]]
 name = "atuin-common"
-version = "18.20.0-beta.3"
+version = "18.20.0"
 dependencies = [
  "base64",
  "crypto_secretbox",
@@ -505,7 +505,7 @@ dependencies = [
 
 [[package]]
 name = "atuin-daemon"
-version = "18.20.0-beta.3"
+version = "18.20.0"
 dependencies = [
  "atuin-client",
  "atuin-common",
@@ -545,7 +545,7 @@ dependencies = [
 
 [[package]]
 name = "atuin-domain"
-version = "18.20.0-beta.3"
+version = "18.20.0"
 dependencies = [
  "async-trait",
  "atuin-common",
@@ -579,7 +579,7 @@ dependencies = [
 
 [[package]]
 name = "atuin-dotfiles"
-version = "18.20.0-beta.3"
+version = "18.20.0"
 dependencies = [
  "atuin-client",
  "atuin-common",
@@ -597,7 +597,7 @@ dependencies = [
 
 [[package]]
 name = "atuin-history"
-version = "18.20.0-beta.3"
+version = "18.20.0"
 dependencies = [
  "atuin-client",
  "codspeed-divan-compat",
@@ -611,7 +611,7 @@ dependencies = [
 
 [[package]]
 name = "atuin-kv"
-version = "18.20.0-beta.3"
+version = "18.20.0"
 dependencies = [
  "atuin-client",
  "atuin-common",
@@ -630,7 +630,7 @@ dependencies = [
 
 [[package]]
 name = "atuin-lab-share"
-version = "18.20.0-beta.3"
+version = "18.20.0"
 dependencies = [
  "aes-gcm",
  "atuin-common",
@@ -652,7 +652,7 @@ dependencies = [
 
 [[package]]
 name = "atuin-pty-proxy"
-version = "18.20.0-beta.3"
+version = "18.20.0"
 dependencies = [
  "atuin-common",
  "clap",
@@ -666,7 +666,7 @@ dependencies = [
 
 [[package]]
 name = "atuin-scripts"
-version = "18.20.0-beta.3"
+version = "18.20.0"
 dependencies = [
  "atuin-client",
  "atuin-common",
@@ -704,7 +704,7 @@ dependencies = [
 
 [[package]]
 name = "atuin-server"
-version = "18.20.0-beta.3"
+version = "18.20.0"
 dependencies = [
  "argon2",
  "atuin-client",
@@ -736,7 +736,7 @@ dependencies = [
 
 [[package]]
 name = "atuin-server-database"
-version = "18.20.0-beta.3"
+version = "18.20.0"
 dependencies = [
  "async-trait",
  "atuin-common",
@@ -752,7 +752,7 @@ dependencies = [
 
 [[package]]
 name = "atuin-server-postgres"
-version = "18.20.0-beta.3"
+version = "18.20.0"
 dependencies = [
  "async-trait",
  "atuin-common",
@@ -771,7 +771,7 @@ dependencies = [
 
 [[package]]
 name = "atuin-server-sqlite"
-version = "18.20.0-beta.3"
+version = "18.20.0"
 dependencies = [
  "async-trait",
  "atuin-common",
@@ -5786,7 +5786,7 @@ dependencies = [
 
 [[package]]
 name = "tests-database"
-version = "18.20.0-beta.3"
+version = "18.20.0"
 dependencies = [
  "async-trait",
  "atuin-common",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ resolver = "2"
 exclude = ["ui/backend"]
 
 [workspace.package]
-version = "18.20.0-beta.3"
+version = "18.20.0"
 authors = ["Ellie Huxtable <ellie@atuin.sh>"]
 rust-version = "1.98.0"
 license = "MIT"
@@ -16,18 +16,18 @@ readme = "README.md"
 [workspace.dependencies]
 async-trait = "0.1.58"
 enum_dispatch = "0.3"
-atuin-client = { path = "crates/atuin-client", version = "18.20.0-beta.3" }
-atuin-common = { path = "crates/atuin-common", version = "18.20.0-beta.3" }
-atuin-daemon = { path = "crates/atuin-daemon", version = "18.20.0-beta.3" }
-atuin-domain = { path = "crates/atuin-domain", version = "18.20.0-beta.3" }
-atuin-dotfiles = { path = "crates/atuin-dotfiles", version = "18.20.0-beta.3" }
-atuin-history = { path = "crates/atuin-history", version = "18.20.0-beta.3" }
-atuin-kv = { path = "crates/atuin-kv", version = "18.20.0-beta.3" }
-atuin-scripts = { path = "crates/atuin-scripts", version = "18.20.0-beta.3" }
-atuin-server = { path = "crates/atuin-server", version = "18.20.0-beta.3" }
-atuin-server-database = { path = "crates/atuin-server-database", version = "18.20.0-beta.3" }
-atuin-server-postgres = { path = "crates/atuin-server-postgres", version = "18.20.0-beta.3" }
-atuin-server-sqlite = { path = "crates/atuin-server-sqlite", version = "18.20.0-beta.3" }
+atuin-client = { path = "crates/atuin-client", version = "18.20.0" }
+atuin-common = { path = "crates/atuin-common", version = "18.20.0" }
+atuin-daemon = { path = "crates/atuin-daemon", version = "18.20.0" }
+atuin-domain = { path = "crates/atuin-domain", version = "18.20.0" }
+atuin-dotfiles = { path = "crates/atuin-dotfiles", version = "18.20.0" }
+atuin-history = { path = "crates/atuin-history", version = "18.20.0" }
+atuin-kv = { path = "crates/atuin-kv", version = "18.20.0" }
+atuin-scripts = { path = "crates/atuin-scripts", version = "18.20.0" }
+atuin-server = { path = "crates/atuin-server", version = "18.20.0" }
+atuin-server-database = { path = "crates/atuin-server-database", version = "18.20.0" }
+atuin-server-postgres = { path = "crates/atuin-server-postgres", version = "18.20.0" }
+atuin-server-sqlite = { path = "crates/atuin-server-sqlite", version = "18.20.0" }
 frizbee = "0.12.0"
 base64 = "0.22"
 crossterm = "0.29.0"

--- a/crates/atuin-client/Cargo.toml
+++ b/crates/atuin-client/Cargo.toml
@@ -88,12 +88,12 @@ serde_bytes = "0.11"
 
 [dependencies.atuin-common]
 path = "../atuin-common"
-version = "18.20.0-beta.3"
+version = "18.20.0"
 features = ["os", "sqlite"]
 
 [dependencies.atuin-domain]
 path = "../atuin-domain"
-version = "18.20.0-beta.3"
+version = "18.20.0"
 
 [dev-dependencies]
 tokio = { version = "1", features = ["full"] }
@@ -108,7 +108,7 @@ wiremock = "0.6"
 # This crate's tests require the `test-utils` feature in atuin-common.
 [dev-dependencies.atuin-common]
 path = "../atuin-common"
-version = "18.20.0-beta.3"
+version = "18.20.0"
 features = ["test-utils"]
 
 [[bench]]

--- a/crates/atuin-daemon/Cargo.toml
+++ b/crates/atuin-daemon/Cargo.toml
@@ -14,13 +14,13 @@ readme.workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-atuin-client = { path = "../atuin-client", version = "18.20.0-beta.3" }
+atuin-client = { path = "../atuin-client", version = "18.20.0" }
 parking_lot = { workspace = true }
-atuin-domain = { path = "../atuin-domain", version = "18.20.0-beta.3" }
+atuin-domain = { path = "../atuin-domain", version = "18.20.0" }
 enum_dispatch = { workspace = true }
 derive_more = { workspace = true }
-atuin-dotfiles = { path = "../atuin-dotfiles", version = "18.20.0-beta.3" }
-atuin-history = { path = "../atuin-history", version = "18.20.0-beta.3" }
+atuin-dotfiles = { path = "../atuin-dotfiles", version = "18.20.0" }
+atuin-history = { path = "../atuin-history", version = "18.20.0" }
 
 time = { workspace = true }
 uuid = { workspace = true }
@@ -47,7 +47,7 @@ frizbee = { workspace = true }
 
 [dependencies.atuin-common]
 path = "../atuin-common"
-version = "18.20.0-beta.3"
+version = "18.20.0"
 features = ["os"]
 
 [target.'cfg(target_os = "linux")'.dependencies]

--- a/crates/atuin-dotfiles/Cargo.toml
+++ b/crates/atuin-dotfiles/Cargo.toml
@@ -14,9 +14,9 @@ readme.workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-atuin-common = { path = "../atuin-common", version = "18.20.0-beta.3" }
-atuin-domain = { path = "../atuin-domain", version = "18.20.0-beta.3" }
-atuin-client = { path = "../atuin-client", version = "18.20.0-beta.3" }
+atuin-common = { path = "../atuin-common", version = "18.20.0" }
+atuin-domain = { path = "../atuin-domain", version = "18.20.0" }
+atuin-client = { path = "../atuin-client", version = "18.20.0" }
 derive_more = { workspace = true }
 
 eyre = { workspace = true }

--- a/crates/atuin-history/Cargo.toml
+++ b/crates/atuin-history/Cargo.toml
@@ -14,7 +14,7 @@ readme.workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-atuin-client = { path = "../atuin-client", version = "18.20.0-beta.3" }
+atuin-client = { path = "../atuin-client", version = "18.20.0" }
 
 time = { workspace = true }
 serde = { workspace = true }

--- a/crates/atuin-kv/Cargo.toml
+++ b/crates/atuin-kv/Cargo.toml
@@ -14,9 +14,9 @@ readme.workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-atuin-client = { path = "../atuin-client", version = "18.20.0-beta.3" }
-atuin-common = { path = "../atuin-common", version = "18.20.0-beta.3", features = ["sqlite"] }
-atuin-domain = { path = "../atuin-domain", version = "18.20.0-beta.3" }
+atuin-client = { path = "../atuin-client", version = "18.20.0" }
+atuin-common = { path = "../atuin-common", version = "18.20.0", features = ["sqlite"] }
+atuin-domain = { path = "../atuin-domain", version = "18.20.0" }
 derive_more = { workspace = true }
 
 tracing = { workspace = true }

--- a/crates/atuin-scripts/Cargo.toml
+++ b/crates/atuin-scripts/Cargo.toml
@@ -14,9 +14,9 @@ readme.workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-atuin-client = { path = "../atuin-client", version = "18.20.0-beta.3" }
-atuin-common = { path = "../atuin-common", version = "18.20.0-beta.3", features = ["sqlite"] }
-atuin-domain = { path = "../atuin-domain", version = "18.20.0-beta.3" }
+atuin-client = { path = "../atuin-client", version = "18.20.0" }
+atuin-common = { path = "../atuin-common", version = "18.20.0", features = ["sqlite"] }
+atuin-domain = { path = "../atuin-domain", version = "18.20.0" }
 derive_more = { workspace = true }
 
 tracing = { workspace = true }

--- a/crates/atuin-server-database/Cargo.toml
+++ b/crates/atuin-server-database/Cargo.toml
@@ -10,8 +10,8 @@ homepage = { workspace = true }
 repository = { workspace = true }
 
 [dependencies]
-atuin-common = { path = "../atuin-common", version = "18.20.0-beta.3" }
-atuin-domain = { path = "../atuin-domain", version = "18.20.0-beta.3" }
+atuin-common = { path = "../atuin-common", version = "18.20.0" }
+atuin-domain = { path = "../atuin-domain", version = "18.20.0" }
 derive_more = { workspace = true }
 
 async-trait = { workspace = true }

--- a/crates/atuin-server-postgres/Cargo.toml
+++ b/crates/atuin-server-postgres/Cargo.toml
@@ -10,9 +10,9 @@ homepage = { workspace = true }
 repository = { workspace = true }
 
 [dependencies]
-atuin-common = { path = "../atuin-common", version = "18.20.0-beta.3" }
-atuin-domain = { path = "../atuin-domain", version = "18.20.0-beta.3" }
-atuin-server-database = { path = "../atuin-server-database", version = "18.20.0-beta.3" }
+atuin-common = { path = "../atuin-common", version = "18.20.0" }
+atuin-domain = { path = "../atuin-domain", version = "18.20.0" }
+atuin-server-database = { path = "../atuin-server-database", version = "18.20.0" }
 derive_more = { workspace = true }
 
 eyre = { workspace = true }

--- a/crates/atuin-server-sqlite/Cargo.toml
+++ b/crates/atuin-server-sqlite/Cargo.toml
@@ -10,9 +10,9 @@ homepage = { workspace = true }
 repository = { workspace = true }
 
 [dependencies]
-atuin-common = { path = "../atuin-common", version = "18.20.0-beta.3" }
-atuin-domain = { path = "../atuin-domain", version = "18.20.0-beta.3" }
-atuin-server-database = { path = "../atuin-server-database", version = "18.20.0-beta.3" }
+atuin-common = { path = "../atuin-common", version = "18.20.0" }
+atuin-domain = { path = "../atuin-domain", version = "18.20.0" }
+atuin-server-database = { path = "../atuin-server-database", version = "18.20.0" }
 derive_more = { workspace = true }
 
 eyre = { workspace = true }

--- a/crates/atuin-server/Cargo.toml
+++ b/crates/atuin-server/Cargo.toml
@@ -52,7 +52,7 @@ tracing-subscriber = { workspace = true }
 # client's api_client. atuin-client is only a dev dependency here so the client
 # binary crate stays free of server/postgres deps (see issue #2884).
 [dev-dependencies]
-atuin-client = { path = "../atuin-client", version = "18.20.0-beta.3", default-features = false, features = ["sync"] }
+atuin-client = { path = "../atuin-client", version = "18.20.0", default-features = false, features = ["sync"] }
 rstest = { workspace = true }
 futures-util = "0.3"
 tracing-tree = "0.4"

--- a/crates/atuin/Cargo.toml
+++ b/crates/atuin/Cargo.toml
@@ -73,15 +73,15 @@ profiling-traced = [
 ]
 
 [dependencies]
-atuin-ai = { path = "../atuin-ai", version = "18.20.0-beta.3", optional = true, default-features = false }
-atuin-client = { path = "../atuin-client", version = "18.20.0-beta.3", optional = true, default-features = false }
+atuin-ai = { path = "../atuin-ai", version = "18.20.0", optional = true, default-features = false }
+atuin-client = { path = "../atuin-client", version = "18.20.0", optional = true, default-features = false }
 atuin-common = { workspace = true, features = ["unicode"] }
 atuin-domain = { workspace = true }
 atuin-dotfiles = { workspace = true }
 atuin-history = { workspace = true }
-atuin-daemon = { path = "../atuin-daemon", version = "18.20.0-beta.3", optional = true, default-features = false }
-atuin-pty-proxy = { path = "../atuin-pty-proxy", version = "18.20.0-beta.3", optional = true, default-features = false }
-atuin-lab-share = { path = "../atuin-lab-share", version = "18.20.0-beta.3", optional = true }
+atuin-daemon = { path = "../atuin-daemon", version = "18.20.0", optional = true, default-features = false }
+atuin-pty-proxy = { path = "../atuin-pty-proxy", version = "18.20.0", optional = true, default-features = false }
+atuin-lab-share = { path = "../atuin-lab-share", version = "18.20.0", optional = true }
 atuin-scripts = { workspace = true }
 atuin-kv = { workspace = true }
 axoupdater = { version = "0.10", optional = true }
@@ -147,7 +147,7 @@ daemonize = "0.5.0"
 # compiles cleanly. tree-sitter 0.26's portable/endian.h fails on illumos,
 # Windows cross-compiles, and potentially other exotic targets.
 [target.'cfg(any(target_os = "linux", target_os = "macos", target_os = "windows", target_os = "illumos"))'.dependencies]
-atuin-ai = { path = "../atuin-ai", version = "18.20.0-beta.3", optional = true, default-features = false, features = ["tree-sitter"] }
+atuin-ai = { path = "../atuin-ai", version = "18.20.0", optional = true, default-features = false, features = ["tree-sitter"] }
 tree-sitter = { workspace = true }
 tree-sitter-bash = { workspace = true }
 tree-sitter-fish = { workspace = true }


### PR DESCRIPTION

### Bug Fixes

- *(ai)* Execute commands from enter in the bash integration ([#3892](https://github.com/atuinsh/atuin/issues/3892))
- *(ai)* Answer unrecognized tool calls with an error result ([#3893](https://github.com/atuinsh/atuin/issues/3893))
- *(bash)* Localize "READLINE_{LINE,POINT}" in Bash <= 3.2 ([#3926](https://github.com/atuinsh/atuin/issues/3926))
- *(common)* Survive wide characters on a one-column screen ([#3876](https://github.com/atuinsh/atuin/issues/3876))
- *(docs)* Don't say `enter_accept` defaults to true in example config.toml ([#3865](https://github.com/atuinsh/atuin/issues/3865))
- *(history)* Don't misclassify users named after an agent as agents ([#3951](https://github.com/atuinsh/atuin/issues/3951))
- *(install)* Atuin init for bash ([#3919](https://github.com/atuinsh/atuin/issues/3919))
- *(nix)* Add an RPATH for OpenSSL so the built binary runs ([#3852](https://github.com/atuinsh/atuin/issues/3852))
- *(search)* Prepare daemon search index in shell init scripts ([#3864](https://github.com/atuinsh/atuin/issues/3864))
- *(search)* Fall back when daemon-fuzzy fails ([#3895](https://github.com/atuinsh/atuin/issues/3895))
- *(search)* Don't overflow on a session id with an out-of-range uuid timestamp ([#3965](https://github.com/atuinsh/atuin/issues/3965))
- *(sync)* Fix off-by-one bugs in sync ([#3913](https://github.com/atuinsh/atuin/issues/3913))
- *(wrapped)* Panic when every command is in stats.ignored_commands ([#3925](https://github.com/atuinsh/atuin/issues/3925))
- *(zsh)* Don't clobber RPS1 when wrapping the prompt for OSC 133 ([#3861](https://github.com/atuinsh/atuin/issues/3861))
- 'atuin login' prints 401 failures until authorized ([#3916](https://github.com/atuinsh/atuin/issues/3916))
- Silence hub 401 log spam during installer login ([#3918](https://github.com/atuinsh/atuin/issues/3918))
- Fix panics from `vt100::Parser::new` ([#3933](https://github.com/atuinsh/atuin/issues/3933))
- Make pty-proxy socket path shorter ([#3991](https://github.com/atuinsh/atuin/issues/3991))


### Documentation

- Document rstest/proptest testing conventions in AGENTS.md ([#3942](https://github.com/atuinsh/atuin/issues/3942))


### Features

- *(common)* Add rmp::serde iterator-to-MessagePack helper ([#3897](https://github.com/atuinsh/atuin/issues/3897))
- *(daemon)* Change default daemon socket path ([#3910](https://github.com/atuinsh/atuin/issues/3910))
- *(domain)* Add RecordTag string enum ([#3899](https://github.com/atuinsh/atuin/issues/3899))
- *(sync)* Send the auth token on the capabilities fetch when logged in ([#3974](https://github.com/atuinsh/atuin/issues/3974))
- Add agent hooks for opencode ([#3844](https://github.com/atuinsh/atuin/issues/3844))
- Add devcontainers ([#3871](https://github.com/atuinsh/atuin/issues/3871))
- Setup claude in devcontainers ([#3878](https://github.com/atuinsh/atuin/issues/3878))
- Add windows/powershell highlighting ([#3883](https://github.com/atuinsh/atuin/issues/3883))
- Add turn time and tips to Atuin AI ([#3870](https://github.com/atuinsh/atuin/issues/3870))
- Enable syntax highlighting on illumos ([#3879](https://github.com/atuinsh/atuin/issues/3879))
- Offer account login during install setup ([#3849](https://github.com/atuinsh/atuin/issues/3849))
- Client-side history packfiles ([#3737](https://github.com/atuinsh/atuin/issues/3737))
- Parallel packfile upload/download ([#3944](https://github.com/atuinsh/atuin/issues/3944))
- Eager Key Query ([#3968](https://github.com/atuinsh/atuin/issues/3968))
- Capabilities-driven sync page size ([#3979](https://github.com/atuinsh/atuin/issues/3979))
- Improve powershell highlighting ([#3917](https://github.com/atuinsh/atuin/issues/3917))
- Enable gzip and zstd for reqwest ([#3980](https://github.com/atuinsh/atuin/issues/3980))


### Miscellaneous Tasks

- *(ai)* Remove obsolete `atuin ai init` command ([#3936](https://github.com/atuinsh/atuin/issues/3936))
- *(docker)* Install the toolchain pinned by rust-toolchain.toml ([#3963](https://github.com/atuinsh/atuin/issues/3963))
- *(lints)* Use workspace lints instead of overriding lints in GHA workflow ([#3949](https://github.com/atuinsh/atuin/issues/3949))
- *(rustfmt)* Update Rustfmt config ([#3945](https://github.com/atuinsh/atuin/issues/3945))
- *(tests)* Fix flaky pty-proxy test ([#3874](https://github.com/atuinsh/atuin/issues/3874))
- Add profiling to the app ([#3853](https://github.com/atuinsh/atuin/issues/3853))
- Temporarily drop tailscale and atuin ([#3873](https://github.com/atuinsh/atuin/issues/3873))
- Instruct agents to use `rstest` in AGENTS.md ([#3912](https://github.com/atuinsh/atuin/issues/3912))
- More xdg compliance ([#3932](https://github.com/atuinsh/atuin/issues/3932))
- Remove atuin-nucleo ([#3950](https://github.com/atuinsh/atuin/issues/3950))
- Enable more Clippy lints ([#3953](https://github.com/atuinsh/atuin/issues/3953))
- Update to rust 1.98 ([#3964](https://github.com/atuinsh/atuin/issues/3964))
- Revert changes to `atuin-pty-proxy` from `lab share` PR / feat: store pty-proxy sockets in `/tmp/atuin-$UID` ([#3988](https://github.com/atuinsh/atuin/issues/3988))


### Performance

- *(sql)* Chunked bulk inserts + shared sqlite wrapper ([#3981](https://github.com/atuinsh/atuin/issues/3981))
- *(sync)* Batch post-sync history indexing into bulk transactions ([#3947](https://github.com/atuinsh/atuin/issues/3947))
- *(sync)* Parallel record downloads ([#3955](https://github.com/atuinsh/atuin/issues/3955))
- *(tracing)* OTel export + instrumentation coverage ([#3952](https://github.com/atuinsh/atuin/issues/3952))


### Refactor

- *(ai/bash)* Use existing facility for accept-line ([#3928](https://github.com/atuinsh/atuin/issues/3928))
- *(bash)* Remove redundant check of existing preexec-backend ([#3927](https://github.com/atuinsh/atuin/issues/3927))
- *(caps)* CapClient owns its client and warms on construction ([#3898](https://github.com/atuinsh/atuin/issues/3898))
- *(client)* Own sync_addr via Arc<Url>, drop Client lifetime ([#3896](https://github.com/atuinsh/atuin/issues/3896))
- *(client)* Remove the Database trait in favor of Sqlite ([#3946](https://github.com/atuinsh/atuin/issues/3946))
- *(deps)* Bump pymdown-extensions from 11.0 to 11.0.1 in /docs in the uv group across 1 directory ([#3875](https://github.com/atuinsh/atuin/issues/3875))
- *(domain)* Make Record::with_data consume self, add with_data_clone ([#3900](https://github.com/atuinsh/atuin/issues/3900))
- *(domain)* Make Record.version a RecordVersion enum ([#3903](https://github.com/atuinsh/atuin/issues/3903))
- *(domain)* Drop the vestigial Host.name field ([#3941](https://github.com/atuinsh/atuin/issues/3941))
- *(encryption)* Introduce PasetoV4Key newtype for the encryption key ([#3860](https://github.com/atuinsh/atuin/issues/3860))
- *(encryption)* Move encryption into atuin-common. ([#3863](https://github.com/atuinsh/atuin/issues/3863))
- *(record)* Name the (host, tag) pair as RecordSeriesKey ([#3961](https://github.com/atuinsh/atuin/issues/3961))
- *(sqlx)* Use FromRow instead of manual row mapping ([#3958](https://github.com/atuinsh/atuin/issues/3958))
- *(sync)* Introduce SyncEngine to hold shared sync state ([#3962](https://github.com/atuinsh/atuin/issues/3962))
- Add a `CmdOrigin` Type ([#3943](https://github.com/atuinsh/atuin/issues/3943))


### Bug

- Avoid rare race condition in sync ([#3972](https://github.com/atuinsh/atuin/issues/3972))