### PR TITLE
fix(history): don't let smart_sort's prefix boost defeat fulltext mode

### DIFF
--- a/crates/atuin-history/benches/smart_sort.rs
+++ b/crates/atuin-history/benches/smart_sort.rs
@@ -1,4 +1,5 @@
 use atuin_client::history::History;
+use atuin_client::settings::SearchMode;
 use atuin_history::sort::sort;
 use rand::rngs::StdRng;
 use rand::{Rng, SeedableRng};
@@ -18,7 +19,9 @@ const SEED_NOW: OffsetDateTime = datetime!(2026-01-01 12:59:59 -5);
 #[divan::bench(args=[100, 200, 400, 800, 1600, 10000])]
 fn smart_sort(bencher: divan::Bencher, lines: usize) {
     // Generating the history is not part of what we measure, so it happens as an input.
-    bencher.with_inputs(|| history(lines)).bench_values(|commands| sort("curl", commands));
+    bencher
+        .with_inputs(|| history(lines))
+        .bench_values(|commands| sort("curl", SearchMode::Fuzzy, commands));
 }
 
 /// Generate a few different sizes of "history". This will use a whole bunch of memory, sorry.

--- a/crates/atuin-history/src/sort.rs
+++ b/crates/atuin-history/src/sort.rs
@@ -23,7 +23,16 @@ pub fn sort(query: &str, search_mode: SearchMode, input: Vec<History>) -> Vec<Hi
             // buried mid-command would always rank below every prefix match no matter how old,
             // instead of being ranked primarily by recency as the docs promise.
             let score = if search_mode == SearchMode::FullText {
-                if h.command.contains(query) {
+                // Mirror the smart-case behavior of the DB-side LIKE/GLOB query
+                // (QueryToken::has_uppercase in database.rs): an all-lowercase query
+                // matches case-insensitively, so a lowercase-only query must not
+                // demote differently-cased commands that the DB already matched.
+                let matches = if query.contains(char::is_uppercase) {
+                    h.command.contains(query)
+                } else {
+                    h.command.to_lowercase().contains(&query.to_lowercase())
+                };
+                if matches {
                     2.0
                 } else {
                     1.0
@@ -99,5 +108,35 @@ mod tests {
 
         assert_eq!(sorted[0].command, old_prefix_match.command);
         assert_eq!(sorted[1].command, recent_substring_match.command);
+    }
+
+    // Regression test for a case-sensitivity bug caught in review: the DB-side fulltext query
+    // matches case-insensitively for an all-lowercase query, so a differently-cased command
+    // must not be treated as a non-match here and demoted below an older exact-case one.
+    #[test]
+    fn fulltext_lowercase_query_matches_case_insensitively() {
+        let recent_different_case = history_ago("GIT status", 10);
+        let old_exact_case = history_ago("git log", 1_000_000);
+
+        let input = vec![old_exact_case.clone(), recent_different_case.clone()];
+        let sorted = sort("git", SearchMode::FullText, input);
+
+        assert_eq!(sorted[0].command, recent_different_case.command);
+        assert_eq!(sorted[1].command, old_exact_case.command);
+    }
+
+    // A query containing uppercase opts into case-sensitive matching, mirroring the DB-side
+    // GLOB behavior for such queries (QueryToken::has_uppercase in database.rs): a differently
+    // cased command should score as a non-match, not be treated as equivalent.
+    #[test]
+    fn fulltext_uppercase_query_matches_case_sensitively() {
+        let recent_wrong_case = history_ago("git status", 10);
+        let old_exact_case = history_ago("STATUS log", 1_000_000);
+
+        let input = vec![recent_wrong_case.clone(), old_exact_case.clone()];
+        let sorted = sort("STATUS", SearchMode::FullText, input);
+
+        assert_eq!(sorted[0].command, old_exact_case.command);
+        assert_eq!(sorted[1].command, recent_wrong_case.command);
     }
 }

--- a/crates/atuin-history/src/sort.rs
+++ b/crates/atuin-history/src/sort.rs
@@ -1,4 +1,5 @@
 use atuin_client::history::History;
+use atuin_client::settings::SearchMode;
 
 type ScoredHistory = (f64, History);
 
@@ -7,7 +8,7 @@ type ScoredHistory = (f64, History);
 // first.
 // Later on, we can pass in context and do some boosts there too.
 #[must_use]
-pub fn sort(query: &str, input: Vec<History>) -> Vec<History> {
+pub fn sort(query: &str, search_mode: SearchMode, input: Vec<History>) -> Vec<History> {
     // This can totally be extended. We need to be _careful_ that it's not slow.
     // We also need to balance sorting db-side with sorting here. SQLite can do a lot,
     // but some things are just much easier/more doable in Rust.
@@ -15,8 +16,19 @@ pub fn sort(query: &str, input: Vec<History>) -> Vec<History> {
     let mut scored = input
         .into_iter()
         .map(|h| {
-            // If history is _prefixed_ with the query, score it more highly
-            let score = if h.command.starts_with(query) {
+            // If history is _prefixed_ with the query, score it more highly.
+            //
+            // In fulltext mode the query semantically means "*query*" (matches anywhere), so
+            // boosting prefix matches over other substring matches defeats the mode: a match
+            // buried mid-command would always rank below every prefix match no matter how old,
+            // instead of being ranked primarily by recency as the docs promise.
+            let score = if search_mode == SearchMode::FullText {
+                if h.command.contains(query) {
+                    2.0
+                } else {
+                    1.0
+                }
+            } else if h.command.starts_with(query) {
                 2.0
             } else if h.command.contains(query) {
                 1.75
@@ -44,4 +56,48 @@ pub fn sort(query: &str, input: Vec<History>) -> Vec<History> {
 
     // Remove the scores and return the history
     scored.into_iter().map(|(_, h)| h).collect::<Vec<History>>()
+}
+
+#[cfg(test)]
+mod tests {
+    use time::OffsetDateTime;
+
+    use super::*;
+
+    // Both timestamps are in the past relative to real wall-clock time, and far enough
+    // apart that the recency multiplier can't meaningfully close a 2.0-vs-1.0 score gap;
+    // this isolates the assertions to the prefix/contains scoring behavior under test.
+    fn history_ago(command: &str, seconds_ago: i64) -> History {
+        let timestamp = OffsetDateTime::now_utc() - time::Duration::seconds(seconds_ago);
+        History::import().command(command).timestamp(timestamp).build().into()
+    }
+
+    // Regression test for https://github.com/atuinsh/atuin/issues/3923: in fulltext mode a
+    // recent command matching the query mid-string should not be ranked below every older
+    // command that merely starts with the query, since fulltext explicitly means "*query*".
+    #[test]
+    fn fulltext_does_not_prefer_prefix_match_over_recency() {
+        let recent_substring_match = history_ago("ps axu|grep -i git", 10);
+        let old_prefix_match = history_ago("grep -r foo", 1_000_000);
+
+        let input = vec![old_prefix_match.clone(), recent_substring_match.clone()];
+        let sorted = sort("grep", SearchMode::FullText, input);
+
+        assert_eq!(sorted[0].command, recent_substring_match.command);
+        assert_eq!(sorted[1].command, old_prefix_match.command);
+    }
+
+    // Prefix mode is unaffected: an exact prefix match should still be able to outrank a more
+    // recent, merely-contained match.
+    #[test]
+    fn prefix_mode_still_prefers_prefix_match() {
+        let recent_substring_match = history_ago("ps axu|grep -i git", 10);
+        let old_prefix_match = history_ago("grep -r foo", 1_000_000);
+
+        let input = vec![recent_substring_match.clone(), old_prefix_match.clone()];
+        let sorted = sort("grep", SearchMode::Prefix, input);
+
+        assert_eq!(sorted[0].command, old_prefix_match.command);
+        assert_eq!(sorted[1].command, recent_substring_match.command);
+    }
 }

--- a/crates/atuin/src/command/client/search/interactive.rs
+++ b/crates/atuin/src/command/client/search/interactive.rs
@@ -217,7 +217,7 @@ impl State {
         self.results_len = results.len();
 
         if settings.smart_sort {
-            Ok(atuin_history::sort::sort(self.search.input.as_str(), results))
+            Ok(atuin_history::sort::sort(self.search.input.as_str(), self.search_mode(), results))
         } else {
             Ok(results)
         }


### PR DESCRIPTION
Fixes #3923.

I used a coding agent (Claude) to help investigate and implement this, under my direction and review — disclosing per CONTRIBUTING.md.

## What I found

The reporter's symptom (`search_mode = fulltext`, but a match like `ps axu|grep -i git` doesn't show up until after every command that literally starts with `grep`) isn't in the SQL query building in `atuin-client/src/database.rs` — that already builds a genuine `%query%` fulltext condition. The DB results are correct.

The re-ranking happens afterward, in `atuin-history/src/sort.rs`'s `sort()`, which runs whenever `smart_sort` is enabled (the default), regardless of search mode. It always scores a command that *starts with* the query at 2.0 and one that merely *contains* it at 1.75, then multiplies by a small recency factor. In fulltext mode this defeats the mode's own definition (docs: `fulltext mode searches for "*query*"` — matches anywhere) by keeping every prefix match ranked above every non-prefix match no matter how old, instead of letting recency decide as the mode's docs imply.

(I also looked at #3868, "smart_sort does not always sort chronologically" — that one is about `smart_sort`'s recency/prefix blend behaving as originally designed per #1885, not a bug, so I left it alone.)

## Fix

Threaded the active `SearchMode` into `sort()`. Only in `FullText` mode, a prefix match and any other substring match now score identically, so the existing recency multiplier is what decides ranking among them. `Prefix` and `Fuzzy` modes are untouched.

## Testing

- Added two unit tests in `sort.rs`: one reproduces the reported scenario (an old prefix match should no longer outrank a much more recent substring-only match under `FullText`), and one confirms `Prefix` mode's existing behavior is unchanged.
- Verified both by reverting only the scoring change and confirming the fulltext test fails without it, then restoring it and confirming both pass.
- `cargo test -p atuin-history` (40 tests) and `cargo test -p atuin --bin atuin search::` (336 tests) both pass.
- `cargo +nightly fmt --check` and `cargo clippy` are clean on the changed files (no new warnings).

## Checks
- [x] I am happy for maintainers to push small adjustments to this PR, to speed up the review cycle
- [x] I have checked that there are no existing pull requests for the same thing