### PR TITLE
fix: make `atuin ai init` a no-op instead of erroring

### DIFF
--- a/crates/atuin-ai/src/commands.rs
+++ b/crates/atuin-ai/src/commands.rs
@@ -65,6 +65,8 @@ pub async fn run(command: Command, settings: &Settings) -> eyre::Result<()> {
             ..
         } => inline::run(command, args.api_endpoint, args.api_token, settings, hook).await,
         Command::Init { .. } => {
+            // This is valid comment syntax in all the shells we support and thus a no-op: bash,
+            // zsh, fish, nushell, xonsh, and powershell.
             println!(
                 "# This command is no longer necessary. If you have it in your shell init file, \
                  feel free to remove it."

--- a/crates/atuin-ai/src/commands.rs
+++ b/crates/atuin-ai/src/commands.rs
@@ -35,15 +35,23 @@ pub enum Command {
         #[arg(long, hide = true)]
         hook: bool,
     },
+    #[command(hide = true)]
+    /// This command is no longer necessary. If you have it in your shell init file, feel free to
+    /// remove it.
+    Init {
+        #[arg(hide = true)]
+        _shell: Option<std::ffi::OsString>,
+    },
 }
 
 impl Command {
-    pub fn log_config(&self, settings: &Settings) -> LogConfig {
+    pub fn log_config(&self, settings: &Settings) -> Option<LogConfig> {
         match self {
-            Self::Inline { args, .. } => LogConfig {
+            Self::Inline { args, .. } => Some(LogConfig {
                 file: FileConfig::from_settings(&settings.logs, &settings.logs.ai),
                 stderr: args.verbose.then(StderrConfig::default),
-            },
+            }),
+            Self::Init { .. } => None,
         }
     }
 }
@@ -56,6 +64,13 @@ pub async fn run(command: Command, settings: &Settings) -> eyre::Result<()> {
             args,
             ..
         } => inline::run(command, args.api_endpoint, args.api_token, settings, hook).await,
+        Command::Init { .. } => {
+            println!(
+                "# This command is no longer necessary. If you have it in your shell init file, \
+                 feel free to remove it."
+            );
+            Ok(())
+        }
     }
 }
 

--- a/crates/atuin/src/command/client.rs
+++ b/crates/atuin/src/command/client.rs
@@ -311,7 +311,7 @@ impl Cmd {
             }),
 
             #[cfg(feature = "ai")]
-            Self::Ai(cmd) => Some(cmd.log_config(settings)),
+            Self::Ai(cmd) => cmd.log_config(settings),
 
             Self::Internal(cmd) => cmd.log_config(),
 


### PR DESCRIPTION
`atuin ai init` was removed because it is no longer necessary. However, users might still have it in their `.bashrc` or similar, and we don't want it to error. This PR adds the command back but as a no-op.

If a user runs `atuin ai init` directly in their shell, they will see a message explaining it's no longer necessary. The message is prefixed with `#` so that it is interpreted as a comment by the shell and thus a no-op if they have `eval "$(atuin ai init)"` in their shell init file.