### PR TITLE
fix(daemon): reject invalid pidfile pids before signalling

### DIFF
--- a/crates/atuin/src/command/client/daemon.rs
+++ b/crates/atuin/src/command/client/daemon.rs
@@ -707,7 +707,8 @@ async fn force_cleanup(settings: &Settings) {
     if pidfile_path.exists() {
         if let Ok(contents) = fs::read_to_string(pidfile_path)
             && let Some(pid_str) = contents.lines().next()
-            && let Some(pid) = parse_pid(pid_str)
+            && let Some(pid) = pid_str.trim().parse::<i32>().ok()
+            && pid > 0
             && let Err(e) = atuin_common::os::process::force_terminate(
                 pid.unsigned_abs(),
                 Duration::from_secs(2),

--- a/crates/atuin/src/command/client/daemon.rs
+++ b/crates/atuin/src/command/client/daemon.rs
@@ -692,6 +692,23 @@ async fn run(
     Ok(())
 }
 
+/// Parse and validate a pid read from the daemon pidfile.
+///
+/// Returns `Some(pid)` only for a valid, positive process id (`1..=i32::MAX`).
+/// Any other value (zero, a value in `[2^31, 2^32)` whose signed cast is
+/// negative, or non-numeric garbage) is rejected with `None` so a corrupt
+/// pidfile can never be turned into a signalling target.
+fn parse_daemon_pid(s: &str) -> Option<i32> {
+    // Parse directly as a signed pid and require it to be strictly positive.
+    // This rejects zero, negatives, and any value in `[2^31, 2^32)` that would
+    // otherwise wrap to a negative `i32` and, via `Pid::from_raw`, become a
+    // `kill(-1)` / `kill(-pgid)` mass-signal (or a `debug_assert` panic).
+    match s.parse::<i32>() {
+        Ok(pid) if pid > 0 => Some(pid),
+        _ => None,
+    }
+}
+
 /// Force cleanup: kill existing daemon process and remove socket.
 async fn force_cleanup(settings: &Settings) {
     let pidfile_path = Path::new(&settings.daemon.pidfile_path);
@@ -700,9 +717,10 @@ async fn force_cleanup(settings: &Settings) {
     if pidfile_path.exists() {
         if let Ok(contents) = fs::read_to_string(pidfile_path)
             && let Some(pid_str) = contents.lines().next()
-            && let Ok(pid) = pid_str.parse::<u32>()
+            && let Some(pid) = parse_daemon_pid(pid_str)
             && let Err(e) =
-                atuin_common::os::process::force_terminate(pid, Duration::from_secs(2)).await
+                atuin_common::os::process::force_terminate(pid.unsigned_abs(), Duration::from_secs(2))
+                    .await
         {
             tracing::warn!("could not terminate existing daemon (pid {pid}): {e}");
         }
@@ -753,6 +771,24 @@ mod tests {
         for needle in needles {
             assert!(msg.contains(needle), "got: {msg}");
         }
+    }
+
+    #[rstest]
+    // Valid, positive pids are accepted unchanged.
+    #[case::normal("12345", Some(12345))]
+    #[case::one("1", Some(1))]
+    #[case::max("2147483647", Some(i32::MAX))]
+    // Zero is not a valid pid to signal.
+    #[case::zero("0", None)]
+    // Values in [2^31, 2^32) cast to a negative i32 -> kill(-1)/kill(-pgid).
+    #[case::u32_max("4294967295", None)]
+    #[case::two_pow_31("2147483648", None)]
+    // Non-numeric / negative garbage.
+    #[case::negative("-1", None)]
+    #[case::garbage("not-a-pid", None)]
+    #[case::empty("", None)]
+    fn parse_daemon_pid_rejects_invalid(#[case] input: &str, #[case] expected: Option<i32>) {
+        assert_eq!(parse_daemon_pid(input), expected);
     }
 
     #[test]

--- a/crates/atuin/src/command/client/daemon.rs
+++ b/crates/atuin/src/command/client/daemon.rs
@@ -718,9 +718,11 @@ async fn force_cleanup(settings: &Settings) {
         if let Ok(contents) = fs::read_to_string(pidfile_path)
             && let Some(pid_str) = contents.lines().next()
             && let Some(pid) = parse_daemon_pid(pid_str)
-            && let Err(e) =
-                atuin_common::os::process::force_terminate(pid.unsigned_abs(), Duration::from_secs(2))
-                    .await
+            && let Err(e) = atuin_common::os::process::force_terminate(
+                pid.unsigned_abs(),
+                Duration::from_secs(2),
+            )
+            .await
         {
             tracing::warn!("could not terminate existing daemon (pid {pid}): {e}");
         }

--- a/crates/atuin/src/command/client/daemon.rs
+++ b/crates/atuin/src/command/client/daemon.rs
@@ -692,32 +692,22 @@ async fn run(
     Ok(())
 }
 
-/// Parse and validate a pid read from the daemon pidfile.
-///
-/// Returns `Some(pid)` only for a valid, positive process id (`1..=i32::MAX`).
-/// Any other value (zero, a value in `[2^31, 2^32)` whose signed cast is
-/// negative, or non-numeric garbage) is rejected with `None` so a corrupt
-/// pidfile can never be turned into a signalling target.
-fn parse_daemon_pid(s: &str) -> Option<i32> {
-    // Parse directly as a signed pid and require it to be strictly positive.
-    // This rejects zero, negatives, and any value in `[2^31, 2^32)` that would
-    // otherwise wrap to a negative `i32` and, via `Pid::from_raw`, become a
-    // `kill(-1)` / `kill(-pgid)` mass-signal (or a `debug_assert` panic).
-    match s.parse::<i32>() {
-        Ok(pid) if pid > 0 => Some(pid),
-        _ => None,
-    }
-}
-
 /// Force cleanup: kill existing daemon process and remove socket.
 async fn force_cleanup(settings: &Settings) {
     let pidfile_path = Path::new(&settings.daemon.pidfile_path);
+
+    fn parse_pid(s: &str) -> Option<i32> {
+        match s.parse::<i32>() {
+            Ok(pid) if pid > 0 => Some(pid),
+            _ => None,
+        }
+    }
 
     // Read and kill the existing process if pidfile exists
     if pidfile_path.exists() {
         if let Ok(contents) = fs::read_to_string(pidfile_path)
             && let Some(pid_str) = contents.lines().next()
-            && let Some(pid) = parse_daemon_pid(pid_str)
+            && let Some(pid) = parse_pid(pid_str)
             && let Err(e) = atuin_common::os::process::force_terminate(
                 pid.unsigned_abs(),
                 Duration::from_secs(2),
@@ -773,24 +763,6 @@ mod tests {
         for needle in needles {
             assert!(msg.contains(needle), "got: {msg}");
         }
-    }
-
-    #[rstest]
-    // Valid, positive pids are accepted unchanged.
-    #[case::normal("12345", Some(12345))]
-    #[case::one("1", Some(1))]
-    #[case::max("2147483647", Some(i32::MAX))]
-    // Zero is not a valid pid to signal.
-    #[case::zero("0", None)]
-    // Values in [2^31, 2^32) cast to a negative i32 -> kill(-1)/kill(-pgid).
-    #[case::u32_max("4294967295", None)]
-    #[case::two_pow_31("2147483648", None)]
-    // Non-numeric / negative garbage.
-    #[case::negative("-1", None)]
-    #[case::garbage("not-a-pid", None)]
-    #[case::empty("", None)]
-    fn parse_daemon_pid_rejects_invalid(#[case] input: &str, #[case] expected: Option<i32>) {
-        assert_eq!(parse_daemon_pid(input), expected);
     }
 
     #[test]

--- a/crates/atuin/src/command/client/daemon.rs
+++ b/crates/atuin/src/command/client/daemon.rs
@@ -696,13 +696,6 @@ async fn run(
 async fn force_cleanup(settings: &Settings) {
     let pidfile_path = Path::new(&settings.daemon.pidfile_path);
 
-    fn parse_pid(s: &str) -> Option<i32> {
-        match s.parse::<i32>() {
-            Ok(pid) if pid > 0 => Some(pid),
-            _ => None,
-        }
-    }
-
     // Read and kill the existing process if pidfile exists
     if pidfile_path.exists() {
         if let Ok(contents) = fs::read_to_string(pidfile_path)


### PR DESCRIPTION
`force_cleanup` (in `crates/atuin/src/command/client/daemon.rs`) read the daemon pidfile and parsed it as a `u32`, then handed it to `atuin_common::os::process::force_terminate`, which turns it into a rustix `Pid` via `Pid::from_raw(pid.cast_signed())`.

A corrupt or hand-edited pidfile value in `[2^31, 2^32)` overflows to a **negative** `i32`.