### PR TITLE
feat: switch terminal emulation to `atuin-vt100`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -345,6 +345,7 @@ dependencies = [
  "atuin-common",
  "atuin-daemon",
  "atuin-domain",
+ "atuin-vt100",
  "chrono",
  "chrono-humanize",
  "clap",
@@ -390,7 +391,6 @@ dependencies = [
  "typed-builder",
  "unicode-width 0.2.2",
  "uuid",
- "vt100",
  "xxhash-rust",
  "yaml-rust2",
 ]
@@ -464,6 +464,7 @@ dependencies = [
 name = "atuin-common"
 version = "18.20.0"
 dependencies = [
+ "atuin-vt100",
  "base64",
  "crypto_secretbox",
  "derive_more",
@@ -499,7 +500,6 @@ dependencies = [
  "unicode-width 0.2.2",
  "url",
  "uuid",
- "vt100",
  "zeroize",
 ]
 
@@ -655,13 +655,13 @@ name = "atuin-pty-proxy"
 version = "18.20.0"
 dependencies = [
  "atuin-common",
+ "atuin-vt100",
  "clap",
  "crossterm",
  "eyre",
  "portable-pty",
  "rstest",
  "signal-hook",
- "vt100",
 ]
 
 [[package]]
@@ -785,6 +785,17 @@ dependencies = [
  "time",
  "tracing",
  "uuid",
+]
+
+[[package]]
+name = "atuin-vt100"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f1f37e21bb3cc6e1244deb0e7999c0a18da5e3e58caf92befc19ce53f6367e6"
+dependencies = [
+ "itoa",
+ "unicode-width 0.2.2",
+ "vte",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ atuin-server = { path = "crates/atuin-server", version = "18.20.0" }
 atuin-server-database = { path = "crates/atuin-server-database", version = "18.20.0" }
 atuin-server-postgres = { path = "crates/atuin-server-postgres", version = "18.20.0" }
 atuin-server-sqlite = { path = "crates/atuin-server-sqlite", version = "18.20.0" }
+atuin-vt100 = "0.17"
 frizbee = "0.12.0"
 base64 = "0.22"
 crossterm = "0.29.0"
@@ -83,7 +84,6 @@ minijinja = "2.9.0"
 glob-match = "0.2.1"
 imara-diff = "0.2"
 xxhash-rust = { version = "0.8", features = ["xxh3"] }
-vt100 = "0.16"
 regex = "1.10.5"
 toml_edit = "0.25.4"
 url = { version = "2.5", features = ["serde"] }

--- a/clippy.toml
+++ b/clippy.toml
@@ -22,14 +22,6 @@ path = "time::UtcDateTime::from_unix_timestamp_nanos"
 reason = """same truncation bug as OffsetDateTime (time-rs/time#802); range-check the full i128 \
     before converting"""
 
-[[disallowed-methods]]
-path = "vt100::Parser::new"
-reason = "can panic; `use atuin_common::ansi::Vt100ParserExt as _` and use `Parser::new_safe`"
-
-[[disallowed-methods]]
-path = "vt100::Screen::set_size"
-reason = "can panic; `use atuin_common::ansi::Vt100ScreenExt as _` and use `Screen::set_size_safe`"
-
 [[disallowed-types]]
 path = "std::sync::Mutex"
 reason = "use parking_lot::Mutex which is faster"

--- a/crates/atuin-ai/Cargo.toml
+++ b/crates/atuin-ai/Cargo.toml
@@ -18,14 +18,15 @@ daemon = []
 tree-sitter = ["dep:tree-sitter", "dep:tree-sitter-bash", "dep:tree-sitter-fish"]
 
 [dependencies]
+atuin-client = { workspace = true }
+atuin-domain = { workspace = true }
+atuin-common = { workspace = true, features = ["unicode", "ansi", "sqlite"] }
+atuin-daemon = { workspace = true }
+atuin-vt100 = { workspace = true }
 enum_dispatch = { workspace = true }
 parking_lot = { workspace = true }
 async-trait = { workspace = true }
-atuin-client = { workspace = true }
-atuin-domain = { workspace = true }
 derive_more = { workspace = true }
-atuin-common = { workspace = true, features = ["unicode", "ansi", "sqlite"] }
-atuin-daemon = { workspace = true }
 tokio = { workspace = true }
 eyre = { workspace = true }
 clap = { workspace = true, features = ["derive", "env"] }
@@ -70,7 +71,6 @@ typed-builder = { workspace = true }
 shellexpand = { workspace = true }
 imara-diff = { workspace = true }
 xxhash-rust = { workspace = true }
-vt100 = { workspace = true }
 yaml-rust2 = "0.11"
 tempfile = { workspace = true }
 chrono = "0.4"

--- a/crates/atuin-ai/src/tools/mod.rs
+++ b/crates/atuin-ai/src/tools/mod.rs
@@ -4,7 +4,7 @@ use std::path::{Path, PathBuf};
 use std::time::Duration;
 
 use atuin_client::history::AuthorPattern;
-use atuin_common::ansi::{self, Vt100ParserExt as _};
+use atuin_common::ansi;
 use atuin_common::filter::OrFilter;
 use atuin_common::time::UtcOffsetExt;
 use enum_dispatch::enum_dispatch;
@@ -782,10 +782,10 @@ impl PermissibleToolCall for ShellToolCall {
 }
 
 /// Preview viewport height for VT100 emulation.
-const PREVIEW_HEIGHT: u16 = 10;
+const PREVIEW_HEIGHT: NonZeroU16 = NonZeroU16::new(10).unwrap();
 
 /// Default terminal width for VT100 emulation.
-const PREVIEW_WIDTH: u16 = 120;
+const PREVIEW_WIDTH: NonZeroU16 = NonZeroU16::new(120).unwrap();
 
 /// Extract plain text lines from a VT100 screen buffer.
 ///
@@ -849,7 +849,7 @@ pub async fn execute_shell_command_streaming(
     let stderr = child.stderr.take().expect("stderr was piped");
 
     // VT100 emulator for the live preview (viewport-sized)
-    let mut parser = vt100::Parser::new_safe(PREVIEW_HEIGHT, PREVIEW_WIDTH, 0);
+    let mut parser = vt100::Parser::new(PREVIEW_HEIGHT, PREVIEW_WIDTH, 0);
 
     let mut stdout_reader = tokio::io::BufReader::new(stdout);
     let mut stderr_reader = tokio::io::BufReader::new(stderr);
@@ -941,7 +941,7 @@ pub async fn execute_shell_command_streaming(
 
     // Strip ANSI escape sequences for clean LLM output by running
     // the raw bytes through a VT100 parser and extracting plain text.
-    let cols = NonZeroU16::new(PREVIEW_WIDTH).expect("PREVIEW_WIDTH is nonzero");
+    let cols = PREVIEW_WIDTH;
     let stdout_text = ansi::to_plain_text(&full_stdout, cols);
     let stderr_text = ansi::to_plain_text(&full_stderr, cols);
 

--- a/crates/atuin-common/Cargo.toml
+++ b/crates/atuin-common/Cargo.toml
@@ -21,13 +21,14 @@ unicode = ["dep:unicode-width", "dep:unicode-segmentation"]
 # The `ansi` module: renders raw terminal byte streams (ANSI/ECMA-48 escape
 # sequences, backspaces, carriage returns, cursor motion) into clean plain text
 # via a `vt100` terminal emulator. Compiled only when enabled.
-ansi = ["dep:vt100"]
+ansi = ["dep:atuin-vt100"]
 # Enables OS-specific utilities.
 os = ["dep:rustix"]
 # The `sqlite` module: an atuin-specific wrapper around a bundled SQLite pool.
 sqlite = ["dep:sqlx", "dep:libsqlite3-sys"]
 
 [dependencies]
+atuin-vt100 = { workspace = true, optional = true }
 derive_more = { workspace = true }
 tiny-bip39 = { workspace = true }
 crypto_secretbox = { workspace = true }
@@ -46,7 +47,6 @@ tracing = { workspace = true }
 tracing-subscriber = { workspace = true, optional = true }
 unicode-width = { version = "0.2", optional = true }
 unicode-segmentation = { version = "1.11.0", optional = true }
-vt100 = { workspace = true, optional = true }
 itertools = { workspace = true }
 rusty_paseto = { workspace = true }
 rusty_paserk = { workspace = true }

--- a/crates/atuin-common/src/ansi.rs
+++ b/crates/atuin-common/src/ansi.rs
@@ -6,50 +6,6 @@ use std::num::NonZeroU16;
 /// Arbitrary upper bound on the emulated screen height, in rows. Mitigates OOMs with long output.
 const MAX_ROWS: usize = 16_384;
 
-/// Extension trait for [`vt100::Parser`].
-pub trait Vt100ParserExt: Sized {
-    fn new_safe(rows: u16, cols: u16, scrollback_len: usize) -> Self;
-}
-
-/// Extension trait for [`vt100::Screen`].
-pub trait Vt100ScreenExt: Sized {
-    fn set_size_safe(&mut self, rows: u16, cols: u16);
-}
-
-impl Vt100ParserExt for vt100::Parser {
-    /// Create a new [`vt100::Parser`].
-    ///
-    /// Prefer this function over calling [`vt100::Parser::new`] directly. [`vt100`] has [a bug]
-    /// that can cause panics when `rows` or `cols` is less than 2. This function avoids that
-    /// case by clamping `rows` and `cols` to 2 if either is less than that.
-    ///
-    /// [a bug]: https://github.com/doy/vt100-rust/issues/37
-    fn new_safe(rows: u16, cols: u16, scrollback_len: usize) -> Self {
-        #[allow(
-            clippy::disallowed_methods,
-            reason = "this is the one safe wrapper around the disallowed function"
-        )]
-        Self::new(rows.max(2), cols.max(2), scrollback_len)
-    }
-}
-
-impl Vt100ScreenExt for vt100::Screen {
-    /// Set the size of a [`vt100::Screen`].
-    ///
-    /// Prefer this function over calling [`vt100::Screen::set_size`] directly. [`vt100`] has
-    /// [a bug] that can cause panics when `rows` or `cols` is less than 2. This method avoids
-    /// that case by clamping `rows` and `cols` to 2 if either is less than that.
-    ///
-    /// [a bug]: https://github.com/doy/vt100-rust/issues/37
-    fn set_size_safe(&mut self, rows: u16, cols: u16) {
-        #[allow(
-            clippy::disallowed_methods,
-            reason = "this is the one safe wrapper around the disallowed method"
-        )]
-        self.set_size(rows.max(2), cols.max(2))
-    }
-}
-
 /// Render ANSI-encoded terminal output to plain text, as it would appear on a `cols`-wide terminal.
 ///
 /// Uses [`vt100::Parser`] under the hood meaning that backspaces, ANSI codes, etc. are gracefully
@@ -82,8 +38,9 @@ pub fn to_plain_text(input: impl AsRef<[u8]>, cols: NonZeroU16) -> String {
         .saturating_add(wrapped_rows)
         .saturating_add(1)
         .clamp(1, MAX_ROWS.min(usize::from(u16::MAX))) as u16;
+    let rows = NonZeroU16::new(rows).expect("`rows` is always at least 1 due to `clamp`");
 
-    let mut parser = vt100::Parser::new_safe(rows, cols.get(), 0);
+    let mut parser = vt100::Parser::new(rows, cols, 0);
     parser.process(&normalized);
 
     // The emulator renders onto a fixed grid, so `contents()` comes back with each row right-padded
@@ -161,20 +118,20 @@ mod tests {
         assert_eq!(to_plain_text(b"", cols), "");
     }
 
-    #[test]
-    fn wide_characters_survive_a_one_column_screen() {
-        // A double-width character on a one-column screen used to panic
-        // inside vt100 ("attempt to subtract with overflow"); found by
-        // never_panics_and_strips_controls.
-        assert_eq!(to_plain_text("⺀".as_bytes(), nz(1)), "⺀");
+    #[rstest]
+    fn wide_character_on_a_one_column_screen() {
+        // A double-width character on a one-column screen used to panic inside vt100 ("attempt to
+        // subtract with overflow"); found by never_panics_and_strips_controls. A one-column screen
+        // cannot actually render a wide character, so we expect an empty snapshot.
+        assert_eq!(to_plain_text("⺀".as_bytes(), nz(1)), "");
     }
 
-    #[test]
+    #[rstest]
     fn trailing_blank_lines_are_trimmed() {
         assert_eq!(to_plain_text(b"hi\r\n\r\n\r\n", nz(80)), "hi");
     }
 
-    #[test]
+    #[rstest]
     fn long_lines_wrap_at_the_column_boundary() {
         let wrapped = to_plain_text(b"abcdefghij", nz(4));
         assert_eq!(wrapped, "abcdefghij");

--- a/crates/atuin-lab-share/Cargo.toml
+++ b/crates/atuin-lab-share/Cargo.toml
@@ -26,7 +26,7 @@ url = { workspace = true }
 serde_json = { workspace = true }
 base64 = { workspace = true }
 atuin-common = { workspace = true, features = ["unicode"] }
-vt100 = { workspace = true }
+vt100 = "0.16"
 crossterm = { workspace = true }
 # `features = ["full"]` at the workspace level includes `signal` and `time`;
 # trimming to just what this crate needs would be a workspace change.

--- a/crates/atuin-pty-proxy/Cargo.toml
+++ b/crates/atuin-pty-proxy/Cargo.toml
@@ -15,11 +15,11 @@ clap = { workspace = true }
 
 [target.'cfg(unix)'.dependencies]
 atuin-common = { workspace = true, features = ["ansi", "os"] }
+atuin-vt100 = { workspace = true }
 crossterm = { workspace = true }
 eyre = { workspace = true }
 portable-pty = "0.9"
 signal-hook = "0.3"
-vt100 = { workspace = true }
 
 [dev-dependencies]
 rstest = { workspace = true }

--- a/crates/atuin-pty-proxy/src/screen.rs
+++ b/crates/atuin-pty-proxy/src/screen.rs
@@ -1,9 +1,9 @@
 use std::io::Write;
+use std::num::NonZeroU16;
 use std::os::unix::net::UnixListener;
 use std::path::PathBuf;
 use std::sync::mpsc::{self, Receiver, SyncSender};
 
-use atuin_common::ansi::{Vt100ParserExt as _, Vt100ScreenExt as _};
 use atuin_common::os::unix::{SecureTempDirError, create_secure_temp_dir};
 
 pub enum Msg {
@@ -24,7 +24,9 @@ pub fn socket_path() -> Result<PathBuf, SecureTempDirError> {
 
 pub fn spawn_parser_thread(rows: u16, cols: u16, msg_rx: Receiver<Msg>) {
     std::thread::spawn(move || {
-        let mut parser = vt100::Parser::new_safe(rows, cols, 0);
+        let rows = NonZeroU16::new(rows).unwrap_or(NonZeroU16::MIN);
+        let cols = NonZeroU16::new(cols).unwrap_or(NonZeroU16::MIN);
+        let mut parser = vt100::Parser::new(rows, cols, 0);
 
         loop {
             let Ok(first) = msg_rx.recv() else {
@@ -84,16 +86,16 @@ fn encode_screen(parser: &vt100::Parser) -> Vec<u8> {
     let (rows, cols) = screen.size();
     let (cursor_row, cursor_col) = screen.cursor_position();
 
-    let mut buf: Vec<u8> = Vec::with_capacity(256 + (rows as usize * cols as usize));
+    let mut buf = Vec::with_capacity(256 + (usize::from(rows) * usize::from(cols)));
     buf.extend_from_slice(&rows.to_be_bytes());
     buf.extend_from_slice(&cols.to_be_bytes());
     buf.extend_from_slice(&cursor_row.to_be_bytes());
     buf.extend_from_slice(&cursor_col.to_be_bytes());
 
-    for row_bytes in screen.rows_formatted(0, cols) {
-        let len = row_bytes.len() as u32;
+    for row_data in screen.rows_formatted(0, cols) {
+        let len = row_data.len() as u32;
         buf.extend_from_slice(&len.to_be_bytes());
-        buf.extend_from_slice(&row_bytes);
+        buf.extend_from_slice(row_data.as_bytes());
     }
 
     buf
@@ -102,7 +104,11 @@ fn encode_screen(parser: &vt100::Parser) -> Vec<u8> {
 fn handle_parser_msg(parser: &mut vt100::Parser, msg: Msg) {
     match msg {
         Msg::Data(data) => parser.process(&data),
-        Msg::Resize { rows, cols } => parser.screen_mut().set_size_safe(rows, cols),
+        Msg::Resize { rows, cols } => {
+            let rows = NonZeroU16::new(rows).unwrap_or(NonZeroU16::MIN);
+            let cols = NonZeroU16::new(cols).unwrap_or(NonZeroU16::MIN);
+            parser.screen_mut().set_size(rows, cols);
+        }
         Msg::ScreenRequest(reply_tx) => {
             let _ = reply_tx.send(encode_screen(parser));
         }
@@ -120,8 +126,6 @@ mod tests {
         (u16::from_be_bytes([blob[0], blob[1]]), u16::from_be_bytes([blob[2], blob[3]]))
     }
 
-    /// vt100 can panic when `rows` or `cols` is less than 2 (doy/vt100-rust#37>). Make sure we
-    /// clamp the dimensions to avoid panics.
     #[rstest]
     fn init_small_and_wrap(#[values(0, 1, 2, 3)] rows: u16, #[values(0, 1, 2, 3)] cols: u16) {
         let (msg_tx, msg_rx) = mpsc::sync_channel(8);
@@ -134,18 +138,17 @@ mod tests {
             .recv_timeout(std::time::Duration::from_secs(5))
             .expect("parser thread still answering");
 
-        // Dimensions are clamped to (2, 2) to avoid panics in vt100.
-        assert_eq!(size_of(&blob), (rows.max(2), cols.max(2)));
+        // Dimensions are clamped to (1, 1) because vt100 dimensions must be positive.
+        assert_eq!(size_of(&blob), (rows.max(1), cols.max(1)));
     }
 
-    /// Same test as `init_small_and_wrap`, but for resizes.
     #[rstest]
     fn resize_small_and_wrap(#[values(0, 1, 2, 3)] rows: u16, #[values(0, 1, 2, 3)] cols: u16) {
-        let mut parser = vt100::Parser::new_safe(24, 80, 0);
+        let mut parser = vt100::Parser::default();
         handle_parser_msg(&mut parser, Msg::Resize { rows, cols });
         handle_parser_msg(&mut parser, Msg::Data(b"hello world".to_vec()));
 
-        // Dimensions are clamped to (2, 2) to avoid panics in vt100.
-        assert_eq!(size_of(&encode_screen(&parser)), (rows.max(2), cols.max(2)));
+        // Dimensions are clamped to (1, 1) because vt100 dimensions must be positive.
+        assert_eq!(size_of(&encode_screen(&parser)), (rows.max(1), cols.max(1)));
     }
 }


### PR DESCRIPTION
Switch terminal emulation from [`vt100`](https://github.com/doy/vt100) to [`atuin-vt100`](https://github.com/atuinsh/vt100-rust), Atuin's fork of `vt100`.

This is necessary to enable us to capture the output of commands. It also fixes panics that required us to clamp screen size to a minimum of 2x2, and improves the performance of handling certain kinds of terminal data (multi-line and multi-char escape sequences, in particular).

### Why a fork?

To support some upcoming features in Atuin, like capturing the output of commands, we need more flexible terminal emulation. In particular, we need to make sure output capture is fast and low on memory use, but the design of `vt100` makes this difficult. `atuin-vt100` adds a mechanism for streaming capture of output without having to create a large scrollback buffer. Additionally, we want to preserve formatting like colors and bold, but the “formatted” output provided by `vt100` contains escape sequences that make processing difficult, like sequences that move the cursor to an absolute position. `atuin-vt100` adds a “basic formatted” style that restricts escape sequences to SGR escapes, and control characters to `'\n'`.

We can also use this opportunity to fix some bugs and improve performance. `atuin-vt100` fixes panics on small screen sizes, improves handling of IL and DL sequences to be spec-compliant, and improves the performance of many operations, especially escape sequences that insert/delete multiple rows/characters. See the [changelog](https://github.com/atuinsh/vt100-rust/blob/main/CHANGELOG.md#0170---2026-08-25) for more details.

### Can the changes be upstreamed?

The fix for panics on small screen sizes has an open upstream PR [here](https://github.com/doy/vt100-rust/pull/41). However, upstream seems unmaintained or inconsistently maintained, so we don't want to be blocked on upstream acceptance. Additionally, in my opinion, many of the changes in `atuin-vt100` are opinionated to suit our needs and wouldn't necessarily be good candidates for upstreaming—for example, the new `on_scroll` callback only supports the “basic formatted” style for row contents rather than plain text and fully formatted too. If upstreamed, it would likely need to have support for these other styles, and the basic formatted style itself, which is also new in our fork, could be the subject of debate as well. In the interest of maintaining high development speed on our new features that require more flexible terminal emulation, at this time, a fork seems like the best approach. Of course, iike `vt100`, `atuin-vt100` is fully open-source, released under the permissive MIT license, so everyone is free to copy and adapt our code.

### What changed in the fork?

See the [changelog](https://github.com/atuinsh/vt100-rust/blob/main/CHANGELOG.md#0170---2026-08-25) for an overview. For more details, I recommend looking at the [pull requests](https://github.com/atuinsh/vt100-rust/pulls?q=is%3Apr+is%3Amerged+sort%3Aupdated-asc) that have been merged.

### Who will maintain the fork?

I, @taylordotfish, will maintain the fork, although contributions are welcome from all. I am not expecting the fork to require much maintenance except when we need modifications to support a new feature in Atuin.

### Behavior changes

IL and DL now behave according to the spec (no-ops when the cursor is outside the scroll region). This is an improvement, but technically a change. Also, previously we would clamp terminal dimensions to 2 to avoid panics; now that the panics have been fixed, we clamp them to 1. This means that if you write a wide character to a 1x1 terminal, the character will be discarded (you can't render a wide character on such a terminal); previously it would “work” but only because we were emulating the wrong screen size.