### PR TITLE
fix: auto-generate encryption key if it doesn't exist

### DIFF
--- a/crates/atuin/src/command/client/account/login.rs
+++ b/crates/atuin/src/command/client/account/login.rs
@@ -120,7 +120,8 @@ impl Cmd {
         } else {
             // Interactive login via browser OAuth flow.
             if self.from_registration {
-                paseto_v4::Key::try_load_from_path(&settings.key_path)?;
+                paseto_v4::Key::try_load_or_generate(&settings.key_path)
+                    .context("could not load or generate encryption key")?;
             } else {
                 self.prompt_and_store_key(settings, store).await?;
             }

--- a/crates/atuin/src/command/client/dotfiles/alias.rs
+++ b/crates/atuin/src/command/client/dotfiles/alias.rs
@@ -160,8 +160,8 @@ impl Cmd {
             return Ok(());
         }
 
-        let encryption_key = paseto_v4::Key::try_load_from_path(&settings.key_path)
-            .context("could not load encryption key")?;
+        let encryption_key = paseto_v4::Key::try_load_or_generate(&settings.key_path)
+            .context("could not load or generate encryption key")?;
         let host_id = Settings::host_id().await?;
 
         let alias_store = AliasStore::new(store, host_id, encryption_key);

--- a/crates/atuin/src/command/client/dotfiles/var.rs
+++ b/crates/atuin/src/command/client/dotfiles/var.rs
@@ -164,8 +164,8 @@ impl Cmd {
             return Ok(());
         }
 
-        let encryption_key = paseto_v4::Key::try_load_from_path(&settings.key_path)
-            .context("could not load encryption key")?;
+        let encryption_key = paseto_v4::Key::try_load_or_generate(&settings.key_path)
+            .context("could not load or generate encryption key")?;
         let host_id = Settings::host_id().await?;
 
         let var_store = VarStore::new(store, host_id, encryption_key);

--- a/crates/atuin/src/command/client/history.rs
+++ b/crates/atuin/src/command/client/history.rs
@@ -614,8 +614,8 @@ pub(super) async fn end_history_entry(
         SqliteStore::new(record_store_path, Duration::try_from_secs_f64(settings.local_timeout)?)
             .await?;
 
-    let encryption_key = paseto_v4::Key::try_load_from_path(&settings.key_path)
-        .context("could not load encryption key")?;
+    let encryption_key = paseto_v4::Key::try_load_or_generate(&settings.key_path)
+        .context("could not load or generate encryption key")?;
     let host_id = Settings::host_id().await?;
     let history_store = HistoryStore::new(store.clone(), host_id, encryption_key);
 
@@ -995,8 +995,8 @@ impl Cmd {
                 settings.timezone,
             );
         } else {
-            let encryption_key = paseto_v4::Key::try_load_from_path(&settings.key_path)
-                .context("could not load encryption key")?;
+            let encryption_key = paseto_v4::Key::try_load_or_generate(&settings.key_path)
+                .context("could not load or generate encryption key")?;
             let host_id = Settings::host_id().await?;
             let history_store = HistoryStore::new(store.clone(), host_id, encryption_key);
 
@@ -1050,8 +1050,8 @@ impl Cmd {
                 settings.timezone,
             );
         } else {
-            let encryption_key = paseto_v4::Key::try_load_from_path(&settings.key_path)
-                .context("could not load encryption key")?;
+            let encryption_key = paseto_v4::Key::try_load_or_generate(&settings.key_path)
+                .context("could not load or generate encryption key")?;
             let host_id = Settings::host_id().await?;
             let history_store = HistoryStore::new(store.clone(), host_id, encryption_key);
 
@@ -1129,8 +1129,8 @@ impl Cmd {
                 )
                 .await?;
 
-                let encryption_key = paseto_v4::Key::try_load_from_path(&settings.key_path)
-                    .context("could not load encryption key")?;
+                let encryption_key = paseto_v4::Key::try_load_or_generate(&settings.key_path)
+                    .context("could not load or generate encryption key")?;
 
                 let host_id = Settings::host_id().await?;
                 let history_store = HistoryStore::new(store.clone(), host_id, encryption_key);

--- a/crates/atuin/src/command/client/init.rs
+++ b/crates/atuin/src/command/client/init.rs
@@ -93,8 +93,8 @@ impl Cmd {
         )
         .await?;
 
-        let encryption_key = paseto_v4::Key::try_load_from_path(&settings.key_path)
-            .context("could not load encryption key")?;
+        let encryption_key = paseto_v4::Key::try_load_or_generate(&settings.key_path)
+            .context("could not load or generate encryption key")?;
         let host_id = Settings::host_id().await?;
 
         let alias_store = AliasStore::new(sqlite_store.clone(), host_id, encryption_key.clone());

--- a/crates/atuin/src/command/client/kv.rs
+++ b/crates/atuin/src/command/client/kv.rs
@@ -66,8 +66,8 @@ pub enum Cmd {
 impl Cmd {
     #[instrument(level = "trace", skip_all, err)]
     pub async fn run(&self, settings: &Settings, store: &SqliteStore) -> Result<()> {
-        let encryption_key = paseto_v4::Key::try_load_from_path(&settings.key_path)
-            .context("could not load encryption key")?;
+        let encryption_key = paseto_v4::Key::try_load_or_generate(&settings.key_path)
+            .context("could not load or generate encryption key")?;
 
         let host_id = Settings::host_id().await?;
 

--- a/crates/atuin/src/command/client/scripts.rs
+++ b/crates/atuin/src/command/client/scripts.rs
@@ -12,7 +12,7 @@ use atuin_scripts::execution::{
 use atuin_scripts::store::ScriptStore;
 use atuin_scripts::store::script::Script;
 use clap::{Parser, Subcommand};
-use eyre::{OptionExt, Result, bail};
+use eyre::{Context as _, OptionExt, Result, bail};
 use tempfile::NamedTempFile;
 use tracing::{debug, instrument};
 
@@ -555,7 +555,8 @@ impl Cmd {
         history_db: &Sqlite,
     ) -> Result<()> {
         let host_id = Settings::host_id().await?;
-        let encryption_key = paseto_v4::Key::try_load_from_path(&settings.key_path)?;
+        let encryption_key = paseto_v4::Key::try_load_or_generate(&settings.key_path)
+            .context("could not load or generate encryption key")?;
 
         let script_store = ScriptStore::new(store, host_id, encryption_key);
         let script_db = atuin_scripts::database::Database::new(

--- a/crates/atuin/src/command/client/search.rs
+++ b/crates/atuin/src/command/client/search.rs
@@ -12,7 +12,7 @@ use atuin_common::filter::OrFilter;
 use atuin_common::string::EscapeNonPrintablePosixExt as _;
 use atuin_common::utils;
 use clap::Parser;
-use eyre::Result;
+use eyre::{Context as _, Result};
 use tracing::instrument;
 
 use super::history::ListMode;
@@ -235,7 +235,8 @@ impl Cmd {
         };
         settings.keymap_mode_shell = self.keymap_mode;
 
-        let encryption_key = paseto_v4::Key::try_load_from_path(&settings.key_path)?;
+        let encryption_key = paseto_v4::Key::try_load_or_generate(&settings.key_path)
+            .context("could not load or generate encryption key")?;
 
         let host_id = Settings::host_id().await?;
         let history_store = HistoryStore::new(store.clone(), host_id, encryption_key);

--- a/crates/atuin/src/command/client/store/pull.rs
+++ b/crates/atuin/src/command/client/store/pull.rs
@@ -7,7 +7,7 @@ use atuin_client::settings::Settings;
 use atuin_common::encryption::paseto_v4;
 use atuin_domain::record::RecordTag;
 use clap::Args;
-use eyre::Result;
+use eyre::{Context as _, Result};
 
 #[derive(Args, Debug)]
 pub struct Pull {
@@ -43,7 +43,8 @@ impl Pull {
         // 3. Filter operations by
         //  a) are they a download op?
         //  b) are they for the host/tag we are pushing here?
-        let key = paseto_v4::Key::try_load_from_path(&settings.key_path)?;
+        let key = paseto_v4::Key::try_load_from_path(&settings.key_path)
+            .context("could not load encryption key")?;
         let engine = SyncEngine::builder()
             .store(store.clone())
             .client_source(ClientSource::FromSettings {

--- a/crates/atuin/src/command/client/store/purge.rs
+++ b/crates/atuin/src/command/client/store/purge.rs
@@ -2,7 +2,7 @@ use atuin_client::record::sqlite_store::SqliteStore;
 use atuin_client::settings::Settings;
 use atuin_common::encryption::paseto_v4;
 use clap::Args;
-use eyre::Result;
+use eyre::{Context as _, Result};
 
 #[derive(Args, Debug)]
 pub struct Purge {}
@@ -11,7 +11,8 @@ impl Purge {
     pub async fn run(&self, settings: &Settings, store: SqliteStore) -> Result<()> {
         println!("Purging local records that cannot be decrypted");
 
-        let key = paseto_v4::Key::try_load_from_path(&settings.key_path)?;
+        let key = paseto_v4::Key::try_load_from_path(&settings.key_path)
+            .context("could not load encryption key")?;
 
         match store.purge(&key).await {
             Ok(()) => println!("Local store purge completed OK"),

--- a/crates/atuin/src/command/client/store/push.rs
+++ b/crates/atuin/src/command/client/store/push.rs
@@ -7,7 +7,7 @@ use atuin_client::settings::Settings;
 use atuin_common::encryption::paseto_v4;
 use atuin_domain::record::{HostId, RecordTag};
 use clap::Args;
-use eyre::Result;
+use eyre::{Context as _, Result};
 use uuid::Uuid;
 
 #[derive(Args, Debug)]
@@ -63,7 +63,8 @@ impl Push {
         // 3. Filter operations by
         //  a) are they an upload op?
         //  b) are they for the host/tag we are pushing here?
-        let key = paseto_v4::Key::try_load_from_path(&settings.key_path)?;
+        let key = paseto_v4::Key::try_load_from_path(&settings.key_path)
+            .context("could not load encryption key")?;
         let engine = SyncEngine::builder()
             .store(store)
             .client_source(ClientSource::FromSettings {

--- a/crates/atuin/src/command/client/store/rebuild.rs
+++ b/crates/atuin/src/command/client/store/rebuild.rs
@@ -7,7 +7,7 @@ use atuin_dotfiles::store::AliasStore;
 use atuin_dotfiles::store::var::VarStore;
 use atuin_scripts::store::ScriptStore;
 use clap::Args;
-use eyre::{Result, bail};
+use eyre::{Context as _, Result, bail};
 
 #[cfg(feature = "daemon")]
 use crate::command::client::daemon as daemon_cmd;
@@ -55,7 +55,8 @@ impl Rebuild {
         store: SqliteStore,
         database: &Sqlite,
     ) -> Result<()> {
-        let encryption_key = paseto_v4::Key::try_load_from_path(&settings.key_path)?;
+        let encryption_key = paseto_v4::Key::try_load_from_path(&settings.key_path)
+            .context("could not load encryption key")?;
 
         let host_id = Settings::host_id().await?;
         let history_store = HistoryStore::new(store, host_id, encryption_key);
@@ -69,7 +70,8 @@ impl Rebuild {
     }
 
     async fn rebuild_dotfiles(&self, settings: &Settings, store: SqliteStore) -> Result<()> {
-        let encryption_key = paseto_v4::Key::try_load_from_path(&settings.key_path)?;
+        let encryption_key = paseto_v4::Key::try_load_from_path(&settings.key_path)
+            .context("could not load encryption key")?;
 
         let host_id = Settings::host_id().await?;
 
@@ -83,7 +85,8 @@ impl Rebuild {
     }
 
     async fn rebuild_scripts(&self, settings: &Settings, store: SqliteStore) -> Result<()> {
-        let encryption_key = paseto_v4::Key::try_load_from_path(&settings.key_path)?;
+        let encryption_key = paseto_v4::Key::try_load_from_path(&settings.key_path)
+            .context("could not load encryption key")?;
         let host_id = Settings::host_id().await?;
         let script_store = ScriptStore::new(store, host_id, encryption_key);
         let database = atuin_scripts::database::Database::new(

--- a/crates/atuin/src/command/client/store/rekey.rs
+++ b/crates/atuin/src/command/client/store/rekey.rs
@@ -2,7 +2,7 @@ use atuin_client::record::sqlite_store::SqliteStore;
 use atuin_client::settings::Settings;
 use atuin_common::encryption::paseto_v4;
 use clap::Args;
-use eyre::Result;
+use eyre::{Context as _, Result};
 
 #[derive(Args, Debug)]
 pub struct Rekey {
@@ -21,7 +21,8 @@ impl Rekey {
             paseto_v4::Key::generate()
         };
 
-        let current_key = paseto_v4::Key::try_load_from_path(&settings.key_path)?;
+        let current_key = paseto_v4::Key::try_load_from_path(&settings.key_path)
+            .context("could not load encryption key")?;
 
         store.re_encrypt(&current_key, &key).await?;
 

--- a/crates/atuin/src/command/client/store/verify.rs
+++ b/crates/atuin/src/command/client/store/verify.rs
@@ -2,7 +2,7 @@ use atuin_client::record::sqlite_store::SqliteStore;
 use atuin_client::settings::Settings;
 use atuin_common::encryption::paseto_v4;
 use clap::Args;
-use eyre::Result;
+use eyre::{Context as _, Result};
 
 #[derive(Args, Debug)]
 pub struct Verify {}
@@ -11,7 +11,8 @@ impl Verify {
     pub async fn run(&self, settings: &Settings, store: SqliteStore) -> Result<()> {
         println!("Verifying local store can be decrypted with the current key");
 
-        let key = paseto_v4::Key::try_load_from_path(&settings.key_path)?;
+        let key = paseto_v4::Key::try_load_from_path(&settings.key_path)
+            .context("could not load encryption key")?;
 
         match store.verify(&key).await {
             Ok(()) => println!("Local store encryption verified OK"),


### PR DESCRIPTION
Fix regression introduced in 18.20.0 where the encryption key is no longer automatically generated if it doesn't exist.

Most places that were changed to only load the key have been changed back to generate it as well, *except* for:

* Code that explicitly checks for the existence of the key before trying to load it.
* `sync` commands, as the user should have already logged in, so if the key is missing, something has gone very wrong and we should return an error rather than silently continuing with a new key.
* `store rekey` and `store rebuild`, because these need the correct existing key to be present to work.
* `store purge`, because creating a new key would cause all records to be purged, and this is probably not what the user intended.
* `store verify`, because verification will fail for all records if we create a new key.
* `store push` and `store pull` for the same reason as `sync`.
* `wrapped`, because failing to load the key was already not an error. The key is only used to load aliases, and if a key doesn't exist, we wouldn't expect there to be any aliases anyway.

The places that *have* been changed are:

* `history`
* `search`
* `kv`
* `dotfiles`
* `scripts`
* `init` (when dotfiles is enabled)
* `login`, when generating a new account

Resolves #3996