### PR TITLE
feat: refactor/improve output capturing mechanism

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -693,9 +693,9 @@ dependencies = [
 
 [[package]]
 name = "atuin-vt100"
-version = "0.17.0"
+version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f1f37e21bb3cc6e1244deb0e7999c0a18da5e3e58caf92befc19ce53f6367e6"
+checksum = "5e1ab415760f579e398bed1931668a5a6866b5c1c7cf3718c889605534a76bab"
 dependencies = [
  "itoa",
  "unicode-width 0.2.2",

--- a/crates/atuin-common/proptest-regressions/string/buffer.txt
+++ b/crates/atuin-common/proptest-regressions/string/buffer.txt
@@ -1,0 +1,9 @@
+# Seeds for failure cases proptest has generated in the past. It is
+# automatically read and these particular cases re-run before any
+# novel cases are generated.
+#
+# It is recommended to check this file in to source control so that
+# everyone who runs the test benefits from these saved cases.
+cc 7ce5082ce073916e0c49466755e844ea0b21f05d28dddbd371e26dc097ccce46 # shrinks to (limit, writes) = (13, ["\0¡aa𐀀", "a", " 0 "])
+cc 36d3c81fca65fbf605c404e4b4e3851405b4a4d7aa4b3631bd6b802a6f14c65f # shrinks to (limit, writes) = (0, [])
+cc 22b14135478f4e208c62ee6dc5a355bce1f23c7aa44c972f8ff87d76d8e47860 # shrinks to (limit, writes) = (0, ["0"])

--- a/crates/atuin-common/src/string.rs
+++ b/crates/atuin-common/src/string.rs
@@ -1,22 +1,29 @@
 //! String-related utilities and extension traits.
+
 use std::fmt::{self, Write as _};
+
+#[cfg(feature = "unicode")]
+use unicode_width::UnicodeWidthStr;
+use url::{Position, Url};
 
 #[cfg(feature = "unicode")]
 pub mod align;
 #[cfg(feature = "unicode")]
 pub mod ellipsis;
+pub mod trim;
+
+mod buffer;
 mod escape_non_printable_posix_ext;
 mod non_nul_str;
 
 #[cfg(feature = "unicode")]
 pub use align::{AlignExt, Alignment};
+pub use buffer::BoundedBuffer;
 #[cfg(feature = "unicode")]
 pub use ellipsis::EllipsizeExt;
 pub use escape_non_printable_posix_ext::EscapeNonPrintablePosixExt;
 pub use non_nul_str::{ContainsNul, NonNulStr};
-#[cfg(feature = "unicode")]
-use unicode_width::UnicodeWidthStr;
-use url::{Position, Url};
+pub use trim::TrimExt;
 
 /// Extension trait for [`Url`] to render a `Debug` representation with any
 /// password redacted.

--- a/crates/atuin-common/src/string/buffer.rs
+++ b/crates/atuin-common/src/string/buffer.rs
@@ -90,6 +90,7 @@ impl fmt::Write for BoundedBuffer {
 mod tests {
     use std::fmt::Write as _;
 
+    use proptest::prelude::*;
     use rstest::{fixture, rstest};
 
     use super::BoundedBuffer;
@@ -207,5 +208,114 @@ mod tests {
     fn into_data_returns_what_was_kept(mut buffer: BoundedBuffer) {
         let _ = buffer.write_str("abcdefghij");
         assert_eq!(buffer.into_data(), "abcdefgh");
+    }
+
+    /// Feed `writes` into a fresh buffer of `limit` bytes, ignoring the write results.
+    fn filled(limit: usize, writes: &[String]) -> BoundedBuffer {
+        let mut buffer = BoundedBuffer::new(limit);
+        for write in writes {
+            let _ = buffer.write_str(write);
+        }
+        buffer
+    }
+
+    prop_compose! {
+        /// A limit small enough that the writes below regularly overflow it.
+        fn limit_and_writes()(
+            limit in 0usize..24,
+            writes in prop::collection::vec("(?s).{0,8}", 0..8),
+        ) -> (usize, Vec<String>) {
+            (limit, writes)
+        }
+    }
+
+    proptest! {
+        /// The whole point of the type: whatever it is fed, it never grows past its limit.
+        #[test]
+        fn never_exceeds_the_limit((limit, writes) in limit_and_writes()) {
+            let buffer = filled(limit, &writes);
+            prop_assert!(buffer.data().len() <= limit);
+            prop_assert_eq!(buffer.limit(), limit);
+        }
+
+        /// What is kept is exactly the longest prefix of everything written that fits, cut on a
+        /// character boundary. `data()` being a `&str` at all also proves the cut kept it UTF-8.
+        #[test]
+        fn keeps_the_longest_prefix_that_fits((limit, writes) in limit_and_writes()) {
+            let all = writes.concat();
+            let buffer = filled(limit, &writes);
+            prop_assert_eq!(buffer.data(), &all[..all.floor_char_boundary(limit)]);
+        }
+
+        /// How the data is split across writes cannot change the result.
+        #[test]
+        fn chunking_does_not_matter((limit, writes) in limit_and_writes()) {
+            let chunked = filled(limit, &writes);
+            let at_once = filled(limit, &[writes.concat()]);
+
+            prop_assert_eq!(chunked.data(), at_once.data());
+            prop_assert_eq!(chunked.is_truncated(), at_once.is_truncated());
+        }
+
+        /// Truncation is reported if and only if something was actually dropped.
+        #[test]
+        fn reports_truncation_exactly_when_data_was_dropped((limit, writes) in limit_and_writes()) {
+            let all = writes.concat();
+            let buffer = filled(limit, &writes);
+            prop_assert_eq!(buffer.is_truncated(), all.len() > limit);
+        }
+
+        /// A write fails only once the buffer has given up, and from then on every write fails.
+        #[test]
+        fn writes_fail_only_after_truncation((limit, writes) in limit_and_writes()) {
+            let mut buffer = BoundedBuffer::new(limit);
+            for write in &writes {
+                let was_truncated = buffer.is_truncated();
+                prop_assert_eq!(buffer.write_str(write).is_err(), was_truncated);
+            }
+        }
+
+        /// `take` hands the whole state over and leaves a buffer indistinguishable from a new one.
+        #[test]
+        fn take_moves_the_state_out((limit, writes) in limit_and_writes()) {
+            let mut buffer = filled(limit, &writes);
+            let before = buffer.data().to_string();
+            let was_truncated = buffer.is_truncated();
+
+            let taken = buffer.take();
+            prop_assert_eq!(taken.data(), before);
+            prop_assert_eq!(taken.is_truncated(), was_truncated);
+            prop_assert_eq!(taken.limit(), limit);
+
+            prop_assert_eq!(buffer.data(), "");
+            prop_assert!(!buffer.is_truncated());
+            prop_assert_eq!(buffer.limit(), limit);
+        }
+
+        /// So does `clear`, minus the handing over.
+        #[test]
+        fn clear_is_as_good_as_a_new_buffer((limit, writes) in limit_and_writes()) {
+            let mut buffer = filled(limit, &writes);
+            buffer.clear();
+
+            prop_assert_eq!(buffer.data(), "");
+            prop_assert!(!buffer.is_truncated());
+            prop_assert_eq!(buffer.limit(), limit);
+
+            // And it takes writes again just like a fresh one would.
+            for write in &writes {
+                let _ = buffer.write_str(write);
+            }
+            let fresh = filled(limit, &writes);
+            prop_assert_eq!(buffer.data(), fresh.data());
+        }
+
+        /// Consuming the buffer returns what inspecting it showed.
+        #[test]
+        fn into_data_matches_data((limit, writes) in limit_and_writes()) {
+            let buffer = filled(limit, &writes);
+            let seen = buffer.data().to_string();
+            prop_assert_eq!(buffer.into_data(), seen);
+        }
     }
 }

--- a/crates/atuin-common/src/string/buffer.rs
+++ b/crates/atuin-common/src/string/buffer.rs
@@ -1,0 +1,211 @@
+use std::fmt;
+
+/// A string buffer limited to a certain length.
+#[derive(Clone)]
+pub struct BoundedBuffer {
+    inner: String,
+    limit: usize,
+    truncated: bool,
+}
+
+impl BoundedBuffer {
+    /// Create a new bounded buffer.
+    ///
+    /// `limit` is the maximum length, in bytes, of the buffer.
+    #[must_use]
+    pub fn new(limit: usize) -> Self {
+        Self {
+            inner: String::new(),
+            limit,
+            truncated: false,
+        }
+    }
+
+    /// Get the buffer's maximum length.
+    #[must_use]
+    pub fn limit(&self) -> usize {
+        self.limit
+    }
+
+    /// Inspect the data in the buffer so far.
+    #[must_use]
+    pub fn data(&self) -> &str {
+        &self.inner
+    }
+
+    /// Consume the [`BoundedBuffer`] and return the underlying [`String`].
+    #[must_use]
+    pub fn into_data(self) -> String {
+        self.inner
+    }
+
+    /// Return whether the buffer has been truncated.
+    #[must_use]
+    pub fn is_truncated(&self) -> bool {
+        self.truncated
+    }
+
+    /// Replace this buffer with an empty one, and return the old full buffer.
+    ///
+    /// The buffer's limit is maintained.
+    #[must_use]
+    pub fn take(&mut self) -> Self {
+        Self {
+            inner: std::mem::take(&mut self.inner),
+            truncated: std::mem::take(&mut self.truncated),
+            limit: self.limit,
+        }
+    }
+
+    /// Clear the buffer.
+    pub fn clear(&mut self) {
+        self.inner.clear();
+        self.truncated = false;
+    }
+}
+
+/// Implementation of [`fmt::Write`] for [`BoundedBuffer`].
+///
+/// [`BoundedBuffer`] will return [`fmt::Error`] only when the buffer is full and cannot accept any
+/// more data.
+impl fmt::Write for BoundedBuffer {
+    fn write_str(&mut self, s: &str) -> fmt::Result {
+        if self.truncated {
+            return Err(fmt::Error);
+        }
+
+        let available = self.limit - self.inner.len();
+        if available >= s.len() {
+            self.inner.push_str(s);
+            return Ok(());
+        }
+
+        self.inner.push_str(&s[..s.floor_char_boundary(available)]);
+        self.truncated = true;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fmt::Write as _;
+
+    use rstest::{fixture, rstest};
+
+    use super::BoundedBuffer;
+
+    const LIMIT: usize = 8;
+
+    #[fixture]
+    fn buffer(#[default(LIMIT)] limit: usize) -> BoundedBuffer {
+        BoundedBuffer::new(limit)
+    }
+
+    #[rstest]
+    #[case::empty(&[], "")]
+    #[case::one_write(&["abc"], "abc")]
+    #[case::several_writes(&["ab", "cd", "ef"], "abcdef")]
+    #[case::exactly_the_limit(&["abcdefgh"], "abcdefgh")]
+    #[case::exactly_the_limit_in_pieces(&["abcd", "efgh"], "abcdefgh")]
+    fn keeps_everything_that_fits(
+        mut buffer: BoundedBuffer,
+        #[case] writes: &[&str],
+        #[case] expected: &str,
+    ) {
+        for write in writes {
+            assert!(buffer.write_str(write).is_ok());
+        }
+
+        assert_eq!(buffer.data(), expected);
+        assert!(!buffer.is_truncated(), "nothing was dropped, so nothing to report");
+    }
+
+    #[rstest]
+    // The write that overflows keeps the part that fits, and reports the truncation.
+    #[case::one_oversized_write(&["abcdefghij"], "abcdefgh")]
+    #[case::overflows_part_way(&["abcdef", "ghij"], "abcdefgh")]
+    // A write that lands exactly on the limit is not itself a truncation, but the next one is.
+    #[case::full_then_more(&["abcdefgh", "i"], "abcdefgh")]
+    fn reports_truncation(
+        mut buffer: BoundedBuffer,
+        #[case] writes: &[&str],
+        #[case] expected: &str,
+    ) {
+        for write in writes {
+            let _ = buffer.write_str(write);
+        }
+
+        assert_eq!(buffer.data(), expected);
+        assert!(buffer.is_truncated());
+        assert!(buffer.data().len() <= buffer.limit());
+    }
+
+    #[rstest]
+    fn a_full_buffer_rejects_further_writes(mut buffer: BoundedBuffer) {
+        assert!(buffer.write_str("abcdefghij").is_ok(), "the overflowing write itself succeeds");
+        assert!(buffer.write_str("more").is_err());
+        assert_eq!(buffer.data(), "abcdefgh");
+    }
+
+    #[rstest]
+    #[case::multibyte_split(&["ab", "cdef🦀"], "abcdef")]
+    #[case::multibyte_does_not_fit_at_all(&["abcdefg", "🦀"], "abcdefg")]
+    #[case::multibyte_fits_exactly(&["abcd", "🦀"], "abcd🦀")]
+    fn never_splits_a_character(
+        mut buffer: BoundedBuffer,
+        #[case] writes: &[&str],
+        #[case] expected: &str,
+    ) {
+        for write in writes {
+            let _ = buffer.write_str(write);
+        }
+
+        // `data()` returning a `&str` at all is the real assertion: a byte-wise cut would
+        // have made the buffer invalid UTF-8.
+        assert_eq!(buffer.data(), expected);
+    }
+
+    // Sized per case rather than via the fixture, which only takes literal arguments.
+    #[rstest]
+    #[case::zero(0)]
+    #[case::one(1)]
+    fn tiny_limits(#[case] limit: usize) {
+        let mut buffer = BoundedBuffer::new(limit);
+        let _ = buffer.write_str("hello");
+
+        assert_eq!(buffer.data().len(), limit);
+        assert!(buffer.is_truncated());
+    }
+
+    #[rstest]
+    fn take_hands_over_the_contents_and_resets(mut buffer: BoundedBuffer) {
+        let _ = buffer.write_str("abcdefghij");
+
+        let taken = buffer.take();
+        assert_eq!(taken.data(), "abcdefgh");
+        assert!(taken.is_truncated());
+
+        // The original is empty again, keeps its limit, and accepts writes once more.
+        assert_eq!(buffer.data(), "");
+        assert!(!buffer.is_truncated());
+        assert_eq!(buffer.limit(), LIMIT);
+        assert!(buffer.write_str("xy").is_ok());
+        assert_eq!(buffer.data(), "xy");
+    }
+
+    #[rstest]
+    fn clear_resets_the_truncation_flag(mut buffer: BoundedBuffer) {
+        let _ = buffer.write_str("abcdefghij");
+        buffer.clear();
+
+        assert_eq!(buffer.data(), "");
+        assert!(!buffer.is_truncated());
+        assert!(buffer.write_str("xy").is_ok());
+    }
+
+    #[rstest]
+    fn into_data_returns_what_was_kept(mut buffer: BoundedBuffer) {
+        let _ = buffer.write_str("abcdefghij");
+        assert_eq!(buffer.into_data(), "abcdefgh");
+    }
+}

--- a/crates/atuin-common/src/string/trim.rs
+++ b/crates/atuin-common/src/string/trim.rs
@@ -1,0 +1,172 @@
+mod sealed {
+    pub trait Sealed {}
+}
+
+/// A pattern that, unlike `std::str::pattern::Pattern`, does not consume the pattern when used.
+// Because `std::str::pattern::Pattern` is unstable, we cannot implement `PatternRef` in terms of
+// it. Ideally this trait would be very simple -- an associated type `Self::Pattern<'a>` that
+// implements `std::str::pattern::Pattern`, and a method to go from `&'a mut Self` to
+// `Self::Pattern<'a>`. But because the standard library trait is unstable, we need to implement
+// every `Pattern`-accepting `str` method we want to use here.
+pub trait PatternRef: sealed::Sealed {
+    fn trim_start_matches<'a>(&mut self, s: &'a str) -> &'a str;
+    fn trim_end_matches<'a>(&mut self, s: &'a str) -> &'a str;
+}
+
+macro_rules! impl_pattern_ref {
+    ([$($gen:tt)*], $ty:ty, $to_pattern:expr) => {
+        impl<$($gen)*> sealed::Sealed for $ty {}
+
+        impl<$($gen)*> PatternRef for $ty {
+            fn trim_start_matches<'a>(&mut self, s: &'a str) -> &'a str {
+                s.trim_start_matches(($to_pattern)(self))
+            }
+
+            fn trim_end_matches<'a>(&mut self, s: &'a str) -> &'a str {
+                s.trim_end_matches(($to_pattern)(self))
+            }
+        }
+    };
+}
+
+// Implement `PatternRef` for all of the types that implement `Pattern`.
+impl_pattern_ref!([], char, Clone::clone);
+impl_pattern_ref!([const N: usize], [char; N], Clone::clone);
+impl_pattern_ref!([const N: usize], &[char; N], Clone::clone);
+impl_pattern_ref!([], &[char], Clone::clone);
+impl_pattern_ref!([], &str, Clone::clone);
+impl_pattern_ref!([], &&str, Clone::clone);
+impl_pattern_ref!([F: FnMut(char) -> bool], F, std::convert::identity);
+
+pub trait TrimExt {
+    /// Like [`str::trim_matches`], but modifies the [`String`] in-place instead of returning a
+    /// substring.
+    fn trim_matches_in_place<P: PatternRef>(&mut self, pattern: P);
+
+    /// Like [`str::trim`], but modifies the [`String`] in-place instead of returning a substring.
+    fn trim_in_place(&mut self) {
+        self.trim_matches_in_place(char::is_whitespace);
+    }
+}
+
+impl TrimExt for String {
+    fn trim_matches_in_place<P>(&mut self, mut pattern: P)
+    where
+        P: PatternRef,
+    {
+        self.truncate(pattern.trim_end_matches(self).len());
+        self.drain(..self.len() - pattern.trim_start_matches(self).len());
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use proptest::prelude::*;
+    use rstest::rstest;
+
+    use super::TrimExt;
+
+    /// Run `trim_matches_in_place` over an owned copy of `input`.
+    fn trimmed(input: &str, pattern: impl super::PatternRef) -> String {
+        let mut string = input.to_string();
+        string.trim_matches_in_place(pattern);
+        string
+    }
+
+    #[rstest]
+    #[case::both_ends("xxhixx", "hi")]
+    #[case::leading_only("xxhi", "hi")]
+    #[case::trailing_only("hixx", "hi")]
+    #[case::interior_kept("xhixhix", "hixhi")]
+    #[case::no_match("hi", "hi")]
+    #[case::all_pattern("xxxx", "")]
+    #[case::empty("", "")]
+    #[case::single_char("x", "")]
+    fn trims_a_char_pattern(#[case] input: &str, #[case] expected: &str) {
+        assert_eq!(trimmed(input, 'x'), expected);
+    }
+
+    #[rstest]
+    #[case::blank_lines_and_spaces("\n\n  hi there  \n\n", "hi there")]
+    #[case::mixed_run(" \n \n hi", "hi")]
+    #[case::interior_newline_kept("\none\ntwo\n", "one\ntwo")]
+    fn trims_a_char_array_pattern(#[case] input: &str, #[case] expected: &str) {
+        assert_eq!(trimmed(input, ['\n', ' ']), expected);
+        assert_eq!(trimmed(input, &['\n', ' ']), expected);
+        // A slice, too: `str::trim_matches` accepts one, so `PatternRef` has to as well.
+        assert_eq!(trimmed(input, &['\n', ' '][..]), expected);
+    }
+
+    #[rstest]
+    #[case::str_pattern("abcXabc", "abc", "X")]
+    #[case::repeated_str_pattern("abcabcXabcabc", "abc", "X")]
+    #[case::partial_match_kept("abXab", "abc", "abXab")]
+    fn trims_a_str_pattern(#[case] input: &str, #[case] pattern: &str, #[case] expected: &str) {
+        assert_eq!(trimmed(input, pattern), expected);
+        assert_eq!(trimmed(input, &pattern), expected);
+    }
+
+    #[rstest]
+    #[case::digits("123hi456", "hi")]
+    #[case::only_digits("123", "")]
+    #[case::interior_digits_kept("1h2i3", "h2i")]
+    #[case::nothing_to_trim("hi", "hi")]
+    fn trims_a_closure_pattern(#[case] input: &str, #[case] expected: &str) {
+        assert_eq!(trimmed(input, |c: char| c.is_ascii_digit()), expected);
+    }
+
+    #[rstest]
+    #[case::multibyte_pattern("——hi——", '—', "hi")]
+    #[case::multibyte_content_preserved("xx🦀 世界xx", 'x', "🦀 世界")]
+    #[case::multibyte_content_all_trimmed("🦀🦀", '🦀', "")]
+    fn handles_multibyte_characters(
+        #[case] input: &str,
+        #[case] pattern: char,
+        #[case] expected: &str,
+    ) {
+        assert_eq!(trimmed(input, pattern), expected);
+    }
+
+    #[rstest]
+    #[case::ascii_whitespace(" \t\r\nhi \t\r\n", "hi")]
+    #[case::unicode_whitespace("\u{3000}hi\u{3000}", "hi")]
+    #[case::interior_kept("  a b  ", "a b")]
+    #[case::nothing_to_trim("hi", "hi")]
+    fn trim_in_place_matches_str_trim(#[case] input: &str, #[case] expected: &str) {
+        let mut string = input.to_string();
+        string.trim_in_place();
+        assert_eq!(string, expected);
+        assert_eq!(string, input.trim());
+    }
+
+    #[rstest]
+    fn a_stateful_pattern_is_reused_rather_than_consumed() {
+        // The point of `PatternRef`: a single `FnMut` drives both ends.
+        let mut string = "abhixy".to_string();
+        let mut chars: std::collections::HashSet<char> = string.chars().collect();
+        string.trim_matches_in_place(|c| {
+            assert!(chars.remove(&c), "matcher called on nonexistent char, or same char twice");
+            !c.is_ascii_alphabetic() || "abxy".contains(c)
+        });
+        assert_eq!(string, "hi");
+        assert!(chars.is_empty(), "matcher not called on every char");
+    }
+
+    proptest! {
+        /// However the pattern and haystack are chosen, trimming in place must agree with
+        /// `str::trim_matches` and never leave the string on a non-char boundary.
+        #[test]
+        fn agrees_with_str_trim_matches(input in ".{0,64}", pattern in prop::char::range('a', 'e')) {
+            let mut string = input.clone();
+            string.trim_matches_in_place(pattern);
+            prop_assert_eq!(string, input.trim_matches(pattern));
+        }
+
+        #[test]
+        fn agrees_with_str_trim(input in ".{0,64}") {
+            let mut string = input.clone();
+            string.trim_in_place();
+            prop_assert_eq!(string, input.trim());
+        }
+    }
+}

--- a/crates/atuin-common/src/string/trim.rs
+++ b/crates/atuin-common/src/string/trim.rs
@@ -2,7 +2,7 @@ mod sealed {
     pub trait Sealed {}
 }
 
-/// A pattern that, unlike `std::str::pattern::Pattern`, does not consume the pattern when used.
+/// A pattern that, unlike [`std::str::pattern::Pattern`], does not consume the pattern when used.
 // Because `std::str::pattern::Pattern` is unstable, we cannot implement `PatternRef` in terms of
 // it. Ideally this trait would be very simple -- an associated type `Self::Pattern<'a>` that
 // implements `std::str::pattern::Pattern`, and a method to go from `&'a mut Self` to

--- a/crates/atuin-daemon/proto/semantic.proto
+++ b/crates/atuin-daemon/proto/semantic.proto
@@ -7,13 +7,14 @@ service Semantic {
 }
 
 message CommandCapture {
-  // The shell prompt, as rendered by the terminal. Contains SGR escape
+  // The shell prompt, as rendered by the terminal. May contain SGR escape
   // sequences.
   string prompt = 1;
-  // The command typed by the user, as rendered by the terminal. Contains SGR
-  // escape sequences.
+  // The command typed by the user, as rendered by the terminal. May contain
+  // SGR escape sequences.
   string command = 2;
-  // The rendered output of the command itself. Contains SGR escape sequences.
+  // The rendered output of the command itself. May contain SGR escape
+  // sequences.
   string output = 3;
   optional int32 exit_code = 4;
   optional string history_id = 5;

--- a/crates/atuin-daemon/proto/semantic.proto
+++ b/crates/atuin-daemon/proto/semantic.proto
@@ -7,8 +7,13 @@ service Semantic {
 }
 
 message CommandCapture {
+  // The shell prompt, as rendered by the terminal. Contains SGR escape
+  // sequences.
   string prompt = 1;
+  // The command typed by the user, as rendered by the terminal. Contains SGR
+  // escape sequences.
   string command = 2;
+  // The rendered output of the command itself. Contains SGR escape sequences.
   string output = 3;
   optional int32 exit_code = 4;
   optional string history_id = 5;

--- a/crates/atuin-pty-proxy/src/capture.rs
+++ b/crates/atuin-pty-proxy/src/capture.rs
@@ -56,6 +56,7 @@ impl CommandCapture {
     }
 }
 
+/// Type implementing [`vt100::Callbacks`], used for capturing terminal scrollback.
 struct Scrollback {
     buffer: BoundedBuffer,
     state: vt100::capture::BasicFormattedCaptureState,
@@ -81,11 +82,19 @@ impl vt100::Callbacks for Scrollback {
     }
 }
 
+/// Represents rendered terminal output.
 struct RenderedOutput {
+    /// The terminal data. This may contain SGR escape sequences.
     pub data: String,
+    /// Whether the data has been truncated (exceeded the maximum buffer size).
     pub truncated: bool,
 }
 
+/// The "core" of a [`CommandCaptureTracker`].
+///
+/// This is a separate type to satisfy Rust's borrowing rules. [`CommandCaptureTracker::push`] can't
+/// call other [`CommandCaptureTracker`] methods while [`CommandCaptureTracker::osc_parser`] is
+/// borrowed, so instead we put those methods in a separate type, [`TrackerCore`].
 struct TrackerCore {
     capture: CommandCapture,
     emulator: vt100::Parser<Scrollback>,

--- a/crates/atuin-pty-proxy/src/capture.rs
+++ b/crates/atuin-pty-proxy/src/capture.rs
@@ -1,206 +1,416 @@
 use std::num::NonZeroU16;
-use std::sync::Arc;
-use std::sync::atomic::{AtomicU16, Ordering};
 
-use atuin_common::ansi;
+use atuin_common::string::{BoundedBuffer, TrimExt as _};
 
-use crate::osc133::{Event, Params, Parser, Zone};
+use crate::osc133::{self, Event, EventChunk, EventChunks, Param, Zone};
 
-const HISTORY_ID_PARAM: &str = "history_id";
-const SESSION_ID_PARAM: &str = "session_id";
-const MAX_OUTPUT_CAPTURE_BYTES: usize = 1024 * 1024;
+/// Clears the screen while maintaining cursor position.
+///
+/// We specifically want to clear *without* keeping the current attributes; otherwise the cleared
+/// cells could have background colors etc. So, we save the cursor and attributes with `ESC 7`,
+/// reset the attributes with `CSI m`, clear the screen with `CSI 2 J`, and restore the cursor and
+/// attributes with `ESC 8`.
+const CLEAR_SCREEN_CONTENTS: &[u8] = b"\x1b7\x1b[m\x1b[2J\x1b8";
+const DISABLE_ALTERNATE_SCREEN: &[u8] = b"\x1b[?1049l";
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+const HISTORY_ID_PARAM: &[u8] = b"history_id";
+const SESSION_ID_PARAM: &[u8] = b"session_id";
+
+/// The maximum number of bytes captured per zone.
+///
+/// During the process of capturing, the buffer might grow past this point, but never by more than
+/// one screenful, which is almost certainly only a small fraction of this limit.
+const MAX_CAPTURE_BYTES: usize = 1024 * 1024;
+
+pub type CommandCaptureSink = Box<dyn Fn(CommandCapture) + Send + 'static>;
+
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
 pub struct CommandCapture {
+    /// The shell prompt, as rendered by the terminal. Contains SGR escape sequences.
     pub prompt: String,
+    /// The command typed by the user, as rendered by the terminal. Contains SGR escape sequences.
     pub command: String,
+    /// The rendered output of the command itself. Contains SGR escape sequences.
     pub output: String,
     pub exit_code: Option<i32>,
     pub history_id: Option<String>,
     pub session_id: Option<String>,
-    pub output_truncated: bool,
     pub output_observed_bytes: u64,
+    pub output_truncated: bool,
 }
 
-pub type CommandCaptureSink = Box<dyn Fn(CommandCapture) + Send + 'static>;
-
-#[derive(Default)]
-struct CaptureBuffers {
-    prompt: Vec<u8>,
-    command: Vec<u8>,
-    output: Vec<u8>,
-    output_observed_bytes: u64,
-    output_truncated: bool,
-    exit_code: Option<i32>,
-    history_id: Option<String>,
-    session_id: Option<String>,
+impl CommandCapture {
+    /// Clear the [`CommandCapture`], resetting it to the default state.
+    ///
+    /// This may be more efficient than creating a new [`CommandCapture`], because it preserves
+    /// the capacity of the [`String`] members.
+    fn clear(&mut self) {
+        self.prompt.clear();
+        self.command.clear();
+        self.output.clear();
+        self.exit_code = None;
+        self.history_id = None;
+        self.session_id = None;
+        self.output_observed_bytes = 0;
+        self.output_truncated = false;
+    }
 }
 
-pub struct CommandCaptureTracker {
-    parser: Parser,
+struct Scrollback {
+    buffer: BoundedBuffer,
+    state: vt100::capture::BasicFormattedCaptureState,
     zone: Zone,
-    buffers: CaptureBuffers,
-    cols: Arc<AtomicU16>,
 }
 
-impl CommandCaptureTracker {
-    pub(crate) fn new(cols: Arc<AtomicU16>) -> Self {
+impl Scrollback {
+    pub fn new() -> Self {
         Self {
-            parser: Parser::new(),
+            buffer: BoundedBuffer::new(MAX_CAPTURE_BYTES),
+            state: Default::default(),
             zone: Zone::Unknown,
-            buffers: CaptureBuffers::default(),
-            cols,
+        }
+    }
+}
+
+impl vt100::Callbacks for Scrollback {
+    fn on_scroll(&mut self, contents: vt100::capture::RowContents<'_>, alternate_screen: bool) {
+        if alternate_screen || self.zone == Zone::Unknown {
+            return;
+        }
+        let _ = contents.write_formatted_basic(&mut self.buffer, &mut self.state);
+    }
+}
+
+struct RenderedOutput {
+    pub data: String,
+    pub truncated: bool,
+}
+
+struct TrackerCore {
+    capture: CommandCapture,
+    emulator: vt100::Parser<Scrollback>,
+    sink: CommandCaptureSink,
+}
+
+impl TrackerCore {
+    fn zone(&self) -> Zone {
+        self.emulator.callbacks().zone
+    }
+
+    fn zone_mut(&mut self) -> &mut Zone {
+        &mut self.emulator.callbacks_mut().zone
+    }
+
+    /// Capture and return the rendered output currently on the screen.
+    ///
+    /// This also includes rows that have scrolled off the screen. This method resets the scrollback
+    /// buffers but not the screen. Most likely, you will not want to call this method again until
+    /// you clear the screen.
+    fn take_rendered(&mut self) -> RenderedOutput {
+        let scrollback = self.emulator.callbacks_mut();
+        let mut buffer = scrollback.buffer.take();
+        let mut state = std::mem::take(&mut scrollback.state);
+
+        let _ = self.emulator.screen().write_contents_formatted_basic(&mut buffer, &mut state);
+
+        RenderedOutput {
+            truncated: buffer.is_truncated(),
+            data: buffer.into_data(),
         }
     }
 
-    pub(crate) fn push(&mut self, data: &[u8], mut on_capture: impl FnMut(CommandCapture)) {
-        let mut events = Vec::new();
-        self.parser.push_located(data, |located| events.push(located));
-
-        let mut start = 0;
-        for located in events {
-            let marker_start = located.start_offset.min(data.len()).max(start);
-            let offset = located.offset.min(data.len());
-            self.append(&data[start..marker_start]);
-            self.handle_event(located.event, &located.params, &mut on_capture);
-            self.zone = located.zone;
-            start = offset;
-        }
-
-        let append_end = self
-            .parser
-            .incomplete_osc_sequence_start()
-            .map_or(data.len(), |sequence_start| sequence_start.min(data.len()).max(start));
-        if start < append_end {
-            self.append(&data[start..append_end]);
-        }
+    /// Clear an in-progress capture and the scrollback buffer.
+    fn clear_capture(&mut self) {
+        self.capture.clear();
+        let scrollback = self.emulator.callbacks_mut();
+        scrollback.buffer.clear();
+        scrollback.state = Default::default();
     }
 
-    fn append(&mut self, data: &[u8]) {
-        match self.zone {
-            Zone::Prompt => self.buffers.prompt.extend_from_slice(data),
-            Zone::Input => self.buffers.command.extend_from_slice(data),
-            Zone::Output => self.append_output(data),
+    /// Store a capture of the current zone into the in-progress [`CommandCapture`].
+    fn store_capture(&mut self) {
+        // Before storing the capture, we trim leading and trailing newlines; these correspond to
+        // blank lines in the terminal. For command output, we don't trim spaces since indentation
+        // is meaningful. For the prompt and command, we do, since they can start in the middle of a
+        // line.
+        //
+        // Note that we will end up trimming leading/trailing space that is technically part of the
+        // zone itself too, as it cannot be easily distinguished from empty parts of the terminal
+        // (in some cases it is effectively impossible).
+
+        let zone = self.zone();
+
+        // Capture a "basic" zone (`Prompt` or `Input`) and return the rendered output. This trims
+        // leading and trailing newlines and spaces.
+        let mut capture_basic = || {
+            let mut data = self.take_rendered().data;
+            data.trim_matches_in_place(['\n', ' ']);
+            data
+        };
+
+        match zone {
+            Zone::Prompt => {
+                self.capture.prompt = capture_basic();
+            }
+            Zone::Input => {
+                self.capture.command = capture_basic();
+            }
+            Zone::Output => {
+                let mut rendered = self.take_rendered();
+                rendered.data.trim_matches_in_place('\n');
+                self.capture.output = rendered.data;
+                self.capture.output_truncated |= rendered.truncated;
+            }
             Zone::Unknown => {}
         }
     }
 
-    fn append_output(&mut self, data: &[u8]) {
-        self.buffers.output_observed_bytes =
-            self.buffers.output_observed_bytes.saturating_add(data.len() as u64);
-
-        if self.buffers.output_truncated {
+    /// Enter a new OSC 133 zone.
+    ///
+    /// This is a no-op if we're already in that zone.
+    fn enter_zone(&mut self, zone: Zone) {
+        let current_zone = self.zone();
+        if zone == self.zone() {
             return;
         }
 
-        let remaining = MAX_OUTPUT_CAPTURE_BYTES.saturating_sub(self.buffers.output.len());
-        let retained = data.len().min(remaining);
-        self.buffers.output_truncated = retained < data.len();
+        if self.emulator.screen().alternate_screen() {
+            // If we're in the alternate screen, leave it. We don't capture anything on the
+            // alternate screen (see `Scrollback::on_scroll`). We do not expect to be on the
+            // alternate screen when switching zones (something has gone wrong in this case,
+            // potentially garbage data), so we disable it here as a last resort, just to ensure
+            // we're in a consistent state, and to recover as much of the main screen output as
+            // possible.
+            self.emulator.process(DISABLE_ALTERNATE_SCREEN);
+        }
 
-        if retained > 0 {
-            self.buffers.output.extend_from_slice(&data[..retained]);
+        if matches!(
+            (current_zone, zone),
+            (Zone::Unknown, _) | (Zone::Output, Zone::Prompt | Zone::Input)
+        ) {
+            // If we're coming from the `Unknown` zone, clear the capture to ensure we start in a
+            // fresh state -- there could be a stale capture for which we never received a history
+            // ID.
+            //
+            // If we're in the `Output` zone (capturing command output) but we transition directly
+            // into `Prompt` or `Input` (starting a new command), also clear the capture. Without a
+            // history ID, we can't do anything with it.
+            self.clear_capture();
+        } else {
+            self.store_capture();
+        }
+
+        // Always clear the screen before entering the next zone. This way, we can obtain just this
+        // zone's output without confusing it for the old output of previous zones.
+        self.emulator.process(CLEAR_SCREEN_CONTENTS);
+        *self.zone_mut() = zone;
+    }
+
+    fn finish_capture(&mut self) {
+        let capture = std::mem::take(&mut self.capture);
+        if capture.command.is_empty() && capture.output.is_empty() {
+            return;
+        }
+        (self.sink)(capture);
+    }
+
+    fn handle_chunk<'a>(&mut self, chunk: EventChunk<'_>, params: impl Iterator<Item = Param<'a>>) {
+        let prev_zone = self.zone();
+        self.enter_zone(chunk.event.zone());
+
+        let Event::CommandFinished { exit_code } = chunk.event else {
+            return;
+        };
+
+        let count = &mut self.capture.output_observed_bytes;
+        // If we were just in the output zone, the OSC 133 "command finished" bytes were counted
+        // toward the total. Correct the count by subtracting them. Note that we cannot safely do
+        // this if the count is `u64::MAX` because it might have saturated, so we don't know the
+        // true count. This case is exceedingly unlikely however.
+        if prev_zone == Zone::Output && *count != u64::MAX {
+            *count = count.saturating_sub(u64::try_from(chunk.osc_len).unwrap_or(u64::MAX));
+        }
+
+        let mut history_id = None;
+        let mut session_id = None;
+        for param in params {
+            match param {
+                Param::KeyValue {
+                    key: HISTORY_ID_PARAM,
+                    value,
+                } => {
+                    history_id = Some(value);
+                }
+                Param::KeyValue {
+                    key: SESSION_ID_PARAM,
+                    value,
+                } => {
+                    session_id = Some(value);
+                }
+                _ => {}
+            }
+        }
+
+        let Some(history_id) = history_id else {
+            // We can't finish the capture without a history ID. Hold on to the capture for now
+            // in case we get another `CommandFinished` event that does have an ID.
+            return;
+        };
+        if exit_code.is_some() {
+            self.capture.exit_code = exit_code;
+        }
+        self.capture.history_id = Some(String::from_utf8_lossy(history_id).into_owned());
+        self.capture.session_id = session_id.map(|b| String::from_utf8_lossy(b).into_owned());
+        self.finish_capture();
+    }
+
+    /// Pass data to the vt100 emulator, adding it to the output total if necessary.
+    fn process_counted(&mut self, data: &[u8]) {
+        self.emulator.process(data);
+        if self.zone() == Zone::Output {
+            let count = &mut self.capture.output_observed_bytes;
+            let data_len = u64::try_from(data.len()).unwrap_or(u64::MAX);
+            *count = count.saturating_add(data_len);
         }
     }
 
-    fn handle_event(
-        &mut self,
-        event: Event,
-        params: &Params,
-        on_capture: &mut impl FnMut(CommandCapture),
-    ) {
-        match event {
-            Event::PromptStart => {
-                if self.zone != Zone::Prompt {
-                    self.buffers = CaptureBuffers::default();
-                }
-            }
-            Event::CommandStart | Event::CommandExecuted => {}
-            Event::CommandFinished { exit_code } => {
-                let Some(history_id) = params.get(HISTORY_ID_PARAM).map(str::to_owned) else {
-                    return;
-                };
+    fn handle_chunks(&mut self, mut chunks: EventChunks<'_, '_>) {
+        while let Some(chunk) = chunks.next() {
+            self.process_counted(chunk.data);
+            self.handle_chunk(chunk, chunks.params());
+        }
+        self.process_counted(chunks.trailing_data());
+    }
+}
 
-                if exit_code.is_some() || self.buffers.exit_code.is_none() {
-                    self.buffers.exit_code = exit_code;
-                }
-                self.buffers.history_id = Some(history_id);
-                self.buffers.session_id = params.get(SESSION_ID_PARAM).map(str::to_owned);
+pub struct CommandCaptureTracker {
+    osc_parser: osc133::Parser,
+    core: TrackerCore,
+}
 
-                if let Some(capture) = self.finish_capture() {
-                    on_capture(capture);
-                }
-            }
+impl CommandCaptureTracker {
+    pub fn new(rows: NonZeroU16, cols: NonZeroU16, sink: CommandCaptureSink) -> Self {
+        Self {
+            osc_parser: osc133::Parser::new(),
+            core: TrackerCore {
+                capture: CommandCapture::default(),
+                emulator: vt100::Parser::new_with_callbacks(rows, cols, 0, Scrollback::new()),
+                sink,
+            },
         }
     }
 
-    fn finish_capture(&mut self) -> Option<CommandCapture> {
-        let buffers = std::mem::take(&mut self.buffers);
-        // A terminal width of 0 (e.g. before the size is known) falls back to 1.
-        let cols = NonZeroU16::new(self.cols.load(Ordering::Relaxed)).unwrap_or(NonZeroU16::MIN);
-        let prompt = ansi::to_plain_text(&buffers.prompt, cols);
-        let command = ansi::to_plain_text(&buffers.command, cols)
-            .trim_matches(|c| c == '\r' || c == '\n')
-            .to_string();
-        let output = ansi::to_plain_text(&buffers.output, cols);
-        let output_truncated = buffers.output_truncated;
-        let output_observed_bytes = buffers.output_observed_bytes;
-        let exit_code = buffers.exit_code;
-        let history_id = buffers.history_id;
-        let session_id = buffers.session_id;
+    pub fn resize(&mut self, rows: NonZeroU16, cols: NonZeroU16) {
+        self.core.emulator.screen_mut().set_size(rows, cols);
+    }
 
-        if command.is_empty() && output.is_empty() {
-            return None;
-        }
-
-        Some(CommandCapture {
-            prompt,
-            command,
-            output,
-            exit_code,
-            history_id,
-            session_id,
-            output_truncated,
-            output_observed_bytes,
-        })
+    pub fn push(&mut self, data: &[u8]) {
+        self.core.handle_chunks(self.osc_parser.push(data));
     }
 }
 
 #[cfg(test)]
 mod tests {
+    use std::sync::mpsc::{self, Receiver};
+
     use rstest::{fixture, rstest};
 
     use super::*;
 
+    const ROWS: u16 = 24;
+    const COLS: u16 = 80;
+
+    const PROMPT_START: &[u8] = b"\x1b]133;A\x07";
+    const COMMAND_START: &[u8] = b"\x1b]133;B\x07";
+    const COMMAND_EXECUTED: &[u8] = b"\x1b]133;C\x07";
+
+    /// A [`CommandCaptureTracker`] together with the captures its sink has been handed.
+    struct Tracker {
+        inner: CommandCaptureTracker,
+        received: Receiver<CommandCapture>,
+        collected: Vec<CommandCapture>,
+    }
+
+    impl Tracker {
+        fn new(rows: u16, cols: u16) -> Self {
+            let (sender, received) = mpsc::channel();
+            Self {
+                inner: CommandCaptureTracker::new(
+                    nonzero(rows),
+                    nonzero(cols),
+                    Box::new(move |capture| {
+                        sender.send(capture).expect("test receiver is still alive");
+                    }),
+                ),
+                received,
+                collected: Vec::new(),
+            }
+        }
+
+        fn push(&mut self, data: &[u8]) -> &mut Self {
+            self.inner.push(data);
+            self
+        }
+
+        fn resize(&mut self, rows: u16, cols: u16) -> &mut Self {
+            self.inner.resize(nonzero(rows), nonzero(cols));
+            self
+        }
+
+        /// Every capture reported so far.
+        fn captures(&mut self) -> Vec<CommandCapture> {
+            self.collected.extend(self.received.try_iter());
+            self.collected.clone()
+        }
+
+        /// Assert that exactly one capture was reported, and return it.
+        fn only_capture(&mut self) -> CommandCapture {
+            let mut captures = self.captures();
+            assert_eq!(captures.len(), 1, "expected exactly one capture, got {captures:#?}");
+            captures.pop().expect("length checked above")
+        }
+    }
+
+    fn nonzero(value: u16) -> NonZeroU16 {
+        NonZeroU16::new(value).expect("test dimensions are non-zero")
+    }
+
+    /// A `D` marker carrying the metadata Atuin's shell integration sends.
+    ///
+    /// Its own bytes are discounted from `output_observed_bytes`, so the totals asserted
+    /// below are the raw command output alone.
+    fn finished(exit_code: i32, history_id: &str, session_id: &str) -> Vec<u8> {
+        format!("\x1b]133;D;{exit_code};history_id={history_id};session_id={session_id}\x07")
+            .into_bytes()
+    }
+
+    /// A whole shell interaction, laid out the way a real shell emits it: the prompt, the
+    /// echoed command line ending in the newline the shell prints when Enter is pressed,
+    /// then the command's output.
+    fn interaction(prompt: &str, command: &str, output: &str) -> Vec<u8> {
+        [
+            PROMPT_START,
+            prompt.as_bytes(),
+            COMMAND_START,
+            command.as_bytes(),
+            b"\r\n",
+            COMMAND_EXECUTED,
+            output.as_bytes(),
+            &finished(0, "hist", "sess"),
+        ]
+        .concat()
+    }
+
     #[fixture]
-    fn tracker(#[default(80)] cols: u16) -> CommandCaptureTracker {
-        CommandCaptureTracker::new(Arc::new(AtomicU16::new(cols)))
+    fn tracker(#[default(ROWS)] rows: u16, #[default(COLS)] cols: u16) -> Tracker {
+        Tracker::new(rows, cols)
     }
 
-    fn assert_no_terminal_controls(text: &str) {
-        assert!(
-            !text.chars().any(|ch| ch.is_control() && ch != '\n' && ch != '\t'),
-            "text still contains terminal controls: {text:?}"
-        );
-    }
+    // -- The happy path -------------------------------------------------------
 
     #[rstest]
-    fn command_text_replays_backspaces(mut tracker: CommandCaptureTracker) {
-        let mut captures = Vec::new();
-
-        let input =
-            b"\x1b]133;A\x07$ \x1b]133;B\x07e\x08echo hi\r\n\x1b]133;C\x07hi\r\n\x1b]133;D;0;history_id=hist;session_id=sess\x07\x1b]133;A\x07$ ";
-        tracker.push(input, |capture| captures.push(capture));
-
-        assert_eq!(captures.len(), 1);
-        assert_eq!(captures[0].command, "echo hi");
-        assert_eq!(captures[0].output, "hi");
-        assert_no_terminal_controls(&captures[0].command);
-        assert_no_terminal_controls(&captures[0].output);
-    }
-
-    #[rstest]
-    #[case::complete_command(
-        b"\x1b]133;A\x07$ \x1b]133;B\x07echo hi\r\n\x1b]133;C\x07hi\r\n\x1b]133;D;0;history_id=hist;session_id=sess\x07\x1b]133;A\x07$ ",
+    #[case::full_interaction(
+        interaction("$ ", "echo hi", "hi\r\n"),
         CommandCapture {
             prompt: "$".to_string(),
             command: "echo hi".to_string(),
@@ -208,12 +418,13 @@ mod tests {
             exit_code: Some(0),
             history_id: Some("hist".to_string()),
             session_id: Some("sess".to_string()),
+            output_observed_bytes: b"hi\r\n".len() as u64,
             output_truncated: false,
-            output_observed_bytes: 4,
-        }
+        },
     )]
-    #[case::output_only_from_d_marker(
-        b"\x1b]133;C\x07line one\r\n\x1b]133;D;0;history_id=018f;session_id=abcd\x07",
+    // Only the execute and finish markers: no prompt or command line to capture.
+    #[case::bare_execute_and_finish_markers(
+        [COMMAND_EXECUTED, b"line one\r\n", &finished(0, "018f", "abcd")].concat(),
         CommandCapture {
             prompt: String::new(),
             command: String::new(),
@@ -221,152 +432,429 @@ mod tests {
             exit_code: Some(0),
             history_id: Some("018f".to_string()),
             session_id: Some("abcd".to_string()),
+            output_observed_bytes: b"line one\r\n".len() as u64,
             output_truncated: false,
-            output_observed_bytes: 10,
-        }
+        },
     )]
-    fn captures_full_command(
-        mut tracker: CommandCaptureTracker,
-        #[case] input: &[u8],
+    fn captures_a_full_command_cycle(
+        mut tracker: Tracker,
+        #[case] input: Vec<u8>,
         #[case] expected: CommandCapture,
     ) {
-        let mut captures = Vec::new();
-        tracker.push(input, |capture| captures.push(capture));
-        assert_eq!(captures, vec![expected]);
+        tracker.push(&input);
+        assert_eq!(tracker.only_capture(), expected);
     }
 
     #[rstest]
-    fn strips_ansi_and_split_markers(mut tracker: CommandCaptureTracker) {
-        let mut captures = Vec::new();
+    fn a_command_with_no_output_is_still_captured(mut tracker: Tracker) {
+        tracker.push(&interaction("$ ", "true", ""));
 
-        tracker.push(b"\x1b]133;A\x07\x1b[32m%\x1b[0m ", |_| {});
-        tracker.push(b"\x1b]133;B\x07ls\x1b]133;C", |_| {});
+        let capture = tracker.only_capture();
+        assert_eq!(capture.command, "true");
+        assert_eq!(capture.output, "");
+        // The command produced nothing, and its `D` marker doesn't count as output.
+        assert_eq!(capture.output_observed_bytes, 0);
+    }
+
+    #[rstest]
+    fn reports_the_exit_code(mut tracker: Tracker) {
+        tracker.push(&[COMMAND_EXECUTED, b"nope\r\n", &finished(127, "hist", "sess")].concat());
+
+        assert_eq!(tracker.only_capture().exit_code, Some(127));
+    }
+
+    #[rstest]
+    // Enter pressed on an empty prompt: no command and no output to report.
+    #[case::empty_command(interaction("$ ", "", ""))]
+    #[case::no_markers(b"just some regular terminal output\r\n".to_vec())]
+    // A finish marker with no history ID can't be attached to anything, and the prompt that
+    // follows means no later marker can supply one either.
+    #[case::finish_without_a_history_id(
+        [COMMAND_EXECUTED, b"line one\r\n\x1b]133;D;0\x07", PROMPT_START, b"$ "].concat()
+    )]
+    fn reports_nothing(mut tracker: Tracker, #[case] input: Vec<u8>) {
+        tracker.push(&input);
+        assert_eq!(tracker.captures(), vec![]);
+    }
+
+    // -- Rendering ------------------------------------------------------------
+
+    #[rstest]
+    fn command_text_replays_backspaces(mut tracker: Tracker) {
+        tracker.push(&interaction("$ ", "e\x08echo hi", "hi\r\n"));
+
+        let capture = tracker.only_capture();
+        assert_eq!(capture.command, "echo hi");
+        assert_eq!(capture.output, "hi");
+    }
+
+    #[rstest]
+    // The whole point of driving a terminal emulator: output that moves the cursor to an
+    // absolute position is captured as it appears, not as it was written.
+    #[case::absolute_cursor_movement(b"one\r\ntwo\r\n\x1b[1;1Hzzz\r\n", "zzz\ntwo")]
+    // Progress bars redraw the same line over and over.
+    #[case::carriage_returns_overwrite_in_place(b"  0%\r 50%\r100%\r\n", "100%")]
+    #[case::backspaces_erase(b"oops\x08\x08\x08\x08done\r\n", "done")]
+    #[case::erase_to_end_of_line(b"long line\r\x1b[Kshort\r\n", "short")]
+    fn output_is_rendered_not_replayed(
+        #[with(6, 20)] mut tracker: Tracker,
+        #[case] output: &[u8],
+        #[case] expected: &str,
+    ) {
+        tracker.push(&[COMMAND_EXECUTED, output, &finished(0, "hist", "sess")].concat());
+        assert_eq!(tracker.only_capture().output, expected);
+    }
+
+    #[rstest]
+    fn output_that_scrolls_off_the_screen_is_kept(#[with(4, 20)] mut tracker: Tracker) {
+        let mut data = COMMAND_EXECUTED.to_vec();
+        for i in 0..10 {
+            data.extend_from_slice(format!("line {i}\r\n").as_bytes());
+        }
+        data.extend_from_slice(&finished(0, "hist", "sess"));
+        tracker.push(&data);
+
+        let expected: Vec<String> = (0..10).map(|i| format!("line {i}")).collect();
+        assert_eq!(tracker.only_capture().output, expected.join("\n"));
+    }
+
+    #[rstest]
+    fn keeps_basic_formatting(mut tracker: Tracker) {
+        tracker.push(&interaction("\x1b[32m%\x1b[0m ", "ls", "\x1b[31mfile\x1b[0m\r\n"));
+
+        let capture = tracker.only_capture();
+        assert_eq!(capture.prompt, "\x1b[32m%\x1b[m");
+        assert_eq!(capture.command, "ls");
+        assert_eq!(capture.output, "\x1b[31mfile");
+    }
+
+    #[rstest]
+    fn attributes_left_set_do_not_fill_the_capture_with_blanks(
+        #[with(6, 20)] mut tracker: Tracker,
+    ) {
+        // Erasing the screen at a zone boundary uses the current attributes, so a command
+        // that leaves a background colour set would otherwise turn the whole screen into
+        // non-default cells, and every one of them into a space in the next capture.
+        tracker
+            .push(&[COMMAND_EXECUTED, b"out\r\n\x1b[41m", &finished(0, "one", "sess")].concat())
+            .push(&interaction("$ ", "id", "\x1b[0mok\r\n"));
+
+        let captures = tracker.captures();
+        assert_eq!(captures.len(), 2);
+        assert_eq!(captures[0].output, "out");
+        assert_eq!(captures[1].prompt, "\x1b[41m$");
+        assert_eq!(captures[1].command, "\x1b[41mid");
+        assert_eq!(captures[1].output, "ok");
+    }
+
+    #[rstest]
+    fn alternate_screen_output_is_not_captured(#[with(6, 20)] mut tracker: Tracker) {
         tracker.push(
-            b"\x07\x1b[31mfile\x1b[0m\r\n\x1b]133;D;1;history_id=hist;session_id=sess\x07\x1b]133;A\x07% ",
-            |capture| {
-                captures.push(capture);
-            },
+            &[
+                PROMPT_START,
+                b"$ ",
+                COMMAND_START,
+                b"vim f\r\n",
+                COMMAND_EXECUTED,
+                b"\x1b[?1049hEDITOR\r\nSCREEN\x1b[?1049l",
+                &finished(0, "hist", "sess"),
+            ]
+            .concat(),
         );
 
-        assert_eq!(captures, vec![CommandCapture {
-            prompt: "%".to_string(),
-            command: "ls".to_string(),
-            output: "file".to_string(),
-            exit_code: Some(1),
-            history_id: Some("hist".to_string()),
-            session_id: Some("sess".to_string()),
-            output_truncated: false,
-            output_observed_bytes: 15,
-        }]);
+        let capture = tracker.only_capture();
+        assert_eq!(capture.command, "vim f");
+        assert_eq!(capture.output, "");
+        // The bytes were still observed, even though none of them were captured.
+        let drawn = b"\x1b[?1049hEDITOR\r\nSCREEN\x1b[?1049l".len();
+        assert_eq!(capture.output_observed_bytes, drawn as u64);
     }
 
     #[rstest]
-    fn duplicate_prompt_start_does_not_reset_prompt_capture(mut tracker: CommandCaptureTracker) {
-        let mut captures = Vec::new();
-
+    fn output_still_in_the_alternate_screen_is_not_captured(#[with(6, 20)] mut tracker: Tracker) {
+        // A zone always begins on the main screen, but it can end on the alternate one if the
+        // command never leaves it. Leaving the alternate screen has to happen before the zone's
+        // capture is stored, or the capture is of the alternate screen's contents.
         tracker.push(
-            b"\x1b]133;A\x07$ \x1b]133;A\x07continued \x1b]133;B\x07echo hi\r\n\x1b]133;C\x07hi\r\n\x1b]133;D;0;history_id=hist;session_id=sess\x07\x1b]133;A\x07$ ",
-            |capture| captures.push(capture),
+            &[
+                PROMPT_START,
+                b"$ ",
+                COMMAND_START,
+                b"vim f\r\n",
+                COMMAND_EXECUTED,
+                b"\x1b[?1049hEDITOR\r\nSCREEN",
+                &finished(0, "hist", "sess"),
+            ]
+            .concat(),
         );
 
-        assert_eq!(captures.len(), 1);
-        assert_eq!(captures[0].prompt, "$ continued");
-        assert_eq!(captures[0].command, "echo hi");
-        assert_eq!(captures[0].output, "hi");
+        let capture = tracker.only_capture();
+        assert_eq!(capture.command, "vim f");
+        assert_eq!(capture.output, "");
     }
 
     #[rstest]
-    fn bare_finish_without_metadata_is_ignored(mut tracker: CommandCaptureTracker) {
-        let mut captures = Vec::new();
+    fn a_zone_never_sees_what_the_previous_one_drew(#[with(6, 20)] mut tracker: Tracker) {
+        tracker
+            .push(&interaction("$ ", "first", "aaa\r\n"))
+            .push(&interaction("$ ", "second", "bbb\r\n"));
 
-        tracker.push(b"\x1b]133;C\x07line one\r\n\x1b]133;D;0\x07", |capture| {
-            captures.push(capture);
-        });
-
-        tracker.push(b"\x1b]133;A\x07$ ", |capture| captures.push(capture));
-
-        assert!(captures.is_empty());
+        let captures = tracker.captures();
+        assert_eq!(captures.len(), 2);
+        assert_eq!(captures[0].command, "first");
+        assert_eq!(captures[0].output, "aaa");
+        assert_eq!(captures[1].command, "second");
+        assert_eq!(captures[1].output, "bbb");
     }
 
     #[rstest]
-    fn bare_finish_before_metadata_in_same_push_ignored(mut tracker: CommandCaptureTracker) {
-        let mut captures = Vec::new();
-
+    fn resets_between_consecutive_bare_command_cycles(mut tracker: Tracker) {
         tracker.push(
-            b"\x1b]133;C\x07line one\r\n\x1b]133;D;1\x07\x1b]133;D;0;history_id=018f;session_id=abcd\x07",
-            |capture| captures.push(capture),
+            &[
+                COMMAND_EXECUTED,
+                b"first\r\n",
+                b"\x1b]133;D;0;history_id=one\x07",
+                COMMAND_EXECUTED,
+                b"second\r\n",
+                b"\x1b]133;D;1;history_id=two\x07",
+            ]
+            .concat(),
         );
 
-        assert_eq!(captures.len(), 1);
-        assert_eq!(captures[0].output, "line one");
-        assert_eq!(captures[0].exit_code, Some(0));
-        assert_eq!(captures[0].history_id.as_deref(), Some("018f"));
-        assert_eq!(captures[0].session_id.as_deref(), Some("abcd"));
-    }
-
-    #[rstest]
-    fn metadata_arriving_after_bare_finish_across_pushes(mut tracker: CommandCaptureTracker) {
-        let mut captures = Vec::new();
-
-        tracker.push(b"\x1b]133;C\x07line one\r\n\x1b]133;D;0\x07", |capture| {
-            captures.push(capture);
-        });
-        tracker.push(b"\x1b]133;D;0;history_id=018f", |capture| captures.push(capture));
-
-        assert!(captures.is_empty());
-
-        tracker.push(b";session_id=abcd\x07", |capture| captures.push(capture));
-
-        assert_eq!(captures.len(), 1);
-        assert_eq!(captures[0].output, "line one");
-        assert_eq!(captures[0].exit_code, Some(0));
-        assert_eq!(captures[0].history_id.as_deref(), Some("018f"));
-        assert_eq!(captures[0].session_id.as_deref(), Some("abcd"));
-    }
-
-    #[rstest]
-    fn split_finish_marker_is_not_counted_as_output(mut tracker: CommandCaptureTracker) {
-        let mut captures = Vec::new();
-
-        tracker.push(b"\x1b]133;C\x07line one\r\n\x1b]133;D;0;history_id=018f", |capture| {
-            captures.push(capture);
-        });
-        assert!(captures.is_empty());
-
-        tracker.push(b";session_id=abcd\x07", |capture| captures.push(capture));
-
-        assert_eq!(captures.len(), 1);
-        assert_eq!(captures[0].output, "line one");
-        assert_eq!(captures[0].output_observed_bytes, 10);
-    }
-
-    #[rstest]
-    fn output_capture_is_capped_and_reports_observed_bytes(mut tracker: CommandCaptureTracker) {
-        let mut captures = Vec::new();
-        let mut input = b"\x1b]133;C\x07".to_vec();
-        input.extend(std::iter::repeat_n(b'x', MAX_OUTPUT_CAPTURE_BYTES + 10));
-        input.extend_from_slice(b"\x1b]133;D;0;history_id=big;session_id=session-1\x07");
-
-        tracker.push(&input, |capture| captures.push(capture));
-
-        assert_eq!(captures.len(), 1);
-        assert!(captures[0].output_truncated);
-        assert_eq!(captures[0].output_observed_bytes, (MAX_OUTPUT_CAPTURE_BYTES + 10) as u64);
-    }
-
-    #[rstest]
-    fn resets_buffers_between_c_d_only_captures(mut tracker: CommandCaptureTracker) {
-        let mut captures = Vec::new();
-
-        tracker.push(
-            b"\x1b]133;C\x07first\r\n\x1b]133;D;0;history_id=one\x07\x1b]133;C\x07second\r\n\x1b]133;D;1;history_id=two\x07",
-            |capture| captures.push(capture),
-        );
-
+        let captures = tracker.captures();
         assert_eq!(captures.len(), 2);
         assert_eq!(captures[0].output, "first");
+        assert_eq!(captures[0].exit_code, Some(0));
         assert_eq!(captures[0].history_id.as_deref(), Some("one"));
         assert_eq!(captures[1].output, "second");
+        assert_eq!(captures[1].exit_code, Some(1));
         assert_eq!(captures[1].history_id.as_deref(), Some("two"));
+    }
+
+    // -- Marker handling ------------------------------------------------------
+
+    #[rstest]
+    fn a_repeated_prompt_marker_keeps_the_whole_prompt(mut tracker: Tracker) {
+        tracker.push(
+            &[
+                PROMPT_START,
+                b"$ ",
+                PROMPT_START,
+                b"continued ",
+                COMMAND_START,
+                b"echo hi\r\n",
+                COMMAND_EXECUTED,
+                b"hi\r\n",
+                &finished(0, "hist", "sess"),
+            ]
+            .concat(),
+        );
+
+        let capture = tracker.only_capture();
+        assert_eq!(capture.prompt, "$ continued");
+        assert_eq!(capture.command, "echo hi");
+        assert_eq!(capture.output, "hi");
+    }
+
+    #[rstest]
+    fn a_command_marker_ahead_of_its_prompt_marker_is_tolerated(mut tracker: Tracker) {
+        // Some shells get the order wrong and mark the command line before the prompt. Entering
+        // the prompt zone from the input zone therefore keeps the capture, and the second input
+        // zone simply overwrites what the first one stored.
+        tracker.push(
+            &[
+                COMMAND_START,
+                b"leftover\r\n",
+                PROMPT_START,
+                b"$ ",
+                COMMAND_START,
+                b"echo hi\r\n",
+                COMMAND_EXECUTED,
+                b"hi\r\n",
+                &finished(0, "hist", "sess"),
+            ]
+            .concat(),
+        );
+
+        let capture = tracker.only_capture();
+        assert_eq!(capture.prompt, "$");
+        assert_eq!(capture.command, "echo hi");
+        assert_eq!(capture.output, "hi");
+    }
+
+    #[rstest]
+    fn a_new_prompt_abandons_an_unreported_capture(mut tracker: Tracker) {
+        // The first command finishes without metadata, so it is never reported. The next
+        // prompt must not inherit any of it.
+        tracker
+            .push(&[COMMAND_EXECUTED, b"stale\r\n\x1b]133;D;0\x07"].concat())
+            .push(&interaction("$ ", "echo hi", "hi\r\n"));
+
+        let capture = tracker.only_capture();
+        assert_eq!(capture.command, "echo hi");
+        assert_eq!(capture.output, "hi");
+        assert_eq!(capture.output_observed_bytes, b"hi\r\n".len() as u64);
+    }
+
+    #[rstest]
+    fn an_abandoned_command_leaves_nothing_on_the_screen(#[with(4, 20)] mut tracker: Tracker) {
+        // No `D` marker at all: the command is abandoned when the next prompt starts. Its rows
+        // have scrolled off the screen, so dropping the capture is not enough on its own -- the
+        // buffer they scrolled into has to be dropped with it.
+        let mut abandoned = COMMAND_EXECUTED.to_vec();
+        for i in 0..8 {
+            abandoned.extend_from_slice(format!("stale {i}\r\n").as_bytes());
+        }
+        tracker.push(&abandoned).push(&interaction("$ ", "echo hi", "hi\r\n"));
+
+        let capture = tracker.only_capture();
+        assert_eq!(capture.prompt, "$");
+        assert_eq!(capture.command, "echo hi");
+        assert_eq!(capture.output, "hi");
+    }
+
+    #[rstest]
+    fn an_unreported_capture_is_abandoned_by_a_bare_command_cycle(mut tracker: Tracker) {
+        // Same as `a_new_prompt_abandons_an_unreported_capture`, but the next command arrives
+        // without a prompt, straight from the unknown zone.
+        tracker.push(
+            &[
+                COMMAND_EXECUTED,
+                b"stale\r\n\x1b]133;D;0\x07",
+                COMMAND_EXECUTED,
+                b"fresh\r\n",
+                &finished(0, "hist", "sess"),
+            ]
+            .concat(),
+        );
+
+        let capture = tracker.only_capture();
+        assert_eq!(capture.output, "fresh");
+        assert_eq!(capture.output_observed_bytes, b"fresh\r\n".len() as u64);
+    }
+
+    #[rstest]
+    fn metadata_from_a_later_finish_marker_is_used(mut tracker: Tracker) {
+        const BARE_FINISH: &[u8] = b"\x1b]133;D;1\x07";
+        tracker.push(
+            &[COMMAND_EXECUTED, b"line one\r\n", BARE_FINISH, &finished(0, "018f", "abcd")]
+                .concat(),
+        );
+
+        assert_eq!(tracker.only_capture(), CommandCapture {
+            prompt: String::new(),
+            command: String::new(),
+            output: "line one".to_string(),
+            exit_code: Some(0),
+            history_id: Some("018f".to_string()),
+            session_id: Some("abcd".to_string()),
+            // The first `D` ends the output zone and is discounted; the second arrives
+            // after it, in the unknown zone, so it was never counted to begin with.
+            output_observed_bytes: b"line one\r\n".len() as u64,
+            output_truncated: false,
+        });
+    }
+
+    #[rstest]
+    fn a_marker_split_across_pushes_is_still_recognised(mut tracker: Tracker) {
+        tracker.push(&[COMMAND_EXECUTED, b"line one\r\n\x1b]133;D;0;history_id=018f"].concat());
+        assert_eq!(tracker.captures(), vec![]);
+
+        tracker.push(b";session_id=abcd\x07");
+
+        let capture = tracker.only_capture();
+        assert_eq!(capture.output, "line one");
+        assert_eq!(capture.history_id.as_deref(), Some("018f"));
+        assert_eq!(capture.session_id.as_deref(), Some("abcd"));
+    }
+
+    #[rstest]
+    fn st_terminated_markers_do_not_leak_into_the_capture(mut tracker: Tracker) {
+        // A marker has to reach the emulator whole. Handing it over with its `ESC \\`
+        // terminator split off would leave the emulator mid-sequence, and the stray
+        // backslash would end up printed on the screen we capture.
+        tracker.push(
+            b"\x1b]133;A\x1b\\$ \x1b]133;B\x1b\\echo hi\r\n\x1b]133;C\x1b\\hi\r\n\x1b]133;D;0;history_id=hist\x1b\\",
+        );
+
+        let capture = tracker.only_capture();
+        assert_eq!(capture.prompt, "$");
+        assert_eq!(capture.command, "echo hi");
+        assert_eq!(capture.output, "hi");
+        assert_eq!(capture.output_observed_bytes, b"hi\r\n".len() as u64);
+    }
+
+    #[rstest]
+    fn splitting_a_marker_across_pushes_does_not_change_the_byte_count(mut tracker: Tracker) {
+        tracker
+            .push(&[COMMAND_EXECUTED, b"line one\r\n\x1b]133;D;0;history_id=018f"].concat())
+            .push(b";session_id=abcd\x07");
+
+        // The same total as if the whole marker had arrived in one push: the marker is
+        // discounted in full, however it was split up.
+        assert_eq!(tracker.only_capture().output_observed_bytes, b"line one\r\n".len() as u64);
+    }
+
+    #[rstest]
+    fn markers_split_at_every_byte_boundary(mut tracker: Tracker) {
+        let input = interaction("$ ", "echo hi", "hi\r\n");
+        for byte in &input {
+            tracker.push(std::slice::from_ref(byte));
+        }
+
+        let capture = tracker.only_capture();
+        assert_eq!(capture.prompt, "$");
+        assert_eq!(capture.command, "echo hi");
+        assert_eq!(capture.output, "hi");
+        assert_eq!(capture.output_observed_bytes, b"hi\r\n".len() as u64);
+    }
+
+    // -- Limits ---------------------------------------------------------------
+
+    #[rstest]
+    fn output_capture_is_capped_and_reports_observed_bytes(mut tracker: Tracker) {
+        const LINE_LEN: usize = 70;
+        const LINES: usize = 40_000;
+
+        let finish = finished(0, "big", "session-1");
+        let mut input = COMMAND_EXECUTED.to_vec();
+        for i in 0..LINES {
+            input.extend_from_slice(format!("{i:0LINE_LEN$}\r\n").as_bytes());
+        }
+        input.extend_from_slice(&finish);
+        tracker.push(&input);
+
+        let capture = tracker.only_capture();
+        assert!(capture.output_truncated);
+        assert_eq!(capture.output.len(), MAX_CAPTURE_BYTES);
+        assert_eq!(capture.output_observed_bytes, ((LINE_LEN + 2) * LINES) as u64);
+    }
+
+    #[rstest]
+    fn a_long_prompt_does_not_mark_the_output_truncated(mut tracker: Tracker) {
+        tracker.push(&interaction("$ ", "echo hi", "hi\r\n"));
+        assert!(!tracker.only_capture().output_truncated);
+    }
+
+    // -- Terminal size --------------------------------------------------------
+
+    #[rstest]
+    fn resizing_reflows_the_capture(#[with(6, 20)] mut tracker: Tracker) {
+        tracker.push(&[COMMAND_EXECUTED, b"abcdefghij"].concat());
+        tracker.resize(6, 5);
+        tracker.push(&[b"klmno\r\n".as_slice(), &finished(0, "hist", "sess")].concat());
+
+        // The first ten columns were rendered on a twenty-column screen; narrowing it drops
+        // what no longer fits, and the rest is appended at the new width.
+        assert_eq!(tracker.only_capture().output, "abcdklmno");
+    }
+
+    #[rstest]
+    fn tiny_terminals_do_not_panic(#[values(1, 2, 3)] rows: u16, #[values(1, 2, 3)] cols: u16) {
+        let mut tracker = Tracker::new(rows, cols);
+        tracker.push(&interaction("$ ", "echo hi", "hello world\r\nsecond line\r\n"));
+
+        // Whatever survives on a terminal this small, we must have reported something.
+        assert_eq!(tracker.captures().len(), 1);
     }
 }

--- a/crates/atuin-pty-proxy/src/debug.rs
+++ b/crates/atuin-pty-proxy/src/debug.rs
@@ -15,28 +15,22 @@ impl Osc133DebugHighlighter {
 
     #[must_use]
     pub(crate) fn render(&mut self, data: &[u8]) -> Vec<u8> {
-        let mut events = Vec::new();
-        self.parser.push_located(data, |located| events.push(located));
+        let mut chunk_iter = self.parser.push(data);
+        let chunks: Vec<_> = chunk_iter.by_ref().collect();
 
-        if events.is_empty() {
+        if chunks.is_empty() {
             return data.to_vec();
         }
 
-        let mut rendered = Vec::with_capacity(data.len() + (events.len() * 64));
-        let mut start = 0;
+        let mut rendered = Vec::with_capacity(data.len() + (chunks.len() * 64));
 
-        for located in events {
-            let offset = located.offset.min(data.len());
-            if offset > start {
-                rendered.extend_from_slice(&data[start..offset]);
-            }
-
-            rendered.extend_from_slice(event_label(located.event));
+        for chunk in chunks {
+            rendered.extend_from_slice(chunk.data);
+            rendered.extend_from_slice(event_label(chunk.event));
             rendered.extend_from_slice(RESET);
-            start = offset;
         }
 
-        rendered.extend_from_slice(&data[start..]);
+        rendered.extend_from_slice(chunk_iter.trailing_data());
         rendered
     }
 }
@@ -49,5 +43,123 @@ fn event_label(event: Event) -> &'static [u8] {
         Event::CommandFinished { exit_code: Some(0) } => b"\x1b[1;37;42m[OSC133:D exit=0]\x1b[0m",
         Event::CommandFinished { exit_code: Some(_) } => b"\x1b[1;37;41m[OSC133:D exit!=0]\x1b[0m",
         Event::CommandFinished { exit_code: None } => b"\x1b[1;37;44m[OSC133:D exit=?]\x1b[0m",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use rstest::{fixture, rstest};
+
+    use super::*;
+
+    /// Strip every debug label (and the reset that follows it) back out of rendered output.
+    fn without_labels(rendered: &[u8]) -> Vec<u8> {
+        let mut out = Vec::new();
+        let mut rest = rendered;
+        'outer: while !rest.is_empty() {
+            for event in EVENTS {
+                let label = [event_label(event), RESET].concat();
+                if let Some(remainder) = rest.strip_prefix(label.as_slice()) {
+                    rest = remainder;
+                    continue 'outer;
+                }
+            }
+            out.push(rest[0]);
+            rest = &rest[1..];
+        }
+        out
+    }
+
+    const EVENTS: [Event; 6] = [
+        Event::PromptStart,
+        Event::CommandStart,
+        Event::CommandExecuted,
+        Event::CommandFinished { exit_code: Some(0) },
+        Event::CommandFinished { exit_code: Some(1) },
+        Event::CommandFinished { exit_code: None },
+    ];
+
+    #[fixture]
+    fn highlighter() -> Osc133DebugHighlighter {
+        Osc133DebugHighlighter::new()
+    }
+
+    #[rstest]
+    #[case::no_markers(b"plain output\r\n")]
+    #[case::csi_only(b"\x1b[32mgreen\x1b[0m")]
+    #[case::non_133_osc(b"\x1b]0;window title\x07")]
+    fn passes_unmarked_data_through_unchanged(
+        mut highlighter: Osc133DebugHighlighter,
+        #[case] data: &[u8],
+    ) {
+        assert_eq!(highlighter.render(data), data);
+    }
+
+    #[rstest]
+    #[case::prompt_start_bel(b"\x1b]133;A\x07", Event::PromptStart)]
+    #[case::prompt_start_st(b"\x1b]133;A\x1b\\", Event::PromptStart)]
+    #[case::prompt_start_c1_st(b"\x1b]133;A\x9c", Event::PromptStart)]
+    #[case::command_start(b"\x1b]133;B\x07", Event::CommandStart)]
+    #[case::command_executed(b"\x1b]133;C\x07", Event::CommandExecuted)]
+    #[case::finished_zero(b"\x1b]133;D;0\x07", Event::CommandFinished { exit_code: Some(0) })]
+    #[case::finished_nonzero(b"\x1b]133;D;1\x07", Event::CommandFinished { exit_code: Some(1) })]
+    #[case::finished_bare(b"\x1b]133;D\x07", Event::CommandFinished { exit_code: None })]
+    fn markers_are_passed_through_before_the_label(
+        mut highlighter: Osc133DebugHighlighter,
+        #[case] marker: &[u8],
+        #[case] event: Event,
+    ) {
+        let mut expected = marker.to_vec();
+        expected.extend_from_slice(event_label(event));
+        expected.extend_from_slice(RESET);
+
+        assert_eq!(highlighter.render(marker), expected);
+    }
+
+    #[rstest]
+    fn labels_every_marker_in_a_full_cycle(mut highlighter: Osc133DebugHighlighter) {
+        let data = b"\x1b]133;A\x07$ \x1b]133;B\x07ls\r\n\x1b]133;C\x07file\r\n\x1b]133;D;0\x07";
+        let rendered = highlighter.render(data);
+
+        // Every marker survives verbatim, in place, so downstream consumers (the capture
+        // tracker sees the highlighted stream, not the raw one) still work.
+        assert_eq!(without_labels(&rendered), data);
+        for event in [
+            Event::PromptStart,
+            Event::CommandStart,
+            Event::CommandExecuted,
+            Event::CommandFinished { exit_code: Some(0) },
+        ] {
+            let label = event_label(event);
+            assert!(
+                rendered.windows(label.len()).any(|window| window == label),
+                "missing label for {event:?}"
+            );
+        }
+    }
+
+    #[rstest]
+    fn a_marker_split_across_renders_is_still_passed_through(
+        mut highlighter: Osc133DebugHighlighter,
+    ) {
+        let first = highlighter.render(b"out\x1b]133;D");
+        assert_eq!(first, b"out\x1b]133;D");
+
+        let second = highlighter.render(b";0\x07more");
+        let mut expected = b";0\x07".to_vec();
+        expected.extend_from_slice(event_label(Event::CommandFinished { exit_code: Some(0) }));
+        expected.extend_from_slice(RESET);
+        expected.extend_from_slice(b"more");
+        assert_eq!(second, expected);
+    }
+
+    #[rstest]
+    #[case::zero(Some(0))]
+    #[case::nonzero(Some(1))]
+    #[case::unknown(None)]
+    fn exit_codes_get_distinct_labels(#[case] exit_code: Option<i32>) {
+        let labels: Vec<_> = EVENTS.iter().map(|event| event_label(*event)).collect();
+        let label = event_label(Event::CommandFinished { exit_code });
+        assert_eq!(labels.iter().filter(|other| **other == label).count(), 1);
     }
 }

--- a/crates/atuin-pty-proxy/src/osc133.rs
+++ b/crates/atuin-pty-proxy/src/osc133.rs
@@ -93,10 +93,6 @@ pub enum Param<'a> {
     },
 }
 
-// ---------------------------------------------------------------------------
-// State machine
-// ---------------------------------------------------------------------------
-
 /// An iterator of OSC 133 events, created by [`Parser::push`].
 ///
 /// After exhausting the iterator, you will likely want to call [`Self::trailing_data`] to get the

--- a/crates/atuin-pty-proxy/src/osc133.rs
+++ b/crates/atuin-pty-proxy/src/osc133.rs
@@ -462,12 +462,12 @@ mod tests {
         assert_eq!(event.zone(), expected);
     }
 
-    #[test]
+    #[rstest]
     fn zone_default_is_unknown() {
         assert_eq!(Zone::default(), Zone::Unknown);
     }
 
-    #[test]
+    #[rstest]
     fn full_zone_cycle() {
         let mut parser = Parser::new();
         let mut zones = Vec::new();
@@ -602,7 +602,7 @@ mod tests {
         assert_eq!(rebuilt, data);
     }
 
-    #[test]
+    #[rstest]
     fn a_marker_split_across_pushes_is_reported_by_the_completing_push() {
         let mut parser = Parser::new();
 
@@ -677,7 +677,7 @@ mod tests {
         assert_eq!(result.chunks[0].params, expected_params);
     }
 
-    #[test]
+    #[rstest]
     fn params_belong_to_the_most_recent_event() {
         let mut parser = Parser::new();
         let mut iter =
@@ -712,7 +712,7 @@ mod tests {
         assert_eq!(push(&mut parser, second).events(), expected);
     }
 
-    #[test]
+    #[rstest]
     fn params_split_across_push_boundary() {
         let mut parser = Parser::new();
         assert_eq!(push(&mut parser, b"\x1b]133;D;0;history_id=018f").events(), vec![]);
@@ -790,7 +790,7 @@ mod tests {
 
     // -- Fused ----------------------------------------------------------------
 
-    #[test]
+    #[rstest]
     fn params_are_empty_once_the_iterator_is_exhausted() {
         // Exhausting the iterator scans the trailing data, which can start a fresh OSC and
         // leave stale bytes in the parameter buffer. They belong to no yielded event.
@@ -804,7 +804,7 @@ mod tests {
         assert_eq!(iter.params().count(), 0);
     }
 
-    #[test]
+    #[rstest]
     fn iterator_is_fused() {
         let mut parser = Parser::new();
         let mut iter = parser.push(b"\x1b]133;A\x07tail");
@@ -817,7 +817,7 @@ mod tests {
 
     // -- Default trait --------------------------------------------------------
 
-    #[test]
+    #[rstest]
     fn parser_default_matches_new() {
         assert_eq!(push(&mut Parser::default(), b"\x1b]133;A\x07").events(), vec![
             Event::PromptStart

--- a/crates/atuin-pty-proxy/src/osc133.rs
+++ b/crates/atuin-pty-proxy/src/osc133.rs
@@ -11,17 +11,17 @@
 //!
 //! The wire format is `ESC ] 133 ; <cmd> [; <params>] ST` where `ST` is `BEL`
 //! (0x07), `ESC \` (0x1B 0x5C), or `C1 ST` (0x9C).
-//!
-//! # Design goals
-//!
-//! * **Transparent** — the parser observes the byte stream without modifying it;
-//!   the caller remains responsible for forwarding bytes to their destination.
-//! * **Bounded** — OSC parameter buffering is capped so malformed output cannot
-//!   grow memory without limit.
-//! * **Non-blocking** — [`Parser::push_located`] processes whatever bytes are
-//!   available and returns immediately.
-//! * **Extensible** — marker parameters are preserved so Atuin-specific metadata
-//!   can ride alongside standard OSC 133 markers.
+
+const ESC: u8 = 0x1B;
+const BEL: u8 = 0x07;
+const C1_ST: u8 = 0x9C;
+const BACKSLASH: u8 = b'\\';
+const RIGHT_BRACKET: u8 = b']';
+
+/// Maximum bytes we'll buffer for the OSC parameter string. This is large enough
+/// for Atuin metadata such as history/session IDs while still bounding malformed
+/// OSC sequences.
+const MAX_PARAMS_SIZE: usize = 512;
 
 /// Events emitted when an OSC 133 marker is detected.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -39,69 +39,8 @@ pub enum Event {
     },
 }
 
-/// Parameters attached to an OSC 133 marker.
-#[derive(Debug, Default, Clone, PartialEq, Eq)]
-pub struct Params {
-    items: Vec<Param>,
-}
-
-impl Params {
-    /// Iterate over all marker parameters in order.
-    #[cfg(test)]
-    #[inline]
-    pub fn iter(&self) -> impl Iterator<Item = &Param> {
-        self.items.iter()
-    }
-
-    /// Return the value for the first `key=value` parameter with this key.
-    #[inline]
-    pub fn get(&self, key: &str) -> Option<&str> {
-        self.items.iter().find_map(|item| match item {
-            Param::KeyValue {
-                key: item_key,
-                value,
-            } if item_key == key => Some(value.as_str()),
-            Param::Value(_) | Param::KeyValue { .. } => None,
-        })
-    }
-}
-
-/// A single OSC 133 marker parameter.
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub enum Param {
-    /// A positional parameter without an equals sign.
-    Value(String),
-    /// A `key=value` parameter.
-    KeyValue {
-        key: String,
-        value: String,
-    },
-}
-
-/// An OSC 133 event with its position in the most recent input chunk.
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct LocatedEvent {
-    /// The OSC 133 event that was parsed.
-    pub event: Event,
-    /// Offset where this marker starts in the current chunk.
-    ///
-    /// If a marker started in an earlier [`Parser::push_located`] call, this is
-    /// `0` in the chunk that completed the marker.
-    pub start_offset: usize,
-    /// Offset immediately after this marker's terminator in the current chunk.
-    ///
-    /// If a marker spans multiple [`Parser::push_located`] calls, this is still
-    /// the offset in the chunk that completed the marker.
-    pub offset: usize,
-    /// The semantic zone after applying this event.
-    pub zone: Zone,
-    /// Metadata parameters attached to this marker.
-    pub params: Params,
-}
-
 /// The current semantic zone as determined by the most recent OSC 133 marker.
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
-#[allow(dead_code)]
 pub enum Zone {
     /// No marker seen yet, or after a `D` marker (between commands).
     #[default]
@@ -114,26 +53,214 @@ pub enum Zone {
     Output,
 }
 
-// ---------------------------------------------------------------------------
-// Internal constants
-// ---------------------------------------------------------------------------
+impl Event {
+    /// Get the zone corresponding to the data that comes after this event.
+    pub fn zone(self) -> Zone {
+        match self {
+            Self::PromptStart => Zone::Prompt,
+            Self::CommandStart => Zone::Input,
+            Self::CommandExecuted => Zone::Output,
+            Self::CommandFinished { .. } => Zone::Unknown,
+        }
+    }
+}
 
-const ESC: u8 = 0x1B;
-const BEL: u8 = 0x07;
-const C1_ST: u8 = 0x9C;
-const BACKSLASH: u8 = b'\\';
-const RIGHT_BRACKET: u8 = b']';
+/// An OSC 133 event with the slice of data up to the end of the OSC sequence.
+///
+/// Concatenating [`Self::data`] for every chunk, followed by [`EventChunks::trailing_data`],
+/// exactly reproduces the bytes passed to [`Parser::push`].
+#[derive(Debug, Clone, Copy)]
+pub struct EventChunk<'a> {
+    /// The OSC 133 event.
+    pub event: Event,
 
-/// Maximum bytes we'll buffer for the OSC parameter string. This is large enough
-/// for Atuin metadata such as history/session IDs while still bounding malformed
-/// OSC sequences.
-const PARAM_BUF_CAP: usize = 512;
+    /// All the data between the last event and the end of this event's OSC 133 sequence.
+    ///
+    /// This includes the entire OSC 133 sequence itself.
+    pub data: &'a [u8],
+
+    /// The total length of the OSC 133 sequence corresponding to this event.
+    pub osc_len: usize,
+}
+
+/// A single OSC 133 marker parameter.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Param<'a> {
+    Value(&'a [u8]),
+    KeyValue {
+        key: &'a [u8],
+        value: &'a [u8],
+    },
+}
 
 // ---------------------------------------------------------------------------
 // State machine
 // ---------------------------------------------------------------------------
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+/// An iterator of OSC 133 events, created by [`Parser::push`].
+///
+/// After exhausting the iterator, you will likely want to call [`Self::trailing_data`] to get the
+/// last chunk of data that was not yielded by the iterator. You may need to use
+/// [`Iterator::by_ref`] when iterating to ensure you still have access to the iterator afterward.
+pub struct EventChunks<'parser, 'data> {
+    parser: &'parser mut Parser,
+    data: &'data [u8],
+    /// Index within `parser.param_buf` where unhandled parameters start.
+    params_start: usize,
+    exhausted: bool,
+}
+
+impl<'data> Iterator for EventChunks<'_, 'data> {
+    type Item = EventChunk<'data>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.exhausted {
+            return None;
+        }
+        for (i, b) in self.data.iter().copied().enumerate() {
+            if let Some(item) = self.handle_byte(b, i) {
+                return Some(item);
+            }
+        }
+        self.exhausted = true;
+        None
+    }
+}
+
+impl std::iter::FusedIterator for EventChunks<'_, '_> {}
+
+impl<'data> EventChunks<'_, 'data> {
+    /// Get the OSC 133 params for the most recently yielded event.
+    pub fn params(&self) -> impl Iterator<Item = Param<'_>> {
+        let bytes = if self.exhausted {
+            b""
+        } else {
+            &self.parser.param_bytes()[self.params_start..]
+        };
+        // Make the split iterator conditional on `bytes` being non-empty; otherwise it will yield
+        // an empty param when `bytes` is empty.
+        let split = (!bytes.is_empty()).then(|| bytes.split(|b| *b == b';'));
+        split.into_iter().flatten().map(|bytes| {
+            let Some(sep) = bytes.iter().position(|b| *b == b'=') else {
+                return Param::Value(bytes);
+            };
+            Param::KeyValue {
+                key: &bytes[..sep],
+                value: &bytes[sep + 1..],
+            }
+        })
+    }
+
+    /// Get the last bit of data not yielded by this iterator.
+    ///
+    /// This method is intended to be called once the iterator has been exhausted.
+    pub fn trailing_data(&self) -> &'data [u8] {
+        self.data
+    }
+
+    fn handle_byte(&mut self, byte: u8, offset: usize) -> Option<EventChunk<'data>> {
+        match self.parser.state {
+            State::Ground => {
+                if byte == ESC {
+                    self.parser.state = State::Esc;
+                }
+            }
+            State::Esc => {
+                self.handle_esc(byte);
+            }
+            State::OscParam => {
+                if byte == BEL || byte == C1_ST {
+                    let terminator_len = 1;
+                    return self.end_osc(offset, terminator_len);
+                } else if byte == ESC {
+                    self.parser.state = State::OscEsc;
+                } else if self.parser.append_param_byte(byte).is_err() {
+                    self.parser.state = State::Ground;
+                }
+            }
+            State::OscEsc => {
+                if byte == BACKSLASH {
+                    let terminator_len = 2; // ESC + BACKSLASH
+                    return self.end_osc(offset, terminator_len);
+                }
+                // Fall back to handling this byte as if we had been in the regular `Esc` state.
+                // If something spits out a malformed unterminated OSC sequence, we want the next
+                // legitimate OSC sequence to reset us into the proper state. This accomplishes
+                // that.
+                self.handle_esc(byte);
+            }
+        }
+        None
+    }
+
+    fn handle_esc(&mut self, byte: u8) {
+        match byte {
+            RIGHT_BRACKET => {
+                self.parser.state = State::OscParam;
+                self.parser.clear_param_bytes();
+                self.params_start = 0;
+            }
+            ESC => {
+                // Restart the escape sequence if we get another ESC.
+                self.parser.state = State::Esc;
+            }
+            _ => {
+                self.parser.state = State::Ground;
+            }
+        }
+    }
+
+    /// Finish the OSC sequence whose terminator ends at `offset`.
+    ///
+    /// Returns an [`EventChunk`] if this was an OSC 133 sequence; otherwise, returns [`None`],
+    /// and the bytes will get included as normal data in the next [`EventChunk`] (or in
+    /// [`EventChunks::trailing_data`]).
+    fn end_osc(&mut self, offset: usize, terminator_len: usize) -> Option<EventChunk<'data>> {
+        self.parser.state = State::Ground;
+
+        let param_bytes = self.parser.param_bytes();
+        let mut payload = param_bytes.strip_prefix(b"133")?;
+        if *payload.split_off_first()? != b';' {
+            return None;
+        }
+
+        let cmd = *payload.split_off_first()?;
+        if payload.split_off_first().is_some_and(|b| *b != b';') {
+            return None;
+        }
+
+        let event = match cmd {
+            b'A' => Event::PromptStart,
+            b'B' => Event::CommandStart,
+            b'C' => Event::CommandExecuted,
+            b'D' => {
+                let mut exit_code = None;
+                if let Some(bytes) = payload.split(|b| *b == b';').next()
+                    && let Some(code) = parse_bytes(bytes)
+                {
+                    exit_code = Some(code);
+                    payload = payload.get(bytes.len() + 1..).unwrap_or_default();
+                }
+                Event::CommandFinished { exit_code }
+            }
+            _ => return None,
+        };
+
+        self.params_start = param_bytes.len() - payload.len();
+        let (data, rest) = self.data.split_at(offset + 1);
+        self.data = rest;
+
+        let non_params_len = 2 + terminator_len; // ESC + RIGHT_BRACKET + terminator_len
+        let osc_len = non_params_len + self.parser.param_buf_len;
+        Some(EventChunk {
+            event,
+            data,
+            osc_len,
+        })
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
 enum State {
     /// Normal pass-through.
     Ground,
@@ -148,16 +275,13 @@ enum State {
 
 /// A streaming, zero-allocation parser for OSC 133 escape sequences.
 ///
-/// Feed arbitrary byte slices into [`Parser::push_located`].  The parser detects
-/// OSC 133 markers and reports [`Event`]s through a caller-supplied callback
-/// without modifying the data.  It can sit transparently between a PTY reader
-/// and stdout.
+/// Feed arbitrary byte slices into [`Parser::push`]. The parser detects
+/// OSC 133 markers and returns an iterator of [`EventChunk`]s, each containing
+/// an [`Event`] and the data up to that point.
 pub struct Parser {
     state: State,
-    zone: Zone,
-    sequence_start: Option<usize>,
-    param_buf: [u8; PARAM_BUF_CAP],
-    param_len: usize,
+    param_buf: [u8; MAX_PARAMS_SIZE],
+    param_buf_len: usize,
 }
 
 impl Default for Parser {
@@ -168,199 +292,52 @@ impl Default for Parser {
 
 impl Parser {
     /// Create a new parser in the initial (ground / unknown-zone) state.
-    #[inline]
     pub fn new() -> Self {
         Self {
             state: State::Ground,
-            zone: Zone::Unknown,
-            sequence_start: None,
-            param_buf: [0u8; PARAM_BUF_CAP],
-            param_len: 0,
+            param_buf: [0; MAX_PARAMS_SIZE],
+            param_buf_len: 0,
         }
     }
 
-    /// The current semantic zone based on markers seen so far.
-    #[inline]
-    #[allow(dead_code)]
-    pub fn zone(&self) -> Zone {
-        self.zone
-    }
-
-    /// Start offset of an incomplete OSC sequence in the most recent chunk.
-    #[inline]
-    pub(crate) fn incomplete_osc_sequence_start(&self) -> Option<usize> {
-        matches!(self.state, State::OscParam | State::OscEsc)
-            .then(|| self.sequence_start.unwrap_or(0))
-    }
-
-    /// Process a chunk of bytes, calling `on_event` for every OSC 133 marker
-    /// found.
-    ///
-    /// All bytes in `data` should still be forwarded to the terminal by the
-    /// caller — this method only *observes* the stream.
-    #[cfg(test)]
-    #[inline]
-    pub fn push(&mut self, data: &[u8], mut on_event: impl FnMut(Event)) {
-        self.push_located(data, |located| on_event(located.event));
-    }
-
-    /// Process a chunk of bytes, calling `on_event` for every OSC 133 marker
-    /// found with its byte offset in this chunk.
-    ///
-    /// The offset points to the first byte after the marker terminator, making
-    /// it suitable for callers that need to split the original chunk at marker
-    /// boundaries.
-    #[inline]
-    pub fn push_located(&mut self, data: &[u8], mut on_event: impl FnMut(LocatedEvent)) {
-        self.sequence_start = (self.state != State::Ground).then_some(0);
-
-        for (offset, &byte) in data.iter().enumerate() {
-            match self.state {
-                State::Ground => {
-                    if byte == ESC {
-                        self.state = State::Esc;
-                        self.sequence_start = Some(offset);
-                    }
-                }
-                State::Esc => {
-                    if byte == RIGHT_BRACKET {
-                        self.state = State::OscParam;
-                        self.param_len = 0;
-                    } else {
-                        self.state = State::Ground;
-                        self.sequence_start = None;
-                    }
-                }
-                State::OscParam => {
-                    if byte == BEL || byte == C1_ST {
-                        self.dispatch(offset + 1, &mut on_event);
-                        self.state = State::Ground;
-                        self.sequence_start = None;
-                    } else if byte == ESC {
-                        self.state = State::OscEsc;
-                    } else if self.param_len < PARAM_BUF_CAP {
-                        self.param_buf[self.param_len] = byte;
-                        self.param_len += 1;
-                    }
-                    // If param_len == PARAM_BUF_CAP we silently stop
-                    // accumulating — dispatch will ignore non-133 sequences.
-                }
-                State::OscEsc => {
-                    if byte == BACKSLASH {
-                        self.dispatch(offset + 1, &mut on_event);
-                    }
-                    // Whether we got a valid ST or not, return to ground.
-                    // (A new ESC ] would restart accumulation via the Ground
-                    // -> Esc -> OscParam path on the *next* byte.)
-                    self.state = State::Ground;
-                    self.sequence_start = None;
-                }
-            }
+    /// Process a chunk of bytes, yielding an [`EventChunk`] for every OSC 133 marker
+    /// found, containing the event type and all the data up to that point.
+    pub fn push<'data>(&mut self, data: &'data [u8]) -> EventChunks<'_, 'data> {
+        EventChunks {
+            parser: self,
+            data,
+            params_start: 0,
+            exhausted: false,
         }
     }
 
-    /// Inspect the accumulated parameter buffer.  If it holds an OSC 133
-    /// payload, emit the corresponding [`Event`] and update the zone.
-    #[inline]
-    fn dispatch(&mut self, offset: usize, on_event: &mut impl FnMut(LocatedEvent)) {
-        let payload = &self.param_buf[..self.param_len];
+    fn param_bytes(&self) -> &[u8] {
+        &self.param_buf[..self.param_buf_len]
+    }
 
-        if payload.len() < 5 || &payload[..4] != b"133;" {
-            return;
+    fn append_param_byte(&mut self, byte: u8) -> Result<(), ()> {
+        if self.param_buf_len >= self.param_buf.len() {
+            return Err(());
         }
+        self.param_buf[self.param_buf_len] = byte;
+        self.param_buf_len += 1;
+        Ok(())
+    }
 
-        if payload.len() > 5 && payload[5] != b';' {
-            return;
-        }
-
-        let metadata = payload.get(6..).unwrap_or_default();
-        let cmd = payload[4];
-        let (event, params) = match cmd {
-            b'A' => {
-                self.zone = Zone::Prompt;
-                (Event::PromptStart, parse_params(metadata))
-            }
-            b'B' => {
-                self.zone = Zone::Input;
-                (Event::CommandStart, parse_params(metadata))
-            }
-            b'C' => {
-                self.zone = Zone::Output;
-                (Event::CommandExecuted, parse_params(metadata))
-            }
-            b'D' => {
-                let (exit_code, params) = parse_command_finished_params(metadata);
-                self.zone = Zone::Unknown;
-                (Event::CommandFinished { exit_code }, params)
-            }
-            _ => return,
-        };
-
-        on_event(LocatedEvent {
-            event,
-            start_offset: self.sequence_start.unwrap_or(0),
-            offset,
-            zone: self.zone,
-            params,
-        });
+    fn clear_param_bytes(&mut self) {
+        self.param_buf_len = 0;
     }
 }
 
-fn parse_command_finished_params(metadata: &[u8]) -> (Option<i32>, Params) {
-    if metadata.is_empty() {
-        return (None, Params::default());
-    }
-
-    let Some(separator) = metadata.iter().position(|byte| *byte == b';') else {
-        return parse_exit_code(metadata).map_or_else(
-            || (None, parse_params(metadata)),
-            |exit_code| (Some(exit_code), Params::default()),
-        );
-    };
-
-    let (first, rest) = metadata.split_at(separator);
-    let rest = &rest[1..];
-
-    parse_exit_code(first).map_or_else(
-        || (None, parse_params(metadata)),
-        |exit_code| (Some(exit_code), parse_params(rest)),
-    )
-}
-
-fn parse_exit_code(code: &[u8]) -> Option<i32> {
-    if code.is_empty() {
+fn parse_bytes<T>(bytes: &[u8]) -> Option<T>
+where
+    T: std::str::FromStr,
+{
+    if bytes.is_empty() {
         return None;
     }
-
-    std::str::from_utf8(code).ok().and_then(|code| code.parse::<i32>().ok())
+    std::str::from_utf8(bytes).ok().and_then(|s| s.parse().ok())
 }
-
-fn parse_params(metadata: &[u8]) -> Params {
-    let items = metadata
-        .split(|byte| *byte == b';')
-        .filter(|part| !part.is_empty())
-        .map(parse_param)
-        .collect();
-
-    Params { items }
-}
-
-fn parse_param(param: &[u8]) -> Param {
-    let param = String::from_utf8_lossy(param);
-
-    if let Some((key, value)) = param.split_once('=') {
-        return Param::KeyValue {
-            key: key.to_string(),
-            value: value.to_string(),
-        };
-    }
-
-    Param::Value(param.into_owned())
-}
-
-// ---------------------------------------------------------------------------
-// Tests
-// ---------------------------------------------------------------------------
 
 #[cfg(test)]
 mod tests {
@@ -368,12 +345,87 @@ mod tests {
 
     use super::*;
 
+    /// An owned copy of [`Param`], so tests can hold onto parameters after the
+    /// borrow of the parser ends.
+    #[derive(Debug, Clone, PartialEq, Eq)]
+    enum OwnedParam {
+        Value(Vec<u8>),
+        KeyValue {
+            key: Vec<u8>,
+            value: Vec<u8>,
+        },
+    }
+
+    impl From<Param<'_>> for OwnedParam {
+        fn from(param: Param<'_>) -> Self {
+            match param {
+                Param::Value(value) => Self::Value(value.to_vec()),
+                Param::KeyValue { key, value } => Self::KeyValue {
+                    key: key.to_vec(),
+                    value: value.to_vec(),
+                },
+            }
+        }
+    }
+
+    impl OwnedParam {
+        fn value(value: &str) -> Self {
+            Self::Value(value.as_bytes().to_vec())
+        }
+
+        fn key_value(key: &str, value: &str) -> Self {
+            Self::KeyValue {
+                key: key.as_bytes().to_vec(),
+                value: value.as_bytes().to_vec(),
+            }
+        }
+    }
+
+    /// An owned copy of [`EventChunk`] plus the parameters that went with it.
+    #[derive(Debug, Clone, PartialEq, Eq)]
+    struct OwnedChunk {
+        event: Event,
+        data: Vec<u8>,
+        params: Vec<OwnedParam>,
+    }
+
+    /// The full result of one [`Parser::push`] call.
+    #[derive(Debug, Clone, PartialEq, Eq)]
+    struct Push {
+        chunks: Vec<OwnedChunk>,
+        trailing_data: Vec<u8>,
+    }
+
+    impl Push {
+        fn events(&self) -> Vec<Event> {
+            self.chunks.iter().map(|chunk| chunk.event).collect()
+        }
+    }
+
+    fn push(parser: &mut Parser, data: &[u8]) -> Push {
+        let mut chunks = Vec::new();
+        let mut iter = parser.push(data);
+        while let Some(chunk) = iter.next() {
+            chunks.push(OwnedChunk {
+                event: chunk.event,
+                data: chunk.data.to_vec(),
+                params: iter.params().map(OwnedParam::from).collect(),
+            });
+        }
+        Push {
+            chunks,
+            trailing_data: iter.trailing_data().to_vec(),
+        }
+    }
+
+    /// Push `data` through a fresh parser in a single call.
+    fn parse(data: &[u8]) -> Push {
+        push(&mut Parser::new(), data)
+    }
+
     /// Collect all events from a single `push` call.
     fn parse_events(data: &[u8]) -> Vec<Event> {
-        let mut parser = Parser::new();
-        let mut events = Vec::new();
-        parser.push(data, |e| events.push(e));
-        events
+        parse(data).events()
     }
 
     // -- Basic event detection ------------------------------------------------
@@ -398,37 +450,38 @@ mod tests {
         assert_eq!(parse_events(data), vec![expected]);
     }
 
-    // -- Zone tracking --------------------------------------------------------
+    // -- Zone mapping ---------------------------------------------------------
+
+    #[rstest]
+    #[case(Event::PromptStart, Zone::Prompt)]
+    #[case(Event::CommandStart, Zone::Input)]
+    #[case(Event::CommandExecuted, Zone::Output)]
+    #[case(Event::CommandFinished { exit_code: Some(0) }, Zone::Unknown)]
+    #[case(Event::CommandFinished { exit_code: None }, Zone::Unknown)]
+    fn event_maps_to_zone(#[case] event: Event, #[case] expected: Zone) {
+        assert_eq!(event.zone(), expected);
+    }
 
     #[test]
-    fn zone_starts_unknown() {
-        let parser = Parser::new();
-        assert_eq!(parser.zone(), Zone::Unknown);
+    fn zone_default_is_unknown() {
+        assert_eq!(Zone::default(), Zone::Unknown);
     }
 
     #[test]
     fn full_zone_cycle() {
         let mut parser = Parser::new();
-        let mut events = Vec::new();
+        let mut zones = Vec::new();
 
-        parser.push(b"\x1b]133;A\x07", |e| events.push(e));
-        assert_eq!(parser.zone(), Zone::Prompt);
+        for data in [
+            b"\x1b]133;A\x07".as_slice(),
+            b"\x1b]133;B\x07",
+            b"\x1b]133;C\x07",
+            b"\x1b]133;D;0\x07",
+        ] {
+            zones.extend(push(&mut parser, data).events().into_iter().map(Event::zone));
+        }
 
-        parser.push(b"\x1b]133;B\x07", |e| events.push(e));
-        assert_eq!(parser.zone(), Zone::Input);
-
-        parser.push(b"\x1b]133;C\x07", |e| events.push(e));
-        assert_eq!(parser.zone(), Zone::Output);
-
-        parser.push(b"\x1b]133;D;0\x07", |e| events.push(e));
-        assert_eq!(parser.zone(), Zone::Unknown);
-
-        assert_eq!(events, vec![
-            Event::PromptStart,
-            Event::CommandStart,
-            Event::CommandExecuted,
-            Event::CommandFinished { exit_code: Some(0) },
-        ]);
+        assert_eq!(zones, vec![Zone::Prompt, Zone::Input, Zone::Output, Zone::Unknown]);
     }
 
     // -- Multiple events / interleaved text in one push -----------------------
@@ -442,8 +495,203 @@ mod tests {
     #[case::detects_c1_st_terminator(b"\x1b]133;A\x9c", vec![Event::PromptStart])]
     #[case::back_to_back_osc_no_gap(b"\x1b]133;A\x07\x1b]133;B\x07", vec![Event::PromptStart, Event::CommandStart])]
     #[case::csi_sequences_ignored(b"\x1b[32m\x1b]133;A\x07\x1b[0m$ \x1b]133;B\x07", vec![Event::PromptStart, Event::CommandStart])]
+    #[case::unterminated_osc_then_marker(b"\x1b]0;title\x1b]133;A\x07", vec![Event::PromptStart])]
+    // Enter pressed on an empty prompt, twice.
+    #[case::repeated_prompt_cycle(b"\x1b]133;A\x07$ \x1b]133;B\x07\x1b]133;D\x07\x1b]133;A\x07$ \x1b]133;B\x07", vec![Event::PromptStart, Event::CommandStart, Event::CommandFinished { exit_code: None }, Event::PromptStart, Event::CommandStart])]
     fn emits_events(#[case] data: &[u8], #[case] expected: Vec<Event>) {
         assert_eq!(parse_events(data), expected);
+    }
+
+    // -- Chunk data -----------------------------------------------------------
+
+    #[rstest]
+    #[case::marker_at_the_end(
+        b"before\x1b]133;A\x07",
+        vec![(Event::PromptStart, b"before\x1b]133;A\x07".as_slice())],
+        b"",
+    )]
+    #[case::two_markers(
+        b"before\x1b]133;A\x07between\x1b]133;B\x07after",
+        vec![
+            (Event::PromptStart, b"before\x1b]133;A\x07".as_slice()),
+            (Event::CommandStart, b"between\x1b]133;B\x07".as_slice()),
+        ],
+        b"after",
+    )]
+    // A non-OSC-133 sequence is still terminal output, so it stays in the data we hand back.
+    #[case::non_133_osc_stays_in_the_data(
+        b"\x1b]0;title\x07x\x1b]133;A\x07",
+        vec![(Event::PromptStart, b"\x1b]0;title\x07x\x1b]133;A\x07".as_slice())],
+        b"",
+    )]
+    #[case::partial_marker_is_left_trailing(
+        b"out\x1b]133;C\x07more\x1b]133;D;0",
+        vec![(Event::CommandExecuted, b"out\x1b]133;C\x07".as_slice())],
+        b"more\x1b]133;D;0",
+    )]
+    // The parser has to return to the ground state once a sequence is terminated. Otherwise
+    // plain output keeps accumulating in the parameter buffer, and a bare BEL in that output
+    // fabricates an event out of it.
+    #[case::output_after_a_marker_is_not_parsed_as_parameters(
+        b"\x1b]133;A\x07133;D;99\x07",
+        vec![(Event::PromptStart, b"\x1b]133;A\x07".as_slice())],
+        b"133;D;99\x07",
+    )]
+    // The same, but with output that would graft cleanly onto the parameters of the marker
+    // before it: `133;A` + `;fake` parses as a prompt-start marker carrying a `fake` param.
+    #[case::a_bel_in_output_cannot_extend_the_previous_marker(
+        b"\x1b]133;A\x07;fake\x07more",
+        vec![(Event::PromptStart, b"\x1b]133;A\x07".as_slice())],
+        b";fake\x07more",
+    )]
+    // `ESC ] 133 ; A ESC` is a malformed, unterminated OSC. The second ESC starts a new
+    // sequence rather than aborting into the ground state.
+    #[case::unterminated_sequence_does_not_swallow_the_next_esc(
+        b"\x1b]133;A\x1b\x1b]133;B\x07",
+        vec![(Event::CommandStart, b"\x1b]133;A\x1b\x1b]133;B\x07".as_slice())],
+        b"",
+    )]
+    fn splits_data_at_the_markers(
+        #[case] data: &[u8],
+        #[case] expected_chunks: Vec<(Event, &[u8])>,
+        #[case] expected_trailing: &[u8],
+    ) {
+        let result = parse(data);
+        let chunks: Vec<_> =
+            result.chunks.iter().map(|chunk| (chunk.event, chunk.data.as_slice())).collect();
+
+        assert_eq!(chunks, expected_chunks);
+        assert_eq!(result.trailing_data, expected_trailing);
+    }
+
+    #[rstest]
+    #[case::bel(b"\x1b]133;D;0\x07")]
+    #[case::st(b"\x1b]133;D;0\x1b\\")]
+    #[case::c1_st(b"\x1b]133;D;0\x9c")]
+    fn chunk_data_includes_the_terminator(#[case] marker: &[u8]) {
+        // A chunk that stopped one byte short would leave the marker looking unterminated
+        // to whoever replays the data, and drop its final byte into the next chunk.
+        let data = [b"out".as_slice(), marker, b"rest"].concat();
+
+        let result = parse(&data);
+        assert_eq!(result.chunks.len(), 1);
+        assert_eq!(result.chunks[0].data, [b"out".as_slice(), marker].concat());
+        assert_eq!(result.trailing_data, b"rest");
+    }
+
+    #[rstest]
+    #[case::empty(b"")]
+    #[case::no_markers(b"just some regular terminal output\r\n")]
+    #[case::every_terminator_and_a_partial_marker(
+        b"a\x1b]133;A\x07b\x1b]133;B\x1b\\c\x1b]0;title\x07d\x1b]133;D;0\x9ce\x1b]133;"
+    )]
+    #[case::back_to_back_markers(b"\x1b]133;A\x07\x1b]133;B\x07\x1b]133;C\x07\x1b]133;D;0\x07")]
+    #[case::trailing_lone_esc(b"out\x1b")]
+    #[case::overlong_osc(b"\x1b]133;A\x07\x1b]0;\x07\x1b\x1b]133;B\x07tail")]
+    fn chunks_and_trailing_data_reconstruct_the_input(#[case] data: &[u8]) {
+        // Whatever the parser makes of the stream, every byte handed to it has to come back
+        // out: the caller passes this data straight on to a terminal.
+        let result = parse(data);
+
+        let mut rebuilt = Vec::new();
+        for chunk in &result.chunks {
+            rebuilt.extend_from_slice(&chunk.data);
+        }
+        rebuilt.extend_from_slice(&result.trailing_data);
+
+        assert_eq!(rebuilt, data);
+    }
+
+    #[test]
+    fn a_marker_split_across_pushes_is_reported_by_the_completing_push() {
+        let mut parser = Parser::new();
+
+        let first = push(&mut parser, b"out\x1b]133;D");
+        assert!(first.chunks.is_empty());
+        assert_eq!(first.trailing_data, b"out\x1b]133;D");
+
+        let second = push(&mut parser, b";0;history_id=x\x07rest");
+        assert_eq!(second.chunks.len(), 1);
+        assert_eq!(second.chunks[0].data, b";0;history_id=x\x07");
+        assert_eq!(second.trailing_data, b"rest");
+    }
+
+    // -- Params ---------------------------------------------------------------
+
+    #[rstest]
+    #[case::key_values_and_a_bare_value(
+        b"\x1b]133;D;127;history_id=018f;session_id=abcd;flag\x07",
+        Event::CommandFinished { exit_code: Some(127) },
+        vec![
+            OwnedParam::key_value("history_id", "018f"),
+            OwnedParam::key_value("session_id", "abcd"),
+            OwnedParam::value("flag"),
+        ],
+    )]
+    #[case::params_survive_a_missing_exit_code(
+        b"\x1b]133;D;history_id=018f;session_id=abcd\x07",
+        Event::CommandFinished { exit_code: None },
+        vec![
+            OwnedParam::key_value("history_id", "018f"),
+            OwnedParam::key_value("session_id", "abcd"),
+        ],
+    )]
+    #[case::unparsable_exit_code_is_kept_as_a_param(
+        b"\x1b]133;D;abc;history_id=018f\x07",
+        Event::CommandFinished { exit_code: None },
+        vec![OwnedParam::value("abc"), OwnedParam::key_value("history_id", "018f")],
+    )]
+    // This is what `atuin init bash` emits.
+    #[case::prompt_start_params(
+        b"\x1b]133;A;cl=line\x07",
+        Event::PromptStart,
+        vec![OwnedParam::key_value("cl", "line")],
+    )]
+    #[case::no_params_prompt_start(b"\x1b]133;A\x07", Event::PromptStart, vec![])]
+    #[case::no_params_command_start(b"\x1b]133;B\x07", Event::CommandStart, vec![])]
+    #[case::no_params_command_executed(b"\x1b]133;C\x07", Event::CommandExecuted, vec![])]
+    #[case::no_params_finished_bare(
+        b"\x1b]133;D\x07",
+        Event::CommandFinished { exit_code: None },
+        vec![],
+    )]
+    #[case::no_params_finished_exit_code_only(
+        b"\x1b]133;D;0\x07",
+        Event::CommandFinished { exit_code: Some(0) },
+        vec![],
+    )]
+    #[case::no_params_finished_trailing_semicolon(
+        b"\x1b]133;D;\x07",
+        Event::CommandFinished { exit_code: None },
+        vec![],
+    )]
+    fn parses_params(
+        #[case] data: &[u8],
+        #[case] expected_event: Event,
+        #[case] expected_params: Vec<OwnedParam>,
+    ) {
+        let result = parse(data);
+
+        assert_eq!(result.chunks.len(), 1);
+        assert_eq!(result.chunks[0].event, expected_event);
+        assert_eq!(result.chunks[0].params, expected_params);
+    }
+
+    #[test]
+    fn params_belong_to_the_most_recent_event() {
+        let mut parser = Parser::new();
+        let mut iter =
+            parser.push(b"\x1b]133;D;0;history_id=one\x07\x1b]133;D;1;history_id=two\x07");
+
+        assert!(iter.next().is_some());
+        assert_eq!(iter.params().map(OwnedParam::from).collect::<Vec<_>>(), vec![
+            OwnedParam::key_value("history_id", "one")
+        ]);
+
+        assert!(iter.next().is_some());
+        assert_eq!(iter.params().map(OwnedParam::from).collect::<Vec<_>>(), vec![
+            OwnedParam::key_value("history_id", "two")
+        ]);
     }
 
     // -- Split across push boundaries -----------------------------------------
@@ -460,14 +708,47 @@ mod tests {
         #[case] expected: Vec<Event>,
     ) {
         let mut parser = Parser::new();
-        let mut events = Vec::new();
-        parser.push(first, |e| events.push(e));
-        assert!(events.is_empty());
-        parser.push(second, |e| events.push(e));
-        assert_eq!(events, expected);
+        assert_eq!(push(&mut parser, first).events(), vec![]);
+        assert_eq!(push(&mut parser, second).events(), expected);
     }
 
-    // -- Unknown command letter -----------------------------------------------
+    #[test]
+    fn params_split_across_push_boundary() {
+        let mut parser = Parser::new();
+        assert_eq!(push(&mut parser, b"\x1b]133;D;0;history_id=018f").events(), vec![]);
+
+        let result = push(&mut parser, b";session_id=abcd\x07rest");
+        assert_eq!(result.chunks.len(), 1);
+        assert_eq!(result.chunks[0].params, vec![
+            OwnedParam::key_value("history_id", "018f"),
+            OwnedParam::key_value("session_id", "abcd"),
+        ]);
+        assert_eq!(result.trailing_data, b"rest");
+    }
+
+    #[rstest]
+    fn events_do_not_depend_on_how_the_stream_is_chunked(
+        #[values(1, 2, 3, 7, usize::MAX)] chunk_size: usize,
+    ) {
+        let data = b"\x1b]133;A\x07$ \x1b]133;B\x07ls\r\n\x1b]133;C\x07f\r\n\x1b]133;D;99\x07";
+        let mut parser = Parser::new();
+        let mut events = Vec::new();
+
+        for chunk in data.chunks(chunk_size.min(data.len())) {
+            events.extend(push(&mut parser, chunk).events());
+        }
+
+        assert_eq!(events, vec![
+            Event::PromptStart,
+            Event::CommandStart,
+            Event::CommandExecuted,
+            Event::CommandFinished {
+                exit_code: Some(99)
+            },
+        ]);
+    }
+
+    // -- Input that must not produce events -----------------------------------
 
     #[rstest]
     #[case::osc_7(b"\x1b]7;file:///home/user\x07")]
@@ -475,146 +756,71 @@ mod tests {
     #[case::marker_with_unexpected_trailing_bytes(b"\x1b]133;ABC\x07")]
     // "13" followed by terminator — not "133;" so no event.
     #[case::truncated_133_prefix(b"\x1b]13\x07")]
+    #[case::wrong_osc_number(b"\x1b]1330;A\x07")]
     #[case::empty_osc(b"\x1b]\x07")]
     #[case::empty_input(b"")]
     #[case::only_normal_text(b"just some regular terminal output\r\n")]
+    #[case::csi_only(b"\x1b[2J\x1b[H")]
     fn ignores_input(#[case] data: &[u8]) {
         assert!(parse_events(data).is_empty());
     }
 
     // -- Buffer overflow (very long non-133 OSC) ------------------------------
 
-    #[test]
-    fn very_long_osc_does_not_panic() {
-        let mut data = Vec::new();
-        data.extend_from_slice(b"\x1b]");
-        data.extend(std::iter::repeat_n(b'x', 1000));
+    #[rstest]
+    // An OSC whose parameters overflow the buffer is dropped, without panicking...
+    #[case::overlong_osc_is_dropped(b"\x1b]", b"", vec![])]
+    #[case::overlong_133_osc_is_dropped(b"\x1b]133;D;0;", b"", vec![])]
+    // ...and the parser is back in a state where it recognises the next marker.
+    #[case::parser_recovers(b"\x1b]133;D;0;", b"\x1b]133;A\x07", vec![Event::PromptStart])]
+    fn an_overlong_osc_does_not_panic(
+        #[case] prefix: &[u8],
+        #[case] suffix: &[u8],
+        #[case] expected: Vec<Event>,
+    ) {
+        let mut data = prefix.to_vec();
+        data.extend(std::iter::repeat_n(b'x', MAX_PARAMS_SIZE * 2));
         data.push(BEL);
-        // Should not panic and should produce no event.
-        assert!(parse_events(&data).is_empty());
+        data.extend_from_slice(suffix);
+
+        assert_eq!(parse_events(&data), expected);
     }
 
     // -- Repeated prompts (empty command) ------------------------------------
 
-    #[test]
-    fn repeated_prompt_cycle() {
-        let mut parser = Parser::new();
-        let mut events = Vec::new();
-
-        // User hits enter on an empty prompt twice.
-        let data = b"\x1b]133;A\x07$ \x1b]133;B\x07\x1b]133;D\x07\x1b]133;A\x07$ \x1b]133;B\x07";
-        parser.push(data, |e| events.push(e));
-
-        assert_eq!(events, vec![
-            Event::PromptStart,
-            Event::CommandStart,
-            Event::CommandFinished { exit_code: None },
-            Event::PromptStart,
-            Event::CommandStart,
-        ]);
-        assert_eq!(parser.zone(), Zone::Input);
-    }
-
-    // -- Byte-at-a-time feeding -----------------------------------------------
+    // -- Fused ----------------------------------------------------------------
 
     #[test]
-    fn byte_at_a_time() {
-        let data = b"\x1b]133;D;99\x07";
+    fn params_are_empty_once_the_iterator_is_exhausted() {
+        // Exhausting the iterator scans the trailing data, which can start a fresh OSC and
+        // leave stale bytes in the parameter buffer. They belong to no yielded event.
         let mut parser = Parser::new();
-        let mut events = Vec::new();
+        let mut iter = parser.push(b"\x1b]133;D;0;history_id=x\x07tail\x1b]0;title");
 
-        for &byte in data {
-            parser.push(&[byte], |e| events.push(e));
-        }
+        assert!(iter.next().is_some());
+        assert_eq!(iter.params().count(), 1, "the yielded event still has its params");
 
-        assert_eq!(events, vec![Event::CommandFinished {
-            exit_code: Some(99)
-        }]);
-    }
-
-    // -- Located event offsets ------------------------------------------------
-
-    #[test]
-    fn located_event_reports_offset_after_marker() {
-        let data = b"before\x1b]133;A\x07prompt";
-        let mut parser = Parser::new();
-        let mut events = Vec::new();
-
-        parser.push_located(data, |e| events.push(e));
-
-        assert_eq!(events, vec![LocatedEvent {
-            event: Event::PromptStart,
-            start_offset: b"before".len(),
-            offset: b"before\x1b]133;A\x07".len(),
-            zone: Zone::Prompt,
-            params: Params::default(),
-        }]);
+        assert!(iter.next().is_none());
+        assert_eq!(iter.params().count(), 0);
     }
 
     #[test]
-    fn located_event_offset_is_relative_to_completing_chunk() {
+    fn iterator_is_fused() {
         let mut parser = Parser::new();
-        let mut events = Vec::new();
+        let mut iter = parser.push(b"\x1b]133;A\x07tail");
 
-        parser.push_located(b"\x1b]133;", |e| events.push(e));
-        parser.push_located(b"D;42\x07after", |e| events.push(e));
-
-        assert_eq!(events, vec![LocatedEvent {
-            event: Event::CommandFinished {
-                exit_code: Some(42)
-            },
-            start_offset: 0,
-            offset: b"D;42\x07".len(),
-            zone: Zone::Unknown,
-            params: Params::default(),
-        }]);
-    }
-
-    #[test]
-    fn located_event_preserves_metadata_params() {
-        let mut parser = Parser::new();
-        let mut events = Vec::new();
-
-        parser.push_located(b"\x1b]133;D;127;history_id=018f;session_id=abcd;flag\x07", |event| {
-            events.push(event);
-        });
-
-        assert_eq!(events.len(), 1);
-        let event = &events[0];
-        assert_eq!(event.event, Event::CommandFinished {
-            exit_code: Some(127)
-        });
-        assert_eq!(event.params.get("history_id"), Some("018f"));
-        assert_eq!(event.params.get("session_id"), Some("abcd"));
-        assert!(event.params.iter().any(|param| param == &Param::Value("flag".to_string())));
-    }
-
-    #[test]
-    fn command_finished_metadata_without_exit_code_is_preserved() {
-        let mut parser = Parser::new();
-        let mut events = Vec::new();
-
-        parser.push_located(b"\x1b]133;D;history_id=018f;session_id=abcd\x07", |event| {
-            events.push(event);
-        });
-
-        assert_eq!(events.len(), 1);
-        let event = &events[0];
-        assert_eq!(event.event, Event::CommandFinished { exit_code: None });
-        assert_eq!(event.params.get("history_id"), Some("018f"));
-        assert_eq!(event.params.get("session_id"), Some("abcd"));
+        assert!(iter.next().is_some());
+        assert!(iter.next().is_none());
+        assert!(iter.next().is_none());
+        assert_eq!(iter.trailing_data(), b"tail");
     }
 
     // -- Default trait --------------------------------------------------------
 
     #[test]
-    fn parser_default() {
-        let parser = Parser::default();
-        assert_eq!(parser.zone(), Zone::Unknown);
-    }
-
-    #[test]
-    fn zone_default() {
-        assert_eq!(Zone::default(), Zone::Unknown);
+    fn parser_default_matches_new() {
+        assert_eq!(push(&mut Parser::default(), b"\x1b]133;A\x07").events(), vec![
+            Event::PromptStart
+        ]);
     }
 }

--- a/crates/atuin-pty-proxy/src/runtime.rs
+++ b/crates/atuin-pty-proxy/src/runtime.rs
@@ -1,11 +1,9 @@
 use std::io::{Read, Write};
-use std::sync::atomic::{AtomicU16, Ordering};
-use std::sync::{Arc, mpsc};
+use std::sync::mpsc;
 
 use crossterm::terminal;
 use portable_pty::{CommandBuilder, PtySize, native_pty_system};
 
-use crate::capture::CommandCaptureTracker;
 use crate::debug::{Osc133DebugHighlighter, RESET};
 use crate::pty_proxy::RuntimeOptions;
 use crate::screen::{self, Msg};
@@ -72,53 +70,44 @@ fn run(options: RuntimeOptions) -> eyre::Result<()> {
     }
 
     let mut child = pair.slave.spawn_command(cmd).map_err(|e| eyre::eyre!("{e:#}"))?;
-
     drop(pair.slave);
 
     let mut pty_reader = pair.master.try_clone_reader().map_err(|e| eyre::eyre!("{e:#}"))?;
     let mut pty_writer = pair.master.take_writer().map_err(|e| eyre::eyre!("{e:#}"))?;
 
     let (msg_tx, msg_rx) = mpsc::sync_channel::<Msg>(64);
-    let current_cols = Arc::new(AtomicU16::new(cols.max(1)));
-
-    screen::spawn_parser_thread(rows, cols, msg_rx);
+    screen::spawn_parser_thread(rows, cols, msg_rx, screen::ParserOptions {
+        sink: options.command_capture_sink,
+        debug_osc133: options.debug_osc133,
+    });
     if let Some(path) = &sock_path {
         screen::spawn_socket_server(path.clone(), msg_tx.clone());
     }
-    spawn_resize_handler(pair.master, msg_tx.clone(), current_cols.clone())?;
-
+    spawn_resize_handler(pair.master, msg_tx.clone())?;
     terminal::enable_raw_mode()?;
 
     let stdout_thread = std::thread::spawn(move || {
         let mut stdout = std::io::stdout();
         let mut highlighter = options.debug_osc133.then(Osc133DebugHighlighter::new);
-        let mut capture_tracker =
-            options.command_capture_sink.as_ref().map(|_| CommandCaptureTracker::new(current_cols));
         let mut buf = [0u8; 8192];
 
         loop {
             match pty_reader.read(&mut buf) {
                 Ok(0) | Err(_) => break,
                 Ok(n) => {
-                    if let (Some(tracker), Some(sink)) =
-                        (capture_tracker.as_mut(), options.command_capture_sink.as_ref())
-                    {
-                        tracker.push(&buf[..n], sink);
-                    }
+                    let raw_data = &buf[..n];
+                    let _ = msg_tx.send(Msg::Data(raw_data.to_vec()));
 
-                    if let Some(highlighter) = highlighter.as_mut() {
-                        let rendered = highlighter.render(&buf[..n]);
-                        let _ = msg_tx.send(Msg::Data(rendered.clone()));
-
-                        if stdout.write_all(&rendered).is_err() {
-                            break;
-                        }
+                    let highlighted;
+                    let data: &[u8] = if let Some(highlighter) = &mut highlighter {
+                        highlighted = highlighter.render(raw_data);
+                        &highlighted
                     } else {
-                        let _ = msg_tx.send(Msg::Data(buf[..n].to_vec()));
+                        raw_data
+                    };
 
-                        if stdout.write_all(&buf[..n]).is_err() {
-                            break;
-                        }
+                    if stdout.write_all(data).is_err() {
+                        break;
                     }
                     let _ = stdout.flush();
                 }
@@ -160,7 +149,6 @@ fn run(options: RuntimeOptions) -> eyre::Result<()> {
 fn spawn_resize_handler(
     master: Box<dyn portable_pty::MasterPty + Send>,
     resize_tx: mpsc::SyncSender<Msg>,
-    current_cols: Arc<AtomicU16>,
 ) -> eyre::Result<()> {
     use signal_hook::consts::SIGWINCH;
     use signal_hook::iterator::Signals;
@@ -170,7 +158,6 @@ fn spawn_resize_handler(
     std::thread::spawn(move || {
         for _ in signals.forever() {
             if let Ok((cols, rows)) = terminal::size() {
-                current_cols.store(cols.max(1), Ordering::Relaxed);
                 let _ = master.resize(PtySize {
                     rows,
                     cols,

--- a/crates/atuin-pty-proxy/src/runtime.rs
+++ b/crates/atuin-pty-proxy/src/runtime.rs
@@ -76,7 +76,7 @@ fn run(options: RuntimeOptions) -> eyre::Result<()> {
     let mut pty_writer = pair.master.take_writer().map_err(|e| eyre::eyre!("{e:#}"))?;
 
     let (msg_tx, msg_rx) = mpsc::sync_channel::<Msg>(64);
-    screen::spawn_parser_thread(rows, cols, msg_rx, screen::ParserOptions {
+    let _parser_handle = screen::spawn_parser_thread(rows, cols, msg_rx, screen::ParserOptions {
         sink: options.command_capture_sink,
         debug_osc133: options.debug_osc133,
     });

--- a/crates/atuin-pty-proxy/src/screen.rs
+++ b/crates/atuin-pty-proxy/src/screen.rs
@@ -3,6 +3,7 @@ use std::num::NonZeroU16;
 use std::os::unix::net::UnixListener;
 use std::path::PathBuf;
 use std::sync::mpsc::{self, Receiver, SyncSender};
+use std::thread::JoinHandle;
 
 use atuin_common::os::unix::{SecureTempDirError, create_secure_temp_dir};
 
@@ -62,6 +63,9 @@ impl Parser {
                 self.emulator.process(data);
             }
             Msg::Resize { rows, cols } => {
+                // `vt100` dimensions can't be 0. Upstream would panic; now our `atuin-vt100` fork
+                // requires dimensions to be `NonZeroU16` to ensure we don't hit those panics. Clamp
+                // dimensions to 1.
                 let rows = NonZeroU16::new(rows).unwrap_or(NonZeroU16::MIN);
                 let cols = NonZeroU16::new(cols).unwrap_or(NonZeroU16::MIN);
                 self.emulator.screen_mut().set_size(rows, cols);
@@ -76,15 +80,22 @@ impl Parser {
     }
 }
 
-pub fn spawn_parser_thread(rows: u16, cols: u16, screen_rx: Receiver<Msg>, options: ParserOptions) {
+pub fn spawn_parser_thread(
+    rows: u16,
+    cols: u16,
+    screen_rx: Receiver<Msg>,
+    options: ParserOptions,
+) -> JoinHandle<()> {
     std::thread::spawn(move || {
+        // `vt100` dimensions can't be 0. Upstream would panic; now our `atuin-vt100` fork requires
+        // dimensions to be `NonZeroU16` to ensure we don't hit those panics. Clamp dimensions to 1.
         let rows = NonZeroU16::new(rows).unwrap_or(NonZeroU16::MIN);
         let cols = NonZeroU16::new(cols).unwrap_or(NonZeroU16::MIN);
         let mut parser = Parser::new(rows, cols, options);
         for msg in screen_rx {
             parser.handle_msg(msg);
         }
-    });
+    })
 }
 
 pub fn spawn_socket_server(sock_path: PathBuf, screen_tx: SyncSender<Msg>) {

--- a/crates/atuin-pty-proxy/src/screen.rs
+++ b/crates/atuin-pty-proxy/src/screen.rs
@@ -6,6 +6,9 @@ use std::sync::mpsc::{self, Receiver, SyncSender};
 
 use atuin_common::os::unix::{SecureTempDirError, create_secure_temp_dir};
 
+use crate::capture::{CommandCaptureSink, CommandCaptureTracker};
+use crate::debug::Osc133DebugHighlighter;
+
 pub enum Msg {
     Data(Vec<u8>),
     Resize {
@@ -22,22 +25,64 @@ pub fn socket_path() -> Result<PathBuf, SecureTempDirError> {
     Ok(dir.join(format!("pty-proxy-{}.sock", std::process::id())))
 }
 
-pub fn spawn_parser_thread(rows: u16, cols: u16, msg_rx: Receiver<Msg>) {
+pub struct ParserOptions {
+    pub sink: Option<CommandCaptureSink>,
+    pub debug_osc133: bool,
+}
+
+struct Parser {
+    emulator: vt100::Parser,
+    tracker: Option<CommandCaptureTracker>,
+    highlighter: Option<Osc133DebugHighlighter>,
+}
+
+impl Parser {
+    fn new(rows: NonZeroU16, cols: NonZeroU16, options: ParserOptions) -> Self {
+        Self {
+            emulator: vt100::Parser::new(rows, cols, 0),
+            tracker: options.sink.map(|f| CommandCaptureTracker::new(rows, cols, f)),
+            highlighter: options.debug_osc133.then(Osc133DebugHighlighter::new),
+        }
+    }
+
+    fn handle_msg(&mut self, msg: Msg) {
+        match msg {
+            Msg::Data(raw_data) => {
+                if let Some(tracker) = &mut self.tracker {
+                    tracker.push(&raw_data);
+                }
+
+                let highlighted;
+                let data: &[u8] = if let Some(highlighter) = &mut self.highlighter {
+                    highlighted = highlighter.render(&raw_data);
+                    &highlighted
+                } else {
+                    &raw_data
+                };
+                self.emulator.process(data);
+            }
+            Msg::Resize { rows, cols } => {
+                let rows = NonZeroU16::new(rows).unwrap_or(NonZeroU16::MIN);
+                let cols = NonZeroU16::new(cols).unwrap_or(NonZeroU16::MIN);
+                self.emulator.screen_mut().set_size(rows, cols);
+                if let Some(tracker) = &mut self.tracker {
+                    tracker.resize(rows, cols);
+                }
+            }
+            Msg::ScreenRequest(reply_tx) => {
+                let _ = reply_tx.send(encode_screen(&self.emulator));
+            }
+        }
+    }
+}
+
+pub fn spawn_parser_thread(rows: u16, cols: u16, screen_rx: Receiver<Msg>, options: ParserOptions) {
     std::thread::spawn(move || {
         let rows = NonZeroU16::new(rows).unwrap_or(NonZeroU16::MIN);
         let cols = NonZeroU16::new(cols).unwrap_or(NonZeroU16::MIN);
-        let mut parser = vt100::Parser::new(rows, cols, 0);
-
-        loop {
-            let Ok(first) = msg_rx.recv() else {
-                break;
-            };
-
-            handle_parser_msg(&mut parser, first);
-
-            while let Ok(msg) = msg_rx.try_recv() {
-                handle_parser_msg(&mut parser, msg);
-            }
+        let mut parser = Parser::new(rows, cols, options);
+        for msg in screen_rx {
+            parser.handle_msg(msg);
         }
     });
 }
@@ -101,54 +146,192 @@ fn encode_screen(parser: &vt100::Parser) -> Vec<u8> {
     buf
 }
 
-fn handle_parser_msg(parser: &mut vt100::Parser, msg: Msg) {
-    match msg {
-        Msg::Data(data) => parser.process(&data),
-        Msg::Resize { rows, cols } => {
-            let rows = NonZeroU16::new(rows).unwrap_or(NonZeroU16::MIN);
-            let cols = NonZeroU16::new(cols).unwrap_or(NonZeroU16::MIN);
-            parser.screen_mut().set_size(rows, cols);
-        }
-        Msg::ScreenRequest(reply_tx) => {
-            let _ = reply_tx.send(encode_screen(parser));
-        }
-    }
-}
-
 #[cfg(test)]
 mod tests {
-    use rstest::rstest;
+    use std::time::Duration;
+
+    use rstest::{fixture, rstest};
 
     use super::*;
+    use crate::capture::CommandCapture;
+
+    const TIMEOUT: Duration = Duration::from_secs(5);
 
     /// Get the `rows` and `cols` values from an [`encode_screen`] blob.
     fn size_of(blob: &[u8]) -> (u16, u16) {
         (u16::from_be_bytes([blob[0], blob[1]]), u16::from_be_bytes([blob[2], blob[3]]))
     }
 
-    #[rstest]
-    fn init_small_and_wrap(#[values(0, 1, 2, 3)] rows: u16, #[values(0, 1, 2, 3)] cols: u16) {
-        let (msg_tx, msg_rx) = mpsc::sync_channel(8);
-        spawn_parser_thread(rows, cols, msg_rx);
-        msg_tx.send(Msg::Data(b"hello world".to_vec())).expect("parser thread alive");
+    /// Get the cursor position from an [`encode_screen`] blob.
+    fn cursor_of(blob: &[u8]) -> (u16, u16) {
+        (u16::from_be_bytes([blob[4], blob[5]]), u16::from_be_bytes([blob[6], blob[7]]))
+    }
 
+    /// Get the per-row payloads from an [`encode_screen`] blob.
+    fn rows_of(blob: &[u8]) -> Vec<String> {
+        let (rows, _) = size_of(blob);
+        let mut rest = &blob[8..];
+        (0..rows)
+            .map(|_| {
+                let (len, body) = rest.split_at(4);
+                let len = u32::from_be_bytes(len.try_into().expect("4 bytes")) as usize;
+                let (row, remainder) = body.split_at(len);
+                rest = remainder;
+                String::from_utf8(row.to_vec()).expect("rows are valid UTF-8")
+            })
+            .collect()
+    }
+
+    /// Ask a parser thread for its screen, waiting for it to work through the queue first.
+    fn request_screen(msg_tx: &SyncSender<Msg>) -> Vec<u8> {
         let (reply_tx, reply_rx) = mpsc::channel();
         msg_tx.send(Msg::ScreenRequest(reply_tx)).expect("parser thread alive");
-        let blob = reply_rx
-            .recv_timeout(std::time::Duration::from_secs(5))
-            .expect("parser thread still answering");
-
-        // Dimensions are clamped to (1, 1) because vt100 dimensions must be positive.
-        assert_eq!(size_of(&blob), (rows.max(1), cols.max(1)));
+        reply_rx.recv_timeout(TIMEOUT).expect("parser thread still answering")
     }
 
     #[rstest]
-    fn resize_small_and_wrap(#[values(0, 1, 2, 3)] rows: u16, #[values(0, 1, 2, 3)] cols: u16) {
-        let mut parser = vt100::Parser::default();
-        handle_parser_msg(&mut parser, Msg::Resize { rows, cols });
-        handle_parser_msg(&mut parser, Msg::Data(b"hello world".to_vec()));
+    fn init_small_and_wrap(#[values(0, 1, 2, 3)] rows: u16, #[values(0, 1, 2, 3)] cols: u16) {
+        let (msg_tx, msg_rx) = mpsc::sync_channel(8);
+        spawn_parser_thread(rows, cols, msg_rx, plain());
+        msg_tx.send(Msg::Data(b"hello world".to_vec())).expect("parser thread alive");
 
         // Dimensions are clamped to (1, 1) because vt100 dimensions must be positive.
-        assert_eq!(size_of(&encode_screen(&parser)), (rows.max(1), cols.max(1)));
+        assert_eq!(size_of(&request_screen(&msg_tx)), (rows.max(1), cols.max(1)));
+    }
+
+    #[rstest]
+    fn resize_small_and_wrap(
+        #[with(1, 1)] mut parser: Parser,
+        #[values(0, 1, 2, 3)] rows: u16,
+        #[values(0, 1, 2, 3)] cols: u16,
+    ) {
+        parser.handle_msg(Msg::Resize { rows, cols });
+        parser.handle_msg(Msg::Data(b"hello world".to_vec()));
+
+        // Dimensions are clamped to (1, 1) because vt100 dimensions must be positive.
+        assert_eq!(size_of(&encode_screen(&parser.emulator)), (rows.max(1), cols.max(1)));
+    }
+
+    #[rstest]
+    fn encodes_the_screen_contents_and_cursor(#[with(3, 10)] mut parser: Parser) {
+        parser.handle_msg(Msg::Data(b"one\r\ntwo".to_vec()));
+
+        let blob = encode_screen(&parser.emulator);
+        assert_eq!(size_of(&blob), (3, 10));
+        assert_eq!(cursor_of(&blob), (1, 3));
+
+        let rows = rows_of(&blob);
+        assert_eq!(rows.len(), 3);
+        assert!(rows[0].contains("one"), "{rows:?}");
+        assert!(rows[1].contains("two"), "{rows:?}");
+    }
+
+    #[rstest]
+    fn a_resize_is_forwarded_to_the_capture_tracker() {
+        let (sink, captures) = capture_sink();
+        let mut parser = Parser::new(nonzero(6), nonzero(20), ParserOptions {
+            sink: Some(sink),
+            debug_osc133: false,
+        });
+
+        parser.handle_msg(Msg::Data(b"\x1b]133;C\x07abcdefghij".to_vec()));
+        parser.handle_msg(Msg::Resize { rows: 6, cols: 5 });
+        parser.handle_msg(Msg::Data(b"klmno\r\n\x1b]133;D;0;history_id=hist\x07".to_vec()));
+
+        let captures: Vec<_> = captures.try_iter().collect();
+        assert_eq!(captures.len(), 1);
+        assert_eq!(captures[0].output, "abcdklmno");
+    }
+
+    #[rstest]
+    fn the_parser_thread_feeds_the_capture_sink() {
+        let (sink, captures) = capture_sink();
+        let (msg_tx, msg_rx) = mpsc::sync_channel(8);
+        spawn_parser_thread(24, 80, msg_rx, ParserOptions {
+            sink: Some(sink),
+            debug_osc133: false,
+        });
+
+        msg_tx
+            .send(Msg::Data(
+                b"\x1b]133;A\x07$ \x1b]133;B\x07echo hi\r\n\x1b]133;C\x07hi\r\n\x1b]133;D;0;history_id=hist;session_id=sess\x07".to_vec(),
+            ))
+            .expect("parser thread alive");
+        // A screen request only comes back once the data above has been handled.
+        let blob = request_screen(&msg_tx);
+        assert_eq!(size_of(&blob), (24, 80));
+
+        let captures: Vec<_> = captures.try_iter().collect();
+        assert_eq!(captures.len(), 1);
+        assert_eq!(captures[0].command, "echo hi");
+        assert_eq!(captures[0].output, "hi");
+        assert_eq!(captures[0].history_id.as_deref(), Some("hist"));
+    }
+
+    #[rstest]
+    fn debug_highlighting_reaches_the_screen_but_not_the_capture() {
+        // The highlighter's labels are a debugging aid for the terminal and the screen
+        // snapshot. They are not terminal output the shell produced, so the capture tracker
+        // has to see the raw stream -- otherwise every captured field is prefixed with a
+        // label and `output_observed_bytes` counts them.
+        let (sink, captures) = capture_sink();
+        let mut parser = Parser::new(nonzero(6), nonzero(40), ParserOptions {
+            sink: Some(sink),
+            debug_osc133: true,
+        });
+
+        parser.handle_msg(Msg::Data(
+            [
+                b"\x1b]133;A\x07$ \x1b]133;B\x07echo hi\r\n".as_slice(),
+                b"\x1b]133;C\x07hi\r\n\x1b]133;D;0;history_id=hist;session_id=sess\x07",
+            ]
+            .concat(),
+        ));
+
+        let captures: Vec<_> = captures.try_iter().collect();
+        assert_eq!(captures.len(), 1);
+        assert_eq!(captures[0].prompt, "$");
+        assert_eq!(captures[0].command, "echo hi");
+        assert_eq!(captures[0].output, "hi");
+        assert_eq!(captures[0].output_observed_bytes, b"hi\r\n".len() as u64);
+
+        // The screen snapshot, on the other hand, is where the labels belong.
+        let rows = rows_of(&encode_screen(&parser.emulator)).join("\n");
+        assert!(rows.contains("[OSC133:A prompt]"), "{rows:?}");
+        assert!(rows.contains("[OSC133:D exit=0]"), "{rows:?}");
+    }
+
+    #[rstest]
+    fn a_parser_without_a_sink_still_tracks_the_screen(#[with(6, 20)] mut parser: Parser) {
+        parser.handle_msg(Msg::Data(b"\x1b]133;C\x07hi\r\n\x1b]133;D;0\x07".to_vec()));
+
+        assert!(rows_of(&encode_screen(&parser.emulator))[0].contains("hi"));
+    }
+
+    fn nonzero(value: u16) -> NonZeroU16 {
+        NonZeroU16::new(value).expect("test dimensions are non-zero")
+    }
+
+    /// A [`Parser`] with no capture sink, for the tests that only look at the screen.
+    #[fixture]
+    fn parser(#[default(24)] rows: u16, #[default(80)] cols: u16) -> Parser {
+        Parser::new(nonzero(rows), nonzero(cols), plain())
+    }
+
+    /// Parser options with nothing enabled.
+    fn plain() -> ParserOptions {
+        ParserOptions {
+            sink: None,
+            debug_osc133: false,
+        }
+    }
+
+    /// A capture sink that funnels every capture into the returned receiver.
+    fn capture_sink() -> (CommandCaptureSink, Receiver<CommandCapture>) {
+        let (sender, received) = mpsc::channel();
+        let sink = Box::new(move |capture| {
+            sender.send(capture).expect("test receiver is still alive");
+        });
+        (sink, received)
     }
 }


### PR DESCRIPTION
This PR updates Atuin's command output capturing code. Much of this is to lay the groundwork for future changes, but there are also some immediate benefits:

* OSC 133 parsing has been improved. The parser is now **fully allocation-free**, and bugs relating to escape sequences that spanned chunk boundaries have been fixed.
* Output captures **match reality much more closely**. Previously, we did not correctly handle output that included certain kinds of escape sequences, like those that move the cursor to an absolute position. Now we use a more robust capture mechanism.
* SGR escape sequences (responsible for colors and formatting) are now included in captured output. **This enables Atuin AI to answer questions like “what does the red text mean in the command I just ran?”.**

Atuin AI can now answer questions like this:

<img width="2381" height="836" alt="atuin-ai-colors" src="https://github.com/user-attachments/assets/b298ffec-531c-4bbe-a93a-32834fd57378" />