### PR TITLE
chore(release): prepare for release 18.20.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,33 @@
 
 All notable changes to this project will be documented in this file.
 
+## 18.20.1
+
+### Bug Fixes
+
+- *(client)* Bound WAL growth with journal_size_limit + a periodic compactor ([#3994](https://github.com/atuinsh/atuin/issues/3994))
+- *(docs)* Correct sync_frequency default ([#3984](https://github.com/atuinsh/atuin/issues/3984))
+- *(nu)* Use unique keybinding names ([#3975](https://github.com/atuinsh/atuin/issues/3975))
+- Correct documented local_timeout default ([#3983](https://github.com/atuinsh/atuin/issues/3983))
+- Drop nonexistent session_path and correct path defaults ([#3985](https://github.com/atuinsh/atuin/issues/3985))
+- Auto-generate encryption key if it doesn't exist ([#3998](https://github.com/atuinsh/atuin/issues/3998))
+
+
+### Features
+
+- Switch terminal emulation to `atuin-vt100` ([#3995](https://github.com/atuinsh/atuin/issues/3995))
+
+
+### Miscellaneous Tasks
+
+- *(release)* Include all crates in publish order
+
+
+### Refactor
+
+- *(deps)* Bump uuid from 1.23.2 to 1.25.0 ([#3886](https://github.com/atuinsh/atuin/issues/3886))
+- Remove atuin-lab-share crate ([#3993](https://github.com/atuinsh/atuin/issues/3993))
+
 ## 18.20.0
 
 ### Bug Fixes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -242,7 +242,7 @@ checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "atuin"
-version = "18.20.0"
+version = "18.20.1"
 dependencies = [
  "arboard",
  "async-trait",
@@ -309,7 +309,7 @@ dependencies = [
 
 [[package]]
 name = "atuin-ai"
-version = "18.20.0"
+version = "18.20.1"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -369,7 +369,7 @@ dependencies = [
 
 [[package]]
 name = "atuin-client"
-version = "18.20.0"
+version = "18.20.1"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -434,7 +434,7 @@ dependencies = [
 
 [[package]]
 name = "atuin-common"
-version = "18.20.0"
+version = "18.20.1"
 dependencies = [
  "atuin-vt100",
  "base64",
@@ -478,7 +478,7 @@ dependencies = [
 
 [[package]]
 name = "atuin-daemon"
-version = "18.20.0"
+version = "18.20.1"
 dependencies = [
  "atuin-client",
  "atuin-common",
@@ -518,7 +518,7 @@ dependencies = [
 
 [[package]]
 name = "atuin-domain"
-version = "18.20.0"
+version = "18.20.1"
 dependencies = [
  "async-trait",
  "atuin-common",
@@ -552,7 +552,7 @@ dependencies = [
 
 [[package]]
 name = "atuin-dotfiles"
-version = "18.20.0"
+version = "18.20.1"
 dependencies = [
  "atuin-client",
  "atuin-common",
@@ -570,7 +570,7 @@ dependencies = [
 
 [[package]]
 name = "atuin-history"
-version = "18.20.0"
+version = "18.20.1"
 dependencies = [
  "atuin-client",
  "codspeed-divan-compat",
@@ -584,7 +584,7 @@ dependencies = [
 
 [[package]]
 name = "atuin-kv"
-version = "18.20.0"
+version = "18.20.1"
 dependencies = [
  "atuin-client",
  "atuin-common",
@@ -603,7 +603,7 @@ dependencies = [
 
 [[package]]
 name = "atuin-pty-proxy"
-version = "18.20.0"
+version = "18.20.1"
 dependencies = [
  "atuin-common",
  "atuin-vt100",
@@ -617,7 +617,7 @@ dependencies = [
 
 [[package]]
 name = "atuin-scripts"
-version = "18.20.0"
+version = "18.20.1"
 dependencies = [
  "atuin-client",
  "atuin-common",
@@ -655,7 +655,7 @@ dependencies = [
 
 [[package]]
 name = "atuin-server"
-version = "18.20.0"
+version = "18.20.1"
 dependencies = [
  "argon2",
  "atuin-client",
@@ -687,7 +687,7 @@ dependencies = [
 
 [[package]]
 name = "atuin-server-database"
-version = "18.20.0"
+version = "18.20.1"
 dependencies = [
  "async-trait",
  "atuin-common",
@@ -703,7 +703,7 @@ dependencies = [
 
 [[package]]
 name = "atuin-server-postgres"
-version = "18.20.0"
+version = "18.20.1"
 dependencies = [
  "async-trait",
  "atuin-common",
@@ -722,7 +722,7 @@ dependencies = [
 
 [[package]]
 name = "atuin-server-sqlite"
-version = "18.20.0"
+version = "18.20.1"
 dependencies = [
  "async-trait",
  "atuin-common",
@@ -5670,7 +5670,7 @@ dependencies = [
 
 [[package]]
 name = "tests-database"
-version = "18.20.0"
+version = "18.20.1"
 dependencies = [
  "async-trait",
  "atuin-common",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ resolver = "2"
 exclude = ["ui/backend"]
 
 [workspace.package]
-version = "18.20.0"
+version = "18.20.1"
 authors = ["Ellie Huxtable <ellie@atuin.sh>"]
 rust-version = "1.98.0"
 license = "MIT"
@@ -16,18 +16,18 @@ readme = "README.md"
 [workspace.dependencies]
 async-trait = "0.1.58"
 enum_dispatch = "0.3"
-atuin-client = { path = "crates/atuin-client", version = "18.20.0" }
-atuin-common = { path = "crates/atuin-common", version = "18.20.0" }
-atuin-daemon = { path = "crates/atuin-daemon", version = "18.20.0" }
-atuin-domain = { path = "crates/atuin-domain", version = "18.20.0" }
-atuin-dotfiles = { path = "crates/atuin-dotfiles", version = "18.20.0" }
-atuin-history = { path = "crates/atuin-history", version = "18.20.0" }
-atuin-kv = { path = "crates/atuin-kv", version = "18.20.0" }
-atuin-scripts = { path = "crates/atuin-scripts", version = "18.20.0" }
-atuin-server = { path = "crates/atuin-server", version = "18.20.0" }
-atuin-server-database = { path = "crates/atuin-server-database", version = "18.20.0" }
-atuin-server-postgres = { path = "crates/atuin-server-postgres", version = "18.20.0" }
-atuin-server-sqlite = { path = "crates/atuin-server-sqlite", version = "18.20.0" }
+atuin-client = { path = "crates/atuin-client", version = "18.20.1" }
+atuin-common = { path = "crates/atuin-common", version = "18.20.1" }
+atuin-daemon = { path = "crates/atuin-daemon", version = "18.20.1" }
+atuin-domain = { path = "crates/atuin-domain", version = "18.20.1" }
+atuin-dotfiles = { path = "crates/atuin-dotfiles", version = "18.20.1" }
+atuin-history = { path = "crates/atuin-history", version = "18.20.1" }
+atuin-kv = { path = "crates/atuin-kv", version = "18.20.1" }
+atuin-scripts = { path = "crates/atuin-scripts", version = "18.20.1" }
+atuin-server = { path = "crates/atuin-server", version = "18.20.1" }
+atuin-server-database = { path = "crates/atuin-server-database", version = "18.20.1" }
+atuin-server-postgres = { path = "crates/atuin-server-postgres", version = "18.20.1" }
+atuin-server-sqlite = { path = "crates/atuin-server-sqlite", version = "18.20.1" }
 atuin-vt100 = "0.17"
 frizbee = "0.12.0"
 base64 = "0.22"

--- a/crates/atuin-client/Cargo.toml
+++ b/crates/atuin-client/Cargo.toml
@@ -88,12 +88,12 @@ serde_bytes = "0.11"
 
 [dependencies.atuin-common]
 path = "../atuin-common"
-version = "18.20.0"
+version = "18.20.1"
 features = ["os", "sqlite"]
 
 [dependencies.atuin-domain]
 path = "../atuin-domain"
-version = "18.20.0"
+version = "18.20.1"
 
 [dev-dependencies]
 tokio = { version = "1", features = ["full"] }
@@ -108,7 +108,7 @@ wiremock = "0.6"
 # This crate's tests require the `test-utils` feature in atuin-common.
 [dev-dependencies.atuin-common]
 path = "../atuin-common"
-version = "18.20.0"
+version = "18.20.1"
 features = ["test-utils"]
 
 [[bench]]

--- a/crates/atuin-daemon/Cargo.toml
+++ b/crates/atuin-daemon/Cargo.toml
@@ -14,13 +14,13 @@ readme.workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-atuin-client = { path = "../atuin-client", version = "18.20.0" }
+atuin-client = { path = "../atuin-client", version = "18.20.1" }
 parking_lot = { workspace = true }
-atuin-domain = { path = "../atuin-domain", version = "18.20.0" }
+atuin-domain = { path = "../atuin-domain", version = "18.20.1" }
 enum_dispatch = { workspace = true }
 derive_more = { workspace = true }
-atuin-dotfiles = { path = "../atuin-dotfiles", version = "18.20.0" }
-atuin-history = { path = "../atuin-history", version = "18.20.0" }
+atuin-dotfiles = { path = "../atuin-dotfiles", version = "18.20.1" }
+atuin-history = { path = "../atuin-history", version = "18.20.1" }
 
 time = { workspace = true }
 uuid = { workspace = true }
@@ -47,7 +47,7 @@ frizbee = { workspace = true }
 
 [dependencies.atuin-common]
 path = "../atuin-common"
-version = "18.20.0"
+version = "18.20.1"
 features = ["os"]
 
 [target.'cfg(target_os = "linux")'.dependencies]

--- a/crates/atuin-dotfiles/Cargo.toml
+++ b/crates/atuin-dotfiles/Cargo.toml
@@ -14,9 +14,9 @@ readme.workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-atuin-common = { path = "../atuin-common", version = "18.20.0" }
-atuin-domain = { path = "../atuin-domain", version = "18.20.0" }
-atuin-client = { path = "../atuin-client", version = "18.20.0" }
+atuin-common = { path = "../atuin-common", version = "18.20.1" }
+atuin-domain = { path = "../atuin-domain", version = "18.20.1" }
+atuin-client = { path = "../atuin-client", version = "18.20.1" }
 derive_more = { workspace = true }
 
 eyre = { workspace = true }

--- a/crates/atuin-history/Cargo.toml
+++ b/crates/atuin-history/Cargo.toml
@@ -14,7 +14,7 @@ readme.workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-atuin-client = { path = "../atuin-client", version = "18.20.0" }
+atuin-client = { path = "../atuin-client", version = "18.20.1" }
 
 time = { workspace = true }
 serde = { workspace = true }

--- a/crates/atuin-kv/Cargo.toml
+++ b/crates/atuin-kv/Cargo.toml
@@ -14,9 +14,9 @@ readme.workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-atuin-client = { path = "../atuin-client", version = "18.20.0" }
-atuin-common = { path = "../atuin-common", version = "18.20.0", features = ["sqlite"] }
-atuin-domain = { path = "../atuin-domain", version = "18.20.0" }
+atuin-client = { path = "../atuin-client", version = "18.20.1" }
+atuin-common = { path = "../atuin-common", version = "18.20.1", features = ["sqlite"] }
+atuin-domain = { path = "../atuin-domain", version = "18.20.1" }
 derive_more = { workspace = true }
 
 tracing = { workspace = true }

--- a/crates/atuin-scripts/Cargo.toml
+++ b/crates/atuin-scripts/Cargo.toml
@@ -14,9 +14,9 @@ readme.workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-atuin-client = { path = "../atuin-client", version = "18.20.0" }
-atuin-common = { path = "../atuin-common", version = "18.20.0", features = ["sqlite"] }
-atuin-domain = { path = "../atuin-domain", version = "18.20.0" }
+atuin-client = { path = "../atuin-client", version = "18.20.1" }
+atuin-common = { path = "../atuin-common", version = "18.20.1", features = ["sqlite"] }
+atuin-domain = { path = "../atuin-domain", version = "18.20.1" }
 derive_more = { workspace = true }
 
 tracing = { workspace = true }

--- a/crates/atuin-server-database/Cargo.toml
+++ b/crates/atuin-server-database/Cargo.toml
@@ -10,8 +10,8 @@ homepage = { workspace = true }
 repository = { workspace = true }
 
 [dependencies]
-atuin-common = { path = "../atuin-common", version = "18.20.0" }
-atuin-domain = { path = "../atuin-domain", version = "18.20.0" }
+atuin-common = { path = "../atuin-common", version = "18.20.1" }
+atuin-domain = { path = "../atuin-domain", version = "18.20.1" }
 derive_more = { workspace = true }
 
 async-trait = { workspace = true }

--- a/crates/atuin-server-postgres/Cargo.toml
+++ b/crates/atuin-server-postgres/Cargo.toml
@@ -10,9 +10,9 @@ homepage = { workspace = true }
 repository = { workspace = true }
 
 [dependencies]
-atuin-common = { path = "../atuin-common", version = "18.20.0" }
-atuin-domain = { path = "../atuin-domain", version = "18.20.0" }
-atuin-server-database = { path = "../atuin-server-database", version = "18.20.0" }
+atuin-common = { path = "../atuin-common", version = "18.20.1" }
+atuin-domain = { path = "../atuin-domain", version = "18.20.1" }
+atuin-server-database = { path = "../atuin-server-database", version = "18.20.1" }
 derive_more = { workspace = true }
 
 eyre = { workspace = true }

--- a/crates/atuin-server-sqlite/Cargo.toml
+++ b/crates/atuin-server-sqlite/Cargo.toml
@@ -10,9 +10,9 @@ homepage = { workspace = true }
 repository = { workspace = true }
 
 [dependencies]
-atuin-common = { path = "../atuin-common", version = "18.20.0" }
-atuin-domain = { path = "../atuin-domain", version = "18.20.0" }
-atuin-server-database = { path = "../atuin-server-database", version = "18.20.0" }
+atuin-common = { path = "../atuin-common", version = "18.20.1" }
+atuin-domain = { path = "../atuin-domain", version = "18.20.1" }
+atuin-server-database = { path = "../atuin-server-database", version = "18.20.1" }
 derive_more = { workspace = true }
 
 eyre = { workspace = true }

--- a/crates/atuin-server/Cargo.toml
+++ b/crates/atuin-server/Cargo.toml
@@ -52,7 +52,7 @@ tracing-subscriber = { workspace = true }
 # client's api_client. atuin-client is only a dev dependency here so the client
 # binary crate stays free of server/postgres deps (see issue #2884).
 [dev-dependencies]
-atuin-client = { path = "../atuin-client", version = "18.20.0", default-features = false, features = ["sync"] }
+atuin-client = { path = "../atuin-client", version = "18.20.1", default-features = false, features = ["sync"] }
 rstest = { workspace = true }
 futures-util = "0.3"
 tracing-tree = "0.4"

--- a/crates/atuin/Cargo.toml
+++ b/crates/atuin/Cargo.toml
@@ -73,14 +73,14 @@ profiling-traced = [
 ]
 
 [dependencies]
-atuin-ai = { path = "../atuin-ai", version = "18.20.0", optional = true, default-features = false }
-atuin-client = { path = "../atuin-client", version = "18.20.0", optional = true, default-features = false }
+atuin-ai = { path = "../atuin-ai", version = "18.20.1", optional = true, default-features = false }
+atuin-client = { path = "../atuin-client", version = "18.20.1", optional = true, default-features = false }
 atuin-common = { workspace = true, features = ["unicode"] }
 atuin-domain = { workspace = true }
 atuin-dotfiles = { workspace = true }
 atuin-history = { workspace = true }
-atuin-daemon = { path = "../atuin-daemon", version = "18.20.0", optional = true, default-features = false }
-atuin-pty-proxy = { path = "../atuin-pty-proxy", version = "18.20.0", optional = true, default-features = false }
+atuin-daemon = { path = "../atuin-daemon", version = "18.20.1", optional = true, default-features = false }
+atuin-pty-proxy = { path = "../atuin-pty-proxy", version = "18.20.1", optional = true, default-features = false }
 atuin-scripts = { workspace = true }
 atuin-kv = { workspace = true }
 axoupdater = { version = "0.10", optional = true }
@@ -144,7 +144,7 @@ daemonize = "0.5.0"
 # compiles cleanly. tree-sitter 0.26's portable/endian.h fails on illumos,
 # Windows cross-compiles, and potentially other exotic targets.
 [target.'cfg(any(target_os = "linux", target_os = "macos", target_os = "windows", target_os = "illumos"))'.dependencies]
-atuin-ai = { path = "../atuin-ai", version = "18.20.0", optional = true, default-features = false, features = ["tree-sitter"] }
+atuin-ai = { path = "../atuin-ai", version = "18.20.1", optional = true, default-features = false, features = ["tree-sitter"] }
 tree-sitter = { workspace = true }
 tree-sitter-bash = { workspace = true }
 tree-sitter-fish = { workspace = true }


### PR DESCRIPTION

### Bug Fixes

- *(client)* Bound WAL growth with journal_size_limit + a periodic compactor ([#3994](https://github.com/atuinsh/atuin/issues/3994))
- *(docs)* Correct sync_frequency default ([#3984](https://github.com/atuinsh/atuin/issues/3984))
- *(nu)* Use unique keybinding names ([#3975](https://github.com/atuinsh/atuin/issues/3975))
- Correct documented local_timeout default ([#3983](https://github.com/atuinsh/atuin/issues/3983))
- Drop nonexistent session_path and correct path defaults ([#3985](https://github.com/atuinsh/atuin/issues/3985))
- Auto-generate encryption key if it doesn't exist ([#3998](https://github.com/atuinsh/atuin/issues/3998))


### Features

- Switch terminal emulation to `atuin-vt100` ([#3995](https://github.com/atuinsh/atuin/issues/3995))


### Miscellaneous Tasks

- *(release)* Include all crates in publish order


### Refactor

- *(deps)* Bump uuid from 1.23.2 to 1.25.0 ([#3886](https://github.com/atuinsh/atuin/issues/3886))
- Remove atuin-lab-share crate ([#3993](https://github.com/atuinsh/atuin/issues/3993))