### PR TITLE
fix(daemon): compare process identity before signalling on force-cleanup

### DIFF
--- a/crates/atuin-common/src/os/process.rs
+++ b/crates/atuin-common/src/os/process.rs
@@ -18,19 +18,46 @@ pub(crate) const EXIT_BACKOFF: Backoff = Backoff::Exponential {
 };
 
 /// Gracefully (and then forcefully) terminate the process.
-pub async fn force_terminate(pid: u32, timeout: Duration) -> Result<(), std::io::Error> {
+///
+/// `expected_start_time` is the start_time the caller expects the process at `pid` to have (e.g. the
+/// value persisted alongside the pid). It guards against pid reuse: if the live process's identity
+/// does not match, it is left untouched. Pass `None` when the expected identity is unknown (for
+/// example an old-format pidfile), in which case liveness is best-effort.
+pub async fn force_terminate(
+    pid: u32,
+    expected_start_time: Option<u64>,
+    timeout: Duration,
+) -> Result<(), std::io::Error> {
     #[cfg(unix)]
     {
         let Some(pid) = rustix::process::Pid::from_raw(pid.cast_signed()) else {
             return Ok(());
         };
-        unix::process::force_terminate(pid, timeout).await
+        unix::process::force_terminate(pid, expected_start_time, timeout).await
     }
 
     #[cfg(windows)]
     {
+        // On Windows the process is identified by an OpenProcess handle rather than a start_time,
+        // so there is no separate identity comparison to perform here.
+        let _ = expected_start_time;
         windows::process::Handle::open(pid, PROCESS_TERMINATE | PROCESS_SYNCHRONIZE)?
             .force_stop(timeout)
             .await
+    }
+}
+
+/// Get the start time (in seconds) of the current process, if it can be determined.
+///
+/// This is persisted alongside the daemon pid so that a later force-cleanup can tell whether the
+/// recorded pid still refers to the same process or has been reused by an unrelated one.
+#[must_use]
+pub fn current_process_start_time() -> Option<u64> {
+    let pid = sysinfo::Pid::from_u32(std::process::id());
+    let mut system = sysinfo::System::new();
+    if system.refresh_process(pid) {
+        system.process(pid).map(sysinfo::Process::start_time)
+    } else {
+        None
     }
 }

--- a/crates/atuin-common/src/os/unix/process.rs
+++ b/crates/atuin-common/src/os/unix/process.rs
@@ -9,8 +9,28 @@ use rustix::process::{self, Pid, Signal};
 /// Gracefully terminate the process via `SIGTERM`.
 ///
 /// If the process does not gracefully terminate, it is forcefully killed via `SIGKILL`.
-pub async fn force_terminate(pid: Pid, timeout: Duration) -> Result<(), std::io::Error> {
-    let identity = process_start_time(pid);
+///
+/// `expected_start_time` is the start_time the caller expects the process at `pid` to have (for
+/// example, the value persisted in the daemon pidfile). It is used to detect pid reuse: if the live
+/// process's start_time differs from `expected_start_time`, the pid has been recycled by an
+/// unrelated process and it must NOT be signalled. When `expected_start_time` is `None` (an
+/// old-format pidfile that never persisted the identity), we fall back to best-effort liveness.
+pub async fn force_terminate(
+    pid: Pid,
+    expected_start_time: Option<u64>,
+    timeout: Duration,
+) -> Result<(), std::io::Error> {
+    // Guard against pid reuse BEFORE sending any signal. If the caller told us which process to
+    // expect and the process currently occupying `pid` has a different start_time, the pid has been
+    // recycled by an unrelated process. Signalling it would kill an innocent bystander, so we bail
+    // out cleanly — there is nothing of ours left to terminate.
+    if let Some(expected) = expected_start_time
+        && process_start_time(pid) != Some(expected)
+    {
+        return Ok(());
+    }
+
+    let identity = expected_start_time.or_else(|| process_start_time(pid));
 
     let is_original_alive = || match identity {
         Some(start_time) => process_start_time(pid) == Some(start_time),
@@ -67,5 +87,108 @@ pub fn process_start_time(pid: Pid) -> Option<u64> {
         system.process(pid).map(sysinfo::Process::start_time)
     } else {
         None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::process::{Child, Command};
+
+    use super::*;
+
+    /// A victim process we own, killed on drop so a failing test never leaks a `sleep`.
+    struct Victim(Child);
+
+    impl Victim {
+        fn spawn() -> Self {
+            // A long-lived child we own; it stands in for an innocent process that has been
+            // assigned a pid previously held by the daemon.
+            let child = Command::new("sleep").arg("60").spawn().expect("failed to spawn victim");
+            Self(child)
+        }
+
+        fn pid(&self) -> Pid {
+            Pid::from_raw(i32::try_from(self.0.id()).unwrap()).unwrap()
+        }
+
+        /// Poll until the victim has exited, reaping the zombie, for up to `timeout`.
+        ///
+        /// Returns `true` if it exited within the window. `try_wait` reaps the child, so this also
+        /// avoids leaving a zombie that would still answer `process_start_time`.
+        fn exited_within(&mut self, timeout: Duration) -> bool {
+            let deadline = std::time::Instant::now() + timeout;
+            loop {
+                match self.0.try_wait() {
+                    Ok(Some(_)) => return true,
+                    Ok(None) => {}
+                    Err(_) => return true,
+                }
+                if std::time::Instant::now() >= deadline {
+                    return false;
+                }
+                std::thread::sleep(Duration::from_millis(20));
+            }
+        }
+
+        /// Assert the victim stays alive for the whole `grace` window (was never signalled).
+        fn survives(&mut self, grace: Duration) -> bool {
+            !self.exited_within(grace)
+        }
+    }
+
+    impl Drop for Victim {
+        fn drop(&mut self) {
+            let _ = self.0.kill();
+            let _ = self.0.wait();
+        }
+    }
+
+    /// The core of D2: force_terminate must NOT signal a process whose identity does not match the
+    /// expected start_time. An innocent process that inherited a recycled pid must survive.
+    #[tokio::test]
+    async fn wrong_identity_does_not_terminate_victim() {
+        let mut victim = Victim::spawn();
+        let pid = victim.pid();
+
+        let actual = process_start_time(pid).expect("victim should have a start_time");
+        // A start_time the victim definitely does not have (it started ~now, not far in the future).
+        let wrong = actual.wrapping_add(1_000_000);
+
+        force_terminate(pid, Some(wrong), Duration::from_secs(2)).await.unwrap();
+
+        assert!(
+            victim.survives(Duration::from_millis(500)),
+            "victim was signalled despite a mismatched expected start_time (pid reuse guard failed)"
+        );
+    }
+
+    /// Positive case: when the expected identity matches, the process is terminated as before.
+    #[tokio::test]
+    async fn matching_identity_terminates_victim() {
+        let mut victim = Victim::spawn();
+        let pid = victim.pid();
+
+        let actual = process_start_time(pid).expect("victim should have a start_time");
+
+        force_terminate(pid, Some(actual), Duration::from_secs(2)).await.unwrap();
+
+        assert!(
+            victim.exited_within(Duration::from_secs(2)),
+            "victim with a matching identity should have been terminated"
+        );
+    }
+
+    /// Old-format pidfile (no persisted identity): fall back to best-effort liveness and terminate.
+    #[tokio::test]
+    async fn unknown_identity_terminates_victim() {
+        let mut victim = Victim::spawn();
+        let pid = victim.pid();
+
+        force_terminate(pid, None, Duration::from_secs(2)).await.unwrap();
+
+        assert!(
+            victim.exited_within(Duration::from_secs(2)),
+            "victim should be terminated when no identity is persisted"
+        );
     }
 }

--- a/crates/atuin/src/command/client/daemon.rs
+++ b/crates/atuin/src/command/client/daemon.rs
@@ -127,8 +127,16 @@ impl PidfileGuard {
 
         file.set_len(0)
             .wrap_err_with(|| format!("could not truncate daemon pidfile {}", path.display()))?;
+        // Line 1: pid, line 2: version, line 3 (optional): the daemon's start_time. Persisting the
+        // start_time gives the daemon a stable identity so a later `--force` cleanup can tell
+        // whether the recorded pid still refers to *this* daemon or has been reused by an unrelated
+        // process. Older pidfiles omit line 3; readers must tolerate its absence.
         writeln!(file, "{}", std::process::id())
             .and_then(|()| writeln!(file, "{DAEMON_VERSION}"))
+            .and_then(|()| {
+                atuin_common::os::process::current_process_start_time()
+                    .map_or(Ok(()), |start_time| writeln!(file, "{start_time}"))
+            })
             .wrap_err_with(|| format!("could not write daemon pidfile {}", path.display()))?;
 
         Ok(Self { file })
@@ -701,10 +709,21 @@ async fn force_cleanup(settings: &Settings) {
         if let Ok(contents) = fs::read_to_string(pidfile_path)
             && let Some(pid_str) = contents.lines().next()
             && let Ok(pid) = pid_str.parse::<u32>()
-            && let Err(e) =
-                atuin_common::os::process::force_terminate(pid, Duration::from_secs(2)).await
         {
-            tracing::warn!("could not terminate existing daemon (pid {pid}): {e}");
+            // The recorded start_time (line 3) identifies the original daemon. When present, it
+            // lets `force_terminate` refuse to signal a process that has merely inherited a recycled
+            // pid. Older pidfiles omit it; then cleanup falls back to best-effort liveness.
+            let expected_start_time = contents.lines().nth(2).and_then(|s| s.parse::<u64>().ok());
+
+            if let Err(e) = atuin_common::os::process::force_terminate(
+                pid,
+                expected_start_time,
+                Duration::from_secs(2),
+            )
+            .await
+            {
+                tracing::warn!("could not terminate existing daemon (pid {pid}): {e}");
+            }
         }
 
         // Remove the pidfile
@@ -781,9 +800,19 @@ mod tests {
 
         let contents = std::fs::read_to_string(&pidfile).unwrap();
         let lines: Vec<&str> = contents.lines().collect();
-        assert_eq!(lines.len(), 2);
+        // Line 1: pid, line 2: version, optional line 3: start_time (present whenever it can be
+        // determined for the current process, which it can be here).
+        assert!(lines.len() == 2 || lines.len() == 3, "unexpected pidfile: {contents:?}");
         assert_eq!(lines[0], std::process::id().to_string());
         assert_eq!(lines[1], DAEMON_VERSION);
+        if let Some(start_time_line) = lines.get(2) {
+            let persisted: u64 = start_time_line.parse().expect("start_time line must parse as u64");
+            assert_eq!(
+                Some(persisted),
+                atuin_common::os::process::current_process_start_time(),
+                "persisted start_time should match the current process's identity"
+            );
+        }
 
         // After guard is dropped, lock should be released — acquiring again must succeed.
         let _guard2 = PidfileGuard::acquire(&pidfile).unwrap();


### PR DESCRIPTION
## The defect

`atuin daemon start --force` could send `SIGTERM` (and then `SIGKILL`) to an innocent, unrelated process.

Two gaps combined:

1. **Unconditional signal before any identity check.** In `crates/atuin-common/src/os/unix/process.rs`, `force_terminate` snapshotted `process_start_time(pid)` — the start_time of *whatever* occupies the pid *now* — and then sent `SIGTERM` unconditionally. The start_time comparison only gated the later `SIGKILL` escalation, never the initial signal.
2. **Identity was never persisted.** The daemon pidfile (`crates/atuin/src/command/client/daemon.rs`) stored only `pid` + `version`. The original daemon's start_time was never written, so there was nothing to compare the live process against.

Net effect: when a daemon exits and the OS later reuses its pid for an unrelated process, a subsequent `--force` cleanup reads the stale pid from the pidfile and signals that innocent process. Verified empirically.

## The fix (scoped to this defect only)

- **Persist identity.** The daemon's start_time is now written as an optional third line in the pidfile. Old-format pidfiles without it are still handled — cleanup falls back to current best-effort liveness, never a hard error.
- **Compare before signalling.** `force_terminate` now takes the expected start_time and refuses to send *any* signal when the live process's start_time differs from it (pid reuse → different process → leave it alone, return cleanly). Only a matching identity — or an unknown/old-format one — proceeds to `SIGTERM` → `SIGKILL`.

No pid-range validation is added here; that is a separate concern.

## Tests (strict TDD)

Added unit tests in `crates/atuin-common/src/os/unix/process.rs` that spawn a real victim process the test owns (a `sleep`, killed on drop):

- `wrong_identity_does_not_terminate_victim` — records the victim's actual start_time, calls the termination path with a deliberately-wrong expected start_time, and asserts the victim survives. This test fails against the pre-fix code (which SIGTERMs the innocent victim) and passes with the guard.
- `matching_identity_terminates_victim` — matching identity terminates the victim.
- `unknown_identity_terminates_victim` — `None` (old-format pidfile) falls back to best-effort liveness and terminates.

The pidfile-guard test was updated to tolerate and verify the new start_time line.

https://claude.ai/code/session_012NEBu1EwD9aTfGZHUFWhXb
