### PR TITLE
Explore: back the server Database trait with sea-orm, collapsing the backends

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -25,6 +25,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
 dependencies = [
  "cfg-if",
+ "const-random",
+ "getrandom 0.3.4",
  "once_cell",
  "version_check",
  "zerocopy",
@@ -160,6 +162,165 @@ name = "arrayvec"
 version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3fb67a6e08acf24fdeccbac2cb6ac4305825bd1f117462e0e6f2f193345ad56"
+
+[[package]]
+name = "arrow"
+version = "58.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6cfdd0833e32a9874d2b55089333ad310c0be208aafa277385ce2461dec90be3"
+dependencies = [
+ "arrow-arith",
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-cast",
+ "arrow-data",
+ "arrow-ord",
+ "arrow-row",
+ "arrow-schema",
+ "arrow-select",
+ "arrow-string",
+]
+
+[[package]]
+name = "arrow-arith"
+version = "58.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a41203398f0eaa6f7ec8e62c0da742a21abf282c148fc157f6c35c90e29981a"
+dependencies = [
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-schema",
+ "chrono",
+ "num-traits",
+]
+
+[[package]]
+name = "arrow-array"
+version = "58.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae33dad492b7df00a217563a7b0ef2874df68a0deea1b1a3acf628152f7f7a69"
+dependencies = [
+ "ahash",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-schema",
+ "chrono",
+ "half",
+ "hashbrown 0.17.1",
+ "num-complex",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "arrow-buffer"
+version = "58.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9552f96391c005e6ab449fa941420935e7e062489b12b8b1b08879b2163f5b5"
+dependencies = [
+ "bytes",
+ "half",
+ "num-bigint",
+ "num-traits",
+]
+
+[[package]]
+name = "arrow-cast"
+version = "58.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a8a327c9649f30d8406995f27642b68df354713cca3baaaf100f076f18d5f34"
+dependencies = [
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-ord",
+ "arrow-schema",
+ "arrow-select",
+ "atoi",
+ "base64",
+ "chrono",
+ "half",
+ "lexical-core",
+ "num-traits",
+ "ryu",
+]
+
+[[package]]
+name = "arrow-data"
+version = "58.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b24852db04738907e06c04ea61e42fe7fda962a34513022dc0d0e754fb7976b"
+dependencies = [
+ "arrow-buffer",
+ "arrow-schema",
+ "half",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "arrow-ord"
+version = "58.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63a083ec750f5c043f02946b4baf05fcdbb55f4560a3277055caca5cc99f3eb0"
+dependencies = [
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-schema",
+ "arrow-select",
+]
+
+[[package]]
+name = "arrow-row"
+version = "58.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "514ba0ef0d4c5896202dae736251ce415abb43a950bed570fb7981b8716c0e4c"
+dependencies = [
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-schema",
+ "half",
+]
+
+[[package]]
+name = "arrow-schema"
+version = "58.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21ca356ad6425cecb6eb7b28e4f659f1ee7880fbb1a16127de7dd62901efee9e"
+
+[[package]]
+name = "arrow-select"
+version = "58.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c58da39eb3d8350ad4a549e5c2bc49284dac554016c69829310350f1731b0aad"
+dependencies = [
+ "ahash",
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-schema",
+ "num-traits",
+]
+
+[[package]]
+name = "arrow-string"
+version = "58.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6789b388467525e3271326b6b4915666ecfdf5142aef09779445c954b67543c"
+dependencies = [
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-schema",
+ "arrow-select",
+ "memchr",
+ "num-traits",
+ "regex",
+ "regex-syntax",
+]
 
 [[package]]
 name = "assert-json-diff"
@@ -678,6 +839,7 @@ dependencies = [
  "regex",
  "reqwest",
  "rstest",
+ "sea-orm",
  "serde",
  "sqlx",
  "time",
@@ -1105,7 +1267,7 @@ version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9"
 dependencies = [
- "heck",
+ "heck 0.5.0",
  "proc-macro2",
  "quote",
  "syn 2.0.119",
@@ -1287,6 +1449,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
 
 [[package]]
+name = "const-random"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87e00182fe74b066627d63b85fd550ac2998d4b0bd86bfed477a0ae4c7c71359"
+dependencies = [
+ "const-random-macro",
+]
+
+[[package]]
+name = "const-random-macro"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9d839f2a20b0aee515dc581a6172f2321f96cab76c1a38a4c584a194955390e"
+dependencies = [
+ "getrandom 0.2.17",
+ "once_cell",
+ "tiny-keccak",
+]
+
+[[package]]
 name = "convert_case"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1433,6 +1615,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "crunchy"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
+
+[[package]]
 name = "crypto-common"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1524,12 +1712,35 @@ dependencies = [
 
 [[package]]
 name = "darling"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
+dependencies = [
+ "darling_core 0.20.11",
+ "darling_macro 0.20.11",
+]
+
+[[package]]
+name = "darling"
 version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
 dependencies = [
- "darling_core",
- "darling_macro",
+ "darling_core 0.23.0",
+ "darling_macro 0.23.0",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d00b9596d185e565c2207a0b01f8bd1a135483d02d9b7b0a54b11da8d53412e"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1547,11 +1758,22 @@ dependencies = [
 
 [[package]]
 name = "darling_macro"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
+dependencies = [
+ "darling_core 0.20.11",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "darling_macro"
 version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
 dependencies = [
- "darling_core",
+ "darling_core 0.23.0",
  "quote",
  "syn 2.0.119",
 ]
@@ -1611,6 +1833,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 dependencies = [
  "serde_core",
+]
+
+[[package]]
+name = "derive-where"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d08b3a0bcc0d079199cd476b2cae8435016ec11d1c0986c6901c5ac223041534"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -2266,6 +2499,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "half"
+version = "2.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
+dependencies = [
+ "cfg-if",
+ "crunchy",
+ "num-traits",
+ "zerocopy",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2320,6 +2565,12 @@ checksum = "ea0b22561a9c04a7cb1a302c013e0259cd3b4bb619f145b32f72b8b4bcbed230"
 dependencies = [
  "hashbrown 0.16.1",
 ]
+
+[[package]]
+name = "heck"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
 name = "heck"
@@ -2753,7 +3004,7 @@ version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5eb2d60ef19920a3a9193c3e371f726ec1dafc045dac788d0fb3704272458971"
 dependencies = [
- "darling",
+ "darling 0.23.0",
  "indoc",
  "proc-macro2",
  "quote",
@@ -2888,6 +3139,63 @@ name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+
+[[package]]
+name = "lexical-core"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d8d125a277f807e55a77304455eb7b1cb52f2b18c143b60e766c120bd64a594"
+dependencies = [
+ "lexical-parse-float",
+ "lexical-parse-integer",
+ "lexical-util",
+ "lexical-write-float",
+ "lexical-write-integer",
+]
+
+[[package]]
+name = "lexical-parse-float"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52a9f232fbd6f550bc0137dcb5f99ab674071ac2d690ac69704593cb4abbea56"
+dependencies = [
+ "lexical-parse-integer",
+ "lexical-util",
+]
+
+[[package]]
+name = "lexical-parse-integer"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a7a039f8fb9c19c996cd7b2fcce303c1b2874fe1aca544edc85c4a5f8489b34"
+dependencies = [
+ "lexical-util",
+]
+
+[[package]]
+name = "lexical-util"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2604dd126bb14f13fb5d1bd6a66155079cb9fa655b37f875b3a742c705dbed17"
+
+[[package]]
+name = "lexical-write-float"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50c438c87c013188d415fbabbb1dceb44249ab81664efbd31b14ae55dabb6361"
+dependencies = [
+ "lexical-util",
+ "lexical-write-integer",
+]
+
+[[package]]
+name = "lexical-write-integer"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "409851a618475d2d5796377cad353802345cba92c867d9fbcde9cf4eac4e14df"
+dependencies = [
+ "lexical-util",
+]
 
 [[package]]
 name = "libc"
@@ -3347,6 +3655,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-bigint"
+version = "0.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c89e69e7e0f03bea5ef08013795c25018e101932225a656383bd384495ecc367"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-complex"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "num-conv"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3364,12 +3691,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-integer"
+version = "0.1.47"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ce2d95d4b3734dc35aa2f45e1aa22cd416814592a4f9d9205e11affd5b8e10b"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "num-traits"
 version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+ "libm",
 ]
 
 [[package]]
@@ -3882,6 +4219,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
+name = "pluralizer"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b3eba432a00a1f6c16f39147847a870e94e2e9b992759b503e330efec778cbe"
+dependencies = [
+ "once_cell",
+ "regex",
+]
+
+[[package]]
 name = "poly1305"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4016,7 +4363,7 @@ version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "343d3bd7056eda839b03204e68deff7d1b13aba7af2b2fd16890697274262ee7"
 dependencies = [
- "heck",
+ "heck 0.5.0",
  "itertools 0.14.0",
  "log",
  "multimap",
@@ -4802,6 +5149,135 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
+name = "sea-bae"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "260bbc7148a8d6818ac5032a1b9970da1a68bdd723d45b12d59f7c1bf3565e24"
+dependencies = [
+ "heck 0.4.1",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "sea-orm"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a334e83ced3ae3ee44db0f84d1fcf8d2087a1ad9bb9036f00f9f6067156ea197"
+dependencies = [
+ "async-stream",
+ "async-trait",
+ "derive-where",
+ "derive_more",
+ "futures-util",
+ "itertools 0.14.0",
+ "log",
+ "sea-orm-arrow",
+ "sea-orm-macros",
+ "sea-query",
+ "sea-query-sqlx",
+ "sea-schema",
+ "sqlx",
+ "sqlx-core",
+ "strum 0.28.0",
+ "thiserror 2.0.19",
+ "time",
+ "tracing",
+ "url",
+ "uuid",
+ "web-time",
+]
+
+[[package]]
+name = "sea-orm-arrow"
+version = "2.0.0-rc.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c800d9db902534d7d01728faf98e33d13c1d57bb8c57d8e4c518309172bddda"
+dependencies = [
+ "arrow",
+ "sea-query",
+ "thiserror 2.0.19",
+]
+
+[[package]]
+name = "sea-orm-macros"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4039a86f9acc4d3b52747508b347dddc6fd725bbc429902ebeb6d26225fc2528"
+dependencies = [
+ "heck 0.5.0",
+ "itertools 0.14.0",
+ "pluralizer",
+ "proc-macro2",
+ "quote",
+ "sea-bae",
+ "syn 2.0.119",
+ "unicode-ident",
+]
+
+[[package]]
+name = "sea-query"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "546040c653a705e60ec65ecd3191a809603734bebbc225775916dea9ae409b31"
+dependencies = [
+ "ordered-float",
+ "sea-query-derive",
+ "time",
+ "uuid",
+]
+
+[[package]]
+name = "sea-query-derive"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0b0f466921cdd3cf4b89d5c3ac2173dba89a873ab395b123a645de181ec7537"
+dependencies = [
+ "darling 0.20.11",
+ "heck 0.4.1",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+ "thiserror 2.0.19",
+]
+
+[[package]]
+name = "sea-query-sqlx"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4eaa419cdb9157da1361186b1959983eb2ea0dcb9a3c69dc45c449ecb2af8fef"
+dependencies = [
+ "sea-query",
+ "sqlx",
+]
+
+[[package]]
+name = "sea-schema"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3553c77dceed56e95bece9ea876c4dd67ca879ef51055a0b97a7bb89a8ae4fed"
+dependencies = [
+ "async-trait",
+ "sea-query",
+ "sea-query-sqlx",
+ "sea-schema-derive",
+ "sqlx",
+]
+
+[[package]]
+name = "sea-schema-derive"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "debdc8729c37fdbf88472f97fd470393089f997a909e535ff67c544d18cfccf0"
+dependencies = [
+ "heck 0.4.1",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
 name = "security-framework"
 version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4974,7 +5450,7 @@ version = "3.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "84d57bc0c8b9a17920c178daa6bb924850d54a9c97ab45194bb8c17ad66bb660"
 dependencies = [
- "darling",
+ "darling 0.23.0",
  "proc-macro2",
  "quote",
  "syn 2.0.119",
@@ -5254,7 +5730,7 @@ dependencies = [
  "cfg-if",
  "dotenvy",
  "either",
- "heck",
+ "heck 0.5.0",
  "hex",
  "proc-macro2",
  "quote",
@@ -5432,7 +5908,7 @@ version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7695ce3845ea4b33927c055a39dc438a45b059f7c1b3d91d38d10355fb8cbca7"
 dependencies = [
- "heck",
+ "heck 0.5.0",
  "proc-macro2",
  "quote",
  "syn 2.0.119",
@@ -5444,7 +5920,7 @@ version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab85eea0270ee17587ed4156089e10b9e6880ee688791d45a905f5b1ca36f664"
 dependencies = [
- "heck",
+ "heck 0.5.0",
  "proc-macro2",
  "quote",
  "syn 2.0.119",
@@ -5537,7 +6013,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.3.4",
+ "getrandom 0.4.3",
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",
@@ -5712,6 +6188,15 @@ dependencies = [
  "unicode-normalization",
  "wasm-bindgen",
  "zeroize",
+]
+
+[[package]]
+name = "tiny-keccak"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c9d3793400a45f954c52e73d068316d76b6f4e36977e3fcebb13a2721e80237"
+dependencies = [
+ "crunchy",
 ]
 
 [[package]]

--- a/crates/atuin-server/Cargo.toml
+++ b/crates/atuin-server/Cargo.toml
@@ -49,6 +49,19 @@ derive_more = { workspace = true }
 time = { workspace = true }
 uuid = { workspace = true }
 sqlx = { workspace = true, features = ["postgres", "sqlite", "mysql", "regexp", "tls-native-tls"] }
+# sea-orm rides on the SAME sqlx 0.9 the workspace already pins (it requires
+# sqlx ^0.9), so cargo unifies to one sqlx + one bundled sqlite. default-features
+# is off deliberately: the defaults pull chrono + rust_decimal, and this
+# workspace uses `time`. runtime-tokio-native-tls matches the sqlx tls above.
+sea-orm = { version = "2.0.2", default-features = false, features = [
+  "macros",
+  "sqlx-postgres",
+  "sqlx-mysql",
+  "sqlx-sqlite",
+  "runtime-tokio-native-tls",
+  "with-uuid",
+  "with-time",
+] }
 
 # Integration tests in tests/ spin up a real server and drive it with the
 # client's api_client. atuin-client is only a dev dependency here so the client

--- a/crates/atuin-server/src/db/entities/history.rs
+++ b/crates/atuin-server/src/db/entities/history.rs
@@ -1,0 +1,17 @@
+use sea_orm::entity::prelude::*;
+
+/// The legacy `history` table. No live trait method reads or inserts here; the only
+/// use is `delete_user`, which deletes the user's rows. So we model just the columns
+/// that delete needs — sea-orm only ever references the table name and `user_id`.
+#[derive(Clone, Debug, PartialEq, Eq, DeriveEntityModel)]
+#[sea_orm(table_name = "history")]
+pub struct Model {
+    #[sea_orm(primary_key)]
+    pub id: i64,
+    pub user_id: i64,
+}
+
+#[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]
+pub enum Relation {}
+
+impl ActiveModelBehavior for ActiveModel {}

--- a/crates/atuin-server/src/db/entities/mod.rs
+++ b/crates/atuin-server/src/db/entities/mod.rs
@@ -1,0 +1,18 @@
+//! sea-orm entity definitions for the server database.
+//!
+//! One entity per table, modelling only the columns the [`Database`](super::Database)
+//! trait actually touches. Because sea-orm generates dialect-correct SQL from these
+//! definitions, the same entity drives Postgres, MySQL and SQLite — which is the whole
+//! reason the three hand-written backends could collapse into one shared query layer.
+//!
+//! Note on UUID columns (`store.id`/`client_id`/`host`): the physical type differs per
+//! backend (`uuid` on pg, `VARBINARY(16)` on mysql, blob-in-a-`text`-column on sqlite),
+//! but every backend round-trips through sqlx's `Uuid` codec. sea-orm's `with-uuid`
+//! support goes through that exact same codec, so a single `Uuid` entity column matches
+//! the on-disk representation on all three — byte-for-byte with the previous sqlx code.
+
+pub mod history;
+pub mod sessions;
+pub mod store;
+pub mod total_history_count_user;
+pub mod users;

--- a/crates/atuin-server/src/db/entities/sessions.rs
+++ b/crates/atuin-server/src/db/entities/sessions.rs
@@ -1,0 +1,29 @@
+use sea_orm::entity::prelude::*;
+
+#[derive(Clone, Debug, PartialEq, Eq, DeriveEntityModel)]
+#[sea_orm(table_name = "sessions")]
+pub struct Model {
+    #[sea_orm(primary_key)]
+    pub id: i64,
+    pub user_id: i64,
+    #[sea_orm(unique)]
+    pub token: String,
+}
+
+#[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]
+pub enum Relation {
+    #[sea_orm(
+        belongs_to = "super::users::Entity",
+        from = "Column::UserId",
+        to = "super::users::Column::Id"
+    )]
+    User,
+}
+
+impl Related<super::users::Entity> for Entity {
+    fn to() -> RelationDef {
+        Relation::User.def()
+    }
+}
+
+impl ActiveModelBehavior for ActiveModel {}

--- a/crates/atuin-server/src/db/entities/store.rs
+++ b/crates/atuin-server/src/db/entities/store.rs
@@ -1,0 +1,26 @@
+use sea_orm::entity::prelude::*;
+
+/// The `store` table — the encrypted record WAL. `id`/`client_id`/`host` are UUIDs
+/// (physically `uuid`/`VARBINARY(16)`/blob depending on backend; all via sqlx's Uuid
+/// codec). The unique index `record_uniq(user_id, host, tag, idx)` is what `add_records`
+/// upserts against and what `status` groups by.
+#[derive(Clone, Debug, PartialEq, Eq, DeriveEntityModel)]
+#[sea_orm(table_name = "store")]
+pub struct Model {
+    #[sea_orm(primary_key, auto_increment = false)]
+    pub id: Uuid,
+    pub client_id: Uuid,
+    pub host: Uuid,
+    pub idx: i64,
+    pub timestamp: i64,
+    pub version: String,
+    pub tag: String,
+    pub data: String,
+    pub cek: String,
+    pub user_id: i64,
+}
+
+#[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]
+pub enum Relation {}
+
+impl ActiveModelBehavior for ActiveModel {}

--- a/crates/atuin-server/src/db/entities/total_history_count_user.rs
+++ b/crates/atuin-server/src/db/entities/total_history_count_user.rs
@@ -1,0 +1,17 @@
+use sea_orm::entity::prelude::*;
+
+/// The `total_history_count_user` table exists on **Postgres only** (maintained by a
+/// pg trigger). `delete_user` purges it, but only on pg — the shared query layer gates
+/// this delete on the backend so mysql/sqlite (which lack the table) never touch it.
+#[derive(Clone, Debug, PartialEq, Eq, DeriveEntityModel)]
+#[sea_orm(table_name = "total_history_count_user")]
+pub struct Model {
+    #[sea_orm(primary_key)]
+    pub id: i64,
+    pub user_id: i64,
+}
+
+#[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]
+pub enum Relation {}
+
+impl ActiveModelBehavior for ActiveModel {}

--- a/crates/atuin-server/src/db/entities/users.rs
+++ b/crates/atuin-server/src/db/entities/users.rs
@@ -1,0 +1,25 @@
+use sea_orm::entity::prelude::*;
+
+#[derive(Clone, Debug, PartialEq, Eq, DeriveEntityModel)]
+#[sea_orm(table_name = "users")]
+pub struct Model {
+    #[sea_orm(primary_key)]
+    pub id: i64,
+    pub username: String,
+    pub email: String,
+    pub password: String,
+}
+
+#[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]
+pub enum Relation {
+    #[sea_orm(has_many = "super::sessions::Entity")]
+    Sessions,
+}
+
+impl Related<super::sessions::Entity> for Entity {
+    fn to() -> RelationDef {
+        Relation::Sessions.def()
+    }
+}
+
+impl ActiveModelBehavior for ActiveModel {}

--- a/crates/atuin-server/src/db/mod.rs
+++ b/crates/atuin-server/src/db/mod.rs
@@ -1,3 +1,4 @@
+pub mod entities;
 pub mod models;
 
 pub mod postgres;
@@ -8,9 +9,19 @@ pub mod sqlite;
 
 use async_trait::async_trait;
 use atuin_common::db::OwnedDbUrl;
-use atuin_domain::record::{EncryptedData, Record, RecordIdx, RecordSeriesKey, RecordStatus};
+use atuin_domain::record::{
+    EncryptedData, Host, HostId, Record, RecordId, RecordIdx, RecordSeriesKey, RecordStatus,
+    RecordTag, RecordVersion,
+};
+use sea_orm::ActiveValue::Set;
+use sea_orm::sea_query::{Expr, OnConflict};
+use sea_orm::{
+    ColumnTrait, DatabaseConnection, DbBackend, EntityTrait, FromQueryResult, QueryFilter,
+    QueryOrder, QuerySelect, TransactionTrait,
+};
 use serde::{Deserialize, Serialize};
 pub use sqlite::Sqlite;
+use tracing::instrument;
 
 pub mod mysql;
 
@@ -36,6 +47,14 @@ impl From<sqlx::Error> for DbError {
     }
 }
 
+impl From<sea_orm::DbErr> for DbError {
+    fn from(error: sea_orm::DbErr) -> Self {
+        // sea-orm surfaces "no row" as `Option::None` from the query methods we use, so
+        // every `DbErr` that reaches here is a genuine failure — not a not-found.
+        Self::Other(error.into())
+    }
+}
+
 pub type DbResult<T> = Result<T, DbError>;
 
 // Password redaction lives on `OwnedDbUrl`'s `Debug`, so the derive is safe here.
@@ -44,6 +63,85 @@ pub struct DbSettings {
     pub db_uri: OwnedDbUrl,
 }
 
+/// Chunk size for `add_records` bulk inserts. 100 rows × 10 columns = 1000 bind
+/// parameters, comfortably under SQLite's variable limit and the sync page size.
+const ADD_RECORDS_CHUNK: usize = 100;
+
+/// The `status` aggregate — one row of `(host, tag, max(idx))` per series.
+#[derive(Debug, FromQueryResult)]
+struct StatusRow {
+    host: sea_orm::prelude::Uuid,
+    tag: String,
+    idx: i64,
+}
+
+impl From<entities::sessions::Model> for Session {
+    fn from(m: entities::sessions::Model) -> Self {
+        Self {
+            id: m.id,
+            user_id: m.user_id,
+            token: m.token,
+        }
+    }
+}
+
+impl From<entities::users::Model> for User {
+    fn from(m: entities::users::Model) -> Self {
+        Self {
+            id: m.id,
+            username: m.username,
+            email: m.email,
+            password: m.password,
+        }
+    }
+}
+
+/// The `add_records` upsert, rendered correctly for each dialect.
+///
+/// The intent is "insert, and on a `record_uniq(user_id, host, tag, idx)` collision keep
+/// the existing row unchanged". pg/sqlite express that as `ON CONFLICT (...) DO NOTHING`.
+/// MySQL has no `DO NOTHING`; its equivalent is `ON DUPLICATE KEY UPDATE id = id` (a no-op)
+/// — which is exactly what the hand-written MySQL backend used to emit.
+///
+/// We can't feed one sea-query `do_nothing()` to all three: in sea-query 1.0 it renders
+/// the invalid `ON DUPLICATE KEY IGNORE` for MySQL. So we branch once, here, and every
+/// dialect gets the same SQL the old per-backend code did — pg/sqlite keep the optimal
+/// `DO NOTHING` (no row rewrite), MySQL gets its no-op update.
+fn record_upsert(backend: DbBackend) -> OnConflict {
+    use entities::store::Column;
+    let cols = [Column::UserId, Column::Host, Column::Tag, Column::Idx];
+    match backend {
+        DbBackend::MySql => {
+            OnConflict::columns(cols).value(Column::Id, Expr::col(Column::Id)).to_owned()
+        }
+        // pg, sqlite, and any future dialect: the standard, optimal `DO NOTHING`.
+        _ => OnConflict::columns(cols).do_nothing().to_owned(),
+    }
+}
+
+/// Reconstruct a domain [`Record`] from a `store` row.
+fn record_from_model(m: entities::store::Model) -> Record<EncryptedData> {
+    Record {
+        id: RecordId(m.client_id),
+        host: Host::new(HostId(m.host)),
+        idx: m.idx as u64,
+        timestamp: m.timestamp as u64,
+        version: RecordVersion::from(m.version),
+        tag: RecordTag::from(m.tag),
+        data: EncryptedData {
+            raw: m.data,
+            cek: m.cek,
+        },
+    }
+}
+
+/// A server database backend.
+///
+/// The query surface — every method below `conn` — is implemented **once** here as sea-orm
+/// default methods, because sea-orm renders dialect-correct SQL from the shared
+/// [`entities`]. A backend therefore only has to open its pool ([`connect`](Self::connect))
+/// and hand back a sea-orm connection. That is the entire per-backend surface; Postgres,
+/// MySQL and SQLite differ only in how they connect.
 #[async_trait]
 pub trait Database: Sized + Clone + Send + Sync + 'static {
     /// The backend-specific connection URL this database is built from.
@@ -51,28 +149,252 @@ pub trait Database: Sized + Clone + Send + Sync + 'static {
 
     async fn connect(url: Self::Url) -> DbResult<Self>;
 
-    async fn get_session(&self, token: &str) -> DbResult<Session>;
-    async fn get_session_user(&self, token: &str) -> DbResult<User>;
-    async fn add_session(&self, session: &NewSession) -> DbResult<()>;
+    /// The sea-orm connection every query runs against.
+    fn conn(&self) -> &DatabaseConnection;
 
-    async fn get_user(&self, username: &str) -> DbResult<User>;
-    async fn get_user_session(&self, u: &User) -> DbResult<Session>;
-    async fn add_user(&self, user: &NewUser) -> DbResult<i64>;
+    #[instrument(skip_all)]
+    async fn get_session(&self, token: &str) -> DbResult<Session> {
+        use entities::sessions;
+        sessions::Entity::find()
+            .filter(sessions::Column::Token.eq(token))
+            .one(self.conn())
+            .await?
+            .map(Session::from)
+            .ok_or(DbError::NotFound)
+    }
 
-    async fn update_user_password(&self, u: &User) -> DbResult<()>;
+    #[instrument(skip_all)]
+    async fn get_session_user(&self, token: &str) -> DbResult<User> {
+        use entities::{sessions, users};
+        users::Entity::find()
+            .inner_join(sessions::Entity)
+            .filter(sessions::Column::Token.eq(token))
+            .one(self.conn())
+            .await?
+            .map(User::from)
+            .ok_or(DbError::NotFound)
+    }
 
-    async fn delete_user(&self, u: &User) -> DbResult<()>;
-    async fn delete_store(&self, user: &User) -> DbResult<()>;
+    #[instrument(skip_all)]
+    async fn add_session(&self, session: &NewSession) -> DbResult<()> {
+        use entities::sessions;
+        let row = sessions::ActiveModel {
+            user_id: Set(session.user_id),
+            token: Set(session.token.clone()),
+            ..Default::default()
+        };
+        sessions::Entity::insert(row).exec(self.conn()).await?;
+        Ok(())
+    }
 
-    async fn add_records(&self, user: &User, record: &[Record<EncryptedData>]) -> DbResult<()>;
+    #[instrument(skip_all)]
+    async fn get_user(&self, username: &str) -> DbResult<User> {
+        use entities::users;
+        users::Entity::find()
+            .filter(users::Column::Username.eq(username))
+            .one(self.conn())
+            .await?
+            .map(User::from)
+            .ok_or(DbError::NotFound)
+    }
+
+    #[instrument(skip_all)]
+    async fn get_user_session(&self, u: &User) -> DbResult<Session> {
+        use entities::sessions;
+        sessions::Entity::find()
+            .filter(sessions::Column::UserId.eq(u.id))
+            .one(self.conn())
+            .await?
+            .map(Session::from)
+            .ok_or(DbError::NotFound)
+    }
+
+    #[instrument(skip_all)]
+    async fn add_user(&self, user: &NewUser) -> DbResult<i64> {
+        use entities::users;
+        let row = users::ActiveModel {
+            username: Set(user.username.clone()),
+            email: Set(user.email.clone()),
+            password: Set(user.password.clone()),
+            ..Default::default()
+        };
+        // sea-orm papers over the one real dialect split here: `RETURNING id` on
+        // pg/sqlite vs `last_insert_id()` on mysql.
+        let res = users::Entity::insert(row).exec(self.conn()).await?;
+        Ok(res.last_insert_id)
+    }
+
+    #[instrument(skip_all)]
+    async fn update_user_password(&self, u: &User) -> DbResult<()> {
+        use entities::users;
+        users::Entity::update_many()
+            .col_expr(users::Column::Password, Expr::value(u.password.clone()))
+            .filter(users::Column::Id.eq(u.id))
+            .exec(self.conn())
+            .await?;
+        Ok(())
+    }
+
+    #[instrument(skip_all)]
+    async fn delete_user(&self, u: &User) -> DbResult<()> {
+        use entities::{history, sessions, store, total_history_count_user as thcu, users};
+        let conn = self.conn();
+        // Wrapped in a transaction — the previous per-statement version could leave a
+        // half-deleted user behind if a statement failed midway.
+        let txn = conn.begin().await?;
+        sessions::Entity::delete_many()
+            .filter(sessions::Column::UserId.eq(u.id))
+            .exec(&txn)
+            .await?;
+        history::Entity::delete_many().filter(history::Column::UserId.eq(u.id)).exec(&txn).await?;
+        store::Entity::delete_many().filter(store::Column::UserId.eq(u.id)).exec(&txn).await?;
+        // `total_history_count_user` is a postgres-only table (trigger-maintained);
+        // mysql/sqlite have no such table, so we only purge it on pg.
+        if conn.get_database_backend() == DbBackend::Postgres {
+            thcu::Entity::delete_many().filter(thcu::Column::UserId.eq(u.id)).exec(&txn).await?;
+        }
+        users::Entity::delete_many().filter(users::Column::Id.eq(u.id)).exec(&txn).await?;
+        txn.commit().await?;
+        Ok(())
+    }
+
+    #[instrument(skip_all)]
+    async fn delete_store(&self, user: &User) -> DbResult<()> {
+        use entities::store;
+        store::Entity::delete_many()
+            .filter(store::Column::UserId.eq(user.id))
+            .exec(self.conn())
+            .await?;
+        Ok(())
+    }
+
+    #[instrument(skip_all)]
+    async fn add_records(&self, user: &User, records: &[Record<EncryptedData>]) -> DbResult<()> {
+        use entities::store;
+        if records.is_empty() {
+            return Ok(());
+        }
+
+        let conn = self.conn();
+        let on_conflict = record_upsert(conn.get_database_backend());
+
+        let txn = conn.begin().await?;
+        for chunk in records.chunks(ADD_RECORDS_CHUNK) {
+            let rows = chunk.iter().map(|r| store::ActiveModel {
+                id: Set(atuin_common::utils::uuid_v7()),
+                client_id: Set(r.id.0),
+                host: Set(r.host.id.0),
+                idx: Set(r.idx as i64),
+                // throwing away some data, but i64 is still big in terms of time
+                timestamp: Set(r.timestamp as i64),
+                version: Set(r.version.as_str().to_owned()),
+                tag: Set(r.tag.as_str().to_owned()),
+                data: Set(r.data.raw.clone()),
+                cek: Set(r.data.cek.clone()),
+                user_id: Set(user.id),
+            });
+
+            // One INSERT per chunk instead of the old row-at-a-time loop.
+            store::Entity::insert_many(rows)
+                .on_conflict(on_conflict.clone())
+                .exec_without_returning(&txn)
+                .await?;
+        }
+        txn.commit().await?;
+
+        Ok(())
+    }
+
+    #[instrument(skip_all)]
     async fn next_records(
         &self,
         user: &User,
         series: &RecordSeriesKey,
         start: Option<RecordIdx>,
         count: u64,
-    ) -> DbResult<Vec<Record<EncryptedData>>>;
+    ) -> DbResult<Vec<Record<EncryptedData>>> {
+        use entities::store;
+        tracing::debug!("{:?} - {:?} - {:?}", series.host_id, series.tag, start);
+        let start = start.unwrap_or(0);
+
+        let rows = store::Entity::find()
+            .filter(store::Column::UserId.eq(user.id))
+            .filter(store::Column::Tag.eq(series.tag.as_str()))
+            .filter(store::Column::Host.eq(series.host_id.0))
+            .filter(store::Column::Idx.gte(start as i64))
+            .order_by_asc(store::Column::Idx)
+            .limit(count)
+            .all(self.conn())
+            .await?;
+
+        Ok(rows.into_iter().map(record_from_model).collect())
+    }
 
     // Return the tail record ID for each store, so (HostID, Tag, TailRecordID)
-    async fn status(&self, user: &User) -> DbResult<RecordStatus>;
+    #[instrument(skip_all)]
+    async fn status(&self, user: &User) -> DbResult<RecordStatus> {
+        use entities::store;
+        let rows = store::Entity::find()
+            .select_only()
+            .column(store::Column::Host)
+            .column(store::Column::Tag)
+            .column_as(store::Column::Idx.max(), "idx")
+            .filter(store::Column::UserId.eq(user.id))
+            .group_by(store::Column::Host)
+            .group_by(store::Column::Tag)
+            .into_model::<StatusRow>()
+            .all(self.conn())
+            .await?;
+
+        Ok(RecordStatus::from_points(
+            rows.into_iter().map(|r| {
+                (RecordSeriesKey::new(HostId(r.host), RecordTag::from(r.tag)), r.idx as u64)
+            }),
+        ))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use sea_orm::{DbBackend, QueryTrait};
+
+    use super::*;
+
+    fn upsert_sql(backend: DbBackend) -> String {
+        let row = entities::store::ActiveModel {
+            id: Set(atuin_common::utils::uuid_v7()),
+            client_id: Set(atuin_common::utils::uuid_v7()),
+            host: Set(atuin_common::utils::uuid_v7()),
+            idx: Set(1),
+            timestamp: Set(1),
+            version: Set("2".into()),
+            tag: Set("history".into()),
+            data: Set("d".into()),
+            cek: Set("c".into()),
+            user_id: Set(1),
+        };
+        entities::store::Entity::insert_many([row])
+            .on_conflict(record_upsert(backend))
+            .build(backend)
+            .sql
+    }
+
+    /// The `add_records` upsert must render as the same clause each hand-written backend
+    /// used to emit. This also guards the sea-query 1.0 bug where a plain `do_nothing()`
+    /// renders the invalid `ON DUPLICATE KEY IGNORE` for MySQL (see [`record_upsert`]).
+    #[test]
+    fn add_records_upsert_is_dialect_correct() {
+        let pg = upsert_sql(DbBackend::Postgres);
+        assert!(pg.contains("ON CONFLICT") && pg.contains("DO NOTHING"), "{pg}");
+
+        let sqlite = upsert_sql(DbBackend::Sqlite);
+        assert!(sqlite.contains("ON CONFLICT") && sqlite.contains("DO NOTHING"), "{sqlite}");
+
+        let mysql = upsert_sql(DbBackend::MySql);
+        assert!(mysql.contains("ON DUPLICATE KEY UPDATE"), "{mysql}");
+        assert!(
+            !mysql.contains("IGNORE"),
+            "regression: invalid `ON DUPLICATE KEY IGNORE`: {mysql}"
+        );
+    }
 }

--- a/crates/atuin-server/src/db/models.rs
+++ b/crates/atuin-server/src/db/models.rs
@@ -1,9 +1,8 @@
-use atuin_domain::record::{
-    EncryptedData, Host, HostId, Record, RecordIdx, RecordSeriesKey, RecordTag, RecordVersion,
-};
-use sqlx::Row;
+//! Plain data-transfer types returned by / passed to the [`Database`](super::Database)
+//! trait. Row decoding now lives in the sea-orm [`entities`](super::entities); these are
+//! the backend-agnostic shapes the handlers see, mapped from entity `Model`s in
+//! [`super`].
 
-#[derive(sqlx::FromRow)]
 pub struct User {
     pub id: i64,
     pub username: String,
@@ -11,7 +10,6 @@ pub struct User {
     pub password: String,
 }
 
-#[derive(sqlx::FromRow)]
 pub struct Session {
     pub id: i64,
     pub user_id: i64,
@@ -28,63 +26,3 @@ pub struct NewSession {
     pub user_id: i64,
     pub token: String,
 }
-
-#[derive(derive_more::Into)]
-pub(super) struct DbRecord(pub Record<EncryptedData>);
-
-macro_rules! impl_db_record_from_row {
-    ($row:ty) => {
-        impl<'a> ::sqlx::FromRow<'a, $row> for DbRecord {
-            fn from_row(row: &'a $row) -> ::sqlx::Result<Self> {
-                let idx: i64 = row.try_get("idx")?;
-                let timestamp: i64 = row.try_get("timestamp")?;
-
-                let data = EncryptedData {
-                    raw: row.try_get("data")?,
-                    cek: row.try_get("cek")?,
-                };
-
-                Ok(Self(Record {
-                    id: row.try_get("client_id")?,
-                    host: Host::new(row.try_get("host")?),
-                    idx: idx as u64,
-                    timestamp: timestamp as u64,
-                    version: RecordVersion::from(row.try_get::<String, _>("version")?),
-                    tag: RecordTag::from(row.try_get::<String, _>("tag")?),
-                    data,
-                }))
-            }
-        }
-    };
-}
-
-impl_db_record_from_row!(sqlx::postgres::PgRow);
-impl_db_record_from_row!(sqlx::sqlite::SqliteRow);
-impl_db_record_from_row!(sqlx::mysql::MySqlRow);
-
-#[derive(derive_more::Into)]
-pub(super) struct RecordSeriesPoint {
-    pub(super) series: RecordSeriesKey,
-    pub(super) idx: RecordIdx,
-}
-
-macro_rules! impl_record_series_point_from_row {
-    ($row:ty) => {
-        impl<'a> ::sqlx::FromRow<'a, $row> for RecordSeriesPoint {
-            fn from_row(row: &'a $row) -> ::sqlx::Result<Self> {
-                let host: HostId = row.try_get("host")?;
-                let tag: String = row.try_get("tag")?;
-                let idx: i64 = row.try_get("idx")?;
-
-                Ok(Self {
-                    series: RecordSeriesKey::new(host, RecordTag::from(tag)),
-                    idx: idx as u64,
-                })
-            }
-        }
-    };
-}
-
-impl_record_series_point_from_row!(sqlx::postgres::PgRow);
-impl_record_series_point_from_row!(sqlx::sqlite::SqliteRow);
-impl_record_series_point_from_row!(sqlx::mysql::MySqlRow);

--- a/crates/atuin-server/src/db/mysql/mod.rs
+++ b/crates/atuin-server/src/db/mysql/mod.rs
@@ -1,16 +1,15 @@
 use async_trait::async_trait;
 use atuin_common::db;
 use atuin_common::db::MysqlDbUrl;
-use atuin_domain::record::{EncryptedData, Record, RecordIdx, RecordSeriesKey, RecordStatus};
+use sea_orm::{DatabaseConnection, SqlxMySqlConnector};
 use sqlx::mysql::MySqlPoolOptions;
-use tracing::instrument;
 
-use super::models::{DbRecord, NewSession, NewUser, RecordSeriesPoint, Session, User};
 use super::{Database, DbError, DbResult};
 
 #[derive(Clone)]
 pub struct MySql {
-    pool: sqlx::Pool<sqlx::mysql::MySql>,
+    /// sea-orm connection over the sqlx pool.
+    conn: DatabaseConnection,
 }
 
 #[async_trait]
@@ -24,195 +23,12 @@ impl Database for MySql {
             .await
             .map_err(|error| DbError::Other(error.into()))?;
 
-        Ok(Self { pool })
+        Ok(Self {
+            conn: SqlxMySqlConnector::from_sqlx_mysql_pool(pool),
+        })
     }
 
-    #[instrument(skip_all)]
-    async fn get_session(&self, token: &str) -> DbResult<Session> {
-        db::query_as("select id, user_id, token from sessions where token = ?")
-            .bind(token)
-            .fetch_one(&self.pool)
-            .await
-            .map_err(Into::into)
-    }
-
-    #[instrument(skip_all)]
-    async fn get_session_user(&self, token: &str) -> DbResult<User> {
-        db::query_as(
-            "select users.id, users.username, users.email, users.password from users
-            inner join sessions
-            on users.id = sessions.user_id
-            and sessions.token = ?",
-        )
-        .bind(token)
-        .fetch_one(&self.pool)
-        .await
-        .map_err(Into::into)
-    }
-
-    #[instrument(skip_all)]
-    async fn add_session(&self, session: &NewSession) -> DbResult<()> {
-        let token: &str = &session.token;
-
-        db::query(
-            "insert into sessions
-                (user_id, token)
-            values(?, ?)",
-        )
-        .bind(session.user_id)
-        .bind(token)
-        .execute(&self.pool)
-        .await?;
-
-        Ok(())
-    }
-
-    #[instrument(skip_all)]
-    async fn get_user(&self, username: &str) -> DbResult<User> {
-        db::query_as("select id, username, email, password from users where username = ?")
-            .bind(username)
-            .fetch_one(&self.pool)
-            .await
-            .map_err(Into::into)
-    }
-
-    #[instrument(skip_all)]
-    async fn get_user_session(&self, u: &User) -> DbResult<Session> {
-        db::query_as("select id, user_id, token from sessions where user_id = ?")
-            .bind(u.id)
-            .fetch_one(&self.pool)
-            .await
-            .map_err(Into::into)
-    }
-
-    #[instrument(skip_all)]
-    async fn add_user(&self, user: &NewUser) -> DbResult<i64> {
-        let email: &str = &user.email;
-        let username: &str = &user.username;
-        let password: &str = &user.password;
-
-        let res = db::query(
-            "insert into users
-                (username, email, password)
-            values(?, ?, ?)",
-        )
-        .bind(username)
-        .bind(email)
-        .bind(password)
-        .execute(&self.pool)
-        .await?;
-
-        Ok(res.last_insert_id() as i64)
-    }
-
-    #[instrument(skip_all)]
-    async fn update_user_password(&self, u: &User) -> DbResult<()> {
-        db::query(
-            "update users
-            set password = ?
-            where id = ?",
-        )
-        .bind(&u.password)
-        .bind(u.id)
-        .execute(&self.pool)
-        .await?;
-
-        Ok(())
-    }
-
-    #[instrument(skip_all)]
-    async fn delete_user(&self, u: &User) -> DbResult<()> {
-        db::query("delete from sessions where user_id = ?").bind(u.id).execute(&self.pool).await?;
-
-        db::query("delete from history where user_id = ?").bind(u.id).execute(&self.pool).await?;
-
-        db::query("delete from store where user_id = ?").bind(u.id).execute(&self.pool).await?;
-
-        db::query("delete from users where id = ?").bind(u.id).execute(&self.pool).await?;
-
-        Ok(())
-    }
-
-    #[instrument(skip_all)]
-    async fn delete_store(&self, user: &User) -> DbResult<()> {
-        db::query("delete from store where user_id = ?").bind(user.id).execute(&self.pool).await?;
-
-        Ok(())
-    }
-
-    #[instrument(skip_all)]
-    async fn add_records(&self, user: &User, records: &[Record<EncryptedData>]) -> DbResult<()> {
-        let mut tx = self.pool.begin().await?;
-
-        for i in records {
-            let id = atuin_common::utils::uuid_v7();
-
-            db::query(
-                "insert into store
-                    (id, client_id, host, idx, timestamp, version, tag, data, cek, user_id)
-                values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-                on duplicate key update id = id
-                ",
-            )
-            .bind(id)
-            .bind(i.id)
-            .bind(i.host.id)
-            .bind(i.idx as i64)
-            .bind(i.timestamp as i64) // throwing away some data, but i64 is still big in terms of time
-            .bind(i.version.as_str())
-            .bind(i.tag.as_str())
-            .bind(&i.data.raw)
-            .bind(&i.data.cek)
-            .bind(user.id)
-            .execute(&mut *tx)
-            .await?;
-        }
-
-        tx.commit().await?;
-
-        Ok(())
-    }
-
-    #[instrument(skip_all)]
-    async fn next_records(
-        &self,
-        user: &User,
-        series: &RecordSeriesKey,
-        start: Option<RecordIdx>,
-        count: u64,
-    ) -> DbResult<Vec<Record<EncryptedData>>> {
-        tracing::debug!("{:?} - {:?} - {:?}", series.host_id, series.tag, start);
-        let start = start.unwrap_or(0);
-
-        db::query_as::<_, DbRecord>(
-            "select client_id, host, idx, timestamp, version, tag, data, cek from store
-                    where user_id = ?
-                    and tag = ?
-                    and host = ?
-                    and idx >= ?
-                    order by idx asc
-                    limit ?",
-        )
-        .bind(user.id)
-        .bind(series.tag.as_str())
-        .bind(series.host_id)
-        .bind(start as i64)
-        .bind(count as i64)
-        .fetch_all(&self.pool)
-        .await
-        .map(|records| records.into_iter().map(Into::into).collect())
-        .map_err(Into::into)
-    }
-
-    #[instrument(skip_all)]
-    async fn status(&self, user: &User) -> DbResult<RecordStatus> {
-        const STATUS_SQL: &str =
-            "select host, tag, max(idx) as idx from store where user_id = ? group by host, tag";
-
-        let points = db::query_as::<_, RecordSeriesPoint>(STATUS_SQL)
-            .bind(user.id)
-            .fetch_all(&self.pool)
-            .await?;
-        Ok(RecordStatus::from_points(points.into_iter().map(Into::into)))
+    fn conn(&self) -> &DatabaseConnection {
+        &self.conn
     }
 }

--- a/crates/atuin-server/src/db/postgres/mod.rs
+++ b/crates/atuin-server/src/db/postgres/mod.rs
@@ -1,18 +1,37 @@
 use async_trait::async_trait;
 use atuin_common::db;
 use atuin_common::db::PostgresDbUrl;
-use atuin_domain::record::{EncryptedData, Record, RecordIdx, RecordSeriesKey, RecordStatus};
-use sqlx::postgres::PgPoolOptions;
-use tracing::instrument;
+use sea_orm::{DatabaseConnection, SqlxPostgresConnector};
+use sqlx::postgres::{PgPool, PgPoolOptions};
 
-use super::models::{DbRecord, NewSession, NewUser, RecordSeriesPoint, Session, User};
 use super::{Database, DbError, DbResult};
 
 const MIN_PG_VERSION: u32 = 14;
 
 #[derive(Clone)]
 pub struct Postgres {
-    pool: sqlx::Pool<sqlx::postgres::Postgres>,
+    /// sea-orm connection over the sqlx pool.
+    conn: DatabaseConnection,
+}
+
+/// Ensure a pool points at a PostgreSQL new enough for the queries we run.
+async fn ensure_supported_version(pool: &PgPool) -> DbResult<()> {
+    // Call server_version_num to get the DB server's major version number.
+    // The call returns None for servers older than 8.x.
+    let major = pool
+        .acquire()
+        .await?
+        .server_version_num()
+        .ok_or_else(|| DbError::Other(eyre::Report::msg("could not get PostgreSQL version")))?
+        / 10000;
+
+    if major < MIN_PG_VERSION {
+        return Err(DbError::Other(eyre::Report::msg(format!(
+            "unsupported PostgreSQL version {major}, minimum required is {MIN_PG_VERSION}"
+        ))));
+    }
+
+    Ok(())
 }
 
 #[async_trait]
@@ -21,220 +40,18 @@ impl Database for Postgres {
 
     async fn connect(url: PostgresDbUrl) -> DbResult<Self> {
         let pool = PgPoolOptions::new().max_connections(100).connect(url.as_str()).await?;
-
-        // Call server_version_num to get the DB server's major version number
-        // The call returns None for servers older than 8.x.
-        let pg_major_version: u32 = pool
-            .acquire()
-            .await?
-            .server_version_num()
-            .ok_or(DbError::Other(eyre::Report::msg("could not get PostgreSQL version")))?
-            / 10000;
-
-        if pg_major_version < MIN_PG_VERSION {
-            return Err(DbError::Other(eyre::Report::msg(format!(
-                "unsupported PostgreSQL version {pg_major_version}, minimum required is \
-                 {MIN_PG_VERSION}"
-            ))));
-        }
+        ensure_supported_version(&pool).await?;
 
         db::migrate!(&pool, "src/db/postgres/migrations")
             .await
             .map_err(|error| DbError::Other(error.into()))?;
 
-        Ok(Self { pool })
+        Ok(Self {
+            conn: SqlxPostgresConnector::from_sqlx_postgres_pool(pool),
+        })
     }
 
-    #[instrument(skip_all)]
-    async fn get_session(&self, token: &str) -> DbResult<Session> {
-        db::query_as("select id, user_id, token from sessions where token = $1")
-            .bind(token)
-            .fetch_one(&self.pool)
-            .await
-            .map_err(Into::into)
-    }
-
-    #[instrument(skip_all)]
-    async fn get_user(&self, username: &str) -> DbResult<User> {
-        db::query_as("select id, username, email, password from users where username = $1")
-            .bind(username)
-            .fetch_one(&self.pool)
-            .await
-            .map_err(Into::into)
-    }
-
-    #[instrument(skip_all)]
-    async fn get_session_user(&self, token: &str) -> DbResult<User> {
-        db::query_as(
-            "select users.id, users.username, users.email, users.password from users
-            inner join sessions
-            on users.id = sessions.user_id
-            and sessions.token = $1",
-        )
-        .bind(token)
-        .fetch_one(&self.pool)
-        .await
-        .map_err(Into::into)
-    }
-
-    async fn delete_store(&self, user: &User) -> DbResult<()> {
-        db::query("delete from store where user_id = $1").bind(user.id).execute(&self.pool).await?;
-
-        Ok(())
-    }
-
-    #[instrument(skip_all)]
-    async fn delete_user(&self, u: &User) -> DbResult<()> {
-        db::query("delete from sessions where user_id = $1").bind(u.id).execute(&self.pool).await?;
-
-        db::query("delete from history where user_id = $1").bind(u.id).execute(&self.pool).await?;
-
-        db::query("delete from store where user_id = $1").bind(u.id).execute(&self.pool).await?;
-
-        db::query("delete from total_history_count_user where user_id = $1")
-            .bind(u.id)
-            .execute(&self.pool)
-            .await?;
-
-        db::query("delete from users where id = $1").bind(u.id).execute(&self.pool).await?;
-
-        Ok(())
-    }
-
-    #[instrument(skip_all)]
-    async fn update_user_password(&self, user: &User) -> DbResult<()> {
-        db::query(
-            "update users
-            set password = $1
-            where id = $2",
-        )
-        .bind(&user.password)
-        .bind(user.id)
-        .execute(&self.pool)
-        .await?;
-
-        Ok(())
-    }
-
-    #[instrument(skip_all)]
-    async fn add_user(&self, user: &NewUser) -> DbResult<i64> {
-        let email: &str = &user.email;
-        let username: &str = &user.username;
-        let password: &str = &user.password;
-
-        let res: (i64,) = db::query_as(
-            "insert into users
-                (username, email, password)
-            values($1, $2, $3)
-            returning id",
-        )
-        .bind(username)
-        .bind(email)
-        .bind(password)
-        .fetch_one(&self.pool)
-        .await?;
-
-        Ok(res.0)
-    }
-
-    #[instrument(skip_all)]
-    async fn add_session(&self, session: &NewSession) -> DbResult<()> {
-        let token: &str = &session.token;
-
-        db::query(
-            "insert into sessions
-                (user_id, token)
-            values($1, $2)",
-        )
-        .bind(session.user_id)
-        .bind(token)
-        .execute(&self.pool)
-        .await?;
-
-        Ok(())
-    }
-
-    #[instrument(skip_all)]
-    async fn get_user_session(&self, u: &User) -> DbResult<Session> {
-        db::query_as("select id, user_id, token from sessions where user_id = $1")
-            .bind(u.id)
-            .fetch_one(&self.pool)
-            .await
-            .map_err(Into::into)
-    }
-
-    #[instrument(skip_all)]
-    async fn add_records(&self, user: &User, records: &[Record<EncryptedData>]) -> DbResult<()> {
-        let mut tx = self.pool.begin().await?;
-
-        for i in records {
-            let id = atuin_common::utils::uuid_v7();
-
-            db::query(
-                "insert into store
-                    (id, client_id, host, idx, timestamp, version, tag, data, cek, user_id)
-                values ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
-                on conflict do nothing
-                ",
-            )
-            .bind(id)
-            .bind(i.id)
-            .bind(i.host.id)
-            .bind(i.idx as i64)
-            .bind(i.timestamp as i64) // throwing away some data, but i64 is still big in terms of time
-            .bind(i.version.as_str())
-            .bind(i.tag.as_str())
-            .bind(&i.data.raw)
-            .bind(&i.data.cek)
-            .bind(user.id)
-            .execute(&mut *tx)
-            .await?;
-        }
-
-        tx.commit().await?;
-
-        Ok(())
-    }
-
-    #[instrument(skip_all)]
-    async fn next_records(
-        &self,
-        user: &User,
-        series: &RecordSeriesKey,
-        start: Option<RecordIdx>,
-        count: u64,
-    ) -> DbResult<Vec<Record<EncryptedData>>> {
-        tracing::debug!("{:?} - {:?} - {:?}", series.host_id, series.tag, start);
-        let start = start.unwrap_or(0);
-
-        db::query_as::<_, DbRecord>(
-            "select client_id, host, idx, timestamp, version, tag, data, cek from store
-                    where user_id = $1
-                    and tag = $2
-                    and host = $3
-                    and idx >= $4
-                    order by idx asc
-                    limit $5",
-        )
-        .bind(user.id)
-        .bind(series.tag.as_str())
-        .bind(series.host_id)
-        .bind(start as i64)
-        .bind(count as i64)
-        .fetch_all(&self.pool)
-        .await
-        .map(|records| records.into_iter().map(Into::into).collect())
-        .map_err(Into::into)
-    }
-
-    async fn status(&self, user: &User) -> DbResult<RecordStatus> {
-        const STATUS_SQL: &str =
-            "select host, tag, max(idx) as idx from store where user_id = $1 group by host, tag";
-
-        let points = db::query_as::<_, RecordSeriesPoint>(STATUS_SQL)
-            .bind(user.id)
-            .fetch_all(&self.pool)
-            .await?;
-        Ok(RecordStatus::from_points(points.into_iter().map(Into::into)))
+    fn conn(&self) -> &DatabaseConnection {
+        &self.conn
     }
 }

--- a/crates/atuin-server/src/db/sqlite/mod.rs
+++ b/crates/atuin-server/src/db/sqlite/mod.rs
@@ -3,16 +3,15 @@ use std::str::FromStr;
 use async_trait::async_trait;
 use atuin_common::db;
 use atuin_common::db::SqliteDbUrl;
-use atuin_domain::record::{EncryptedData, Record, RecordIdx, RecordSeriesKey, RecordStatus};
+use sea_orm::{DatabaseConnection, SqlxSqliteConnector};
 use sqlx::sqlite::{SqliteConnectOptions, SqliteJournalMode, SqlitePoolOptions};
-use tracing::instrument;
 
-use super::models::{DbRecord, NewSession, NewUser, RecordSeriesPoint, Session, User};
 use super::{Database, DbError, DbResult};
 
 #[derive(Clone)]
 pub struct Sqlite {
-    pool: sqlx::Pool<sqlx::sqlite::Sqlite>,
+    /// sea-orm connection over the sqlx pool.
+    conn: DatabaseConnection,
 }
 
 #[async_trait]
@@ -30,200 +29,12 @@ impl Database for Sqlite {
             .await
             .map_err(|error| DbError::Other(error.into()))?;
 
-        Ok(Self { pool })
+        Ok(Self {
+            conn: SqlxSqliteConnector::from_sqlx_sqlite_pool(pool),
+        })
     }
 
-    #[instrument(skip_all)]
-    async fn get_session(&self, token: &str) -> DbResult<Session> {
-        db::query_as("select id, user_id, token from sessions where token = $1")
-            .bind(token)
-            .fetch_one(&self.pool)
-            .await
-            .map_err(Into::into)
-    }
-
-    #[instrument(skip_all)]
-    async fn get_session_user(&self, token: &str) -> DbResult<User> {
-        db::query_as(
-            "select users.id, users.username, users.email, users.password from users
-            inner join sessions
-            on users.id = sessions.user_id
-            and sessions.token = $1",
-        )
-        .bind(token)
-        .fetch_one(&self.pool)
-        .await
-        .map_err(Into::into)
-    }
-
-    #[instrument(skip_all)]
-    async fn add_session(&self, session: &NewSession) -> DbResult<()> {
-        let token: &str = &session.token;
-
-        db::query(
-            "insert into sessions
-                (user_id, token)
-            values($1, $2)",
-        )
-        .bind(session.user_id)
-        .bind(token)
-        .execute(&self.pool)
-        .await?;
-
-        Ok(())
-    }
-
-    #[instrument(skip_all)]
-    async fn get_user(&self, username: &str) -> DbResult<User> {
-        db::query_as("select id, username, email, password from users where username = $1")
-            .bind(username)
-            .fetch_one(&self.pool)
-            .await
-            .map_err(Into::into)
-    }
-
-    #[instrument(skip_all)]
-    async fn get_user_session(&self, u: &User) -> DbResult<Session> {
-        db::query_as("select id, user_id, token from sessions where user_id = $1")
-            .bind(u.id)
-            .fetch_one(&self.pool)
-            .await
-            .map_err(Into::into)
-    }
-
-    #[instrument(skip_all)]
-    async fn add_user(&self, user: &NewUser) -> DbResult<i64> {
-        let email: &str = &user.email;
-        let username: &str = &user.username;
-        let password: &str = &user.password;
-
-        let res: (i64,) = db::query_as(
-            "insert into users
-                (username, email, password)
-            values($1, $2, $3)
-            returning id",
-        )
-        .bind(username)
-        .bind(email)
-        .bind(password)
-        .fetch_one(&self.pool)
-        .await?;
-
-        Ok(res.0)
-    }
-
-    #[instrument(skip_all)]
-    async fn update_user_password(&self, user: &User) -> DbResult<()> {
-        db::query(
-            "update users
-            set password = $1
-            where id = $2",
-        )
-        .bind(&user.password)
-        .bind(user.id)
-        .execute(&self.pool)
-        .await?;
-
-        Ok(())
-    }
-
-    #[instrument(skip_all)]
-    async fn delete_user(&self, u: &User) -> DbResult<()> {
-        db::query("delete from sessions where user_id = $1").bind(u.id).execute(&self.pool).await?;
-
-        db::query("delete from history where user_id = $1").bind(u.id).execute(&self.pool).await?;
-
-        db::query("delete from store where user_id = $1").bind(u.id).execute(&self.pool).await?;
-
-        db::query("delete from users where id = $1").bind(u.id).execute(&self.pool).await?;
-
-        Ok(())
-    }
-
-    async fn delete_store(&self, user: &User) -> DbResult<()> {
-        db::query(
-            "delete from store
-            where user_id = $1",
-        )
-        .bind(user.id)
-        .execute(&self.pool)
-        .await?;
-
-        Ok(())
-    }
-
-    #[instrument(skip_all)]
-    async fn add_records(&self, user: &User, records: &[Record<EncryptedData>]) -> DbResult<()> {
-        let mut tx = self.pool.begin().await?;
-
-        for i in records {
-            let id = atuin_common::utils::uuid_v7();
-
-            db::query(
-                "insert into store
-                    (id, client_id, host, idx, timestamp, version, tag, data, cek, user_id)
-                values ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
-                on conflict do nothing
-                ",
-            )
-            .bind(id)
-            .bind(i.id)
-            .bind(i.host.id)
-            .bind(i.idx as i64)
-            .bind(i.timestamp as i64) // throwing away some data, but i64 is still big in terms of time
-            .bind(i.version.as_str())
-            .bind(i.tag.as_str())
-            .bind(&i.data.raw)
-            .bind(&i.data.cek)
-            .bind(user.id)
-            .execute(&mut *tx)
-            .await?;
-        }
-
-        tx.commit().await?;
-
-        Ok(())
-    }
-
-    #[instrument(skip_all)]
-    async fn next_records(
-        &self,
-        user: &User,
-        series: &RecordSeriesKey,
-        start: Option<RecordIdx>,
-        count: u64,
-    ) -> DbResult<Vec<Record<EncryptedData>>> {
-        tracing::debug!("{:?} - {:?} - {:?}", series.host_id, series.tag, start);
-        let start = start.unwrap_or(0);
-
-        db::query_as::<_, DbRecord>(
-            "select client_id, host, idx, timestamp, version, tag, data, cek from store
-                    where user_id = $1
-                    and tag = $2
-                    and host = $3
-                    and idx >= $4
-                    order by idx asc
-                    limit $5",
-        )
-        .bind(user.id)
-        .bind(series.tag.as_str())
-        .bind(series.host_id)
-        .bind(start as i64)
-        .bind(count as i64)
-        .fetch_all(&self.pool)
-        .await
-        .map(|records| records.into_iter().map(Into::into).collect())
-        .map_err(Into::into)
-    }
-
-    async fn status(&self, user: &User) -> DbResult<RecordStatus> {
-        const STATUS_SQL: &str =
-            "select host, tag, max(idx) as idx from store where user_id = $1 group by host, tag";
-
-        let points = db::query_as::<_, RecordSeriesPoint>(STATUS_SQL)
-            .bind(user.id)
-            .fetch_all(&self.pool)
-            .await?;
-        Ok(RecordStatus::from_points(points.into_iter().map(Into::into)))
+    fn conn(&self) -> &DatabaseConnection {
+        &self.conn
     }
 }


### PR DESCRIPTION
## What this is

An exploration of introducing **sea-orm** to the atuin **server** DB layer, per the ask:
add it, prove it coexists with our sqlx, and delete as much duplicated query code as is
*safe* — keeping raw sqlx anywhere sea-orm would generate worse SQL. Draft, for deciding
whether to go further.

> Rebased onto current `main` (the server-db consolidation it built on, #4009, has merged).
> One focused commit. #4009 also dropped read-replicas from the `Database` trait, so this is
> adapted to that — each backend exposes a single `conn()`, no read/write split.

## The headline: the three server backends were ~90% duplicate

`Postgres`, `MySql` and `Sqlite` hand-wrote the same twelve queries three times, differing
only in placeholder (`$1` vs `?`), the `add_records` upsert clause, and `add_user`'s
`RETURNING` vs `last_insert_id`. sea-orm renders dialect-correct SQL from one set of
entities, so **those twelve methods now live once** as default methods on the `Database`
trait. Each backend implements only `connect()` + a single `conn()` accessor.

```
crates/atuin-server/src/db/{postgres,mysql,sqlite}/mod.rs:  -602 / +46 LOC
                          (query methods → zero duplication; only connect() remains)
```

**sqlx keeps what it's good at** (pool setup, the pg version check, sqlite WAL,
`db::migrate!`); sea-orm wraps that *same pool* — `SqlxSqliteConnector::from_sqlx_sqlite_pool(pool)`
etc. — so there is **one sqlx 0.9 and one bundled sqlite**, no second pool. (sea-orm 2.0
requires sqlx `^0.9`, which is exactly what the workspace pins.)

## Correctness: proven on all three dialects

`tests/db_story.rs` is a backend-generic oracle exercising all 13 trait methods. It passes
against **SQLite, Postgres *and* MySQL**:

```
ATUIN_TEST_DB_URI=sqlite://…                      cargo nextest run -p atuin-server --test db_story  ✅
ATUIN_TEST_DB_URI=postgres://atuin:pass@…/atuin   …                                                  ✅
ATUIN_TEST_DB_URI=mysql://root:pass@…/atuin       …                                                  ✅
```

The **MySQL trait path had no CI coverage at all** before this — running it surfaced (and
this PR works around) a real sea-query 1.0 bug (below). All 20 server HTTP integration tests
(pg) pass; clippy `-D warnings`, nightly `fmt`, `cargo doc`, and `cargo deny` are green. A
unit test locks in the dialect-correct upsert SQL.

## Performance: equal-or-faster on every hot path

Measured during the exploration with a divan A/B of the sea-orm path vs the *original*
hand-written sqlx queries over an identical SQLite fixture (the bench itself is left out of
this PR to keep it lean; numbers for the record):

| method | sea-orm (median) | sqlx (median) | result |
|---|---|---|---|
| `add_records` n=1 | 76.6 µs | 75.5 µs | parity |
| `add_records` n=10 | **114 µs** | 171 µs | **1.5× faster** |
| `add_records` n=100 (sync page) | **401 µs** | 1058 µs | **2.6× faster** |
| `next_records` (page 100) | **185 µs** | 293 µs | **1.6× faster** |
| `status` (GROUP BY) | 141 µs | 140 µs | parity |
| `get_session_user` (join) | 23.1 µs | 20.4 µs | sqlx ~3 µs faster |

The big `add_records` win is real: sea-orm's `insert_many` issues **one multi-row INSERT**
where the old code looped row-by-row (N round-trips). The only regression is ~3 µs of ORM
overhead on the trivial single-row join — noise in absolute terms.

## Notable findings / decisions

- **sea-query 1.0 MySQL upsert bug.** A plain `.do_nothing()` renders the invalid
  `ON DUPLICATE KEY IGNORE` for MySQL (this is what the mysql db_story run first hit). So
  `record_upsert()` branches once: pg/sqlite get the optimal `ON CONFLICT … DO NOTHING`,
  MySQL gets the no-op `ON DUPLICATE KEY UPDATE id = id` the hand-written backend already
  used. The unit test guards this per dialect.
- **UUIDs.** Server `store` UUIDs go through sqlx's `Uuid` codec (native uuid / binary /
  sqlite-blob); sea-orm's `with-uuid` uses the same codec, so the `Uuid` entity columns
  match on-disk bytes exactly.
- **`delete_user`** is now wrapped in a transaction (it wasn't), and the pg-only
  `total_history_count_user` purge is gated on the backend — preserving existing behaviour.
- **Footgun guard.** sea-orm never emits `*` and never `ALTER`s (migrations stay in sqlx),
  so the `db::query` banned-pattern protection is preserved in spirit for migrated methods.

## Scope

- **This PR:** the server `Database` trait only.
- **Deliberately left as raw sqlx** (would be worse under an ORM): the history search engine,
  bulk-insert chunking, the foreign-schema importers, PRAGMA/FFI.
- **Client stores** (`atuin-scripts`, `record/sqlite_store.rs`, `atuin-kv`, `atuin-ai`,
  `meta.rs`, the simple half of `atuin-client/database.rs`) carry the same KV-upsert /
  repeated-column-list boilerplate and are candidates for follow-up PRs. A worked
  `atuin-scripts` conversion (relations killing an N+1 tag loop) exists on a separate branch.
- **Cost:** sea-orm is a heavy dependency (several transitive crates, all pass `cargo deny`).

## Recommendation

The server result: **zero duplicated query code across three backends, faster on every hot
path, and MySQL correctness we never actually tested before.** Because sea-orm rides the
existing sqlx pool, adoption is incremental and reversible — convert store-by-store, keep
raw sqlx wherever it earns its place. Worth continuing; the search path should stay
hand-written.

---
🤖 Generated with [Claude Code](https://claude.ai/code) · https://claude.ai/code/session_017SS5zdUbKUE3knrNBxdC9W
