### PR TITLE
refactor(server): polymorphic database

### DIFF
--- a/crates/atuin-server/src/db/mod.rs
+++ b/crates/atuin-server/src/db/mod.rs
@@ -45,12 +45,6 @@ pub struct DbSettings {
 }
 
 /// A database backend, used at runtime behind `Arc<dyn Database>`.
-///
-/// This trait is deliberately object-safe: it has no associated types and no
-/// methods returning `Self`, so the server can hold a single
-/// `Arc<dyn Database>` regardless of which backend was configured. Backend
-/// construction (which *is* backend-specific) lives on [`ConnectableDatabase`]
-/// instead.
 #[async_trait]
 pub trait Database: Send + Sync + 'static {
     async fn get_session(&self, token: &str) -> DbResult<Session>;
@@ -80,12 +74,6 @@ pub trait Database: Send + Sync + 'static {
 }
 
 /// A [`Database`] backend that can be constructed from a connection URL.
-///
-/// This is kept separate from [`Database`] because it carries an associated
-/// `Url` type and a constructor returning `Self`, both of which would make
-/// `Database` non-object-safe. The runtime uses [`Database`] via
-/// `Arc<dyn Database>`; this trait is only needed where a concrete backend is
-/// built (the connection factory and the test harness).
 #[async_trait]
 pub trait ConnectableDatabase: Database + Sized {
     /// The backend-specific connection URL this database is built from.

--- a/crates/atuin-server/src/db/mod.rs
+++ b/crates/atuin-server/src/db/mod.rs
@@ -44,13 +44,15 @@ pub struct DbSettings {
     pub db_uri: OwnedDbUrl,
 }
 
+/// A database backend, used at runtime behind `Arc<dyn Database>`.
+///
+/// This trait is deliberately object-safe: it has no associated types and no
+/// methods returning `Self`, so the server can hold a single
+/// `Arc<dyn Database>` regardless of which backend was configured. Backend
+/// construction (which *is* backend-specific) lives on [`ConnectableDatabase`]
+/// instead.
 #[async_trait]
-pub trait Database: Sized + Clone + Send + Sync + 'static {
-    /// The backend-specific connection URL this database is built from.
-    type Url;
-
-    async fn connect(url: Self::Url) -> DbResult<Self>;
-
+pub trait Database: Send + Sync + 'static {
     async fn get_session(&self, token: &str) -> DbResult<Session>;
     async fn get_session_user(&self, token: &str) -> DbResult<User>;
     async fn add_session(&self, session: &NewSession) -> DbResult<()>;
@@ -75,4 +77,19 @@ pub trait Database: Sized + Clone + Send + Sync + 'static {
 
     // Return the tail record ID for each store, so (HostID, Tag, TailRecordID)
     async fn status(&self, user: &User) -> DbResult<RecordStatus>;
+}
+
+/// A [`Database`] backend that can be constructed from a connection URL.
+///
+/// This is kept separate from [`Database`] because it carries an associated
+/// `Url` type and a constructor returning `Self`, both of which would make
+/// `Database` non-object-safe. The runtime uses [`Database`] via
+/// `Arc<dyn Database>`; this trait is only needed where a concrete backend is
+/// built (the connection factory and the test harness).
+#[async_trait]
+pub trait ConnectableDatabase: Database + Sized {
+    /// The backend-specific connection URL this database is built from.
+    type Url;
+
+    async fn connect(url: Self::Url) -> DbResult<Self>;
 }

--- a/crates/atuin-server/src/db/mysql/mod.rs
+++ b/crates/atuin-server/src/db/mysql/mod.rs
@@ -6,7 +6,7 @@ use sqlx::mysql::MySqlPoolOptions;
 use tracing::instrument;
 
 use super::models::{DbRecord, NewSession, NewUser, RecordSeriesPoint, Session, User};
-use super::{Database, DbError, DbResult};
+use super::{ConnectableDatabase, Database, DbError, DbResult};
 
 #[derive(Clone)]
 pub struct MySql {
@@ -14,7 +14,7 @@ pub struct MySql {
 }
 
 #[async_trait]
-impl Database for MySql {
+impl ConnectableDatabase for MySql {
     type Url = MysqlDbUrl;
 
     async fn connect(url: MysqlDbUrl) -> DbResult<Self> {
@@ -26,7 +26,10 @@ impl Database for MySql {
 
         Ok(Self { pool })
     }
+}
 
+#[async_trait]
+impl Database for MySql {
     #[instrument(skip_all)]
     async fn get_session(&self, token: &str) -> DbResult<Session> {
         db::query_as("select id, user_id, token from sessions where token = ?")

--- a/crates/atuin-server/src/db/postgres/mod.rs
+++ b/crates/atuin-server/src/db/postgres/mod.rs
@@ -6,7 +6,7 @@ use sqlx::postgres::PgPoolOptions;
 use tracing::instrument;
 
 use super::models::{DbRecord, NewSession, NewUser, RecordSeriesPoint, Session, User};
-use super::{Database, DbError, DbResult};
+use super::{ConnectableDatabase, Database, DbError, DbResult};
 
 const MIN_PG_VERSION: u32 = 14;
 
@@ -16,7 +16,7 @@ pub struct Postgres {
 }
 
 #[async_trait]
-impl Database for Postgres {
+impl ConnectableDatabase for Postgres {
     type Url = PostgresDbUrl;
 
     async fn connect(url: PostgresDbUrl) -> DbResult<Self> {
@@ -44,7 +44,10 @@ impl Database for Postgres {
 
         Ok(Self { pool })
     }
+}
 
+#[async_trait]
+impl Database for Postgres {
     #[instrument(skip_all)]
     async fn get_session(&self, token: &str) -> DbResult<Session> {
         db::query_as("select id, user_id, token from sessions where token = $1")

--- a/crates/atuin-server/src/db/sqlite/mod.rs
+++ b/crates/atuin-server/src/db/sqlite/mod.rs
@@ -8,7 +8,7 @@ use sqlx::sqlite::{SqliteConnectOptions, SqliteJournalMode, SqlitePoolOptions};
 use tracing::instrument;
 
 use super::models::{DbRecord, NewSession, NewUser, RecordSeriesPoint, Session, User};
-use super::{Database, DbError, DbResult};
+use super::{ConnectableDatabase, Database, DbError, DbResult};
 
 #[derive(Clone)]
 pub struct Sqlite {
@@ -16,7 +16,7 @@ pub struct Sqlite {
 }
 
 #[async_trait]
-impl Database for Sqlite {
+impl ConnectableDatabase for Sqlite {
     type Url = SqliteDbUrl;
 
     async fn connect(url: SqliteDbUrl) -> DbResult<Self> {
@@ -32,7 +32,10 @@ impl Database for Sqlite {
 
         Ok(Self { pool })
     }
+}
 
+#[async_trait]
+impl Database for Sqlite {
     #[instrument(skip_all)]
     async fn get_session(&self, token: &str) -> DbResult<Session> {
         db::query_as("select id, user_id, token from sessions where token = $1")

--- a/crates/atuin-server/src/handlers/mod.rs
+++ b/crates/atuin-server/src/handlers/mod.rs
@@ -6,7 +6,6 @@ use axum::response::IntoResponse;
 use axum::{Json, http};
 use tracing::instrument;
 
-use crate::db::Database;
 use crate::router::AppState;
 
 pub mod health;
@@ -16,7 +15,7 @@ pub mod v0;
 const VERSION: &str = env!("CARGO_PKG_VERSION");
 
 #[instrument(skip_all)]
-pub async fn index<DB: Database>(state: State<AppState<DB>>) -> Json<IndexResponse> {
+pub async fn index(state: State<AppState>) -> Json<IndexResponse> {
     let homage = r#""Through the fathomless deeps of space swims the star turtle Great A'Tuin, bearing on its back the four giant elephants who carry on their shoulders the mass of the Discworld." -- Sir Terry Pratchett"#;
 
     let version = state.settings.fake_version.clone().unwrap_or(VERSION.to_string());

--- a/crates/atuin-server/src/handlers/user.rs
+++ b/crates/atuin-server/src/handlers/user.rs
@@ -16,8 +16,8 @@ use reqwest::header::CONTENT_TYPE;
 use tracing::{debug, error, info, instrument, warn};
 
 use super::{ErrorResponse, ErrorResponseStatus, RespExt};
-use crate::db::models::{NewSession, NewUser};
 use crate::db::DbError;
+use crate::db::models::{NewSession, NewUser};
 use crate::router::{AppState, UserAuth};
 
 pub fn verify_str(hash: &str, password: &str) -> bool {

--- a/crates/atuin-server/src/handlers/user.rs
+++ b/crates/atuin-server/src/handlers/user.rs
@@ -17,7 +17,7 @@ use tracing::{debug, error, info, instrument, warn};
 
 use super::{ErrorResponse, ErrorResponseStatus, RespExt};
 use crate::db::models::{NewSession, NewUser};
-use crate::db::{Database, DbError};
+use crate::db::DbError;
 use crate::router::{AppState, UserAuth};
 
 pub fn verify_str(hash: &str, password: &str) -> bool {
@@ -53,9 +53,9 @@ async fn send_register_hook(url: &url::Url, username: String, registered: String
 }
 
 #[instrument(skip_all, err(level = "warn"), fields(user.username = username.as_str()))]
-pub async fn get<DB: Database>(
+pub async fn get(
     Path(username): Path<String>,
-    state: State<AppState<DB>>,
+    state: State<AppState>,
 ) -> Result<Json<UserResponse>, ErrorResponseStatus<'static>> {
     let db = &state.0.database;
     let user = match db.get_user(username.as_ref()).await {
@@ -77,8 +77,8 @@ pub async fn get<DB: Database>(
 }
 
 #[instrument(skip_all, err(level = "warn"), fields(user.username = register.username.as_str()))]
-pub async fn register<DB: Database>(
-    state: State<AppState<DB>>,
+pub async fn register(
+    state: State<AppState>,
     Json(register): Json<RegisterRequest>,
 ) -> Result<Json<RegisterResponse>, ErrorResponseStatus<'static>> {
     if !state.settings.open_registration {
@@ -153,9 +153,9 @@ pub async fn register<DB: Database>(
 }
 
 #[instrument(skip_all, err(level = "warn"), fields(user.id = user.id, user.username = user.username.as_str()))]
-pub async fn delete<DB: Database>(
+pub async fn delete(
     UserAuth(user): UserAuth,
-    state: State<AppState<DB>>,
+    state: State<AppState>,
 ) -> Result<Json<DeleteUserResponse>, ErrorResponseStatus<'static>> {
     debug!("request to delete user {}", user.id);
 
@@ -175,9 +175,9 @@ pub async fn delete<DB: Database>(
 }
 
 #[instrument(skip_all, err(level = "warn"), fields(user.id = user.id))]
-pub async fn change_password<DB: Database>(
+pub async fn change_password(
     UserAuth(mut user): UserAuth,
-    state: State<AppState<DB>>,
+    state: State<AppState>,
     Json(change_password): Json<ChangePasswordRequest>,
 ) -> Result<Json<ChangePasswordResponse>, ErrorResponseStatus<'static>> {
     let db = &state.0.database;
@@ -205,9 +205,9 @@ pub async fn change_password<DB: Database>(
 }
 
 #[instrument(skip_all, err(level = "warn"), fields(client.ip = %addr.ip(), user.username = login.username.as_str()))]
-pub async fn login<DB: Database>(
+pub async fn login(
     ConnectInfo(addr): ConnectInfo<SocketAddr>,
-    state: State<AppState<DB>>,
+    state: State<AppState>,
     login: Json<LoginRequest>,
 ) -> Result<Json<LoginResponse>, ErrorResponseStatus<'static>> {
     let db = &state.0.database;

--- a/crates/atuin-server/src/handlers/v0/record.rs
+++ b/crates/atuin-server/src/handlers/v0/record.rs
@@ -8,14 +8,13 @@ use metrics::counter;
 use serde::Deserialize;
 use tracing::{error, instrument};
 
-use crate::db::Database;
 use crate::handlers::{ErrorResponse, ErrorResponseStatus, RespExt};
 use crate::router::{AppState, UserAuth};
 
 #[instrument(skip_all, err(level = "warn"), fields(user.id = user.id, record.count = records.len()))]
-pub async fn post<DB: Database>(
+pub async fn post(
     UserAuth(user): UserAuth,
-    state: State<AppState<DB>>,
+    state: State<AppState>,
     Json(records): Json<Vec<Record<EncryptedData>>>,
 ) -> Result<(), ErrorResponseStatus<'static>> {
     let State(AppState {
@@ -48,9 +47,9 @@ pub async fn post<DB: Database>(
 }
 
 #[instrument(skip_all, err(level = "warn"), fields(user.id = user.id))]
-pub async fn index<DB: Database>(
+pub async fn index(
     UserAuth(user): UserAuth,
-    state: State<AppState<DB>>,
+    state: State<AppState>,
 ) -> Result<Json<RecordStatus>, ErrorResponseStatus<'static>> {
     let State(AppState { database, .. }) = state;
 
@@ -78,10 +77,10 @@ pub struct NextParams {
 }
 
 #[instrument(skip_all, err(level = "warn"), fields(user.id = user.id, host.id = %params.host, tag = params.tag.as_str(), count = params.count))]
-pub async fn next<DB: Database>(
+pub async fn next(
     params: Query<NextParams>,
     UserAuth(user): UserAuth,
-    state: State<AppState<DB>>,
+    state: State<AppState>,
 ) -> Result<Json<Vec<Record<EncryptedData>>>, ErrorResponseStatus<'static>> {
     let State(AppState { database, .. }) = state;
     let params = params.0;

--- a/crates/atuin-server/src/handlers/v0/store.rs
+++ b/crates/atuin-server/src/handlers/v0/store.rs
@@ -4,7 +4,6 @@ use metrics::counter;
 use serde::Deserialize;
 use tracing::{error, instrument};
 
-use crate::db::Database;
 use crate::handlers::{ErrorResponse, ErrorResponseStatus, RespExt};
 use crate::router::{AppState, UserAuth};
 
@@ -12,10 +11,10 @@ use crate::router::{AppState, UserAuth};
 pub struct DeleteParams {}
 
 #[instrument(skip_all, err(level = "warn"), fields(user.id = user.id))]
-pub async fn delete<DB: Database>(
+pub async fn delete(
     _params: Query<DeleteParams>,
     UserAuth(user): UserAuth,
-    state: State<AppState<DB>>,
+    state: State<AppState>,
 ) -> Result<(), ErrorResponseStatus<'static>> {
     let State(AppState { database, .. }) = state;
 

--- a/crates/atuin-server/src/lib.rs
+++ b/crates/atuin-server/src/lib.rs
@@ -68,11 +68,6 @@ pub async fn launch_with_tcp_listener(
 }
 
 /// Pick the backend from the connection URL and connect it.
-///
-/// Backend selection and connection are one and the same match: each arm hands its
-/// backend a URL of exactly the right type, so pairing the wrong backend with a URL
-/// is a compile error rather than a runtime check. The concrete backend is then
-/// erased behind `Arc<dyn Database>` so the router is monomorphized only once.
 async fn connect(db_uri: OwnedDbUrl) -> DbResult<Arc<dyn Database>> {
     Ok(match db_uri {
         DbUrl::Sqlite(url) => Arc::new(Sqlite::connect(url).await?),

--- a/crates/atuin-server/src/lib.rs
+++ b/crates/atuin-server/src/lib.rs
@@ -2,12 +2,13 @@
 
 use std::future::Future;
 use std::net::SocketAddr;
+use std::sync::Arc;
 
-use atuin_common::db::DbUrl;
+use atuin_common::db::{DbUrl, OwnedDbUrl};
 use axum::{Router, serve};
 use eyre::{Context, Result};
 
-use crate::db::{Database, MySql, Postgres, Sqlite};
+use crate::db::{ConnectableDatabase, Database, DbResult, MySql, Postgres, Sqlite};
 
 mod handlers;
 mod metrics;
@@ -70,32 +71,22 @@ pub async fn launch_with_tcp_listener(
 ///
 /// Backend selection and connection are one and the same match: each arm hands its
 /// backend a URL of exactly the right type, so pairing the wrong backend with a URL
-/// is a compile error rather than a runtime check.
+/// is a compile error rather than a runtime check. The concrete backend is then
+/// erased behind `Arc<dyn Database>` so the router is monomorphized only once.
+async fn connect(db_uri: OwnedDbUrl) -> DbResult<Arc<dyn Database>> {
+    Ok(match db_uri {
+        DbUrl::Sqlite(url) => Arc::new(Sqlite::connect(url).await?),
+        DbUrl::Postgres(url) => Arc::new(Postgres::connect(url).await?),
+        DbUrl::Mysql(url) => Arc::new(MySql::connect(url).await?),
+    })
+}
+
 async fn connect_and_build_router(settings: Settings) -> Result<Router> {
-    let db_uri = settings.db_settings.db_uri.clone();
+    let database = connect(settings.db_settings.db_uri.clone())
+        .await
+        .wrap_err_with(|| format!("failed to connect to db: {:?}", settings.db_settings))?;
 
-    let router = match db_uri {
-        DbUrl::Sqlite(url) => {
-            let db = Sqlite::connect(url)
-                .await
-                .wrap_err_with(|| format!("failed to connect to db: {:?}", settings.db_settings))?;
-            router::router(db, settings)
-        }
-        DbUrl::Postgres(url) => {
-            let db = Postgres::connect(url)
-                .await
-                .wrap_err_with(|| format!("failed to connect to db: {:?}", settings.db_settings))?;
-            router::router(db, settings)
-        }
-        DbUrl::Mysql(url) => {
-            let db = MySql::connect(url)
-                .await
-                .wrap_err_with(|| format!("failed to connect to db: {:?}", settings.db_settings))?;
-            router::router(db, settings)
-        }
-    };
-
-    Ok(router)
+    Ok(router::router(database, settings))
 }
 
 // The separate listener means it's much easier to ensure metrics are not accidentally exposed to

--- a/crates/atuin-server/src/router.rs
+++ b/crates/atuin-server/src/router.rs
@@ -23,16 +23,13 @@ use crate::settings::Settings;
 
 pub struct UserAuth(pub User);
 
-impl<DB> FromRequestParts<AppState<DB>> for UserAuth
-where
-    DB: Database + Send + Sync,
-{
+impl FromRequestParts<AppState> for UserAuth {
     type Rejection = ErrorResponseStatus<'static>;
 
     #[tracing::instrument(name = "auth", skip_all)]
     async fn from_request_parts(
         req: &mut Parts,
-        state: &AppState<DB>,
+        state: &AppState,
     ) -> Result<Self, Self::Rejection> {
         let auth_header = req.headers.get(http::header::AUTHORIZATION).ok_or_else(|| {
             tracing::debug!("request is missing the authorization header");
@@ -99,8 +96,8 @@ async fn semver(request: Request, next: Next) -> Response {
 }
 
 #[derive(Clone)]
-pub struct AppState<DB: Database> {
-    pub database: DB,
+pub struct AppState {
+    pub database: Arc<dyn Database>,
     pub settings: Settings,
 }
 
@@ -115,7 +112,7 @@ fn capabilities() -> CapServer {
         .expect("PageSizeCap is registered exactly once")
 }
 
-pub fn router<DB: Database>(database: DB, settings: Settings) -> Router {
+pub fn router(database: Arc<dyn Database>, settings: Settings) -> Router {
     // Advertise the self-referential capabilities capability, so every server that speaks the
     // protocol carries at least one concrete capability a client can observe.
     let caps = Arc::new(capabilities());

--- a/crates/atuin-server/tests/db_story.rs
+++ b/crates/atuin-server/tests/db_story.rs
@@ -6,7 +6,7 @@ use atuin_domain::record::{
     EncryptedData, Host, HostId, Record, RecordIdx, RecordSeriesKey, RecordTag,
 };
 use atuin_server::db::models::{NewSession, NewUser, User};
-use atuin_server::db::{Database, DbError, DbSettings, MySql, Postgres, Sqlite};
+use atuin_server::db::{ConnectableDatabase, DbError, DbSettings, MySql, Postgres, Sqlite};
 use rstest::rstest;
 use sqlx::migrate::MigrateDatabase;
 use url::Url;
@@ -95,7 +95,7 @@ async fn test_full_db_story() -> eyre::Result<()> {
     }
 }
 
-async fn run_the_test<DB: Database>(url: DB::Url) -> eyre::Result<()> {
+async fn run_the_test<DB: ConnectableDatabase>(url: DB::Url) -> eyre::Result<()> {
     let db = DB::connect(url).await?;
     // register a user
     let new_user = NewUser {


### PR DESCRIPTION
Migrate the `DB` away from a monomorphic type in `atuin-server` to a runtime polymorphic type.

This unlocks commonizing sqlite and postgresql DB implementations in atuin-server.