### PR TITLE
feat(nu): Support shell integration for Nushell Helix edit modes

### DIFF
--- a/crates/atuin/src/command/client/init/nu.rs
+++ b/crates/atuin/src/command/client/init/nu.rs
@@ -7,7 +7,7 @@ const BIND_CTRL_R: &str = r"$env.config = (
             name: atuin
             modifier: control
             keycode: char_r
-            mode: [emacs, vi_normal, vi_insert]
+            mode: ([emacs, vi_normal, vi_insert] | append (_atuin_helix_edit_modes_if_supported [helix_normal, helix_insert, helix_select]))
             event: { send: executehostcommand cmd: (_atuin_search_cmd) }
         }
     )
@@ -20,7 +20,7 @@ const BIND_UP_ARROW: &str = r"$env.config = (
             name: atuin_up_arrow
             modifier: none
             keycode: up
-            mode: [emacs, vi_normal, vi_insert]
+            mode: ([emacs, vi_normal, vi_insert] | append (_atuin_helix_edit_modes_if_supported))
             event: {
                 until: [
                     {send: menuup}

--- a/crates/atuin/src/shell/atuin.nu
+++ b/crates/atuin/src/shell/atuin.nu
@@ -119,6 +119,10 @@ $env.config = (
 
 $env.config = ($env.config | default [] keybindings)
 
+def _atuin_helix_edit_modes_if_supported [modes: list<string> = [helix_normal, helix_insert]] {
+    if ((version).major > 0 or (version).minor >= 115) { $modes } else { [] }
+}
+
 if (version).minor >= 104 or (version).major > 0 {
     with-env { ATUIN_SHELL: nu } {
         job spawn {


### PR DESCRIPTION
Adds support for Helix edit modes of Nushell (new in [Nushell 0.115](https://www.nushell.sh/blog/2026-08-15-nushell_v0_115_0.html#added-helix-edit-mode)).

Supports `helix_normal` and `helix_insert`.
Does not register for `helix_select`.

Note that this is a new Nushell edit mode, and Nushell will complain if there are invalid modes in the keybindings' mode config. Thus, the version guard is necessary to not break Nushell integration for Nushell versions < 0.115.

<!-- Thank you for making a PR! Bug fixes are always welcome, but if you're adding a new feature or changing an existing one, we'd really appreciate if you open an issue, post on the forum, or drop in on Discord -->

## Checks
- [x] I am happy for maintainers to push small adjustments to this PR, to speed up the review cycle
- [x] I have checked that there are no existing pull requests for the same thing
