### PR TITLE
fix(nix): Export OpenSSL lib for LD_LIBRARY_PATH in nix devshell

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -55,6 +55,11 @@
             RUST_SRC_PATH = "${pkgs.rustPlatform.rustLibSrc}";
 
             shellHook = ''
+              # See atuin.nix's preBuild for explanation.
+              export LD_LIBRARY_PATH="${
+                pkgs.lib.makeLibraryPath [ pkgs.openssl ]
+              }''${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
+
               echo >&2 "Setting development database path"
               export ATUIN_DB_PATH="/tmp/atuin_dev.db"
               export ATUIN_RECORD_STORE_PATH="/tmp/atuin_records.db"


### PR DESCRIPTION
From `atuin.nix`:

```nix
  # native-tls pulls OpenSSL into the sqlx-macros proc-macro, which rustc dlopens at
  # build time. With OPENSSL_NO_VENDOR it links libssl.so.3 dynamically, so the loader
  # needs it on LD_LIBRARY_PATH while the proc-macro is loaded.
  preBuild = ''
    export LD_LIBRARY_PATH="${lib.makeLibraryPath [ openssl ]}''${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
  '';
```

The same fix is needed for the Nix dev shell so that you can run, e.g., `cargo run`, yet it was not present there. This PR copies the fix into the nix dev shell shell hook.

<!-- Thank you for making a PR! Bug fixes are always welcome, but if you're adding a new feature or changing an existing one, we'd really appreciate if you open an issue, post on the forum, or drop in on Discord -->

## Checks
- [x] I am happy for maintainers to push small adjustments to this PR, to speed up the review cycle
- [x] I have checked that there are no existing pull requests for the same thing
