### PR TITLE
feat(sqlite): rename compactor to maintenance_task + incremental vacuum

### DIFF
--- a/crates/atuin-common/src/sqlite/builder.rs
+++ b/crates/atuin-common/src/sqlite/builder.rs
@@ -4,7 +4,7 @@ use std::time::Duration;
 
 use sqlx::sqlite::{SqliteConnectOptions, SqliteJournalMode, SqliteSynchronous};
 
-use super::compactor::Compactor;
+use super::maintenance_task::MaintenanceTask;
 use super::{Sqlite, SqliteOpenOrCreateError};
 use crate::path::PathExt;
 
@@ -17,7 +17,7 @@ pub enum Journaling {
         /// The maximum size of the journal before sqlite is configured to automatically sweep it.
         ///
         /// Do note that this is a suggestion for Sqlite and under heavy concurrent reads will not
-        /// be respected. See [`Compactor`] for a strict maximum size.
+        /// be respected. See [`MaintenanceTask`] for a strict maximum size.
         #[allow(rustdoc::private_intra_doc_links)]
         max_size_hint: u64,
     },
@@ -136,7 +136,8 @@ impl<P: AsRef<Path>> SqliteBuilder<P> {
         let mut sqlite = Sqlite::connect(opts.clone(), self.timeout).await?;
 
         if matches!(self.journal, Some(Journaling::Wal { .. })) {
-            sqlite.compactor = Compactor::spawn_active(opts, sqlite.info.clone()).await;
+            sqlite.maintenance_task =
+                MaintenanceTask::spawn_active(opts, sqlite.info.clone()).await;
         }
 
         #[cfg(unix)]

--- a/crates/atuin-common/src/sqlite/builder.rs
+++ b/crates/atuin-common/src/sqlite/builder.rs
@@ -120,6 +120,7 @@ impl<P: AsRef<Path>> SqliteBuilder<P> {
                 opts = opts
                     .journal_mode(SqliteJournalMode::Wal)
                     .pragma("journal_size_limit", max_size_hint.to_string())
+                    .pragma("auto_vacuum", "INCREMENTAL")
             }
             Some(Journaling::Delete) => {
                 opts = opts.journal_mode(SqliteJournalMode::Delete);
@@ -148,5 +149,25 @@ impl<P: AsRef<Path>> SqliteBuilder<P> {
         }
 
         Ok(sqlite)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::sqlite::Sqlite;
+
+    #[tokio::test]
+    async fn new_wal_db_is_created_in_incremental_auto_vacuum() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("history.db");
+
+        let sqlite = Sqlite::builder(&path).open().await.unwrap();
+
+        let mode: i64 = sqlx::query_scalar("PRAGMA auto_vacuum")
+            .fetch_one(sqlite.pool())
+            .await
+            .unwrap();
+
+        assert_eq!(mode, 2, "new WAL database should be auto_vacuum=INCREMENTAL");
     }
 }

--- a/crates/atuin-common/src/sqlite/maintenance_task.rs
+++ b/crates/atuin-common/src/sqlite/maintenance_task.rs
@@ -40,6 +40,33 @@ impl ActiveMaintenanceTask {
     // What is the maximum acceptable period to compact the WAL?
     const MAX_TIMEOUT: Duration = Duration::from_millis(500);
 
+    // How often the vacuum check runs. Deliberately far slower than the WAL check.
+    const VACUUM_PERIOD: Duration = Duration::from_hours(6);
+
+    // Delay before the first vacuum check, so we never vacuum during startup.
+    const VACUUM_INITIAL_DELAY: Duration = Duration::from_mins(5);
+
+    // Reclaim only when at least this fraction of the file is free pages.
+    const VACUUM_FREE_RATIO_THRESHOLD: f64 = 0.20;
+
+    // ...and only when at least this many bytes are actually reclaimable.
+    const VACUUM_MIN_RECLAIMABLE_BYTES: i64 = 8 * 1024 * 1024;
+
+    // How many freelist pages to reclaim per incremental_vacuum call, keeping each write lock short.
+    const INCREMENTAL_VACUUM_CHUNK_PAGES: i64 = 256;
+
+    fn should_reclaim(page_count: i64, freelist: i64, page_size: i64) -> bool {
+        if page_count <= 0 {
+            return false;
+        }
+
+        let free_ratio = freelist as f64 / page_count as f64;
+        let reclaimable = freelist.saturating_mul(page_size);
+
+        free_ratio >= Self::VACUUM_FREE_RATIO_THRESHOLD
+            && reclaimable >= Self::VACUUM_MIN_RECLAIMABLE_BYTES
+    }
+
     fn spawn(conn: SqliteConnection, info: EagerFutureCell<Info>) -> Self {
         let task = tokio::spawn(Self::run(conn, info));
 
@@ -102,6 +129,90 @@ impl ActiveMaintenanceTask {
         Ok(())
     }
 
+    /// Ensure the database is in `auto_vacuum=INCREMENTAL`.
+    ///
+    /// Existing (field) databases default to `NONE`; switching modes on a populated database
+    /// requires a full `VACUUM`. Returns `true` iff a conversion VACUUM was performed.
+    async fn ensure_incremental_mode(
+        conn: &mut SqliteConnection,
+    ) -> Result<bool, MaintenanceError> {
+        let mode: i64 = sqlx::query_scalar("PRAGMA auto_vacuum").fetch_one(&mut *conn).await?;
+
+        // 2 == INCREMENTAL; already done.
+        if mode == 2 {
+            return Ok(false);
+        }
+
+        sqlx::query("PRAGMA auto_vacuum = INCREMENTAL").execute(&mut *conn).await?;
+        sqlx::query("VACUUM").execute(&mut *conn).await?;
+        sqlx::query("PRAGMA wal_checkpoint(TRUNCATE)").execute(&mut *conn).await?;
+
+        Ok(true)
+    }
+
+    /// Returns `(page_count, freelist_count, page_size)`.
+    async fn free_space_stats(
+        conn: &mut SqliteConnection,
+    ) -> Result<(i64, i64, i64), MaintenanceError> {
+        let page_count: i64 =
+            sqlx::query_scalar("PRAGMA page_count").fetch_one(&mut *conn).await?;
+        let freelist: i64 =
+            sqlx::query_scalar("PRAGMA freelist_count").fetch_one(&mut *conn).await?;
+        let page_size: i64 =
+            sqlx::query_scalar("PRAGMA page_size").fetch_one(&mut *conn).await?;
+
+        Ok((page_count, freelist, page_size))
+    }
+
+    /// Reclaim the entire freelist in bounded chunks, then push freed space to disk.
+    async fn drain_freelist(conn: &mut SqliteConnection) -> Result<(), MaintenanceError> {
+        let chunk = Self::INCREMENTAL_VACUUM_CHUNK_PAGES;
+        let sql = format!("PRAGMA incremental_vacuum({chunk})");
+
+        loop {
+            let before: i64 =
+                sqlx::query_scalar("PRAGMA freelist_count").fetch_one(&mut *conn).await?;
+            if before == 0 {
+                break;
+            }
+
+            sqlx::query(sqlx::AssertSqlSafe(sql.as_str())).execute(&mut *conn).await?;
+
+            let after: i64 =
+                sqlx::query_scalar("PRAGMA freelist_count").fetch_one(&mut *conn).await?;
+            if after >= before {
+                // No progress (e.g. not actually in incremental mode). Stop rather than spin.
+                warn!("incremental_vacuum made no progress; stopping freelist drain");
+                break;
+            }
+        }
+
+        sqlx::query("PRAGMA wal_checkpoint(TRUNCATE)").execute(&mut *conn).await?;
+
+        Ok(())
+    }
+
+    /// Reclaim free space if fragmentation has crossed the thresholds.
+    async fn reclaim_if_needed(conn: &mut SqliteConnection) -> Result<(), MaintenanceError> {
+        let (page_count, freelist, page_size) = Self::free_space_stats(conn).await?;
+        if !Self::should_reclaim(page_count, freelist, page_size) {
+            return Ok(());
+        }
+
+        Self::drain_freelist(conn).await
+    }
+
+    /// One vacuum-maintenance cycle: convert legacy databases once, otherwise reclaim on threshold.
+    async fn maintain_vacuum(conn: &mut SqliteConnection) -> Result<(), MaintenanceError> {
+        // A conversion runs a full VACUUM which already reclaims everything, so skip the
+        // incremental pass on the cycle that converts.
+        if Self::ensure_incremental_mode(conn).await? {
+            return Ok(());
+        }
+
+        Self::reclaim_if_needed(conn).await
+    }
+
     async fn connect(opts: SqliteConnectOptions) -> Result<SqliteConnection, MaintenanceError> {
         let conn = SqliteConnection::connect_with(&opts.busy_timeout(Self::MAX_TIMEOUT)).await?;
 
@@ -152,5 +263,116 @@ impl MaintenanceTask {
         Self {
             _inner: MaintenanceTaskInner::Inactive,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use std::str::FromStr;
+
+    use sqlx::sqlite::{SqliteConnectOptions, SqliteJournalMode};
+    use sqlx::Connection;
+
+    #[test]
+    fn should_reclaim_requires_ratio_and_absolute_bytes() {
+        // 1 GiB file, 30% free -> both thresholds tripped.
+        let page_size = 4096;
+        let total_pages = 262_144; // 1 GiB / 4 KiB
+        let free_pages = 78_643; // ~30%
+        assert!(ActiveMaintenanceTask::should_reclaim(total_pages, free_pages, page_size));
+    }
+
+    #[test]
+    fn should_reclaim_false_when_ratio_below_threshold() {
+        let page_size = 4096;
+        let total_pages = 262_144;
+        let free_pages = 13_107; // ~5% -> below 20%
+        assert!(!ActiveMaintenanceTask::should_reclaim(total_pages, free_pages, page_size));
+    }
+
+    #[test]
+    fn should_reclaim_false_when_absolute_bytes_below_floor() {
+        // Tiny DB: 50% free but only ~1 MiB reclaimable -> below 8 MiB floor.
+        let page_size = 4096;
+        let total_pages = 512; // 2 MiB
+        let free_pages = 256; // 50%, but 1 MiB
+        assert!(!ActiveMaintenanceTask::should_reclaim(total_pages, free_pages, page_size));
+    }
+
+    #[test]
+    fn should_reclaim_false_for_empty_db() {
+        assert!(!ActiveMaintenanceTask::should_reclaim(0, 0, 4096));
+    }
+
+    async fn open_conn(path: &std::path::Path) -> SqliteConnection {
+        let opts = SqliteConnectOptions::from_str(path.to_str().unwrap())
+            .unwrap()
+            .create_if_missing(true)
+            .journal_mode(SqliteJournalMode::Wal);
+        SqliteConnection::connect_with(&opts).await.unwrap()
+    }
+
+    #[tokio::test]
+    async fn ensure_incremental_mode_converts_none_database() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("legacy.db");
+        let mut conn = open_conn(&path).await;
+
+        // Simulate a legacy DB: default auto_vacuum=NONE with a populated table.
+        sqlx::query("CREATE TABLE t (id INTEGER PRIMARY KEY, blob TEXT)")
+            .execute(&mut conn)
+            .await
+            .unwrap();
+        let mode: i64 = sqlx::query_scalar("PRAGMA auto_vacuum").fetch_one(&mut conn).await.unwrap();
+        assert_eq!(mode, 0, "precondition: legacy DB is auto_vacuum=NONE");
+
+        let converted = ActiveMaintenanceTask::ensure_incremental_mode(&mut conn).await.unwrap();
+        assert!(converted, "should report that a conversion happened");
+
+        let mode: i64 = sqlx::query_scalar("PRAGMA auto_vacuum").fetch_one(&mut conn).await.unwrap();
+        assert_eq!(mode, 2, "database should now be auto_vacuum=INCREMENTAL");
+
+        // Idempotent: a second call is a no-op.
+        let converted_again = ActiveMaintenanceTask::ensure_incremental_mode(&mut conn).await.unwrap();
+        assert!(!converted_again, "second call should not re-convert");
+    }
+
+    #[tokio::test]
+    async fn drain_freelist_empties_the_freelist() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("churn.db");
+        // Incremental mode must be set before tables exist for incremental_vacuum to work.
+        let opts = SqliteConnectOptions::from_str(path.to_str().unwrap())
+            .unwrap()
+            .create_if_missing(true)
+            .journal_mode(SqliteJournalMode::Wal)
+            .pragma("auto_vacuum", "INCREMENTAL");
+        let mut conn = SqliteConnection::connect_with(&opts).await.unwrap();
+        sqlx::query("CREATE TABLE t (id INTEGER PRIMARY KEY, blob BLOB)")
+            .execute(&mut conn)
+            .await
+            .unwrap();
+
+        // Allocate many pages, then free them to build a freelist.
+        for i in 0..2000 {
+            sqlx::query("INSERT INTO t (id, blob) VALUES (?, zeroblob(1024))")
+                .bind(i)
+                .execute(&mut conn)
+                .await
+                .unwrap();
+        }
+        sqlx::query("DELETE FROM t").execute(&mut conn).await.unwrap();
+
+        let before: i64 =
+            sqlx::query_scalar("PRAGMA freelist_count").fetch_one(&mut conn).await.unwrap();
+        assert!(before > 0, "precondition: freelist should be non-empty, got {before}");
+
+        ActiveMaintenanceTask::drain_freelist(&mut conn).await.unwrap();
+
+        let after: i64 =
+            sqlx::query_scalar("PRAGMA freelist_count").fetch_one(&mut conn).await.unwrap();
+        assert_eq!(after, 0, "freelist should be fully drained");
     }
 }

--- a/crates/atuin-common/src/sqlite/maintenance_task.rs
+++ b/crates/atuin-common/src/sqlite/maintenance_task.rs
@@ -14,7 +14,7 @@ use crate::sqlite::Info;
 use crate::sync::EagerFutureCell;
 
 #[derive(Debug, Error)]
-enum WalCompactionError {
+enum MaintenanceError {
     #[error("failed to compact the WAL due to a sqlx error: {0}")]
     Sqlx(#[from] sqlx::Error),
     #[error("failed to compact the WAL due to an IO error: {0}")]
@@ -22,11 +22,11 @@ enum WalCompactionError {
 }
 
 #[derive(Debug, Clone)]
-struct ActiveCompactor {
+struct ActiveMaintenanceTask {
     _task: Arc<AbortOnDropHandle<()>>,
 }
 
-impl ActiveCompactor {
+impl ActiveMaintenanceTask {
     // How many bytes does the WAL need to reach before it is force-compacted.
     // Normally, SQLite will try to keep its WAL around 4MB.
     //
@@ -85,7 +85,7 @@ impl ActiveCompactor {
     async fn compact_wal(
         conn: &mut SqliteConnection,
         wal: &tokio::fs::File,
-    ) -> Result<(), WalCompactionError> {
+    ) -> Result<(), MaintenanceError> {
         let meta = wal.metadata().await?;
         if meta.len() < Self::THRESHOLD_BYTES {
             return Ok(());
@@ -102,7 +102,7 @@ impl ActiveCompactor {
         Ok(())
     }
 
-    async fn connect(opts: SqliteConnectOptions) -> Result<SqliteConnection, WalCompactionError> {
+    async fn connect(opts: SqliteConnectOptions) -> Result<SqliteConnection, MaintenanceError> {
         let conn = SqliteConnection::connect_with(&opts.busy_timeout(Self::MAX_TIMEOUT)).await?;
 
         Ok(conn)
@@ -110,9 +110,9 @@ impl ActiveCompactor {
 }
 
 #[derive(Debug, Clone)]
-enum CompactorInner {
+enum MaintenanceTaskInner {
     Active {
-        _compactor: ActiveCompactor,
+        _compactor: ActiveMaintenanceTask,
     },
     Inactive,
 }
@@ -126,19 +126,19 @@ enum CompactorInner {
 ///
 /// This seems to be generally present in high parallel uses of AI agents.
 #[derive(Debug, Clone)]
-pub(super) struct Compactor {
-    _inner: CompactorInner,
+pub(super) struct MaintenanceTask {
+    _inner: MaintenanceTaskInner,
 }
 
-impl Compactor {
+impl MaintenanceTask {
     pub(super) async fn spawn_active(
         opts: SqliteConnectOptions,
         info: EagerFutureCell<Info>,
     ) -> Self {
-        match ActiveCompactor::connect(opts).await {
+        match ActiveMaintenanceTask::connect(opts).await {
             Ok(conn) => Self {
-                _inner: CompactorInner::Active {
-                    _compactor: ActiveCompactor::spawn(conn, info),
+                _inner: MaintenanceTaskInner::Active {
+                    _compactor: ActiveMaintenanceTask::spawn(conn, info),
                 },
             },
             Err(error) => {
@@ -150,7 +150,7 @@ impl Compactor {
 
     pub(super) fn inactive() -> Self {
         Self {
-            _inner: CompactorInner::Inactive,
+            _inner: MaintenanceTaskInner::Inactive,
         }
     }
 }

--- a/crates/atuin-common/src/sqlite/maintenance_task.rs
+++ b/crates/atuin-common/src/sqlite/maintenance_task.rs
@@ -92,12 +92,30 @@ impl ActiveMaintenanceTask {
             }
         };
 
-        let mut ticker = tokio::time::interval(Self::PERIOD);
-        ticker.tick().await;
+        let mut compaction_ticker = tokio::time::interval(Self::PERIOD);
+        // Consume the immediate first tick so the first WAL check happens after one PERIOD,
+        // preserving the previous behavior.
+        compaction_ticker.tick().await;
+
+        // Fire the first vacuum check after an initial delay (never during startup), then
+        // every VACUUM_PERIOD. interval_at's first tick lands at the deadline, not immediately.
+        let mut vacuum_ticker = tokio::time::interval_at(
+            tokio::time::Instant::now() + Self::VACUUM_INITIAL_DELAY,
+            Self::VACUUM_PERIOD,
+        );
+
         loop {
-            ticker.tick().await;
-            if let Err(error) = Self::compact_wal(&mut conn, &wal).await {
-                warn!(%error, "failed to compact the WAL");
+            tokio::select! {
+                _ = compaction_ticker.tick() => {
+                    if let Err(error) = Self::compact_wal(&mut conn, &wal).await {
+                        warn!(%error, "failed to compact the WAL");
+                    }
+                }
+                _ = vacuum_ticker.tick() => {
+                    if let Err(error) = Self::maintain_vacuum(&mut conn).await {
+                        warn!(%error, "failed to vacuum the database");
+                    }
+                }
             }
         }
     }

--- a/crates/atuin-common/src/sqlite/mod.rs
+++ b/crates/atuin-common/src/sqlite/mod.rs
@@ -1,15 +1,15 @@
 //! Sqlite-related utilities.
 
 mod builder;
-mod compactor;
 mod info;
+mod maintenance_task;
 
 use std::path::{Path, PathBuf};
 use std::time::Duration;
 
 pub use builder::{Journaling, SqliteBuilder};
-use compactor::Compactor;
 pub use info::{Info, VersionError};
+use maintenance_task::MaintenanceTask;
 use sqlx::sqlite::{SqliteConnectOptions, SqlitePool, SqlitePoolOptions};
 use thiserror::Error;
 
@@ -28,7 +28,7 @@ pub struct Sqlite {
     info: EagerFutureCell<Info>,
 
     /// A periodic task which compacts the WAL if necessary.
-    compactor: Compactor,
+    maintenance_task: MaintenanceTask,
 }
 
 #[derive(Debug, Error)]
@@ -68,7 +68,7 @@ impl Sqlite {
         Ok(Self {
             info: Info::new_eager_future(pool.clone()),
             pool,
-            compactor: Compactor::inactive(),
+            maintenance_task: MaintenanceTask::inactive(),
         })
     }
 


### PR DESCRIPTION
## What

Renames the SQLite `compactor` module in `atuin-common` to `maintenance_task`, and extends its background task so that — in addition to compacting the WAL — it now reclaims free space via SQLite **incremental auto-vacuum**.

## Why

The WAL compactor (#3994) only bounds the WAL. Nothing reclaimed free pages left behind by deletes/retention, so the main DB file only ever grew. This generalises that one background task into a maintenance task that also vacuums, on a low-frequency cadence, without disrupting the frequent-write workload.

## Approach

The strategy was chosen after deep research into SQLite vacuuming (sources: sqlite.org VACUUM/PRAGMA/WAL docs, Jim Nelson's auto_vacuum writeup, PhotoStructure's WAL-VACUUM notes, sqlx discussion #3284):

- **`auto_vacuum = INCREMENTAL`** rather than `FULL` (which taxes every commit) or a periodic full `VACUUM` (2× disk, whole-DB write lock, WAL spike). Incremental gives bounded, low-lock, on-demand reclaim that coexists with the daemon and the existing checkpoint compactor.
- **New WAL databases** are created in `auto_vacuum=INCREMENTAL` at creation (the pragma runs before any table exists).
- **Existing field databases** (default `auto_vacuum=NONE`) are converted **once** via `PRAGMA auto_vacuum=INCREMENTAL; VACUUM; wal_checkpoint(TRUNCATE)` the first time the vacuum check runs.
- **Reclaim** is threshold-gated (`free_ratio ≥ 20% && reclaimable ≥ 8 MiB`), then done in bounded `incremental_vacuum(256)` chunks with a no-progress guard, ending in `wal_checkpoint(TRUNCATE)` so freed space actually leaves the WAL and shrinks the file on disk.
- The vacuum check runs on a **6 h cadence with a 5-minute initial delay** (never at startup); WAL compaction keeps its 1-minute cadence. Both share the maintenance task's single dedicated connection via `tokio::select!` (one arm at a time — no aliasing, and VACUUM/checkpoint self-serialise rather than contend).

## Commits

1. `refactor(sqlite)`: rename `compactor` module → `maintenance_task` (pure rename, `git mv`, no behaviour change)
2. `feat(sqlite)`: create new WAL databases with `auto_vacuum=INCREMENTAL`
3. `feat(sqlite)`: add incremental vacuum + legacy conversion helpers (with unit + real-DB tests)
4. `feat(sqlite)`: run periodic vacuum check in the maintenance task loop

## Tests

`cargo test -p atuin-common --features sqlite` — 343 passed. New tests build a genuine ~2 MiB freelist and assert it drains to 0, and assert a legacy DB actually flips `auto_vacuum` 0→2 (idempotent). `cargo clippy --all-targets -D warnings` clean; `cargo build --workspace` green.

## Notes for reviewers

- ⚠️ **One-time conversion cost on large legacy DBs:** the first successful conversion runs a full `VACUUM` on every existing default-WAL database (client `history.db`, kv, scripts, ai). On a multi-GB `history.db` this transiently ~doubles disk use and grows the WAL until the trailing `wal_checkpoint(TRUNCATE)` runs (`journal_size_limit` does not bound the WAL mid-VACUUM). It happens once per DB, during an idle window, and fails-safe under the 500 ms busy timeout (retrying in 6 h). Worth a release note / telemetry watch.
- A few module doc comments still say "Compactor"/"compacts" and now under-describe the task — left untouched deliberately (I don't edit comment/doc prose without a separate pass); happy to update them if you'd prefer.
- Non-goals (intentional): no full-`VACUUM` "big red button" for defragmentation; incremental only.

## Checks
- [x] I am happy for maintainers to push small adjustments to this PR, to speed up the review cycle
- [x] I have checked that there are no existing pull requests for the same thing
