### PR TITLE
chore: lift dependencies into top-level Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,8 +16,6 @@ readme = "README.md"
 [workspace.dependencies]
 async-trait = "0.1.58"
 enum_dispatch = "0.3"
-# default-features is disabled here (not in the consuming crate) because a
-# workspace-inherited dependency cannot turn off default features itself.
 atuin-ai = { path = "crates/atuin-ai", version = "18.21.0", default-features = false }
 atuin-client = { path = "crates/atuin-client", version = "18.21.0" }
 atuin-common = { path = "crates/atuin-common", version = "18.21.0" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -98,8 +98,6 @@ rusty_paserk = { version = "0.5.0", default-features = false, features = [
 strum = { version = "0.27", features = ["strum_macros"] }
 strum_macros = "0.28"
 
-# tracing-appender is pinned to 0.2.4 (the tighter of the two requirements it
-# previously had across crates) so both consumers resolve to one version.
 tracing-appender = "0.2.4"
 tracing-futures = { version = "0.2", features = ["futures-03"] }
 tracing-tree = "0.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,13 +16,17 @@ readme = "README.md"
 [workspace.dependencies]
 async-trait = "0.1.58"
 enum_dispatch = "0.3"
+# default-features is disabled here (not in the consuming crate) because a
+# workspace-inherited dependency cannot turn off default features itself.
+atuin-ai = { path = "crates/atuin-ai", version = "18.21.0", default-features = false }
 atuin-client = { path = "crates/atuin-client", version = "18.21.0" }
 atuin-common = { path = "crates/atuin-common", version = "18.21.0" }
-atuin-daemon = { path = "crates/atuin-daemon", version = "18.21.0" }
+atuin-daemon = { path = "crates/atuin-daemon", version = "18.21.0", default-features = false }
 atuin-domain = { path = "crates/atuin-domain", version = "18.21.0" }
 atuin-dotfiles = { path = "crates/atuin-dotfiles", version = "18.21.0" }
 atuin-history = { path = "crates/atuin-history", version = "18.21.0" }
 atuin-kv = { path = "crates/atuin-kv", version = "18.21.0" }
+atuin-pty-proxy = { path = "crates/atuin-pty-proxy", version = "18.21.0", default-features = false }
 atuin-scripts = { path = "crates/atuin-scripts", version = "18.21.0" }
 atuin-server = { path = "crates/atuin-server", version = "18.21.0" }
 atuin-vt100 = "0.17"
@@ -95,6 +99,76 @@ rusty_paserk = { version = "0.5.0", default-features = false, features = [
 ] }
 strum = { version = "0.27", features = ["strum_macros"] }
 strum_macros = "0.28"
+
+# tracing-appender is pinned to 0.2.4 (the tighter of the two requirements it
+# previously had across crates) so both consumers resolve to one version.
+tracing-appender = "0.2.4"
+tracing-futures = { version = "0.2", features = ["futures-03"] }
+tracing-tree = "0.4"
+tracing-opentelemetry = "0.33"
+opentelemetry = "0.32"
+opentelemetry_sdk = "0.32"
+opentelemetry-otlp = "0.32"
+futures = "0.3"
+futures-util = "0.3"
+async-stream = "0.3"
+eventsource-stream = "0.2"
+pulldown-cmark = "0.13.0"
+tui-textarea-2 = "0.10.2"
+unicode-width = "0.2"
+unicode-segmentation = "1.11.0"
+eye_declare = "0.6.4"
+eye_declare_engine = { version = "0.6.4", features = ["test-util"] }
+ratatui-core = "0.1"
+ratatui-widgets = "0.3"
+toml = "1.1"
+yaml-rust2 = "0.11"
+chrono = "0.4"
+chrono-humanize = "0.2"
+rmcp = { version = "2.1.0", default-features = false, features = ["server", "transport-io"] }
+humantime = "2.1.0"
+minspan = "0.1.5"
+serde_regex = "1.1.0"
+serde_with = "3.8.1"
+serde_bytes = "0.11"
+memchr = "2.7"
+notify = "8"
+indicatif = "0.18.0"
+palette = { version = "0.7.5", features = ["serializing"] }
+zstd = "0.13"
+divan = { version = "5.0.1", package = "codspeed-divan-compat" }
+sysinfo = "0.30.7"
+getrandom = "0.4"
+dashmap = "6.1.0"
+lasso = { version = "0.7", features = ["multi-threaded"] }
+tonic = "0.14"
+tonic-types = "0.14"
+tonic-prost = "0.14"
+tonic-build = "0.14"
+tonic-prost-build = "0.14"
+prost = "0.14"
+prost-types = "0.14"
+protox = "0.9"
+tokio-stream = { version = "0.1.14", features = ["net"] }
+hyper-util = "0.1"
+listenfd = "1.0.1"
+axum = "0.8"
+portable-pty = "0.9"
+signal-hook = "0.3"
+tower-http = { version = "0.6", features = ["trace"] }
+argon2 = "0.5"
+metrics = "0.24"
+metrics-exporter-prometheus = { version = "0.18", default-features = false }
+clap_complete = "4.6.1"
+clap_complete_nushell = "4.5.4"
+rpassword = "7.0"
+runtime-format = "0.1.3"
+colored = "2.0.4"
+norm = { version = "0.1.1", features = ["fzf-v2"] }
+shlex = "2.0.1"
+arboard = { version = "3.4", default-features = false }
+daemonize = "0.5.0"
+axoupdater = "0.10"
 
 [workspace.dependencies.tracing-subscriber]
 version = "0.3"

--- a/crates/atuin-ai/Cargo.toml
+++ b/crates/atuin-ai/Cargo.toml
@@ -38,30 +38,30 @@ tracing-subscriber = { workspace = true, features = [
   "env-filter",
 ] }
 directories = { workspace = true }
-tracing-appender = "0.2.4"
+tracing-appender = { workspace = true }
 reqwest = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 crossterm = { workspace = true, features = ["use-dev-tty", "event-stream"] }
 ratatui = { workspace = true }
 fs-err = { workspace = true }
-futures = "0.3"
-eventsource-stream = "0.2"
-pulldown-cmark = "0.13.0"
-async-stream = "0.3"
+futures = { workspace = true }
+eventsource-stream = { workspace = true }
+pulldown-cmark = { workspace = true }
+async-stream = { workspace = true }
 uuid = { workspace = true }
-tui-textarea-2 = "0.10.2"
-unicode-width = "0.2"
+tui-textarea-2 = { workspace = true }
+unicode-width = { workspace = true }
 # Path dependency until eye_declare 0.6.0 publishes; then just a version.
-eye_declare = "0.6.4"
-eye_declare_engine = { version = "0.6.4", features = ["test-util"] }
-ratatui-core = "0.1"
-ratatui-widgets = "0.3"
+eye_declare = { workspace = true }
+eye_declare_engine = { workspace = true }
+ratatui-core = { workspace = true }
+ratatui-widgets = { workspace = true }
 thiserror = { workspace = true }
 glob-match = { workspace = true }
 regex = { workspace = true }
 time = { workspace = true }
-toml = "1.1"
+toml = { workspace = true }
 toml_edit = { workspace = true }
 tree-sitter = { workspace = true, optional = true }
 tree-sitter-bash = { workspace = true, optional = true }
@@ -71,11 +71,11 @@ typed-builder = { workspace = true }
 shellexpand = { workspace = true }
 imara-diff = { workspace = true }
 xxhash-rust = { workspace = true }
-yaml-rust2 = "0.11"
+yaml-rust2 = { workspace = true }
 tempfile = { workspace = true }
-chrono = "0.4"
-chrono-humanize = "0.2"
-rmcp = { version = "2.1.0", default-features = false, features = ["server", "transport-io"] }
+chrono = { workspace = true }
+chrono-humanize = { workspace = true }
+rmcp = { workspace = true }
 
 [dev-dependencies]
 pretty_assertions = { workspace = true }

--- a/crates/atuin-client/Cargo.toml
+++ b/crates/atuin-client/Cargo.toml
@@ -26,7 +26,7 @@ vendored-tls = ["reqwest?/native-tls-vendored"]
 [dependencies]
 derive_more = { workspace = true }
 tracing = { workspace = true }
-tracing-futures = { version = "0.2", features = ["futures-03"] }
+tracing-futures = { workspace = true }
 base64 = { workspace = true }
 zeroize = { workspace = true }
 time = { workspace = true, features = ["macros", "formatting", "parsing"] }
@@ -40,7 +40,7 @@ config = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 url = { workspace = true }
-humantime = "2.1.0"
+humantime = { workspace = true }
 enum_dispatch = { workspace = true }
 async-trait = { workspace = true }
 itertools = { workspace = true }
@@ -48,67 +48,61 @@ rand = { workspace = true }
 shellexpand = { workspace = true }
 sqlx = { workspace = true, features = ["sqlite", "regexp"] }
 libsqlite3-sys = { workspace = true }
-minspan = "0.1.5"
+minspan = { workspace = true }
 regex = { workspace = true }
-serde_regex = "1.1.0"
+serde_regex = { workspace = true }
 fs-err = { workspace = true }
 sql-builder = { workspace = true }
-memchr = "2.7"
+memchr = { workspace = true }
 typed-builder = { workspace = true }
 tokio = { workspace = true }
 semver = { workspace = true }
 thiserror = { workspace = true }
-futures = "0.3"
-async-stream = "0.3"
-notify = "8"
-serde_with = "3.8.1"
+futures = { workspace = true }
+async-stream = { workspace = true }
+notify = { workspace = true }
+serde_with = { workspace = true }
 
 # encryption
-rusty_paseto = { version = "0.8.0", default-features = false }
-rusty_paserk = { version = "0.5.0", default-features = false, features = [
-  "v4",
-  "serde",
-] }
+rusty_paseto = { workspace = true }
+rusty_paserk = { workspace = true }
 
 # sync
 reqwest = { workspace = true, optional = true }
 reqwest-middleware = { workspace = true, optional = true, features = ["json", "query"] }
-indicatif = "0.18.0"
+indicatif = { workspace = true }
 tiny-bip39 = { workspace = true }
 
 # theme
 crossterm = { workspace = true, features = ["serde"] }
-palette = { version = "0.7.5", features = ["serializing"] }
+palette = { workspace = true }
 strum = { workspace = true }
 strum_macros = { workspace = true }
 
 # packfile
-zstd = "0.13"
-serde_bytes = "0.11"
+zstd = { workspace = true }
+serde_bytes = { workspace = true }
 
 [dependencies.atuin-common]
-path = "../atuin-common"
-version = "18.21.0"
+workspace = true
 features = ["os", "sqlite"]
 
 [dependencies.atuin-domain]
-path = "../atuin-domain"
-version = "18.21.0"
+workspace = true
 
 [dev-dependencies]
-tokio = { version = "1", features = ["full"] }
+tokio = { workspace = true }
 pretty_assertions = { workspace = true }
 proptest = { workspace = true }
 rstest = { workspace = true }
-divan = { version = "5.0.1", package = "codspeed-divan-compat" }
-tempfile = "3"
-toml = "1.1"
-wiremock = "0.6"
+divan = { workspace = true }
+tempfile = { workspace = true }
+toml = { workspace = true }
+wiremock = { workspace = true }
 
 # This crate's tests require the `test-utils` feature in atuin-common.
 [dev-dependencies.atuin-common]
-path = "../atuin-common"
-version = "18.21.0"
+workspace = true
 features = ["test-utils"]
 
 [[bench]]

--- a/crates/atuin-common/Cargo.toml
+++ b/crates/atuin-common/Cargo.toml
@@ -27,26 +27,26 @@ tiny-bip39 = { workspace = true }
 crypto_secretbox = { workspace = true }
 time = { workspace = true, features = ["formatting", "parsing"] }
 serde = { workspace = true }
-serde_with = "3.8.1"
+serde_with = { workspace = true }
 uuid = { workspace = true }
 eyre = { workspace = true }
 url = { workspace = true }
 thiserror = { workspace = true }
 directories = { workspace = true }
-sysinfo = "0.30.7"
+sysinfo = { workspace = true }
 base64 = { workspace = true }
-getrandom = "0.4"
+getrandom = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true, optional = true }
-unicode-width = { version = "0.2", optional = true }
-unicode-segmentation = { version = "1.11.0", optional = true }
+unicode-width = { workspace = true, optional = true }
+unicode-segmentation = { workspace = true, optional = true }
 itertools = { workspace = true }
 rusty_paseto = { workspace = true }
 rusty_paserk = { workspace = true }
 tokio = { workspace = true }
 tokio-util = { workspace = true, optional = true }
 parking_lot = { workspace = true }
-futures = "0.3"
+futures = { workspace = true }
 serde_json = { workspace = true }
 zeroize = { workspace = true }
 rmp = { workspace = true }

--- a/crates/atuin-daemon/Cargo.toml
+++ b/crates/atuin-daemon/Cargo.toml
@@ -14,13 +14,13 @@ readme.workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-atuin-client = { path = "../atuin-client", version = "18.21.0" }
+atuin-client = { workspace = true }
 parking_lot = { workspace = true }
-atuin-domain = { path = "../atuin-domain", version = "18.21.0" }
+atuin-domain = { workspace = true }
 enum_dispatch = { workspace = true }
 derive_more = { workspace = true }
-atuin-dotfiles = { path = "../atuin-dotfiles", version = "18.21.0" }
-atuin-history = { path = "../atuin-history", version = "18.21.0" }
+atuin-dotfiles = { workspace = true }
+atuin-history = { workspace = true }
 
 time = { workspace = true }
 uuid = { workspace = true }
@@ -31,36 +31,35 @@ tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
 reqwest = { workspace = true }
 
-dashmap = "6.1.0"
-lasso = { version = "0.7", features = ["multi-threaded"] }
-tonic-types = "0.14"
-tonic = "0.14"
-tonic-prost = "0.14"
-prost = "0.14"
-prost-types = "0.14"
-tokio-stream = { version = "0.1.14", features = ["net"] }
-futures = "0.3"
-hyper-util = "0.1"
+dashmap = { workspace = true }
+lasso = { workspace = true }
+tonic-types = { workspace = true }
+tonic = { workspace = true }
+tonic-prost = { workspace = true }
+prost = { workspace = true }
+prost-types = { workspace = true }
+tokio-stream = { workspace = true }
+futures = { workspace = true }
+hyper-util = { workspace = true }
 
 rand.workspace = true
 frizbee = { workspace = true }
 
 [dependencies.atuin-common]
-path = "../atuin-common"
-version = "18.21.0"
+workspace = true
 features = ["os"]
 
 [target.'cfg(target_os = "linux")'.dependencies]
-listenfd = "1.0.1"
+listenfd = { workspace = true }
 
 [dev-dependencies]
 tempfile = { workspace = true }
 rstest = { workspace = true }
 
 [build-dependencies]
-protox = "0.9"
-tonic-build = "0.14"
-tonic-prost-build = "0.14"
+protox = { workspace = true }
+tonic-build = { workspace = true }
+tonic-prost-build = { workspace = true }
 
 [lints]
 workspace = true

--- a/crates/atuin-domain/Cargo.toml
+++ b/crates/atuin-domain/Cargo.toml
@@ -33,7 +33,7 @@ reqwest-middleware = { workspace = true }
 http = { workspace = true }
 xxhash-rust = { workspace = true }
 tokio = { workspace = true }
-axum = { version = "0.8", optional = true }
+axum = { workspace = true, optional = true }
 strum = { workspace = true }
 strum_macros = { workspace = true }
 

--- a/crates/atuin-dotfiles/Cargo.toml
+++ b/crates/atuin-dotfiles/Cargo.toml
@@ -14,15 +14,15 @@ readme.workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-atuin-common = { path = "../atuin-common", version = "18.21.0" }
-atuin-domain = { path = "../atuin-domain", version = "18.21.0" }
-atuin-client = { path = "../atuin-client", version = "18.21.0" }
+atuin-common = { workspace = true }
+atuin-domain = { workspace = true }
+atuin-client = { workspace = true }
 derive_more = { workspace = true }
 
 eyre = { workspace = true }
 tokio = { workspace = true }
 tracing = { workspace = true }
-rmp = { version = "0.8.14" }
+rmp = { workspace = true }
 rand = { workspace = true }
 serde = { workspace = true }
 crypto_secretbox = { workspace = true }

--- a/crates/atuin-history/Cargo.toml
+++ b/crates/atuin-history/Cargo.toml
@@ -14,15 +14,15 @@ readme.workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-atuin-client = { path = "../atuin-client", version = "18.21.0" }
+atuin-client = { workspace = true }
 
 time = { workspace = true }
 serde = { workspace = true }
 crossterm = { workspace = true, features = ["use-dev-tty"] }
-unicode-segmentation = "1.11.0"
+unicode-segmentation = { workspace = true }
 
 [dev-dependencies]
-divan = { version = "5.0.1", package = "codspeed-divan-compat" }
+divan = { workspace = true }
 rand = { workspace = true }
 rstest = { workspace = true }
 

--- a/crates/atuin-kv/Cargo.toml
+++ b/crates/atuin-kv/Cargo.toml
@@ -14,14 +14,14 @@ readme.workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-atuin-client = { path = "../atuin-client", version = "18.21.0" }
-atuin-common = { path = "../atuin-common", version = "18.21.0", features = ["sqlite"] }
-atuin-domain = { path = "../atuin-domain", version = "18.21.0" }
+atuin-client = { workspace = true }
+atuin-common = { workspace = true, features = ["sqlite"] }
+atuin-domain = { workspace = true }
 derive_more = { workspace = true }
 
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
-rmp = { version = "0.8.14" }
+rmp = { workspace = true }
 eyre = { workspace = true }
 tokio = { workspace = true }
 typed-builder = { workspace = true }

--- a/crates/atuin-pty-proxy/Cargo.toml
+++ b/crates/atuin-pty-proxy/Cargo.toml
@@ -18,8 +18,8 @@ atuin-common = { workspace = true, features = ["ansi", "os"] }
 atuin-vt100 = { workspace = true }
 crossterm = { workspace = true }
 eyre = { workspace = true }
-portable-pty = "0.9"
-signal-hook = "0.3"
+portable-pty = { workspace = true }
+signal-hook = { workspace = true }
 
 [dev-dependencies]
 rstest = { workspace = true }

--- a/crates/atuin-scripts/Cargo.toml
+++ b/crates/atuin-scripts/Cargo.toml
@@ -14,14 +14,14 @@ readme.workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-atuin-client = { path = "../atuin-client", version = "18.21.0" }
-atuin-common = { path = "../atuin-common", version = "18.21.0", features = ["sqlite"] }
-atuin-domain = { path = "../atuin-domain", version = "18.21.0" }
+atuin-client = { workspace = true }
+atuin-common = { workspace = true, features = ["sqlite"] }
+atuin-domain = { workspace = true }
 derive_more = { workspace = true }
 
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
-rmp = { version = "0.8.14" }
+rmp = { workspace = true }
 uuid = { workspace = true }
 eyre = { workspace = true }
 tokio = { workspace = true }

--- a/crates/atuin-search-bench/Cargo.toml
+++ b/crates/atuin-search-bench/Cargo.toml
@@ -17,7 +17,7 @@ bench = false
 atuin-client = { workspace = true }
 atuin-common = { workspace = true }
 atuin-daemon = { workspace = true }
-divan = { version = "5.0.1", package = "codspeed-divan-compat" }
+divan = { workspace = true }
 parking_lot = { workspace = true }
 time = { workspace = true }
 tokio = { workspace = true }

--- a/crates/atuin-server/Cargo.toml
+++ b/crates/atuin-server/Cargo.toml
@@ -33,15 +33,15 @@ config = { workspace = true }
 serde = { workspace = true }
 rand = { workspace = true }
 tokio = { workspace = true }
-axum = "0.8"
+axum = { workspace = true }
 fs-err = { workspace = true }
 tower = { workspace = true }
-tower-http = { version = "0.6", features = ["trace"] }
+tower-http = { workspace = true }
 reqwest = { workspace = true }
 url = { workspace = true }
-argon2 = "0.5"
-metrics-exporter-prometheus = { version = "0.18", default-features = false }
-metrics = "0.24"
+argon2 = { workspace = true }
+metrics-exporter-prometheus = { workspace = true }
+metrics = { workspace = true }
 clap = { workspace = true }
 tracing-subscriber = { workspace = true }
 async-trait = { workspace = true }
@@ -56,8 +56,8 @@ sqlx = { workspace = true, features = ["postgres", "sqlite", "mysql", "regexp", 
 [dev-dependencies]
 atuin-client = { path = "../atuin-client", version = "18.21.0", default-features = false, features = ["sync"] }
 rstest = { workspace = true }
-futures-util = "0.3"
-tracing-tree = "0.4"
+futures-util = { workspace = true }
+tracing-tree = { workspace = true }
 tower = { workspace = true, features = ["util"] }
 regex = { workspace = true }
 

--- a/crates/atuin/Cargo.toml
+++ b/crates/atuin/Cargo.toml
@@ -73,85 +73,86 @@ profiling-traced = [
 ]
 
 [dependencies]
-atuin-ai = { path = "../atuin-ai", version = "18.21.0", optional = true, default-features = false }
+atuin-ai = { workspace = true, optional = true }
+# default-features = false cannot be set on a workspace-inherited dependency, and
+# atuin-client's defaults (sync/hub/daemon) are needed by its other consumers, so
+# the workspace entry keeps them on. This crate opts out via a direct path dep.
 atuin-client = { path = "../atuin-client", version = "18.21.0", optional = true, default-features = false }
 atuin-common = { workspace = true, features = ["unicode", "os"] }
 atuin-domain = { workspace = true }
 atuin-dotfiles = { workspace = true }
 atuin-history = { workspace = true }
-atuin-daemon = { path = "../atuin-daemon", version = "18.21.0", optional = true, default-features = false }
-atuin-pty-proxy = { path = "../atuin-pty-proxy", version = "18.21.0", optional = true, default-features = false }
+atuin-daemon = { workspace = true, optional = true }
+atuin-pty-proxy = { workspace = true, optional = true }
 atuin-scripts = { workspace = true }
 atuin-kv = { workspace = true }
-axoupdater = { version = "0.10", optional = true }
+axoupdater = { workspace = true, optional = true }
 derive_more = { workspace = true }
 
 time = { workspace = true }
 eyre = { workspace = true }
 url = { workspace = true }
-indicatif = "0.18.0"
+indicatif = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 crossterm = { workspace = true, features = ["use-dev-tty"] }
-unicode-width = "0.2"
+unicode-width = { workspace = true }
 itertools = { workspace = true }
 tokio = { workspace = true }
 enum_dispatch = { workspace = true }
 async-trait = { workspace = true }
 interim = { workspace = true }
 clap = { workspace = true }
-clap_complete = "4.6.1"
-clap_complete_nushell = "4.5.4"
-rpassword = "7.0"
+clap_complete = { workspace = true }
+clap_complete_nushell = { workspace = true }
+rpassword = { workspace = true }
 semver = { workspace = true }
 rustix = { workspace = true }
-runtime-format = "0.1.3"
+runtime-format = { workspace = true }
 tiny-bip39 = { workspace = true }
-futures-util = "0.3"
-colored = "2.0.4"
+futures-util = { workspace = true }
+colored = { workspace = true }
 ratatui = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
-tracing-appender = "0.2"
-tracing-opentelemetry = { version = "0.33", optional = true }
-opentelemetry = { version = "0.32", optional = true }
-opentelemetry_sdk = { version = "0.32", optional = true }
-opentelemetry-otlp = { version = "0.32", optional = true }
+tracing-appender = { workspace = true }
+tracing-opentelemetry = { workspace = true, optional = true }
+opentelemetry = { workspace = true, optional = true }
+opentelemetry_sdk = { workspace = true, optional = true }
+opentelemetry-otlp = { workspace = true, optional = true }
 uuid = { workspace = true }
-sysinfo = "0.30.7"
-regex = "1.10.5"
-norm = { version = "0.1.1", features = ["fzf-v2"] }
+sysinfo = { workspace = true }
+regex = { workspace = true }
+norm = { workspace = true }
 frizbee = { workspace = true }
 tempfile = { workspace = true }
-shlex = "2.0.1"
+shlex = { workspace = true }
 thiserror = { workspace = true }
 
 # settings editor with comment and relative ordering preservation
 toml_edit = { workspace = true }
 
 [target.'cfg(any(target_os = "windows", target_os = "macos"))'.dependencies]
-arboard = { version = "3.4", optional = true, default-features = false }
+arboard = { workspace = true, optional = true }
 
 [target.'cfg(target_os = "linux")'.dependencies]
-arboard = { version = "3.4", optional = true, default-features = false, features = [
-    "wayland-data-control",
-] }
+arboard = { workspace = true, optional = true, features = ["wayland-data-control"] }
 
 [target.'cfg(unix)'.dependencies]
-daemonize = "0.5.0"
+daemonize = { workspace = true }
 
 # Enable tree-sitter shell parsing on platforms where tree-sitter's bundled C
 # compiles cleanly. tree-sitter 0.26's portable/endian.h fails on illumos,
 # Windows cross-compiles, and potentially other exotic targets.
 [target.'cfg(any(target_os = "linux", target_os = "macos", target_os = "windows", target_os = "illumos"))'.dependencies]
-atuin-ai = { path = "../atuin-ai", version = "18.21.0", optional = true, default-features = false, features = ["tree-sitter"] }
+atuin-ai = { workspace = true, optional = true, features = ["tree-sitter"] }
 tree-sitter = { workspace = true }
 tree-sitter-bash = { workspace = true }
 tree-sitter-fish = { workspace = true }
 tree-sitter-powershell = { workspace = true }
 
 [target.'cfg(windows)'.dependencies]
-windows-sys = { version = "0.61.2", features = ["Win32_System_Console"] }
+windows-sys = { workspace = true }
 
 [dev-dependencies]
 proptest = { workspace = true }


### PR DESCRIPTION
This PR:

  - Moves `Cargo.toml` dependencies out of our subpackages into the top-level workspace.

Motivation:

  - Easier maintenance
  - Avoiding accidental duplicate dependencies (we had two `tracing-appender` versions).