### PR TITLE
fix: normalize output of `atuin --version`

### DIFF
--- a/crates/atuin/build.rs
+++ b/crates/atuin/build.rs
@@ -3,8 +3,8 @@ fn main() {
     let output = Command::new("git").args(["rev-parse", "HEAD"]).output();
 
     let sha = match output {
-        Ok(sha) => String::from_utf8(sha.stdout).unwrap(),
-        Err(_) => String::from("NO_GIT"),
+        Ok(sha) if sha.status.success() => String::from_utf8(sha.stdout).unwrap(),
+        _ => String::from("NO_GIT"),
     };
 
     println!("cargo:rustc-env=GIT_HASH={sha}");


### PR DESCRIPTION
Right now, if you build Atuin from a source tree that has no `.git` directory, `atuin --version` will report:

* `atuin 18.20.1 (NO_GIT)` if `git` is not installed
* `atuin 18.20.1 ()` if `git` is installed

The second is what users who have installed from crates.io see.

This PR normalizes the output of `atuin --version` so that it always prints `(NO_GIT)` when building a non-Git source tree, instead of sometimes showing empty parentheses.

Note: If you build a non-Git version of Atuin within a different Git repository, we will report that repository's hash. We could consider changing that, but it is not a regression in this PR. This PR strictly improves the status quo.