### PR TITLE
fix(server): purge orphaned store rows on Postgres

### DIFF
--- a/crates/atuin-server/src/db/postgres/migrations/20260829000000_purge-orphaned-store.sql
+++ b/crates/atuin-server/src/db/postgres/migrations/20260829000000_purge-orphaned-store.sql
@@ -1,0 +1,3 @@
+-- Postgres deployments hit the same delete_user bug (shared code path) that left
+-- orphaned store rows behind. Clean them up. See the sqlite counterpart.
+delete from store where user_id not in (select id from users);

--- a/crates/atuin-server/tests/pg_purge_orphaned_store.rs
+++ b/crates/atuin-server/tests/pg_purge_orphaned_store.rs
@@ -1,0 +1,112 @@
+//! Regression test for D4: orphaned `store` rows must be purged on Postgres.
+//!
+//! The historical `delete_user` bug lived in the SHARED blanket-impl path that
+//! serves both SQLite and Postgres, so Postgres deployments that ran the buggy
+//! code carry orphaned `store` rows (rows whose `user_id` no longer exists in
+//! `users`). SQLite shipped a cleanup migration; Postgres did not. This test
+//! proves the Postgres migration chain purges those orphans.
+//!
+//! It only runs when `ATUIN_TEST_DB_URI` points at a Postgres instance, e.g.:
+//!
+//!   docker run -d --rm --name d4-pg -e POSTGRES_USER=atuin \
+//!     -e POSTGRES_PASSWORD=pass -e POSTGRES_DB=atuin -p 15439:5432 postgres:16
+//!   ATUIN_TEST_DB_URI=postgres://atuin:pass@localhost:15439/atuin \
+//!     cargo test -p atuin-server --test pg_purge_orphaned_store
+
+use sqlx::{Row, postgres::PgPoolOptions};
+
+#[tokio::test]
+async fn postgres_migration_purges_orphaned_store_rows() -> eyre::Result<()> {
+    let Ok(uri) = std::env::var("ATUIN_TEST_DB_URI") else {
+        eprintln!("skipping: ATUIN_TEST_DB_URI not set");
+        return Ok(());
+    };
+    if !uri.starts_with("postgres") {
+        eprintln!("skipping: ATUIN_TEST_DB_URI is not a Postgres URI");
+        return Ok(());
+    }
+
+    let pool = PgPoolOptions::new().max_connections(4).connect(&uri).await?;
+
+    // Bring the schema up to head using the exact embedded Postgres migration
+    // chain the server ships.
+    let migrator = sqlx::migrate!("src/db/postgres/migrations");
+    migrator.run(&pool).await?;
+
+    // Simulate a database that ran the old buggy code: two real users with
+    // owned store rows, plus orphaned store rows pointing at users that no
+    // longer exist.
+    sqlx::query("delete from store").execute(&pool).await?;
+    sqlx::query("delete from users").execute(&pool).await?;
+
+    let alice: i64 = sqlx::query(
+        "insert into users (username, email, password) values ('alice', 'a@example.com', 'pw-a') \
+         returning id",
+    )
+    .fetch_one(&pool)
+    .await?
+    .get(0);
+    let bob: i64 = sqlx::query(
+        "insert into users (username, email, password) values ('bob', 'b@example.com', 'pw-b') \
+         returning id",
+    )
+    .fetch_one(&pool)
+    .await?
+    .get(0);
+
+    // A user_id guaranteed not to exist in `users`.
+    let orphan_uid = alice.max(bob) + 1000;
+
+    let insert_store = |uid: i64| {
+        let pool = pool.clone();
+        async move {
+            sqlx::query(
+                "insert into store (id, client_id, host, idx, timestamp, version, tag, data, cek, \
+                 user_id) values (gen_random_uuid(), gen_random_uuid(), gen_random_uuid(), 1, 0, \
+                 '1', 'history', 'd', 'k', $1)",
+            )
+            .bind(uid)
+            .execute(&pool)
+            .await
+        }
+    };
+
+    // Owned rows (must survive) and orphaned rows (must be purged).
+    insert_store(alice).await?;
+    insert_store(bob).await?;
+    insert_store(orphan_uid).await?;
+    insert_store(orphan_uid).await?;
+
+    // Sanity: the orphans are present before we apply the purge.
+    let orphans_before: i64 =
+        sqlx::query("select count(*) from store where user_id not in (select id from users)")
+            .fetch_one(&pool)
+            .await?
+            .get(0);
+    assert_eq!(orphans_before, 2, "test setup should have created 2 orphaned store rows");
+
+    // Apply the purge migration from the embedded Postgres chain. With the fix
+    // present, this migration exists and removes the orphans; without it, no
+    // purge runs and the orphans survive, failing the assertion below.
+    if let Some(purge) =
+        migrator.iter().find(|m| m.description.contains("purge-orphaned-store"))
+    {
+        sqlx::query(sqlx::AssertSqlSafe(purge.sql.as_str().to_owned())).execute(&pool).await?;
+    }
+
+    let orphans_after: i64 =
+        sqlx::query("select count(*) from store where user_id not in (select id from users)")
+            .fetch_one(&pool)
+            .await?
+            .get(0);
+    assert_eq!(
+        orphans_after, 0,
+        "orphaned store rows must be purged by the Postgres migration chain"
+    );
+
+    // Owned rows must be untouched.
+    let owned: i64 = sqlx::query("select count(*) from store").fetch_one(&pool).await?.get(0);
+    assert_eq!(owned, 2, "store rows owned by existing users must be retained");
+
+    Ok(())
+}


### PR DESCRIPTION
## Defect

The historical `delete_user` bug -- where a deleted user's `store` rows were left behind -- lived in the **shared** blanket-impl `delete_user` path (`crates/atuin-server/src/db/mod.rs`) that serves **both** SQLite and Postgres. When it was fixed, a cleanup migration was shipped only for SQLite (`20260828000000_purge-orphaned-store.sql`). Postgres never got an equivalent, so Postgres deployments that ran the old buggy code still carry **orphaned `store` rows** (`user_id not in users`) that are never cleaned up. atuin.sh's primary production backend is Postgres, so this is a real correctness gap. (MySQL is unreleased and out of scope.)

## The fix

Add the mirroring Postgres migration `20260829000000_purge-orphaned-store.sql` (the `20260828000000` slot is already taken by `drop-history-count-trigger`, so a new strictly-higher version is used):

```sql
delete from store where user_id not in (select id from users);
```

The `NOT IN` NULL caveat is safe here: `users.id` is `bigserial` (never NULL) and `store.user_id` is `NOT NULL`. The shared `delete_user` Rust code is already converged and is not touched.

## TDD

Added `crates/atuin-server/tests/pg_purge_orphaned_store.rs`. It brings a real Postgres instance up to head via the embedded Postgres migration chain, seeds two owned `store` rows plus two orphaned rows, then applies the purge migration from the chain and asserts the orphans are gone while owned rows remain.

- **RED** (before the migration existed): the purge migration is absent from the embedded chain, so no purge runs and the orphans survive -- `assertion left == right failed ... left: 2, right: 0`.
- **GREEN** (after adding the migration): `test result: ok. 1 passed`.

Verified with `postgres:16` in Docker; the full chain also applies cleanly via the existing `db_story` harness against Postgres.

https://claude.ai/code/session_012NEBu1EwD9aTfGZHUFWhXb