### PR TITLE
fix(docs): disambiguate sqlx intra-doc links to functions

### DIFF
--- a/crates/atuin-common/src/db/mod.rs
+++ b/crates/atuin-common/src/db/mod.rs
@@ -46,7 +46,7 @@ fn debug_sanity_check_query(sql: &str) {
     }
 }
 
-/// Equivalent to [`sqlx::query`].
+/// Equivalent to [`sqlx::query()`].
 pub fn query<'a, DB>(sql: impl SqlSafeStr) -> Query<'a, DB, <DB as Database>::Arguments>
 where
     DB: Database,
@@ -57,7 +57,7 @@ where
     sqlx::query(sql)
 }
 
-/// Equivalent to [`sqlx::query_as`].
+/// Equivalent to [`sqlx::query_as()`].
 pub fn query_as<'q, DB, O>(sql: impl SqlSafeStr) -> QueryAs<'q, DB, O, <DB as Database>::Arguments>
 where
     DB: Database,
@@ -69,7 +69,7 @@ where
     sqlx::query_as(sql)
 }
 
-/// Equivalent to [`sqlx::query_scalar`].
+/// Equivalent to [`sqlx::query_scalar()`].
 pub fn query_scalar<'q, DB, O>(
     sql: impl SqlSafeStr,
 ) -> QueryScalar<'q, DB, O, <DB as Database>::Arguments>


### PR DESCRIPTION
The `docs` job on `main` is red after #4006 merged.

`cargo doc --document-private-items --no-deps --workspace` (run with `RUSTDOCFLAGS=-D warnings`) fails because the wrapper doc comments in `atuin-common/src/db/mod.rs` link to `[`sqlx::query`]` / `[`sqlx::query_as`]` / `[`sqlx::query_scalar`]`, each of which is ambiguous (`sqlx::query` is a function, a module, *and* a macro):

```
error: `sqlx::query` is a function, a module, and a macro
  --> crates/atuin-common/src/db/mod.rs:49:21
```

Fix: disambiguate to the functions with `()` — `[`sqlx::query()`]` etc. — which keeps them as working intra-doc links.

Verified locally:
```
RUSTDOCFLAGS="-D warnings" cargo doc --document-private-items --no-deps --workspace
```
now builds clean.

https://claude.ai/code/session_018dN2S2jstjW9D86fWSZUAR