### PR TITLE
refactor(deps): bump shlex from v1 to v2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -285,7 +285,7 @@ dependencies = [
  "semver",
  "serde",
  "serde_json",
- "shlex 1.3.0",
+ "shlex",
  "sysinfo",
  "tempfile",
  "thiserror 2.0.19",
@@ -980,7 +980,7 @@ dependencies = [
  "find-msvc-tools",
  "jobserver",
  "libc",
- "shlex 2.0.1",
+ "shlex",
 ]
 
 [[package]]
@@ -5057,12 +5057,6 @@ checksum = "32824fab5e16e6c4d86dc1ba84489390419a39f97699852b66480bb87d297ed8"
 dependencies = [
  "dirs",
 ]
-
-[[package]]
-name = "shlex"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "shlex"

--- a/crates/atuin/Cargo.toml
+++ b/crates/atuin/Cargo.toml
@@ -123,7 +123,7 @@ regex = "1.10.5"
 norm = { version = "0.1.1", features = ["fzf-v2"] }
 frizbee = { workspace = true }
 tempfile = { workspace = true }
-shlex = "1.3.0"
+shlex = "2.0.1"
 thiserror = { workspace = true }
 
 # settings editor with comment and relative ordering preservation


### PR DESCRIPTION
<!-- Thank you for making a PR! Bug fixes are always welcome, but if you're adding a new feature or changing an existing one, we'd really appreciate if you open an issue, post on the forum, or drop in on Discord -->

See https://github.com/comex/rust-shlex/blob/653936e120cdd0a8d1b4f0837e2cce0f347da4c0/CHANGELOG.md. There’s only one call into `shlex`, and it doesn’t use any of the APIs that were removed in v2:

https://github.com/atuinsh/atuin/blob/e34b9dd1b7e7213cd27c9b4b882cc8bc550a5b22/crates/atuin/src/command/client/scripts.rs#L139

## Checks
- [x] I am happy for maintainers to push small adjustments to this PR, to speed up the review cycle
- [x] I have checked that there are no existing pull requests for the same thing
