### PR TITLE
Bugfix: Retry empty daemon search index loads

### DIFF
--- a/crates/atuin-daemon/src/components/search.rs
+++ b/crates/atuin-daemon/src/components/search.rs
@@ -46,17 +46,20 @@ where
     info!("Loading history into search index; page size = {}", PAGE_SIZE);
     let db = handle.history_db();
     let mut pager = db.all_paged(PAGE_SIZE, false, true);
+    let mut saw_rows = false;
     loop {
         match pager.next().await {
             Ok(Some(histories)) => {
                 info!("Loading {} history entries into search index", histories.len());
+                saw_rows = true;
                 index().await.add_histories(&histories);
             }
             Ok(None) => {
-                info!(
-                    "History load complete; {} unique commands indexed",
-                    index().await.command_count()
-                );
+                let index = index().await;
+                if saw_rows {
+                    index.mark_loaded();
+                }
+                info!("History load complete; {} unique commands indexed", index.command_count());
                 return Ok(());
             }
             Err(e) => {
@@ -292,11 +295,14 @@ impl SearchGrpcService {
         &self,
         shells: OrFilter<Vec<String>>,
     ) -> Result<Option<SearchIndex>, ()> {
-        if self.index.read().await.shells == shells {
-            return Ok(None);
+        {
+            let index = self.index.read().await;
+            if index.shells == shells && index.is_loaded() {
+                return Ok(None);
+            }
         }
 
-        info!("Rebuilding search index from database after shell filter change");
+        info!("Rebuilding search index from database");
 
         let new_index = SearchIndex::new(shells);
         build_index(async || &new_index, &self.handle).await?;

--- a/crates/atuin-daemon/src/search/index.rs
+++ b/crates/atuin-daemon/src/search/index.rs
@@ -11,6 +11,7 @@ use std::borrow::Cow;
 use std::cmp::Ordering;
 use std::collections::HashSet;
 use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering as AtomicOrdering};
 
 use atuin_client::history::History;
 use atuin_client::settings::Search;
@@ -351,6 +352,11 @@ pub struct SearchIndex {
 
     /// Controls which shells' commands are included.
     pub shells: OrFilter<Vec<String>>,
+
+    /// Whether this index has been successfully populated from the database.
+    ///
+    /// Stays false if the load failed or returned no rows, so a later request retries it.
+    loaded: AtomicBool,
 }
 
 impl SearchIndex {
@@ -363,7 +369,19 @@ impl SearchIndex {
             frecency_map: RwLock::new(None),
             interner: Arc::new(ThreadedRodeo::new()),
             shells,
+            loaded: AtomicBool::new(false),
         }
+    }
+
+    /// Whether this index has been successfully populated from the database.
+    #[must_use]
+    pub fn is_loaded(&self) -> bool {
+        self.loaded.load(AtomicOrdering::Relaxed)
+    }
+
+    /// Mark this index as successfully populated from the database.
+    pub fn mark_loaded(&self) {
+        self.loaded.store(true, AtomicOrdering::Relaxed);
     }
 
     /// Add a history entry to the index.


### PR DESCRIPTION
I hit a bug on Mac OS where the indexing failed and it resulted in it caching an empty history, so no searches would work and I had to manually restart the daemon. It makes no sense to cache an empty history since the rebuild is very cheap anyway?

Btw, I didn't run `cargo fmt` since I don't have nightly on this machine.

-----------------------------

An initial index load can return no rows without reporting an error, leaving daemon-fuzzy search stuck with an empty cached index for the lifetime of the daemon.

Track whether a search index completed a load that returned at least one database row. Empty loads remain unready, so prepare and search requests retry them. Track input rows rather than indexed commands because agent commands and shell filters can legitimately produce an empty index.

<!-- Thank you for making a PR! Bug fixes are always welcome, but if you're adding a new feature or changing an existing one, we'd really appreciate if you open an issue, post on the forum, or drop in on Discord -->

## Checks
- [x] I am happy for maintainers to push small adjustments to this PR, to speed up the review cycle
- [x] I have checked that there are no existing pull requests for the same thing
