### PR TITLE
fix(daemon): check for socket in `/tmp` even when `$TMPDIR` is set

### DIFF
--- a/crates/atuin-client/src/settings/daemon.rs
+++ b/crates/atuin-client/src/settings/daemon.rs
@@ -98,7 +98,7 @@ impl Daemon {
             return SocketPath::Default(path);
         }
 
-        SocketPath::Default(ctx.default_socket_path())
+        SocketPath::Default(ctx.default_socket_path().primary)
     }
 
     fn existing_socket_path_ctx(&self, ctx: impl SocketCtx) -> Cow<'_, Path> {
@@ -365,7 +365,7 @@ mod unix_tests {
             ..TestCtx::default()
         };
 
-        assert_eq!(ctx.default_socket_path(), Path::new(expected));
+        assert_eq!(ctx.default_socket_path().primary, Path::new(expected));
     }
 
     #[rstest]

--- a/crates/atuin-client/src/settings/daemon.rs
+++ b/crates/atuin-client/src/settings/daemon.rs
@@ -131,14 +131,9 @@ impl Daemon {
         // (both pointing to `$XDG_RUNTIME_DIR`), so don't include the legacy path in that case.
         let legacy_path = runtime_path.is_none().then(|| ctx.legacy_socket_path());
         let default_socket_path = ctx.default_socket_path();
-        [
-            runtime_path,
-            Some(default_socket_path.primary),
-            legacy_path,
-            default_socket_path.envless,
-        ]
-        .into_iter()
-        .flatten()
+        [runtime_path, Some(default_socket_path.primary), legacy_path, default_socket_path.envless]
+            .into_iter()
+            .flatten()
     }
 }
 

--- a/crates/atuin-client/src/settings/daemon.rs
+++ b/crates/atuin-client/src/settings/daemon.rs
@@ -4,6 +4,8 @@ use std::{borrow::Cow, path::Path};
 
 #[cfg(unix)]
 use atuin_common::os::unix::{SecureTempDirError, create_secure_temp_dir};
+#[cfg(unix)]
+use atuin_common::path::EnvDependentPathBuf;
 use serde::{Deserialize, Serialize};
 
 #[cfg(unix)]
@@ -110,31 +112,33 @@ impl Daemon {
         candidates.find(|path| path.exists()).unwrap_or(primary)
     }
 
-    fn potential_socket_paths_ctx<C: SocketCtx>(
+    fn potential_socket_paths_ctx(
         &self,
-        ctx: C,
-    ) -> impl Iterator<Item = Cow<'_, Path>> + use<'_, C> {
+        ctx: impl SocketCtx,
+    ) -> impl Iterator<Item = Cow<'_, Path>> {
         let is_user_defined = self.socket_path.is_some();
-        // `defaults_limit` is an optimization; in the case of a user-defined socket path where we
-        // don't yield the default paths, the iterator can return earlier, without having to scan
-        // the entire array of [`None`]s.
-        let (defaults, defaults_limit) = if is_user_defined {
-            (Default::default(), 0)
-        } else {
-            (self.default_socket_paths(ctx), usize::MAX)
-        };
-
-        let defaults = defaults.into_iter().take(defaults_limit).flatten().map(Cow::Owned);
-
+        let defaults = (!is_user_defined)
+            .then(|| self.default_socket_paths(ctx))
+            .into_iter()
+            .flatten()
+            .map(Cow::Owned);
         self.socket_path.as_deref().map(Cow::Borrowed).into_iter().chain(defaults)
     }
 
-    fn default_socket_paths(&self, ctx: impl SocketCtx) -> [Option<PathBuf>; 3] {
+    fn default_socket_paths(&self, ctx: impl SocketCtx) -> impl Iterator<Item = PathBuf> {
         let runtime_path = self.systemd_socket.then(|| ctx.runtime_socket_path()).flatten();
         // If `runtime_socket_path` is `Some`, `ctx.legacy_socket_path()` will return the same path
         // (both pointing to `$XDG_RUNTIME_DIR`), so don't include the legacy path in that case.
         let legacy_path = runtime_path.is_none().then(|| ctx.legacy_socket_path());
-        [runtime_path, Some(ctx.default_socket_path()), legacy_path]
+        let default_socket_path = ctx.default_socket_path();
+        [
+            runtime_path,
+            Some(default_socket_path.primary),
+            legacy_path,
+            default_socket_path.envless,
+        ]
+        .into_iter()
+        .flatten()
     }
 }
 
@@ -149,6 +153,14 @@ trait SocketCtx: Copy + Sized {
         atuin_common::os::unix::tmp_dir()
     }
 
+    /// Like [`Self::tmp_dir`] but not dependent on `$TMPDIR`.
+    ///
+    /// This is a workaround for systems in which the daemon is spawned in an environment that
+    /// has `$TMPDIR` unset, but where `$TMPDIR` *is* set when the client is run.
+    fn envless_tmp_dir(&self) -> &Path {
+        Path::new("/tmp")
+    }
+
     fn runtime_dir(&self) -> Option<PathBuf> {
         atuin_common::utils::env_abspath("XDG_RUNTIME_DIR")
     }
@@ -161,8 +173,18 @@ trait SocketCtx: Copy + Sized {
         atuin_common::os::unix::uid()
     }
 
-    fn default_socket_path(&self) -> PathBuf {
-        self.tmp_dir().join(format!("atuin-{}", self.uid())).join(SOCKET_NAME)
+    fn default_socket_path(&self) -> EnvDependentPathBuf {
+        let subdir_name = format!("atuin-{}", self.uid());
+        let make_socket_path = |tmp: PathBuf| tmp.join(&subdir_name).join(SOCKET_NAME);
+
+        let tmp = self.tmp_dir();
+        let envless_tmp = self.envless_tmp_dir();
+        let envless_tmp = (tmp != envless_tmp).then(|| PathBuf::from(envless_tmp));
+
+        EnvDependentPathBuf {
+            primary: make_socket_path(tmp),
+            envless: envless_tmp.map(make_socket_path),
+        }
     }
 
     fn runtime_socket_path(&self) -> Option<PathBuf> {
@@ -283,6 +305,10 @@ mod unix_tests {
         }
     }
 
+    const TMPDIR: &str = "/var/folders/xy";
+    /// Where the socket lives when `$TMPDIR` is set to [`TMPDIR`].
+    const TMPDIR_DEFAULT: &str = "/var/folders/xy/atuin-1234/atuin.sock";
+    /// Where the socket lives when `$TMPDIR` is unset. Also the `$TMPDIR`-independent fallback.
     const DEFAULT: &str = "/tmp/atuin-1234/atuin.sock";
     const RUNTIME: &str = "/run/user/1234/atuin.sock";
     const LEGACY: &str = "/home/user/.local/share/atuin/atuin.sock";
@@ -294,6 +320,7 @@ mod unix_tests {
     #[derive(Clone, Copy)]
     struct TestCtx<'a> {
         tmp_dir: &'a Path,
+        envless_tmp_dir: &'a Path,
         runtime_dir: Option<&'a Path>,
     }
 
@@ -301,6 +328,7 @@ mod unix_tests {
         fn default() -> Self {
             Self {
                 tmp_dir: Path::new("/tmp"),
+                envless_tmp_dir: Path::new("/tmp"),
                 runtime_dir: Some(Path::new("/run/user/1234")),
             }
         }
@@ -309,6 +337,10 @@ mod unix_tests {
     impl SocketCtx for TestCtx<'_> {
         fn tmp_dir(&self) -> PathBuf {
             self.tmp_dir.into()
+        }
+
+        fn envless_tmp_dir(&self) -> &Path {
+            self.envless_tmp_dir
         }
 
         fn runtime_dir(&self) -> Option<PathBuf> {
@@ -328,7 +360,7 @@ mod unix_tests {
     /// configured it depends on nothing but the temporary directory and the uid.
     #[rstest]
     #[case::default_tmp_dir("/tmp", DEFAULT)]
-    #[case::tmpdir_set("/var/folders/xy", "/var/folders/xy/atuin-1234/atuin.sock")]
+    #[case::tmpdir_set(TMPDIR, TMPDIR_DEFAULT)]
     fn the_default_socket_lives_in_a_per_uid_tmp_dir(
         #[case] tmp_dir: &str,
         #[case] expected: &str,
@@ -343,16 +375,29 @@ mod unix_tests {
 
     #[rstest]
     // With nothing configured we use the per-uid default, and only fall back to where an older
-    // version of Atuin would have left a socket.
-    #[case::unconfigured(None, false, true, vec![DEFAULT, RUNTIME])]
-    #[case::unconfigured_without_runtime_dir(None, false, false, vec![DEFAULT, LEGACY])]
+    // version of Atuin would have left a socket. `$TMPDIR` is unset here, so the default already
+    // is the `/tmp` path and it is not yielded a second time.
+    #[case::unconfigured("/tmp", None, false, true, vec![DEFAULT, RUNTIME])]
+    #[case::unconfigured_without_runtime_dir("/tmp", None, false, false, vec![DEFAULT, LEGACY])]
     // A socket-activated unit listens on `%t/atuin.sock`, which is also the legacy path.
-    #[case::systemd(None, true, true, vec![RUNTIME, DEFAULT])]
-    #[case::systemd_without_runtime_dir(None, true, false, vec![DEFAULT, LEGACY])]
+    #[case::systemd("/tmp", None, true, true, vec![RUNTIME, DEFAULT])]
+    #[case::systemd_without_runtime_dir("/tmp", None, true, false, vec![DEFAULT, LEGACY])]
     // A configured path is the only one we ever consider.
-    #[case::configured(Some(CUSTOM), false, true, vec![CUSTOM])]
-    #[case::configured_with_systemd(Some(CUSTOM), true, true, vec![CUSTOM])]
+    #[case::configured("/tmp", Some(CUSTOM), false, true, vec![CUSTOM])]
+    #[case::configured_with_systemd("/tmp", Some(CUSTOM), true, true, vec![CUSTOM])]
+    // With `$TMPDIR` set, the `$TMPDIR` socket still wins, but `/tmp` is tried last, because the
+    // daemon may have been started in an environment where `$TMPDIR` was unset.
+    #[case::tmpdir_set(TMPDIR, None, false, true, vec![TMPDIR_DEFAULT, RUNTIME, DEFAULT])]
+    #[case::tmpdir_set_without_runtime_dir(
+        TMPDIR, None, false, false, vec![TMPDIR_DEFAULT, LEGACY, DEFAULT]
+    )]
+    #[case::tmpdir_set_with_systemd(
+        TMPDIR, None, true, true, vec![RUNTIME, TMPDIR_DEFAULT, DEFAULT]
+    )]
+    // A configured path stays the only one we consider, `$TMPDIR` or not.
+    #[case::tmpdir_set_and_configured(TMPDIR, Some(CUSTOM), false, true, vec![CUSTOM])]
     fn socket_paths_are_tried_in_priority_order(
+        #[case] tmp_dir: &str,
         #[case] configured: Option<&str>,
         #[case] systemd_socket: bool,
         #[case] runtime_dir: bool,
@@ -360,6 +405,7 @@ mod unix_tests {
     ) {
         let daemon = daemon(configured.map(PathBuf::from), systemd_socket);
         let ctx = TestCtx {
+            tmp_dir: Path::new(tmp_dir),
             runtime_dir: runtime_dir.then_some(Path::new("/run/user/1234")),
             ..TestCtx::default()
         };
@@ -374,9 +420,13 @@ mod unix_tests {
     /// The path we connect to is the first one that is actually there, so that a daemon listening
     /// on a fallback path is still found.
     #[rstest]
-    #[case::none_exist(&[], DEFAULT)]
-    #[case::only_the_fallback_exists(&[RUNTIME], RUNTIME)]
-    #[case::both_exist(&[DEFAULT, RUNTIME], DEFAULT)]
+    #[case::none_exist(&[], TMPDIR_DEFAULT)]
+    #[case::only_the_runtime_fallback_exists(&[RUNTIME], RUNTIME)]
+    // The case this fallback exists for: a daemon started without `$TMPDIR` is listening on
+    // `/tmp`, while the client that looks for it has `$TMPDIR` set.
+    #[case::only_the_envless_fallback_exists(&[DEFAULT], DEFAULT)]
+    #[case::runtime_fallback_beats_envless(&[RUNTIME, DEFAULT], RUNTIME)]
+    #[case::all_exist(&[TMPDIR_DEFAULT, RUNTIME, DEFAULT], TMPDIR_DEFAULT)]
     fn the_existing_socket_is_the_first_one_present(
         tmp: TempDir,
         #[case] present: &[&str],
@@ -384,9 +434,11 @@ mod unix_tests {
     ) {
         // Prefix a path with `tmp`.
         let scoped = |path: &str| tmp.path().join(path.trim_start_matches('/'));
-        let (tmp_dir, runtime_dir) = (scoped("/tmp"), scoped("/run/user/1234"));
+        let (tmp_dir, envless_tmp_dir, runtime_dir) =
+            (scoped(TMPDIR), scoped("/tmp"), scoped("/run/user/1234"));
         let ctx = TestCtx {
             tmp_dir: &tmp_dir,
+            envless_tmp_dir: &envless_tmp_dir,
             runtime_dir: Some(&runtime_dir),
         };
 

--- a/crates/atuin-common/src/path/mod.rs
+++ b/crates/atuin-common/src/path/mod.rs
@@ -2,7 +2,7 @@
 
 pub mod display_rich;
 
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 pub use display_rich::{DisplayRichExt, RichDisplay};
 
@@ -17,4 +17,21 @@ impl<P: AsRef<Path>> PathExt for P {
         let path: &Path = self.as_ref();
         path.is_symlink() && !path.exists()
     }
+}
+
+/// An owned path that is dependent on environment variables.
+///
+/// This type is used as part of a workaround to handle the case where the daemon may have been
+/// spawned in an environment with `$TMPDIR` unset, but where `$TMPDIR` *is* set when the client is
+/// run. This type contains *both* paths the client needs to try to connect to.
+pub struct EnvDependentPathBuf {
+    /// The primary form of the path.
+    ///
+    /// For example, `$TMPDIR/example.txt`.
+    pub primary: PathBuf,
+
+    /// The path that would be used if none of the relevant environment variables were set.
+    ///
+    /// For example, `/tmp/example.txt` even when `$TMPDIR` is set.
+    pub envless: Option<PathBuf>,
 }


### PR DESCRIPTION
If the daemon starts in an environment where `$TMPDIR` is unset but the client runs in an environment where `$TMPDIR` *is* set, the client will fail to connect to the daemon. We will then try to acquire the pidfile lock and block for 5 seconds.

This PR adds `/tmp/atuin-$UID/atuin.sock` to the list of socket paths that are tried, even when `$TMPDIR` is set. `$TMPDIR` is still preferred over `/tmp` if the socket exists there. A more robust solution is in the works; this is a hotfix.