### PR TITLE
Use `easy-cast` instead of primitive `as` casts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -264,6 +264,7 @@ dependencies = [
  "crossterm",
  "daemonize",
  "derive_more",
+ "easy-cast",
  "enum_dispatch",
  "eyre",
  "frizbee",
@@ -324,6 +325,7 @@ dependencies = [
  "crossterm",
  "derive_more",
  "directories",
+ "easy-cast",
  "enum_dispatch",
  "eventsource-stream",
  "eye_declare",
@@ -382,6 +384,7 @@ dependencies = [
  "crossterm",
  "derive_more",
  "directories",
+ "easy-cast",
  "enum_dispatch",
  "eyre",
  "fs-err",
@@ -441,6 +444,7 @@ dependencies = [
  "crypto_secretbox",
  "derive_more",
  "directories",
+ "easy-cast",
  "eyre",
  "fs-err",
  "futures",
@@ -488,6 +492,7 @@ dependencies = [
  "atuin-history",
  "dashmap",
  "derive_more",
+ "easy-cast",
  "enum_dispatch",
  "eyre",
  "frizbee",
@@ -525,6 +530,7 @@ dependencies = [
  "atuin-common",
  "axum",
  "derive_more",
+ "easy-cast",
  "eyre",
  "http",
  "parking_lot",
@@ -576,6 +582,7 @@ dependencies = [
  "atuin-client",
  "codspeed-divan-compat",
  "crossterm",
+ "easy-cast",
  "rand 0.8.7",
  "rstest",
  "serde",
@@ -611,6 +618,7 @@ dependencies = [
  "atuin-vt100",
  "clap",
  "crossterm",
+ "easy-cast",
  "eyre",
  "portable-pty",
  "rstest",
@@ -625,6 +633,7 @@ dependencies = [
  "atuin-common",
  "atuin-domain",
  "derive_more",
+ "easy-cast",
  "eyre",
  "minijinja",
  "pretty_assertions",
@@ -651,6 +660,7 @@ dependencies = [
  "atuin-common",
  "atuin-daemon",
  "codspeed-divan-compat",
+ "easy-cast",
  "parking_lot",
  "time",
  "tokio",
@@ -669,6 +679,7 @@ dependencies = [
  "clap",
  "config",
  "derive_more",
+ "easy-cast",
  "eyre",
  "fs-err",
  "futures-util",
@@ -1752,6 +1763,12 @@ name = "dyn-clone"
 version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
+
+[[package]]
+name = "easy-cast"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eae1c5aaf1bfdc24a9b5bf6daf3afee62c478afe08706a6bd9fd996f73630494"
 
 [[package]]
 name = "ed25519"
@@ -5531,7 +5548,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.3.4",
+ "getrandom 0.4.3",
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,6 +40,7 @@ clap = { version = "4.5.7", features = ["derive"] }
 config = { version = "0.15.8", default-features = false, features = ["toml"] }
 derive_more = { version = "2", features = ["as_ref", "deref", "display", "error", "from", "into", "debug"] }
 directories = "6.0.0"
+easy-cast = "0.7.1"
 eyre = "0.6"
 fs-err = "3.1"
 http = "1.5"

--- a/crates/atuin-ai/Cargo.toml
+++ b/crates/atuin-ai/Cargo.toml
@@ -18,6 +18,7 @@ daemon = []
 tree-sitter = ["dep:tree-sitter", "dep:tree-sitter-bash", "dep:tree-sitter-fish"]
 
 [dependencies]
+easy-cast = { workspace = true }
 atuin-client = { workspace = true }
 atuin-domain = { workspace = true }
 atuin-common = { workspace = true, features = ["unicode", "ansi", "sqlite"] }

--- a/crates/atuin-ai/Cargo.toml
+++ b/crates/atuin-ai/Cargo.toml
@@ -18,7 +18,6 @@ daemon = []
 tree-sitter = ["dep:tree-sitter", "dep:tree-sitter-bash", "dep:tree-sitter-fish"]
 
 [dependencies]
-easy-cast = { workspace = true }
 atuin-client = { workspace = true }
 atuin-domain = { workspace = true }
 atuin-common = { workspace = true, features = ["unicode", "ansi", "sqlite"] }
@@ -77,6 +76,7 @@ tempfile = { workspace = true }
 chrono = { workspace = true }
 chrono-humanize = { workspace = true }
 rmcp = { workspace = true }
+easy-cast = { workspace = true }
 
 [dev-dependencies]
 pretty_assertions = { workspace = true }

--- a/crates/atuin-ai/src/commands/inline.rs
+++ b/crates/atuin-ai/src/commands/inline.rs
@@ -1,6 +1,7 @@
 use std::time::Duration;
 
 use atuin_client::database::Sqlite;
+use easy_cast::Conv;
 use eyre::{Context as _, Result, bail};
 use tracing::{debug, info};
 
@@ -182,7 +183,7 @@ async fn run_inline_tui(
             Ok(Some(cached_snapshot)) => {
                 let age =
                     time::OffsetDateTime::now_utc().unix_timestamp() - cached_snapshot.written_at;
-                let fresh = age < crate::usage::REFRESH_AFTER.as_secs() as i64;
+                let fresh = age < i64::conv(crate::usage::REFRESH_AFTER.as_secs());
                 (Some(cached_snapshot.snapshot), fresh)
             }
             Ok(None) => (None, false),
@@ -383,7 +384,7 @@ fn prompt_ai_setup() -> Result<SetupChoice> {
 
         let ev = event::read().context("failed to read key event")?;
 
-        crossterm::execute!(stdout, cursor::MoveUp(options.len() as u16))?;
+        crossterm::execute!(stdout, cursor::MoveUp(u16::conv(options.len())))?;
 
         if let Event::Key(key) = ev {
             if key.kind != KeyEventKind::Press {

--- a/crates/atuin-ai/src/diff.rs
+++ b/crates/atuin-ai/src/diff.rs
@@ -4,6 +4,7 @@
 //! imara-diff's Histogram algorithm, producing structured hunks with
 //! typed lines (Context, Added, Removed) suitable for TUI rendering.
 
+use easy_cast::Conv;
 use imara_diff::{Algorithm, Diff, InternedInput};
 
 /// Number of context lines to show around each change.
@@ -134,7 +135,7 @@ fn build_hunk(group: &[&imara_diff::Hunk], input: &InternedInput<&str>) -> DiffH
     let last = group.last().unwrap();
 
     let context_start = first.before.start.saturating_sub(CONTEXT_LINES);
-    let context_end = (last.before.end + CONTEXT_LINES).min(input.before.len() as u32);
+    let context_end = (last.before.end + CONTEXT_LINES).min(u32::conv(input.before.len()));
 
     // The after-file position of context_start: same offset as before since
     // context before the first change is identical in both files.
@@ -182,7 +183,7 @@ fn token_text(input: &InternedInput<&str>, is_before: bool, idx: u32) -> String 
     } else {
         &input.after
     };
-    let text = input.interner[tokens[idx as usize]];
+    let text = input.interner[tokens[usize::conv(idx)]];
     text.strip_suffix('\n')
         .unwrap_or(text)
         .strip_suffix('\r')

--- a/crates/atuin-ai/src/edit_permissions.rs
+++ b/crates/atuin-ai/src/edit_permissions.rs
@@ -12,6 +12,7 @@ use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use std::time::SystemTime;
 
+use easy_cast::Conv;
 use eyre::Result;
 use serde::{Deserialize, Serialize};
 
@@ -55,7 +56,7 @@ impl EditPermissionCache {
 fn now_ms() -> i64 {
     SystemTime::now()
         .duration_since(SystemTime::UNIX_EPOCH)
-        .map(|d| d.as_millis() as i64)
+        .map(|d| i64::conv(d.as_millis()))
         .unwrap_or(0)
 }
 

--- a/crates/atuin-ai/src/event_serde.rs
+++ b/crates/atuin-ai/src/event_serde.rs
@@ -4,6 +4,7 @@
 //! independently. Each event is stored as an `(event_type, event_data)` pair
 //! where `event_data` is a JSON string.
 
+use easy_cast::Conv;
 use eyre::{Result, eyre};
 use serde_json::Value;
 
@@ -106,7 +107,7 @@ pub fn deserialize_event(event_type: &str, event_data: &str) -> Result<Conversat
                 .and_then(Value::as_bool)
                 .ok_or_else(|| eyre!("tool_result missing 'is_error' field"))?,
             remote: data.get("remote").and_then(Value::as_bool).unwrap_or(false),
-            content_length: data.get("content_length").and_then(Value::as_u64).map(|v| v as usize),
+            content_length: data.get("content_length").and_then(Value::as_u64).map(usize::conv),
         }),
         "out_of_band_output" => Ok(ConversationEvent::OutOfBandOutput {
             name: json_string(&data, "name")?,

--- a/crates/atuin-ai/src/file_tracker.rs
+++ b/crates/atuin-ai/src/file_tracker.rs
@@ -13,6 +13,7 @@ use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use std::time::SystemTime;
 
+use easy_cast::Conv;
 use eyre::Result;
 use serde::{Deserialize, Serialize};
 
@@ -114,7 +115,7 @@ impl FileReadTracker {
 }
 
 fn system_time_to_ms(t: SystemTime) -> i64 {
-    t.duration_since(SystemTime::UNIX_EPOCH).map(|d| d.as_millis() as i64).unwrap_or(0)
+    t.duration_since(SystemTime::UNIX_EPOCH).map(|d| i64::conv(d.as_millis())).unwrap_or(0)
 }
 
 fn hash_content(content: &[u8]) -> u64 {

--- a/crates/atuin-ai/src/snapshots.rs
+++ b/crates/atuin-ai/src/snapshots.rs
@@ -12,6 +12,7 @@ use std::collections::HashMap;
 use std::io::Write;
 use std::path::{Path, PathBuf};
 
+use easy_cast::Conv;
 use eyre::{Result, eyre};
 use serde::{Deserialize, Serialize};
 use time::OffsetDateTime;
@@ -84,7 +85,7 @@ impl SnapshotStore {
         let entry = SnapshotEntry {
             original_path: canonical_path.to_string_lossy().into_owned(),
             snapshot_at: format_iso8601(now),
-            size_bytes: content.len() as u64,
+            size_bytes: u64::conv(content.len()),
         };
 
         self.manifest.files.insert(filename, entry);

--- a/crates/atuin-ai/src/stream.rs
+++ b/crates/atuin-ai/src/stream.rs
@@ -5,6 +5,7 @@
 use atuin_client::history::History;
 use atuin_client::settings::AiCapabilities;
 use atuin_common::url::UrlAppendExt;
+use easy_cast::Conv;
 use eventsource_stream::Eventsource;
 use eyre::Result;
 use futures::StreamExt;
@@ -241,7 +242,10 @@ pub fn create_chat_stream(
                                 let content = json.get("content").and_then(|v| v.as_str()).unwrap_or("").to_string();
                                 let is_error = json.get("is_error").and_then(|v| v.as_bool()).unwrap_or(false);
                                 let remote = json.get("remote").and_then(|v| v.as_bool()).unwrap_or(false);
-                                let content_length = json.get("content_length").and_then(|v| v.as_u64()).map(|v| v as usize);
+                                let content_length = json
+                                    .get("content_length")
+                                    .and_then(|v| v.as_u64())
+                                    .map(usize::conv);
                                 yield Ok(StreamFrame::Content(StreamContent::ToolResult { tool_use_id, content, is_error, remote, content_length }));
                             }
                         }

--- a/crates/atuin-ai/src/tools/mod.rs
+++ b/crates/atuin-ai/src/tools/mod.rs
@@ -8,6 +8,7 @@ use atuin_client::history::{AuthorPattern, HistoryId};
 use atuin_common::ansi;
 use atuin_common::filter::OrFilter;
 use atuin_common::time::UtcOffsetExt;
+use easy_cast::Conv;
 use enum_dispatch::enum_dispatch;
 use eyre::Result;
 
@@ -335,15 +336,15 @@ impl ReadToolCall {
 
         let raw_lines = reader
             .lines()
-            .skip(self.offset as usize)
-            .take(self.limit as usize)
+            .skip(usize::conv(self.offset))
+            .take(usize::conv(self.limit))
             .collect::<Result<Vec<_>, _>>();
 
         match raw_lines {
             Ok(lines) => {
-                let first_line_no = self.offset as usize + 1;
+                let first_line_no = usize::conv(self.offset) + 1;
                 let last_line_no = first_line_no + lines.len().saturating_sub(1);
-                let width = last_line_no.max(1).ilog10() as usize + 1;
+                let width = usize::conv(last_line_no.max(1).ilog10()) + 1;
 
                 let numbered: String = lines
                     .iter()
@@ -799,9 +800,9 @@ const PREVIEW_WIDTH: NonZeroU16 = NonZeroU16::new(120).unwrap();
 /// instead of the real output.
 fn vt100_screen_lines(screen: &vt100::Screen) -> Vec<String> {
     let (rows, cols) = screen.size();
-    let mut lines = Vec::with_capacity(rows as usize);
+    let mut lines = Vec::with_capacity(usize::conv(rows));
     for row in 0..rows {
-        let mut line = String::with_capacity(cols as usize);
+        let mut line = String::with_capacity(usize::conv(cols));
         for col in 0..cols {
             if let Some(cell) = screen.cell(row, col) {
                 line.push_str(cell.contents());
@@ -952,7 +953,7 @@ pub async fn execute_shell_command_streaming(
         stdout: stdout_text,
         stderr: stderr_text,
         exit_code,
-        duration_ms: duration.as_millis() as u64,
+        duration_ms: u64::conv(duration.as_millis()),
         interrupted,
     }
 }
@@ -1178,7 +1179,8 @@ impl PermissibleToolCall for AtuinOutputToolCall {
 
 fn format_output_lines_for_llm(lines: &[atuin_daemon::semantic::OutputLine]) -> String {
     let width =
-        lines.iter().map(|line| line.line_number).max().unwrap_or(1).max(1).ilog10() as usize + 1;
+        usize::conv(lines.iter().map(|line| line.line_number).max().unwrap_or(1).max(1).ilog10())
+            + 1;
     let mut formatted = Vec::with_capacity(lines.len());
     let mut previous_line_number = None;
 

--- a/crates/atuin-ai/src/tui/tips.rs
+++ b/crates/atuin-ai/src/tui/tips.rs
@@ -2,6 +2,7 @@
 //! line. One tip is pulled per turn and rides through both.
 
 use atuin_client::settings::Settings;
+use easy_cast::Conv;
 
 /// Facts a tip's relevance predicate may consult. Assembled fresh at each
 /// pull so predicates see current session state, not startup state.
@@ -98,7 +99,7 @@ impl TipRotation {
     pub(crate) fn new() -> Self {
         let nanos = std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)
-            .map(|d| d.subsec_nanos() as usize)
+            .map(|d| usize::conv(d.subsec_nanos()))
             .unwrap_or(0);
         Self::starting_at(nanos % TIPS.len().max(1))
     }

--- a/crates/atuin-ai/src/tui/view/mod.rs
+++ b/crates/atuin-ai/src/tui/view/mod.rs
@@ -6,6 +6,7 @@
 //! app's keymap, not here — elements are display-only.
 
 use atuin_common::path::DisplayRichExt;
+use easy_cast::{Cast, Conv};
 use eye_declare::{
     AnyElement, Element, ElementExt, Fluent, Markdown, MarkdownStyles, Spinner, col, empty,
     markdown, row, spinner, text, viewport,
@@ -268,7 +269,7 @@ fn shell_tool_view(command: &str, preview: Option<&ToolPreview>) -> AnyElement<'
             .child(
                 row().fixed(2, text("└ ").style(Style::default().fg(Color::DarkGray))).fill(
                     viewport(preview.lines.iter().cloned())
-                        .height((preview.lines.len() as u16).clamp(1, MAX_SHELL_PREVIEW_LINES))
+                        .height(preview.lines.len().clamp(1, MAX_SHELL_PREVIEW_LINES.into()).cast())
                         .style(Style::default().fg(Color::Gray))
                         .wrap(false),
                 ),
@@ -323,7 +324,7 @@ fn file_edit_tool_view(
         return status_line;
     }
 
-    let gutter_w = gutter_width(preview.max_line_number() as usize);
+    let gutter_w = gutter_width(usize::conv(preview.max_line_number()));
 
     col()
         .child(status_line)
@@ -340,7 +341,7 @@ fn hunk_view(hunk: &crate::diff::DiffHunk, gutter_w: u16) -> impl Element + use<
 
     let mut before_pos = hunk.before_start;
     let mut after_pos = hunk.after_start;
-    let num_w = (gutter_w - 1) as usize;
+    let num_w = usize::conv(gutter_w - 1);
 
     col().children(hunk.lines.iter().map(move |line| {
         let (prefix, content, style, gutter) = match line {
@@ -390,7 +391,7 @@ fn file_write_tool_view(
     }
 
     let gutter_w = gutter_width(preview.total_lines);
-    let num_w = (gutter_w - 1) as usize;
+    let num_w = usize::conv(gutter_w - 1);
     let remaining = preview.remaining_lines();
     let dim = Style::default().fg(Color::DarkGray);
 
@@ -413,7 +414,7 @@ fn file_write_tool_view(
 
 /// Line-number gutter width for the highest displayed number, plus spacing.
 fn gutter_width(max_line_num: usize) -> u16 {
-    max_line_num.to_string().len().max(2) as u16 + 1
+    u16::conv(max_line_num.to_string().len().max(2)) + 1
 }
 
 /// Shared pending/success/error status line for edit and write.
@@ -814,7 +815,7 @@ pub fn status_bar_view(
         Color::Green
     };
 
-    let width = (USAGE_BAR_WIDTH + pct_text.chars().count() + resets_text.chars().count()) as u16;
+    let width = u16::conv(USAGE_BAR_WIDTH + pct_text.chars().count() + resets_text.chars().count());
 
     row()
         .fill(left)

--- a/crates/atuin-ai/src/tui/view/trunc.rs
+++ b/crates/atuin-ai/src/tui/view/trunc.rs
@@ -13,6 +13,7 @@ use std::time::Duration;
 
 use atuin_common::string::ellipsis::{Indicator, Pos};
 use atuin_common::string::{EllipsizeExt as _, Measure};
+use easy_cast::Conv;
 use eye_declare::{Element, Spinner};
 use ratatui_core::buffer::Buffer;
 use ratatui_core::layout::Rect;
@@ -58,7 +59,7 @@ impl CommandSpinner {
             2
         };
         let budget =
-            (width as usize).saturating_sub(marker_cols).saturating_sub(self.prefix.width());
+            usize::conv(width).saturating_sub(marker_cols).saturating_sub(self.prefix.width());
         let label = format!("{}{}", self.prefix, fit_middle(&self.command, budget));
         super::tool_spinner(label, self.done).hide_checkmark()
     }
@@ -119,7 +120,7 @@ impl Element for TruncatedLine {
         if area.width == 0 || area.height == 0 {
             return;
         }
-        let width = area.width as usize;
+        let width = usize::conv(area.width);
         buf.set_stringn(area.x, area.y, &self.prefix, width, self.prefix_style);
         let used = self.prefix.width().min(width);
         let budget = width - used;
@@ -127,7 +128,7 @@ impl Element for TruncatedLine {
             return;
         }
         buf.set_stringn(
-            area.x + used as u16,
+            area.x + u16::conv(used),
             area.y,
             fit_middle(&self.value, budget),
             budget,

--- a/crates/atuin-client/Cargo.toml
+++ b/crates/atuin-client/Cargo.toml
@@ -24,7 +24,6 @@ check-update = []
 vendored-tls = ["reqwest?/native-tls-vendored"]
 
 [dependencies]
-easy-cast = { workspace = true }
 derive_more = { workspace = true }
 tracing = { workspace = true }
 tracing-futures = { workspace = true }
@@ -63,6 +62,7 @@ futures = { workspace = true }
 async-stream = { workspace = true }
 notify = { workspace = true }
 serde_with = { workspace = true }
+easy-cast = { workspace = true }
 
 # encryption
 rusty_paseto = { workspace = true }

--- a/crates/atuin-client/Cargo.toml
+++ b/crates/atuin-client/Cargo.toml
@@ -24,6 +24,7 @@ check-update = []
 vendored-tls = ["reqwest?/native-tls-vendored"]
 
 [dependencies]
+easy-cast = { workspace = true }
 derive_more = { workspace = true }
 tracing = { workspace = true }
 tracing-futures = { workspace = true }

--- a/crates/atuin-client/benches/record/encryption.rs
+++ b/crates/atuin-client/benches/record/encryption.rs
@@ -4,6 +4,7 @@ use atuin_common::utils::uuid_v7;
 use atuin_domain::record::{
     DecryptedData, EncryptedData, Host, HostId, Record, RecordTag, RecordVersion,
 };
+use easy_cast::Conv;
 
 use crate::_util::context::BenchCtx;
 use crate::history::BenchHistory;
@@ -62,7 +63,7 @@ fn decrypted_records(n: usize) -> Vec<Record<DecryptedData>> {
                 .version(RecordVersion::from(Version::LATEST.name()))
                 .tag(RecordTag::History)
                 .data(data)
-                .idx(idx as u64)
+                .idx(u64::conv(idx))
                 .build()
         })
         .collect()

--- a/crates/atuin-client/benches/record/sqlite_store.rs
+++ b/crates/atuin-client/benches/record/sqlite_store.rs
@@ -3,6 +3,7 @@ use std::time::Duration;
 use atuin_client::record::sqlite_store::SqliteStore;
 use atuin_common::utils::uuid_v7;
 use atuin_domain::record::{EncryptedData, Host, HostId, Record, RecordTag, RecordVersion};
+use easy_cast::Conv;
 use rand::Rng;
 use rand::distributions::Alphanumeric;
 use tempfile::TempDir;
@@ -40,7 +41,7 @@ impl BenchRecord {
         let key: String =
             ctx.rng().sample_iter(&Alphanumeric).take(Self::KEY_SIZE).map(char::from).collect();
 
-        (0..n as u64)
+        (0..u64::conv(n))
             .map(|idx| {
                 Record::builder()
                     .host(host.clone())

--- a/crates/atuin-client/src/api_client.rs
+++ b/crates/atuin-client/src/api_client.rs
@@ -16,6 +16,7 @@ use atuin_domain::caps::{AuthHeaderProvider, CapClient, CapMismatch, Capabilitie
 use atuin_domain::record::{
     EncryptedData, Record, RecordId, RecordIdx, RecordSeriesKey, RecordStatus,
 };
+use easy_cast::Conv;
 use eyre::{Result, bail};
 use futures::{Stream, StreamExt, TryStreamExt, stream};
 use reqwest::header::{AUTHORIZATION, HeaderMap, HeaderName, HeaderValue, USER_AGENT};
@@ -350,7 +351,7 @@ impl RecordsRequest {
                     return;
                 }
 
-                let len = page.len() as u64;
+                let len = u64::conv(page.len());
                 progress += len;
                 yield page;
 
@@ -379,7 +380,7 @@ impl RecordsRequest {
                         match this.page(cursor..stop).await {
                             Ok(page) if page.is_empty() => None,
                             Ok(page) => {
-                                let next = cursor + page.len() as u64;
+                                let next = cursor + u64::conv(page.len());
                                 Some((Ok(page), (next, this)))
                             }
                             Err(e) => Some((Err(e), (chunks.end(), this))),

--- a/crates/atuin-client/src/database.rs
+++ b/crates/atuin-client/src/database.rs
@@ -8,6 +8,7 @@ use atuin_common::filter::{self, OrFilter};
 use atuin_common::time::OffsetDateTimeExt;
 use atuin_common::{db, utils};
 use atuin_domain::record::{CmdOrigin, UNKNOWN_USER};
+use easy_cast::Conv;
 use itertools::Itertools;
 use sql_builder::bind::Bind;
 use sql_builder::{SqlBuilder, SqlName, esc, quote};
@@ -368,7 +369,7 @@ impl Sqlite {
             ) values(?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13)",
         )
         .bind(h.id)
-        .bind(h.timestamp.unix_timestamp_nanos() as i64)
+        .bind(i64::conv(h.timestamp.unix_timestamp_nanos()))
         .bind(h.duration)
         .bind(h.exit)
         .bind(h.command.as_str())
@@ -377,7 +378,7 @@ impl Sqlite {
         .bind(h.cmd_origin.as_str())
         .bind(h.author.as_str())
         .bind(h.intent.as_deref())
-        .bind(h.deleted_at.map(|t| t.unix_timestamp_nanos() as i64))
+        .bind(h.deleted_at.map(|t| i64::conv(t.unix_timestamp_nanos())))
         .bind(h.shell.as_deref())
         .bind(h.author_kind.map(|kind| i64::from(kind.as_u8())))
         .execute(&mut **tx)
@@ -431,7 +432,7 @@ impl Sqlite {
 
             builder.push_values(h.by_ref().take(rows_per_insert), |mut b, h| {
                 b.push_bind(h.id)
-                    .push_bind(h.timestamp.unix_timestamp_nanos() as i64)
+                    .push_bind(i64::conv(h.timestamp.unix_timestamp_nanos()))
                     .push_bind(h.duration)
                     .push_bind(h.exit)
                     .push_bind(h.command.as_str())
@@ -440,7 +441,7 @@ impl Sqlite {
                     .push_bind(h.cmd_origin.as_str())
                     .push_bind(h.author.as_str())
                     .push_bind(h.intent.as_deref())
-                    .push_bind(h.deleted_at.map(|t| t.unix_timestamp_nanos() as i64))
+                    .push_bind(h.deleted_at.map(|t| i64::conv(t.unix_timestamp_nanos())))
                     .push_bind(h.shell.as_deref())
                     .push_bind(h.author_kind.map(|kind| i64::from(kind.as_u8())));
             });
@@ -528,7 +529,7 @@ impl Sqlite {
                 where id = ?1",
         )
         .bind(h.id)
-        .bind(h.timestamp.unix_timestamp_nanos() as i64)
+        .bind(i64::conv(h.timestamp.unix_timestamp_nanos()))
         .bind(h.duration)
         .bind(h.exit)
         .bind(h.command.as_str())
@@ -537,7 +538,7 @@ impl Sqlite {
         .bind(h.cmd_origin.as_str())
         .bind(h.author.as_str())
         .bind(h.intent.as_deref())
-        .bind(h.deleted_at.map(|t| t.unix_timestamp_nanos() as i64))
+        .bind(h.deleted_at.map(|t| i64::conv(t.unix_timestamp_nanos())))
         .bind(h.author_kind.map(|kind| i64::from(kind.as_u8())))
         .execute(self.sqlite.pool())
         .await?;
@@ -600,8 +601,8 @@ impl Sqlite {
         // Inclusive on both ends, matching `range()`. `stats` relies on this to count a
         // command recorded exactly on a period boundary (e.g. at midnight).
         if let Some((from, to)) = range {
-            query.and_where_ge("timestamp", from.unix_timestamp_nanos() as i64);
-            query.and_where_le("timestamp", to.unix_timestamp_nanos() as i64);
+            query.and_where_ge("timestamp", i64::conv(from.unix_timestamp_nanos()));
+            query.and_where_le("timestamp", i64::conv(to.unix_timestamp_nanos()));
         }
 
         let query = query.sql().expect("bug in list query. please report");
@@ -621,8 +622,8 @@ impl Sqlite {
             "select {HISTORY_COLUMNS} from history where timestamp >= ?1 and timestamp <= ?2 \
              order by timestamp asc"
         )))
-        .bind(from.unix_timestamp_nanos() as i64)
-        .bind(to.unix_timestamp_nanos() as i64)
+        .bind(i64::conv(from.unix_timestamp_nanos()))
+        .bind(i64::conv(to.unix_timestamp_nanos()))
         .fetch_all(self.sqlite.pool())
         .await?;
 
@@ -647,7 +648,7 @@ impl Sqlite {
             "select {HISTORY_COLUMNS} from history where timestamp < ?1 order by timestamp desc \
              limit ?2"
         )))
-        .bind(timestamp.unix_timestamp_nanos() as i64)
+        .bind(i64::conv(timestamp.unix_timestamp_nanos()))
         .bind(count)
         .fetch_all(self.sqlite.pool())
         .await?;
@@ -783,7 +784,7 @@ impl Sqlite {
                             format!("invalid `before` filter {before:?}: {e}").into(),
                         )
                     })?;
-            sql.and_where_lt("timestamp", quote(parsed.unix_timestamp_nanos() as i64));
+            sql.and_where_lt("timestamp", quote(i64::conv(parsed.unix_timestamp_nanos())));
         }
 
         if let Some(after) = filter_options.after {
@@ -792,7 +793,7 @@ impl Sqlite {
                     .map_err(|e| {
                         sqlx::Error::Decode(format!("invalid `after` filter {after:?}: {e}").into())
                     })?;
-            sql.and_where_gt("timestamp", quote(parsed.unix_timestamp_nanos() as i64));
+            sql.and_where_gt("timestamp", quote(i64::conv(parsed.unix_timestamp_nanos())));
         }
 
         apply_author_filter(&mut sql, filter_options.authors);
@@ -1007,11 +1008,11 @@ impl Sqlite {
             Vec<(String, f64)>,
         ) = tokio::try_join!(
             db::query_as::<_, History>(sqlx::AssertSqlSafe(prev))
-                .bind(h.timestamp.unix_timestamp_nanos() as i64)
+                .bind(i64::conv(h.timestamp.unix_timestamp_nanos()))
                 .bind(&h.session)
                 .fetch_optional(self.sqlite.pool()),
             db::query_as::<_, History>(sqlx::AssertSqlSafe(next))
-                .bind(h.timestamp.unix_timestamp_nanos() as i64)
+                .bind(i64::conv(h.timestamp.unix_timestamp_nanos()))
                 .bind(&h.session)
                 .fetch_optional(self.sqlite.pool()),
             db::query_as(sqlx::AssertSqlSafe(total)).bind(&h.command).fetch_one(self.sqlite.pool()),
@@ -1033,7 +1034,7 @@ impl Sqlite {
         Ok(HistoryStats {
             next,
             previous: prev,
-            total: total.0 as u64,
+            total: u64::conv(total.0),
             average_duration: average.0 as u64,
             exits,
             day_of_week,

--- a/crates/atuin-client/src/history.rs
+++ b/crates/atuin-client/src/history.rs
@@ -7,6 +7,7 @@ use atuin_common::rmp::encode::{self, ByteBuf, EncodeError};
 use atuin_common::time::OffsetDateTimeExt;
 use atuin_common::utils::{normalize_optional_string, uuid_v7};
 use atuin_domain::record::{CmdOrigin, DecryptedData, UNKNOWN_USER};
+use easy_cast::Conv;
 use eyre::{Result, bail};
 use serde::{Deserialize, Serialize};
 use time::OffsetDateTime;
@@ -436,7 +437,7 @@ impl History {
         encode::write_array_len(&mut output, LATEST_SERIALIZED_FIELDS)?;
 
         encode::write_str(&mut output, &self.id.to_string())?;
-        encode::write_u64(&mut output, self.timestamp.unix_timestamp_nanos() as u64)?;
+        encode::write_u64(&mut output, u64::conv(self.timestamp.unix_timestamp_nanos()))?;
         encode::write_sint(&mut output, self.duration)?;
         encode::write_sint(&mut output, self.exit)?;
         encode::write_str(&mut output, &self.command)?;
@@ -446,7 +447,7 @@ impl History {
 
         encode::write_optional(
             &mut output,
-            self.deleted_at.map(|d| d.unix_timestamp_nanos() as u64),
+            self.deleted_at.map(|d| u64::conv(d.unix_timestamp_nanos())),
             encode::write_u64,
         )?;
         encode::write_str(&mut output, self.author.as_str())?;

--- a/crates/atuin-client/src/history/store.rs
+++ b/crates/atuin-client/src/history/store.rs
@@ -10,6 +10,7 @@ use atuin_domain::record::{
     DecryptedData, Host, HostId, Record, RecordId, RecordIdx, RecordSeriesKey, RecordTag,
     RecordVersion,
 };
+use easy_cast::Conv;
 use eyre::{Result, bail, eyre};
 use futures::{Stream, StreamExt, TryStreamExt, future, stream};
 use indicatif::{ProgressBar, ProgressState, ProgressStyle};
@@ -184,7 +185,7 @@ impl HistoryStore {
                 .host(Host::new(self.host_id))
                 .version(RecordVersion::from(Version::LATEST.name()))
                 .tag(RecordTag::History)
-                .idx(idx + n as u64)
+                .idx(idx + u64::conv(n))
                 .data(bytes)
                 .build();
 
@@ -462,6 +463,7 @@ mod tests {
     use atuin_domain::record::{
         CmdOrigin, DecryptedData, Host, HostId, Record, RecordTag, RecordVersion,
     };
+    use easy_cast::Conv;
     use futures::TryStreamExt;
     use rstest::*;
     use time::Duration;
@@ -621,7 +623,8 @@ mod tests {
     fn history_n(n: usize) -> History {
         History {
             id: format!("{n:032x}").parse().unwrap(),
-            timestamp: datetime!(2024-01-04 00:00:00.000000 +00:00) + Duration::seconds(n as i64),
+            timestamp: datetime!(2024-01-04 00:00:00.000000 +00:00)
+                + Duration::seconds(i64::conv(n)),
             command: format!("command {n}"),
             ..sample_history()
         }

--- a/crates/atuin-client/src/import/powershell.rs
+++ b/crates/atuin-client/src/import/powershell.rs
@@ -2,6 +2,7 @@ use std::path::PathBuf;
 
 use async_trait::async_trait;
 use directories::BaseDirs;
+use easy_cast::Conv;
 use eyre::{Result, eyre};
 use time::{Duration, OffsetDateTime};
 
@@ -73,7 +74,7 @@ impl Importer for PowerShell {
 
     async fn load(mut self, h: &mut impl Loader) -> Result<()> {
         let line_count = self.entries().await?;
-        let start = OffsetDateTime::now_utc() - Duration::milliseconds(line_count as i64);
+        let start = OffsetDateTime::now_utc() - Duration::milliseconds(i64::conv(line_count));
 
         let mut counter = 0;
         let mut iter = unix_byte_lines(&self.bytes);

--- a/crates/atuin-client/src/import/resh.rs
+++ b/crates/atuin-client/src/import/resh.rs
@@ -107,14 +107,12 @@ impl Importer for Resh {
             };
 
             #[allow(clippy::cast_possible_truncation)]
-            #[allow(clippy::cast_sign_loss)]
             let start = {
                 let secs = entry.realtime_before.floor() as i64;
                 let nanosecs = (entry.realtime_before.fract() * 1_000_000_000_f64).round() as i64;
                 OffsetDateTime::from_timespec(i128::from(secs), i128::from(nanosecs))
             };
             #[allow(clippy::cast_possible_truncation)]
-            #[allow(clippy::cast_sign_loss)]
             let end = {
                 let secs = entry.realtime_after.floor() as i64;
                 let nanosecs = (entry.realtime_after.fract() * 1_000_000_000_f64).round() as i64;

--- a/crates/atuin-client/src/import/xonsh_sqlite.rs
+++ b/crates/atuin-client/src/import/xonsh_sqlite.rs
@@ -6,6 +6,7 @@ use atuin_common::db;
 use atuin_common::time::OffsetDateTimeExt;
 use atuin_domain::record::CmdOrigin;
 use directories::BaseDirs;
+use easy_cast::Conv;
 use eyre::{Result, eyre};
 use futures::TryStreamExt;
 use sqlx::sqlite::SqlitePool;
@@ -101,7 +102,7 @@ impl Importer for XonshSqlite {
         let query = "SELECT COUNT(*) FROM xonsh_history";
         let row = db::query(query).fetch_one(&self.pool).await?;
         let count: u32 = row.get(0);
-        Ok(count as usize)
+        Ok(usize::conv(count))
     }
 
     async fn load(self, loader: &mut impl Loader) -> Result<()> {

--- a/crates/atuin-client/src/packfile/record.rs
+++ b/crates/atuin-client/src/packfile/record.rs
@@ -403,6 +403,7 @@ impl<'a> PackManifestRecordView<'a> {
 mod tests {
     use atuin_common::utils::uuid_v7;
     use atuin_domain::record::Host;
+    use easy_cast::Conv;
     use rstest::{fixture, rstest};
     use uuid::Uuid;
 
@@ -423,7 +424,7 @@ mod tests {
                     .host(host.clone())
                     .version("v1".into())
                     .tag("history".into())
-                    .idx(i as u64)
+                    .idx(u64::conv(i))
                     .data(DecryptedData(b"ls -la /very/repetitive/path".to_vec()))
                     .build()
             })

--- a/crates/atuin-client/src/record/sqlite_store.rs
+++ b/crates/atuin-client/src/record/sqlite_store.rs
@@ -13,6 +13,7 @@ use atuin_domain::record::{
     Host, HostId, Record, RecordId, RecordIdx, RecordSeriesKey, RecordStatus, RecordTag,
     RecordVersion,
 };
+use easy_cast::Conv;
 use eyre::{Result, eyre};
 use sqlx::Row;
 use sqlx::sqlite::{SqlitePool, SqliteRow};
@@ -49,9 +50,9 @@ impl<'r> ::sqlx::FromRow<'r, SqliteRow> for DbRecord {
 
         Ok(Self(Record {
             id: RecordId(parse_uuid("id")?),
-            idx: idx as u64,
+            idx: u64::conv(idx),
             host: Host::new(HostId(parse_uuid("host")?)),
-            timestamp: timestamp as u64,
+            timestamp: u64::conv(timestamp),
             tag: RecordTag::from(row.try_get::<String, _>("tag")?),
             version: RecordVersion::from(row.try_get::<String, _>("version")?),
             data: paseto_v4::EncryptedData {
@@ -103,10 +104,10 @@ impl SqliteStore {
                 values(?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)",
         )
         .bind(r.id.as_hyphenated().to_string())
-        .bind(r.idx as i64)
+        .bind(i64::conv(r.idx))
         .bind(r.host.id.as_hyphenated().to_string())
         .bind(r.tag.as_str())
-        .bind(r.timestamp as i64)
+        .bind(i64::conv(r.timestamp))
         .bind(r.version.as_str())
         .bind(r.data.raw.as_str())
         .bind(r.data.cek.as_str())
@@ -153,10 +154,10 @@ impl SqliteStore {
 
             builder.push_values(records.by_ref().take(rows_per_insert), |mut b, r| {
                 b.push_bind(r.id.0.as_hyphenated().to_string())
-                    .push_bind(r.idx as i64)
+                    .push_bind(i64::conv(r.idx))
                     .push_bind(r.host.id.0.as_hyphenated().to_string())
                     .push_bind(r.tag.as_str())
-                    .push_bind(r.timestamp as i64)
+                    .push_bind(i64::conv(r.timestamp))
                     .push_bind(r.version.as_str())
                     .push_bind(r.data.raw.as_str())
                     .push_bind(r.data.cek.as_str());
@@ -233,7 +234,7 @@ impl SqliteStore {
             db::query_as("select count(*) from store").fetch_one(self.sqlite.pool()).await;
         match res {
             Err(e) => Err(eyre!("failed to fetch local store len: {}", e)),
-            Ok(v) => Ok(v.0 as u64),
+            Ok(v) => Ok(u64::conv(v.0)),
         }
     }
 
@@ -246,7 +247,7 @@ impl SqliteStore {
                 .await;
         match res {
             Err(e) => Err(eyre!("failed to fetch local store len: {}", e)),
-            Ok(v) => Ok(v.0 as u64),
+            Ok(v) => Ok(u64::conv(v.0)),
         }
     }
 
@@ -278,7 +279,7 @@ impl SqliteStore {
         .fetch_one(self.sqlite.pool())
         .await?;
 
-        Ok(gap.unwrap_or(0) as u64)
+        Ok(u64::conv(gap.unwrap_or(0)))
     }
 
     #[instrument(level = "trace", skip_all, fields(host = ?series.host_id, tag = ?series.tag, idx, limit), err)]
@@ -292,10 +293,10 @@ impl SqliteStore {
             "select {STORE_COLUMNS} from store where idx >= ?1 and host = ?2 and tag = ?3 order \
              by idx asc limit ?4"
         )))
-        .bind(idx as i64)
+        .bind(i64::conv(idx))
         .bind(series.host_id.as_hyphenated().to_string())
         .bind(series.tag.as_str())
-        .bind(limit as i64)
+        .bind(i64::conv(limit))
         .fetch_all(self.sqlite.pool())
         .await?;
 
@@ -311,7 +312,7 @@ impl SqliteStore {
         let res = db::query_as::<_, DbRecord>(sqlx::AssertSqlSafe(format!(
             "select {STORE_COLUMNS} from store where idx = ?1 and host = ?2 and tag = ?3"
         )))
-        .bind(idx as i64)
+        .bind(i64::conv(idx))
         .bind(series.host_id.as_hyphenated().to_string())
         .bind(series.tag.as_str())
         .fetch_one(self.sqlite.pool())
@@ -343,7 +344,7 @@ impl SqliteStore {
                 Uuid::from_str(i.0.as_str()).expect("failed to parse uuid for local store status"),
             );
 
-            status.set_raw(RecordSeriesKey::new(host, RecordTag::from(i.1)), i.2 as u64);
+            status.set_raw(RecordSeriesKey::new(host, RecordTag::from(i.1)), u64::conv(i.2));
         }
 
         Ok(status)

--- a/crates/atuin-client/src/record/sync/mod.rs
+++ b/crates/atuin-client/src/record/sync/mod.rs
@@ -23,6 +23,7 @@ use atuin_domain::caps::{PackfileCap, PageSizeCap};
 use atuin_domain::record::{
     Diff, EncryptedData, Record, RecordId, RecordIdx, RecordSeriesKey, RecordStatus, RecordTag,
 };
+use easy_cast::Conv;
 use eyre::Result;
 use futures::{StreamExt, TryStreamExt, stream};
 use indicatif::{ProgressBar, ProgressState, ProgressStyle};
@@ -413,7 +414,7 @@ impl Keyed<'_> {
                 SyncError::RemoteRequestError { msg: e.to_string() }
             })?;
 
-            progress += page.len() as u64;
+            progress += u64::conv(page.len());
             pb.set_position(progress);
         }
 
@@ -570,7 +571,7 @@ impl Keyed<'_> {
 
             ret.extend(page.iter().map(|f| f.id));
 
-            progress += page.len() as u64;
+            progress += u64::conv(page.len());
             pb.set_position(progress);
         }
 
@@ -1325,15 +1326,13 @@ mod packfile_sync_tests {
             .await
             .unwrap();
 
-        assert_eq!(
-            down.next(&RecordSeriesKey::new(host, RecordTag::History), 0, count)
-                .await
-                .unwrap()
-                .len() as u64,
-            count,
-            "every page must be reassembled, none skipped"
-        );
-        assert_eq!(returned.len() as u64, count);
+        let len = down
+            .next(&RecordSeriesKey::new(host, RecordTag::History), 0, count)
+            .await
+            .unwrap()
+            .len();
+        assert_eq!(u64::conv(len), count, "every page must be reassembled, none skipped");
+        assert_eq!(u64::conv(returned.len()), count);
     }
 
     /// Build `num_packs` contiguous packfiles of `per` history records each for a single host,
@@ -1362,7 +1361,7 @@ mod packfile_sync_tests {
         let manifests =
             up.next(&RecordSeriesKey::new(host, RecordTag::Packfile), 0, num_packs).await.unwrap();
         assert_eq!(
-            manifests.len() as u64,
+            u64::conv(manifests.len()),
             num_packs,
             "fixture expects exactly one manifest per pack"
         );
@@ -1466,7 +1465,7 @@ mod packfile_sync_tests {
         );
         let history =
             down.next(&RecordSeriesKey::new(host, RecordTag::History), 0, total).await.unwrap();
-        assert_eq!(history.len() as u64, total, "all covered history must be populated");
+        assert_eq!(u64::conv(history.len()), total, "all covered history must be populated");
         assert_eq!(history[0].clone().decrypt(&key).unwrap().data.0, b"cmd 0");
         for id in &history_ids {
             assert!(

--- a/crates/atuin-common/Cargo.toml
+++ b/crates/atuin-common/Cargo.toml
@@ -21,7 +21,6 @@ db = ["dep:sqlx"]
 sqlite = ["db", "sqlx/sqlite", "sqlx/regexp", "dep:libsqlite3-sys", "dep:tokio-util"]
 
 [dependencies]
-easy-cast = { workspace = true }
 atuin-vt100 = { workspace = true, optional = true }
 derive_more = { workspace = true }
 tiny-bip39 = { workspace = true }
@@ -55,6 +54,7 @@ fs-err = { workspace = true }
 semver = { workspace = true }
 sqlx = { workspace = true, optional = true }
 libsqlite3-sys = { workspace = true, optional = true }
+easy-cast = { workspace = true }
 
 [target.'cfg(unix)'.dependencies]
 rustix = { workspace = true, optional = true }

--- a/crates/atuin-common/Cargo.toml
+++ b/crates/atuin-common/Cargo.toml
@@ -21,6 +21,7 @@ db = ["dep:sqlx"]
 sqlite = ["db", "sqlx/sqlite", "sqlx/regexp", "dep:libsqlite3-sys", "dep:tokio-util"]
 
 [dependencies]
+easy-cast = { workspace = true }
 atuin-vt100 = { workspace = true, optional = true }
 derive_more = { workspace = true }
 tiny-bip39 = { workspace = true }

--- a/crates/atuin-common/src/ansi.rs
+++ b/crates/atuin-common/src/ansi.rs
@@ -3,6 +3,8 @@
 use std::borrow::Borrow;
 use std::num::NonZeroU16;
 
+use easy_cast::Cast;
+
 /// Arbitrary upper bound on the emulated screen height, in rows. Mitigates OOMs with long output.
 const MAX_ROWS: usize = 16_384;
 
@@ -34,10 +36,11 @@ pub fn to_plain_text(input: impl AsRef<[u8]>, cols: NonZeroU16) -> String {
     // Note this overshoots, but that's OK, we'll clean up later.
     let newline_rows = newlines + 1;
     let wrapped_rows = normalized.len() / usize::from(cols.get());
-    let rows = newline_rows
+    let rows: u16 = newline_rows
         .saturating_add(wrapped_rows)
         .saturating_add(1)
-        .clamp(1, MAX_ROWS.min(usize::from(u16::MAX))) as u16;
+        .clamp(1, MAX_ROWS.min(usize::from(u16::MAX)))
+        .cast();
     let rows = NonZeroU16::new(rows).expect("`rows` is always at least 1 due to `clamp`");
 
     let mut parser = vt100::Parser::new(rows, cols, 0);

--- a/crates/atuin-common/src/encryption/paseto_v4.rs
+++ b/crates/atuin-common/src/encryption/paseto_v4.rs
@@ -11,6 +11,7 @@ use base64::engine::general_purpose::{
     STANDARD as B64_STANDARD, URL_SAFE_NO_PAD as B64_URL_SAFE_NO_PAD,
 };
 use crypto_secretbox::{KeyInit, XSalsa20Poly1305, aead};
+use easy_cast::Conv;
 use rusty_paseto::{Paseto, core as rusty_paseto};
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
@@ -157,7 +158,7 @@ impl Key {
         // A msgpack array16 header (3 bytes) followed by each byte as at most a 2-byte uint.
         let mut buf = Vec::with_capacity(3 + 2 * key_bytes.len());
         // Writing to a `Vec` is infallible, so neither of these can actually error.
-        rmp::encode::write_array_len(&mut buf, key_bytes.len() as u32)
+        rmp::encode::write_array_len(&mut buf, u32::conv(key_bytes.len()))
             .expect("writing to a Vec is infallible");
         for b in key_bytes {
             rmp::encode::write_uint(&mut buf, u64::from(*b))

--- a/crates/atuin-common/src/os/windows/mod.rs
+++ b/crates/atuin-common/src/os/windows/mod.rs
@@ -11,6 +11,8 @@ pub mod process;
 /// Query the system for the last set error.
 #[must_use]
 pub fn get_last_error() -> std::io::Error {
+    // Wrapping behavior of `as` is intended here -- reinterpreting `DWORD` Windows error codes as
+    // `i32` is what `std::io::Error` expects.
     std::io::Error::from_raw_os_error(unsafe { GetLastError() } as i32)
 }
 

--- a/crates/atuin-common/src/time/duration.rs
+++ b/crates/atuin-common/src/time/duration.rs
@@ -3,6 +3,8 @@
 use core::fmt;
 use std::ops::ControlFlow;
 
+use easy_cast::Conv;
+
 /// Returned by [`DurationExt::try_new`] when the requested seconds/nanoseconds cannot be
 /// represented by the target `Duration` type.
 ///
@@ -164,7 +166,7 @@ impl DurationExt<Self> for std::time::Duration {
     #[allow(clippy::disallowed_methods)]
     fn try_new(secs: u64, nsecs: u64) -> Result<Self, DurationOverflow> {
         let carry = nsecs / 1_000_000_000;
-        let nanos = (nsecs % 1_000_000_000) as u32;
+        let nanos = u32::conv(nsecs % 1_000_000_000);
         let secs = secs.checked_add(carry).ok_or(DurationOverflow { secs, nsecs })?;
         Ok(Self::new(secs, nanos))
     }
@@ -209,13 +211,13 @@ mod tests {
     #[case::positive(1_500_000_000, 1_500_000_000)]
     #[case::negative_clamps_to_zero(-1, 0)]
     #[case::min_clamps_to_zero(i64::MIN, 0)]
-    #[case::max(i64::MAX, i64::MAX as u128)]
+    #[case::max(i64::MAX, u128::conv(i64::MAX))]
     fn saturating_from_nanos_i64_clamps(#[case] nanos: i64, #[case] expected: u128) {
         assert_eq!(std::time::Duration::saturating_from_nanos_i64(nanos).as_nanos(), expected);
         assert_eq!(
             <time::Duration as DurationExt<_>>::saturating_from_nanos_i64(nanos)
                 .whole_nanoseconds(),
-            expected as i128
+            i128::conv(expected)
         );
     }
 
@@ -227,7 +229,7 @@ mod tests {
         assert_eq!(std::time::Duration::try_new(secs, nsecs).unwrap().as_nanos(), expected);
         assert_eq!(
             <time::Duration as DurationExt<_>>::try_new(secs, nsecs).unwrap().whole_nanoseconds(),
-            expected as i128
+            i128::conv(expected)
         );
     }
 
@@ -240,9 +242,9 @@ mod tests {
     }
 
     #[rstest]
-    #[case::max_i64_seconds(i64::MAX as u64, 0, true)]
-    #[case::one_second_past_i64(i64::MAX as u64 + 1, 0, false)]
-    #[case::carry_crosses_i64(i64::MAX as u64, 1_000_000_000, false)]
+    #[case::max_i64_seconds(u64::conv(i64::MAX), 0, true)]
+    #[case::one_second_past_i64(u64::conv(i64::MAX) + 1, 0, false)]
+    #[case::carry_crosses_i64(u64::conv(i64::MAX), 1_000_000_000, false)]
     #[case::past_u64_seconds(u64::MAX, 0, false)]
     #[case::carry_overflows_u64_seconds(u64::MAX, 1_000_000_000, false)]
     fn time_try_new_range(#[case] secs: u64, #[case] nsecs: u64, #[case] representable: bool) {
@@ -312,9 +314,11 @@ mod tests {
             let time_result = <time::Duration as DurationExt<_>>::try_new(secs, nsecs);
 
             match (std_result, time_result) {
-                (Ok(s), Ok(t)) => prop_assert_eq!(t.whole_nanoseconds(), s.as_nanos() as i128),
+                (Ok(s), Ok(t)) => {
+                    prop_assert_eq!(t.whole_nanoseconds(), i128::conv(s.as_nanos()));
+                }
                 // time is narrower: it rejects what does not fit an i64 of seconds
-                (Ok(s), Err(_)) => prop_assert!(s.as_secs() > i64::MAX as u64),
+                (Ok(s), Err(_)) => prop_assert!(s.as_secs() > u64::conv(i64::MAX)),
                 (Err(_), Err(_)) => {}
                 (Err(_), Ok(_)) => prop_assert!(false, "time succeeded where std failed"),
             }

--- a/crates/atuin-common/src/time/offset_date_time.rs
+++ b/crates/atuin-common/src/time/offset_date_time.rs
@@ -125,6 +125,8 @@ impl fmt::Display for OffsetDateTimeDisplay {
 }
 
 const _: () = assert!(
+    // Using plain `as` casts here because trait methods like `try_from` aren't available in const
+    // contexts.
     (i64::MIN as i128) >= MIN_UNIX_NANOS
         && (i64::MAX as i128) <= MAX_UNIX_NANOS
         && (u64::MAX as i128) <= MAX_UNIX_NANOS,

--- a/crates/atuin-daemon/Cargo.toml
+++ b/crates/atuin-daemon/Cargo.toml
@@ -14,7 +14,6 @@ readme.workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-easy-cast = { workspace = true }
 atuin-client = { workspace = true }
 parking_lot = { workspace = true }
 atuin-domain = { workspace = true }
@@ -45,6 +44,7 @@ hyper-util = { workspace = true }
 
 rand.workspace = true
 frizbee = { workspace = true }
+easy-cast = { workspace = true }
 
 [dependencies.atuin-common]
 workspace = true

--- a/crates/atuin-daemon/Cargo.toml
+++ b/crates/atuin-daemon/Cargo.toml
@@ -14,6 +14,7 @@ readme.workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+easy-cast = { workspace = true }
 atuin-client = { workspace = true }
 parking_lot = { workspace = true }
 atuin-domain = { workspace = true }

--- a/crates/atuin-daemon/src/client.rs
+++ b/crates/atuin-daemon/src/client.rs
@@ -5,6 +5,7 @@ use atuin_client::database::Context;
 use atuin_client::history::{History, HistoryId};
 use atuin_client::settings::{FilterMode, Settings};
 use atuin_common::filter::{self, OrFilter};
+use easy_cast::Conv;
 use eyre::{Context as EyreContext, Result};
 use hyper_util::rt::TokioIo;
 #[cfg(windows)]
@@ -127,7 +128,7 @@ impl HistoryClient {
             cwd: h.cwd,
             hostname: h.cmd_origin.into_string(),
             session: h.session,
-            timestamp: h.timestamp.unix_timestamp_nanos() as u64,
+            timestamp: u64::conv(h.timestamp.unix_timestamp_nanos()),
             author: h.author,
             intent: h.intent.unwrap_or_default(),
             shell: h.shell.unwrap_or_default(),

--- a/crates/atuin-daemon/src/components/history.rs
+++ b/crates/atuin-daemon/src/components/history.rs
@@ -13,6 +13,7 @@ use atuin_common::time::OffsetDateTimeExt;
 use atuin_domain::caps::PackfileCap;
 use atuin_domain::record::{CmdOrigin, RecordSeriesKey, RecordTag};
 use dashmap::DashMap;
+use easy_cast::Conv;
 use eyre::Result;
 use time::OffsetDateTime;
 use tokio_stream::Stream;
@@ -122,7 +123,7 @@ fn history_to_tail_reply(kind: HistoryEventKind, history: History) -> TailHistor
     TailHistoryReply {
         kind: kind as i32,
         history: Some(HistoryEntry {
-            timestamp: history.timestamp.unix_timestamp_nanos() as u64,
+            timestamp: u64::conv(history.timestamp.unix_timestamp_nanos()),
             id: history.id.to_string(),
             command: history.command,
             cwd: history.cwd,

--- a/crates/atuin-daemon/src/components/semantic.rs
+++ b/crates/atuin-daemon/src/components/semantic.rs
@@ -8,6 +8,7 @@ use std::collections::{HashMap, VecDeque};
 use std::sync::Arc;
 
 use atuin_client::history::{History, HistoryId};
+use easy_cast::Conv;
 use eyre::Result;
 use tokio::sync::Mutex;
 use tonic::{Request, Response, Status, Streaming};
@@ -193,7 +194,7 @@ impl SemanticState {
         capture.history_id = Some(history_id.to_string());
         capture.session_id = Some(session_id.to_string());
         if capture.output_observed_bytes == 0 {
-            capture.output_observed_bytes = capture.output.len() as u64;
+            capture.output_observed_bytes = u64::conv(capture.output.len());
         }
 
         let record = SemanticCommandRecord { capture, history };
@@ -249,13 +250,13 @@ impl SemanticState {
             self.sessions.get(&capture_ref.session_id)?.stored_capture(capture_ref.capture_id)?;
         let output = &stored.record.capture.output;
         let output_observed_bytes =
-            stored.record.capture.output_observed_bytes.max(output.len() as u64);
+            stored.record.capture.output_observed_bytes.max(u64::conv(output.len()));
 
         Some(CommandOutputReply {
             found: true,
             output: String::new(),
-            total_bytes: output.len() as u64,
-            total_lines: output.lines().count() as u64,
+            total_bytes: u64::conv(output.len()),
+            total_lines: u64::conv(output.lines().count()),
             lines: select_output_ranges(output, ranges),
             output_truncated: stored.record.capture.output_truncated,
             output_observed_bytes,
@@ -526,7 +527,7 @@ fn select_output_ranges(output: &str, ranges: &[crate::semantic::OutputRange]) -
         .into_iter()
         .flat_map(|(start, end)| {
             lines[start..=end].iter().enumerate().map(move |(offset, line)| OutputLine {
-                line_number: (start + offset + 1) as u64,
+                line_number: u64::conv(start + offset + 1),
                 content: (*line).to_string(),
             })
         })
@@ -553,7 +554,7 @@ fn normalize_line_range(start: i64, end: i64, line_count: usize) -> Option<(usiz
     let start = start.max(0);
     let end = end.min(line_count - 1);
 
-    (start <= end).then_some((start as usize, end as usize))
+    (start <= end).then_some((usize::conv(start), usize::conv(end)))
 }
 
 fn log_record(record: &SemanticCommandRecord, message: &'static str) {
@@ -636,7 +637,7 @@ mod tests {
             history_id: id.map(|id| id.to_string()),
             session_id: session.map(str::to_string),
             output_truncated: false,
-            output_observed_bytes: output.len() as u64,
+            output_observed_bytes: u64::conv(output.len()),
         }
     }
 
@@ -712,18 +713,18 @@ mod tests {
 
     #[rstest]
     fn evicts_oldest_command_when_session_ring_is_full(mut state: SemanticState) {
-        for index in 0..=MAX_COMMANDS_PER_SESSION as u128 {
+        for index in 0..=u128::conv(MAX_COMMANDS_PER_SESSION) {
             assert!(state.record_capture(capture(Some(hid(index)), Some("session-1"), "output")));
         }
 
         assert!(!output_for(&mut state, hid(0)).found);
-        assert!(output_for(&mut state, hid(MAX_COMMANDS_PER_SESSION as u128)).found);
+        assert!(output_for(&mut state, hid(u128::conv(MAX_COMMANDS_PER_SESSION))).found);
         assert_eq!(state.record_count(), MAX_COMMANDS_PER_SESSION);
     }
 
     #[rstest]
     fn evicts_oldest_session_after_lru_limit(mut state: SemanticState) {
-        for index in 0..MAX_SESSIONS as u128 {
+        for index in 0..u128::conv(MAX_SESSIONS) {
             assert!(state.record_capture(capture(
                 Some(hid(index)),
                 Some(&format!("session-{index}")),

--- a/crates/atuin-daemon/src/components/sync.rs
+++ b/crates/atuin-daemon/src/components/sync.rs
@@ -11,6 +11,7 @@ use atuin_client::record::sync::{ClientSource, SyncEngine};
 use atuin_client::settings::Settings;
 use atuin_dotfiles::store::AliasStore;
 use atuin_dotfiles::store::var::VarStore;
+use easy_cast::Conv;
 use eyre::Result;
 use futures::StreamExt;
 use rand::Rng;
@@ -293,7 +294,7 @@ async fn do_sync_tick(
 
             // Emit sync completed event
             handle.emit(DaemonEvent::SyncCompleted {
-                uploaded: uploaded_count as usize,
+                uploaded: usize::conv(uploaded_count),
                 downloaded: downloaded_records.len(),
             });
 

--- a/crates/atuin-daemon/src/search/index.rs
+++ b/crates/atuin-daemon/src/search/index.rs
@@ -17,6 +17,7 @@ use atuin_client::settings::Search;
 use atuin_common::filter::OrFilter;
 use atuin_common::path::DisplayRichExt;
 use dashmap::DashMap;
+use easy_cast::Conv;
 use lasso::{Spur, ThreadedRodeo};
 use parking_lot::RwLock;
 use time::OffsetDateTime;
@@ -67,7 +68,7 @@ impl FrecencyData {
         }
 
         // Time-based decay: score decreases as time passes
-        let age_seconds = (now - self.last_used).max(0) as u64;
+        let age_seconds = u64::conv((now - self.last_used).max(0));
         let age_hours = age_seconds / 3600;
 
         // Decay factor: recent commands get higher scores
@@ -438,13 +439,13 @@ impl SearchIndex {
         // Filter pre-pass: collect the candidate commands for this filter mode. This is sorted
         // vector of haystack indices.
         let get_candidates = || match &filter {
-            CompiledFilter::All => haystack.iter().enumerate().map(|(i, _)| i as u32).collect(),
+            CompiledFilter::All => haystack.iter().enumerate().map(|(i, _)| u32::conv(i)).collect(),
             CompiledFilter::Nothing => Vec::new(),
             _ => {
                 let mut indices: Vec<u32> = self
                     .commands
                     .iter()
-                    .filter(|entry| (entry.haystack_index as usize) < haystack.len())
+                    .filter(|entry| usize::conv(entry.haystack_index) < haystack.len())
                     .filter(|entry| match &filter {
                         CompiledFilter::All | CompiledFilter::Nothing => unreachable!(),
                         CompiledFilter::Directory(dir) => entry.has_invocation_in_dir(*dir),
@@ -467,7 +468,7 @@ impl SearchIndex {
             tracing::span!(Level::TRACE, "index_search_filter").in_scope(get_candidates);
 
         let candidate_frecency = |candidate_index: usize| {
-            let hay_idx = candidates[candidate_index] as usize;
+            let hay_idx = usize::conv(candidates[candidate_index]);
             frecency_map.as_ref().and_then(|f| f.get(hay_idx).copied()).unwrap_or(0)
         };
 
@@ -483,14 +484,14 @@ impl SearchIndex {
                 .map(|i| Score {
                     fuzzy_score: 0,
                     frecency: candidate_frecency(i),
-                    index: i as u32,
+                    index: u32::conv(i),
                 })
                 .collect()
         } else {
             // This is a vec of `&Arc<str>` instead of `&str` because `&Arc<str>` is the size of one
             // pointer while `&str` is the size of two.
             let normalized_commands: Vec<&Arc<str>> =
-                candidates.iter().map(|i| &haystack[*i as usize].normalized).collect();
+                candidates.iter().map(|i| &haystack[usize::conv(*i)].normalized).collect();
             // Use all cores when the number of commands is sufficiently large.
             let threads = std::thread::available_parallelism().map_or(1, |n| n.get());
             let matches = tracing::span!(Level::TRACE, "index_search_match").in_scope(|| {
@@ -504,7 +505,7 @@ impl SearchIndex {
                 .iter()
                 .map(|m| Score {
                     fuzzy_score: m.score,
-                    frecency: candidate_frecency(m.index as usize),
+                    frecency: candidate_frecency(usize::conv(m.index)),
                     index: m.index,
                 })
                 .collect()
@@ -513,16 +514,16 @@ impl SearchIndex {
         tracing::span!(Level::TRACE, "index_search_results").in_scope(|| {
             // only the top `limit` results are returned, so partition them
             // out before sorting instead of sorting every match
-            let limit = limit as usize;
+            let limit = usize::conv(limit);
             if scored.len() > limit {
                 scored.select_nth_unstable(limit);
                 scored.truncate(limit);
             }
             scored.sort_unstable();
             scored.into_iter().filter_map(move |score| {
-                let haystack_index = candidates[score.index as usize];
+                let haystack_index = candidates[usize::conv(score.index)];
                 self.commands
-                    .get(haystack[haystack_index as usize].original.as_ref())
+                    .get(haystack[usize::conv(haystack_index)].original.as_ref())
                     .map(|data| data.most_recent_id())
             })
         })
@@ -898,7 +899,7 @@ mod tests {
         let index = SearchIndex::default();
         for (i, command) in equivalence_corpus().iter().enumerate() {
             // spread timestamps so frecency scores actually differ
-            let ts = datetime!(2024-01-01 00:00 UTC) + time::Duration::minutes((i % 1440) as i64);
+            let ts = datetime!(2024-01-01 00:00 UTC) + time::Duration::minutes(i64::conv(i % 1440));
             index.add_history(&make_history(command, "/tmp", ts));
         }
         assert!(index.command_count() > 10_000, "corpus must cross threshold");

--- a/crates/atuin-domain/Cargo.toml
+++ b/crates/atuin-domain/Cargo.toml
@@ -13,7 +13,6 @@ repository = { workspace = true }
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-easy-cast = { workspace = true }
 serde = { workspace = true }
 atuin-common = { workspace = true }
 whoami = { workspace = true }
@@ -37,6 +36,7 @@ tokio = { workspace = true }
 axum = { workspace = true, optional = true }
 strum = { workspace = true }
 strum_macros = { workspace = true }
+easy-cast = { workspace = true }
 
 [features]
 # Feature-gated axum integration for the server-side capability handlers (`caps::axum`).

--- a/crates/atuin-domain/Cargo.toml
+++ b/crates/atuin-domain/Cargo.toml
@@ -13,6 +13,7 @@ repository = { workspace = true }
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+easy-cast = { workspace = true }
 serde = { workspace = true }
 atuin-common = { workspace = true }
 whoami = { workspace = true }

--- a/crates/atuin-domain/src/record/mod.rs
+++ b/crates/atuin-domain/src/record/mod.rs
@@ -1,6 +1,7 @@
 use std::collections::HashMap;
 
 pub use atuin_common::encryption::paseto_v4::{self, EncryptedData};
+use easy_cast::Conv;
 use eyre::WrapErr;
 use serde::{Deserialize, Serialize};
 use typed_builder::TypedBuilder;
@@ -102,7 +103,7 @@ pub struct Record<Data> {
     pub host: Host,
 
     /// The creation time in nanoseconds since unix epoch
-    #[builder(default = time::OffsetDateTime::now_utc().unix_timestamp_nanos() as u64)]
+    #[builder(default = u64::conv(time::OffsetDateTime::now_utc().unix_timestamp_nanos()))]
     pub timestamp: u64,
 
     /// The version the data in the entry conforms to

--- a/crates/atuin-history/Cargo.toml
+++ b/crates/atuin-history/Cargo.toml
@@ -15,12 +15,12 @@ readme.workspace = true
 
 [dependencies]
 atuin-client = { workspace = true }
-easy-cast = { workspace = true }
 
 time = { workspace = true }
 serde = { workspace = true }
 crossterm = { workspace = true, features = ["use-dev-tty"] }
 unicode-segmentation = { workspace = true }
+easy-cast = { workspace = true }
 
 [dev-dependencies]
 divan = { workspace = true }

--- a/crates/atuin-history/Cargo.toml
+++ b/crates/atuin-history/Cargo.toml
@@ -15,6 +15,7 @@ readme.workspace = true
 
 [dependencies]
 atuin-client = { workspace = true }
+easy-cast = { workspace = true }
 
 time = { workspace = true }
 serde = { workspace = true }

--- a/crates/atuin-history/src/stats.rs
+++ b/crates/atuin-history/src/stats.rs
@@ -4,6 +4,7 @@ use atuin_client::history::History;
 use atuin_client::settings::Settings;
 use atuin_client::theme::{Meaning, Theme};
 use crossterm::style::{Color, ResetColor, SetAttribute, SetForegroundColor};
+use easy_cast::Conv;
 use serde::{Deserialize, Serialize};
 use unicode_segmentation::UnicodeSegmentation;
 
@@ -165,7 +166,7 @@ fn strip_leading_env_vars(command: &str) -> &str {
 
 pub fn pretty_print(stats: Stats, ngram_size: usize, theme: &Theme) {
     let max = stats.top.iter().map(|x| x.1).max().unwrap();
-    let num_pad = max.ilog10() as usize + 1;
+    let num_pad = usize::conv(max.ilog10()) + 1;
 
     // Find the length of the longest command name for each column
     let column_widths = stats

--- a/crates/atuin-pty-proxy/Cargo.toml
+++ b/crates/atuin-pty-proxy/Cargo.toml
@@ -11,8 +11,8 @@ homepage = { workspace = true }
 repository = { workspace = true }
 
 [dependencies]
-easy-cast = { workspace = true }
 clap = { workspace = true }
+easy-cast = { workspace = true }
 
 [target.'cfg(unix)'.dependencies]
 atuin-common = { workspace = true, features = ["ansi", "os"] }

--- a/crates/atuin-pty-proxy/Cargo.toml
+++ b/crates/atuin-pty-proxy/Cargo.toml
@@ -11,6 +11,7 @@ homepage = { workspace = true }
 repository = { workspace = true }
 
 [dependencies]
+easy-cast = { workspace = true }
 clap = { workspace = true }
 
 [target.'cfg(unix)'.dependencies]

--- a/crates/atuin-pty-proxy/src/capture.rs
+++ b/crates/atuin-pty-proxy/src/capture.rs
@@ -322,6 +322,7 @@ impl CommandCaptureTracker {
 mod tests {
     use std::sync::mpsc::{self, Receiver};
 
+    use easy_cast::Conv;
     use rstest::{fixture, rstest};
 
     use super::*;
@@ -427,7 +428,7 @@ mod tests {
             exit_code: Some(0),
             history_id: Some("hist".to_string()),
             session_id: Some("sess".to_string()),
-            output_observed_bytes: b"hi\r\n".len() as u64,
+            output_observed_bytes: u64::conv(b"hi\r\n".len()),
             output_truncated: false,
         },
     )]
@@ -441,7 +442,7 @@ mod tests {
             exit_code: Some(0),
             history_id: Some("018f".to_string()),
             session_id: Some("abcd".to_string()),
-            output_observed_bytes: b"line one\r\n".len() as u64,
+            output_observed_bytes: u64::conv(b"line one\r\n".len()),
             output_truncated: false,
         },
     )]
@@ -576,7 +577,7 @@ mod tests {
         assert_eq!(capture.output, "");
         // The bytes were still observed, even though none of them were captured.
         let drawn = b"\x1b[?1049hEDITOR\r\nSCREEN\x1b[?1049l".len();
-        assert_eq!(capture.output_observed_bytes, drawn as u64);
+        assert_eq!(capture.output_observed_bytes, u64::conv(drawn));
     }
 
     #[rstest]
@@ -702,7 +703,7 @@ mod tests {
         let capture = tracker.only_capture();
         assert_eq!(capture.command, "echo hi");
         assert_eq!(capture.output, "hi");
-        assert_eq!(capture.output_observed_bytes, b"hi\r\n".len() as u64);
+        assert_eq!(capture.output_observed_bytes, u64::conv(b"hi\r\n".len()));
     }
 
     #[rstest]
@@ -739,7 +740,7 @@ mod tests {
 
         let capture = tracker.only_capture();
         assert_eq!(capture.output, "fresh");
-        assert_eq!(capture.output_observed_bytes, b"fresh\r\n".len() as u64);
+        assert_eq!(capture.output_observed_bytes, u64::conv(b"fresh\r\n".len()));
     }
 
     #[rstest]
@@ -759,7 +760,7 @@ mod tests {
             session_id: Some("abcd".to_string()),
             // The first `D` ends the output zone and is discounted; the second arrives
             // after it, in the unknown zone, so it was never counted to begin with.
-            output_observed_bytes: b"line one\r\n".len() as u64,
+            output_observed_bytes: u64::conv(b"line one\r\n".len()),
             output_truncated: false,
         });
     }
@@ -790,7 +791,7 @@ mod tests {
         assert_eq!(capture.prompt, "$");
         assert_eq!(capture.command, "echo hi");
         assert_eq!(capture.output, "hi");
-        assert_eq!(capture.output_observed_bytes, b"hi\r\n".len() as u64);
+        assert_eq!(capture.output_observed_bytes, u64::conv(b"hi\r\n".len()));
     }
 
     #[rstest]
@@ -801,7 +802,7 @@ mod tests {
 
         // The same total as if the whole marker had arrived in one push: the marker is
         // discounted in full, however it was split up.
-        assert_eq!(tracker.only_capture().output_observed_bytes, b"line one\r\n".len() as u64);
+        assert_eq!(tracker.only_capture().output_observed_bytes, u64::conv(b"line one\r\n".len()));
     }
 
     #[rstest]
@@ -815,7 +816,7 @@ mod tests {
         assert_eq!(capture.prompt, "$");
         assert_eq!(capture.command, "echo hi");
         assert_eq!(capture.output, "hi");
-        assert_eq!(capture.output_observed_bytes, b"hi\r\n".len() as u64);
+        assert_eq!(capture.output_observed_bytes, u64::conv(b"hi\r\n".len()));
     }
 
     // -- Limits ---------------------------------------------------------------
@@ -836,7 +837,7 @@ mod tests {
         let capture = tracker.only_capture();
         assert!(capture.output_truncated);
         assert_eq!(capture.output.len(), MAX_CAPTURE_BYTES);
-        assert_eq!(capture.output_observed_bytes, ((LINE_LEN + 2) * LINES) as u64);
+        assert_eq!(capture.output_observed_bytes, u64::conv((LINE_LEN + 2) * LINES));
     }
 
     #[rstest]

--- a/crates/atuin-pty-proxy/src/runtime.rs
+++ b/crates/atuin-pty-proxy/src/runtime.rs
@@ -178,6 +178,7 @@ fn process_exit_code(code: u32) -> i32 {
 
 #[cfg(test)]
 mod tests {
+    use easy_cast::Conv;
     use rstest::rstest;
 
     use super::process_exit_code;
@@ -185,8 +186,8 @@ mod tests {
     #[rstest]
     #[case::zero(0, 0)]
     #[case::mid_range(127, 127)]
-    #[case::max_i32(i32::MAX as u32, i32::MAX)]
-    #[case::overflow_defaults_to_one(i32::MAX as u32 + 1, 1)]
+    #[case::max_i32(u32::conv(i32::MAX), i32::MAX)]
+    #[case::overflow_defaults_to_one(u32::conv(i32::MAX) + 1, 1)]
     fn maps_exit_code(#[case] input: u32, #[case] expected: i32) {
         assert_eq!(process_exit_code(input), expected);
     }

--- a/crates/atuin-pty-proxy/src/screen.rs
+++ b/crates/atuin-pty-proxy/src/screen.rs
@@ -6,6 +6,7 @@ use std::sync::mpsc::{self, Receiver, SyncSender};
 use std::thread::JoinHandle;
 
 use atuin_common::os::unix::{SecureTempDirError, create_secure_temp_dir};
+use easy_cast::Conv;
 
 use crate::capture::{CommandCaptureSink, CommandCaptureTracker};
 use crate::debug::Osc133DebugHighlighter;
@@ -149,7 +150,7 @@ fn encode_screen(parser: &vt100::Parser) -> Vec<u8> {
     buf.extend_from_slice(&cursor_col.to_be_bytes());
 
     for row_data in screen.rows_formatted(0, cols) {
-        let len = row_data.len() as u32;
+        let len = u32::conv(row_data.len());
         buf.extend_from_slice(&len.to_be_bytes());
         buf.extend_from_slice(row_data.as_bytes());
     }
@@ -185,7 +186,7 @@ mod tests {
         (0..rows)
             .map(|_| {
                 let (len, body) = rest.split_at(4);
-                let len = u32::from_be_bytes(len.try_into().expect("4 bytes")) as usize;
+                let len = usize::conv(u32::from_be_bytes(len.try_into().expect("4 bytes")));
                 let (row, remainder) = body.split_at(len);
                 rest = remainder;
                 String::from_utf8(row.to_vec()).expect("rows are valid UTF-8")
@@ -304,7 +305,7 @@ mod tests {
         assert_eq!(captures[0].prompt, "$");
         assert_eq!(captures[0].command, "echo hi");
         assert_eq!(captures[0].output, "hi");
-        assert_eq!(captures[0].output_observed_bytes, b"hi\r\n".len() as u64);
+        assert_eq!(captures[0].output_observed_bytes, u64::conv(b"hi\r\n".len()));
 
         // The screen snapshot, on the other hand, is where the labels belong.
         let rows = rows_of(&encode_screen(&parser.emulator)).join("\n");

--- a/crates/atuin-scripts/Cargo.toml
+++ b/crates/atuin-scripts/Cargo.toml
@@ -14,6 +14,7 @@ readme.workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+easy-cast = { workspace = true }
 atuin-client = { workspace = true }
 atuin-common = { workspace = true, features = ["sqlite"] }
 atuin-domain = { workspace = true }

--- a/crates/atuin-scripts/Cargo.toml
+++ b/crates/atuin-scripts/Cargo.toml
@@ -14,7 +14,6 @@ readme.workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-easy-cast = { workspace = true }
 atuin-client = { workspace = true }
 atuin-common = { workspace = true, features = ["sqlite"] }
 atuin-domain = { workspace = true }
@@ -35,6 +34,7 @@ tempfile = { workspace = true }
 minijinja = { workspace = true }
 serde_json = { workspace = true }
 semver = { workspace = true }
+easy-cast = { workspace = true }
 
 [dev-dependencies]
 rstest = { workspace = true }

--- a/crates/atuin-scripts/src/store/script.rs
+++ b/crates/atuin-scripts/src/store/script.rs
@@ -1,4 +1,5 @@
 use atuin_domain::record::DecryptedData;
+use easy_cast::Conv;
 use eyre::{Result, bail, ensure};
 use rmp::decode::{self, Bytes};
 use rmp::encode;
@@ -50,7 +51,7 @@ impl Script {
         encode::write_str(&mut output, &self.name)?;
         encode::write_str(&mut output, &self.description)?;
         encode::write_str(&mut output, &self.shebang)?;
-        encode::write_array_len(&mut output, self.tags.len() as u32)?;
+        encode::write_array_len(&mut output, u32::conv(self.tags.len()))?;
 
         for tag in &tags {
             encode::write_str(&mut output, tag)?;

--- a/crates/atuin-search-bench/Cargo.toml
+++ b/crates/atuin-search-bench/Cargo.toml
@@ -13,6 +13,9 @@ dist = false
 [lib]
 bench = false
 
+[dependencies]
+easy-cast = { workspace = true }
+
 [dev-dependencies]
 atuin-client = { workspace = true }
 atuin-common = { workspace = true }

--- a/crates/atuin-search-bench/benches/search.rs
+++ b/crates/atuin-search-bench/benches/search.rs
@@ -34,6 +34,7 @@ use atuin_common::filter::OrFilter;
 use atuin_common::path::DisplayRichExt;
 use atuin_daemon::search::{IndexFilterMode, SearchIndex};
 use atuin_search_bench::corpus;
+use easy_cast::Conv;
 use parking_lot::Mutex;
 use time::OffsetDateTime;
 
@@ -149,7 +150,7 @@ fn commands() -> &'static Vec<String> {
             }
             lines
         } else {
-            let seed = env_usize("BENCH_SEED", 42) as u64;
+            let seed = u64::conv(env_usize("BENCH_SEED", 42));
             eprintln!("corpus: generating {max_scale} synthetic history lines (seed {seed})...");
             corpus::generate(max_scale, seed)
         }
@@ -176,7 +177,7 @@ fn index(scale: usize) -> Arc<SearchIndex> {
     let now = OffsetDateTime::now_utc();
     for (i, command) in commands()[..scale].iter().enumerate() {
         let history: History = History::import()
-            .timestamp(now - time::Duration::seconds(((i * 37) % 31_536_000) as i64))
+            .timestamp(now - time::Duration::seconds(i64::conv((i * 37) % 31_536_000)))
             .command(command.as_str())
             .cwd(DIRS[i % DIRS.len()])
             .build()

--- a/crates/atuin-search-bench/src/corpus.rs
+++ b/crates/atuin-search-bench/src/corpus.rs
@@ -9,6 +9,8 @@
 //! comparisons). Same seed → same corpus, so results are comparable across
 //! runs and machines.
 
+use easy_cast::Conv;
+
 #[must_use]
 pub fn generate(n: usize, seed: u64) -> Vec<String> {
     let mut rng = Rng::new(seed);
@@ -33,7 +35,7 @@ impl Rng {
     }
 
     fn below(&mut self, n: usize) -> usize {
-        (self.next() % n as u64) as usize
+        usize::conv(self.next() % u64::conv(n))
     }
 
     fn pick(&mut self, xs: &[&'static str]) -> &'static str {

--- a/crates/atuin-server/Cargo.toml
+++ b/crates/atuin-server/Cargo.toml
@@ -24,7 +24,6 @@ path = "src/bin/main.rs"
 vendored-tls = ["reqwest/native-tls-vendored"]
 
 [dependencies]
-easy-cast = { workspace = true }
 atuin-common = { workspace = true, features = ["db"] }
 atuin-domain = { workspace = true, features = ["axum"] }
 
@@ -50,6 +49,7 @@ derive_more = { workspace = true }
 time = { workspace = true }
 uuid = { workspace = true }
 sqlx = { workspace = true, features = ["postgres", "sqlite", "mysql", "regexp", "tls-native-tls"] }
+easy-cast = { workspace = true }
 
 # Integration tests in tests/ spin up a real server and drive it with the
 # client's api_client. atuin-client is only a dev dependency here so the client

--- a/crates/atuin-server/Cargo.toml
+++ b/crates/atuin-server/Cargo.toml
@@ -24,6 +24,7 @@ path = "src/bin/main.rs"
 vendored-tls = ["reqwest/native-tls-vendored"]
 
 [dependencies]
+easy-cast = { workspace = true }
 atuin-common = { workspace = true, features = ["db"] }
 atuin-domain = { workspace = true, features = ["axum"] }
 

--- a/crates/atuin-server/src/db/mod.rs
+++ b/crates/atuin-server/src/db/mod.rs
@@ -61,6 +61,7 @@ mod sqlite;
 use async_trait::async_trait;
 use atuin_common::db::OwnedDbUrl;
 use atuin_domain::record::{EncryptedData, Record, RecordIdx, RecordSeriesKey, RecordStatus};
+use easy_cast::Conv;
 use serde::{Deserialize, Serialize};
 pub use sqlite::Sqlite;
 mod mysql;
@@ -332,8 +333,9 @@ where
                 .bind(id)
                 .bind(i.id)
                 .bind(i.host.id)
-                .bind(i.idx as i64)
-                .bind(i.timestamp as i64) // throwing away some data, but i64 is still big in terms of time
+                .bind(i64::conv(i.idx))
+                // throwing away some data, but i64 is still big in terms of time
+                .bind(i64::conv(i.timestamp))
                 .bind(i.version.as_str())
                 .bind(i.tag.as_str())
                 .bind(i.data.raw.as_str())
@@ -363,8 +365,8 @@ where
             .bind(user.id)
             .bind(series.tag.as_str())
             .bind(series.host_id)
-            .bind(start as i64)
-            .bind(count as i64)
+            .bind(i64::conv(start))
+            .bind(i64::conv(count))
             .fetch_all(self.pool())
             .await
             .map(|records| records.into_iter().map(Into::into).collect())

--- a/crates/atuin-server/src/db/models.rs
+++ b/crates/atuin-server/src/db/models.rs
@@ -1,6 +1,7 @@
 use atuin_domain::record::{
     EncryptedData, Host, HostId, Record, RecordIdx, RecordSeriesKey, RecordTag, RecordVersion,
 };
+use easy_cast::Conv;
 use sqlx::Row;
 
 #[derive(sqlx::FromRow)]
@@ -47,8 +48,8 @@ macro_rules! impl_db_record_from_row {
                 Ok(Self(Record {
                     id: row.try_get("client_id")?,
                     host: Host::new(row.try_get("host")?),
-                    idx: idx as u64,
-                    timestamp: timestamp as u64,
+                    idx: u64::conv(idx),
+                    timestamp: u64::conv(timestamp),
                     version: RecordVersion::from(row.try_get::<String, _>("version")?),
                     tag: RecordTag::from(row.try_get::<String, _>("tag")?),
                     data,
@@ -78,7 +79,7 @@ macro_rules! impl_record_series_point_from_row {
 
                 Ok(Self {
                     series: RecordSeriesKey::new(host, RecordTag::from(tag)),
-                    idx: idx as u64,
+                    idx: u64::conv(idx),
                 })
             }
         }

--- a/crates/atuin-server/src/db/mysql/mod.rs
+++ b/crates/atuin-server/src/db/mysql/mod.rs
@@ -1,6 +1,7 @@
 use async_trait::async_trait;
 use atuin_common::db;
 use atuin_common::db::MysqlDbUrl;
+use easy_cast::Conv;
 use sqlx::mysql::MySqlPoolOptions;
 use tracing::instrument;
 
@@ -43,6 +44,6 @@ impl Database for MySql {
             .execute(self.pool())
             .await?;
 
-        Ok(res.last_insert_id() as i64)
+        Ok(i64::conv(res.last_insert_id()))
     }
 }

--- a/crates/atuin-server/src/handlers/v0/record.rs
+++ b/crates/atuin-server/src/handlers/v0/record.rs
@@ -4,6 +4,7 @@ use atuin_domain::record::{
 use axum::Json;
 use axum::extract::{Query, State};
 use axum::http::StatusCode;
+use easy_cast::Conv;
 use metrics::counter;
 use serde::Deserialize;
 use tracing::{error, instrument};
@@ -23,7 +24,7 @@ pub async fn post(
 
     tracing::debug!(count = records.len(), user = user.username, "request to add records");
 
-    counter!("atuin_record_uploaded").increment(records.len() as u64);
+    counter!("atuin_record_uploaded").increment(u64::conv(records.len()));
 
     let keep = records
         .iter()
@@ -96,7 +97,7 @@ pub async fn next(
         }
     };
 
-    counter!("atuin_record_downloaded").increment(records.len() as u64);
+    counter!("atuin_record_downloaded").increment(u64::conv(records.len()));
 
     Ok(Json(records))
 }

--- a/crates/atuin-server/tests/sync.rs
+++ b/crates/atuin-server/tests/sync.rs
@@ -9,6 +9,7 @@ use atuin_common::utils::uuid_v7;
 use atuin_domain::record::{EncryptedData, Host, HostId, Record, RecordId, RecordIdx, RecordTag};
 use atuin_server::db::DbSettings;
 use atuin_server::{Settings as ServerSettings, launch_with_tcp_listener};
+use easy_cast::Conv;
 use futures_util::TryFutureExt;
 use rstest::{fixture, rstest};
 use tokio::net::TcpListener;
@@ -146,7 +147,7 @@ async fn download(
 
     let store = SqliteStore::in_memory(Duration::from_secs(2)).await.unwrap();
     if let Some(local_max) = local_max {
-        store.push_batch(records.iter().take(local_max as usize + 1)).await.unwrap();
+        store.push_batch(records.iter().take(usize::conv(local_max) + 1)).await.unwrap();
     }
 
     let key = key();
@@ -213,7 +214,7 @@ async fn upload(
     store.push_batch(records.iter()).await.unwrap();
 
     if let Some(remote_max) = remote_max {
-        client.post_records(&records[..=remote_max as usize]).await.unwrap();
+        client.post_records(&records[..=usize::conv(remote_max)]).await.unwrap();
     }
 
     let key = key();

--- a/crates/atuin/Cargo.toml
+++ b/crates/atuin/Cargo.toml
@@ -73,6 +73,7 @@ profiling-traced = [
 ]
 
 [dependencies]
+easy-cast = { workspace = true }
 atuin-ai = { workspace = true, optional = true }
 # default-features = false cannot be set on a workspace-inherited dependency, and
 # atuin-client's defaults (sync/hub/daemon) are needed by its other consumers, so

--- a/crates/atuin/Cargo.toml
+++ b/crates/atuin/Cargo.toml
@@ -73,7 +73,6 @@ profiling-traced = [
 ]
 
 [dependencies]
-easy-cast = { workspace = true }
 atuin-ai = { workspace = true, optional = true }
 # default-features = false cannot be set on a workspace-inherited dependency, and
 # atuin-client's defaults (sync/hub/daemon) are needed by its other consumers, so
@@ -129,6 +128,7 @@ frizbee = { workspace = true }
 tempfile = { workspace = true }
 shlex = { workspace = true }
 thiserror = { workspace = true }
+easy-cast = { workspace = true }
 
 # settings editor with comment and relative ordering preservation
 toml_edit = { workspace = true }

--- a/crates/atuin/src/command/client/history.rs
+++ b/crates/atuin/src/command/client/history.rs
@@ -194,7 +194,6 @@ impl ListMode {
     }
 }
 
-#[allow(clippy::cast_sign_loss)]
 #[instrument(level = "trace", skip_all, fields(count = h.len()))]
 pub fn print_list(
     h: &[History],
@@ -318,7 +317,6 @@ impl CmdFormat {
 
 /// defines how to format the history
 impl FormatKey for FmtHistory<'_> {
-    #[allow(clippy::cast_sign_loss)]
     fn fmt(&self, key: &str, f: &mut fmt::Formatter<'_>) -> Result<(), FormatKeyError> {
         match key {
             "command" => match self.cmd_format {
@@ -914,7 +912,7 @@ impl Cmd {
         Ok(())
     }
 
-    #[allow(clippy::too_many_lines, clippy::cast_possible_truncation)]
+    #[allow(clippy::too_many_lines)]
     #[allow(clippy::too_many_arguments)]
     #[allow(clippy::fn_params_excessive_bools)]
     #[instrument(level = "trace", skip_all, err)]

--- a/crates/atuin/src/command/client/import.rs
+++ b/crates/atuin/src/command/client/import.rs
@@ -16,6 +16,7 @@ use atuin_client::import::zsh::Zsh;
 use atuin_client::import::zsh_histdb::ZshHistDb;
 use atuin_client::import::{Importer, Loader};
 use clap::Parser;
+use easy_cast::Conv;
 use eyre::Result;
 use indicatif::ProgressBar;
 use tracing::instrument;
@@ -144,7 +145,7 @@ pub struct HistoryImporter<'db> {
 impl<'db> HistoryImporter<'db> {
     fn new(db: &'db Sqlite, len: usize) -> Self {
         Self {
-            pb: ProgressBar::new(len as u64),
+            pb: ProgressBar::new(u64::conv(len)),
             buf: Vec::with_capacity(BATCH_SIZE),
             db,
         }

--- a/crates/atuin/src/command/client/search/engines/daemon.rs
+++ b/crates/atuin/src/command/client/search/engines/daemon.rs
@@ -3,6 +3,7 @@ use atuin_client::history::{History, HistoryId, all_user_author_filter};
 use atuin_client::settings::Settings;
 use atuin_daemon::client::{SearchClient, SearchParams};
 use atuin_daemon::search::{normalize_diacritics, truncate_query};
+use easy_cast::Conv;
 use eyre::Result;
 use tracing::{Level, debug, instrument, span};
 
@@ -258,7 +259,7 @@ impl SearchEngine for Search {
         indices.sort_unstable();
         indices.dedup();
         if command.is_ascii() {
-            indices.into_iter().map(|i| i as usize).collect()
+            indices.into_iter().map(usize::conv).collect()
         } else {
             let matchable_byte_to_char: std::collections::HashMap<usize, usize> = matchable
                 .char_indices()
@@ -269,7 +270,7 @@ impl SearchEngine for Search {
                 command.char_indices().map(|(byte_idx, _)| byte_idx).collect();
             let mut bytes: Vec<usize> = indices
                 .into_iter()
-                .filter_map(|i| matchable_byte_to_char.get(&(i as usize)))
+                .filter_map(|i| matchable_byte_to_char.get(&usize::conv(i)))
                 .filter_map(|&char_idx| command_char_to_byte.get(char_idx).copied())
                 .collect();
             bytes.dedup();

--- a/crates/atuin/src/command/client/search/history_list.rs
+++ b/crates/atuin/src/command/client/search/history_list.rs
@@ -7,6 +7,7 @@ use atuin_common::string::align::Alignment;
 use atuin_common::string::ellipsis::{Indicator, Pos};
 use atuin_common::string::{EllipsizeExt as _, EscapeNonPrintablePosixExt as _, Measure};
 use atuin_common::time::{DurationExt, OffsetDateTimeExt};
+use easy_cast::Conv;
 use itertools::Itertools;
 use ratatui::backend::FromCrossterm;
 use ratatui::buffer::Buffer;
@@ -87,7 +88,7 @@ impl StatefulWidget for HistoryList<'_> {
         if list_area.width < 1 || list_area.height < 1 || self.history.is_empty() {
             return;
         }
-        let list_height = list_area.height as usize;
+        let list_height = usize::conv(list_area.height);
 
         let (start, end) = self.get_items_bounds(state.selected, state.offset, list_height);
         state.offset = start;
@@ -234,7 +235,7 @@ impl DrawState<'_> {
 
     fn index(&mut self) {
         if !self.show_numeric_shortcuts {
-            let i = self.y as usize + self.state.offset;
+            let i = usize::conv(self.y) + self.state.offset;
             let is_selected = i == self.state.selected();
             let prompt: &str = if is_selected {
                 self.indicator
@@ -248,7 +249,7 @@ impl DrawState<'_> {
         // these encode the slices of `" > "`, `" {n} "`, or `"   "` in a compact form.
         // Yes, this is a hack, but it makes me feel happy
 
-        let i = self.y as usize + self.state.offset;
+        let i = usize::conv(self.y) + self.state.offset;
         let i = i.checked_sub(self.state.selected);
         let i = i.unwrap_or(10).min(10) * 2;
         let prompt: &str = if i == 0 {
@@ -267,7 +268,7 @@ impl DrawState<'_> {
         });
         let duration = Duration::saturating_from_nanos_i64(h.duration);
         let formatted = duration.display().largest_unit().to_string();
-        let w = width as usize;
+        let w = usize::conv(width);
         // Right-align within the column, ellipsizing if it somehow overflows.
         let display = formatted.pad_ellipsize(
             Measure::Columns(w),
@@ -284,7 +285,7 @@ impl DrawState<'_> {
         let time = (self.now)().saturating_duration_since(h.timestamp).display().largest_unit();
 
         // Format as "Xs ago" right-aligned within column width
-        let w = width as usize;
+        let w = usize::conv(width);
         let time_str = format!("{time} ago");
 
         let display = time_str.pad_ellipsize(
@@ -299,7 +300,8 @@ impl DrawState<'_> {
     fn command(&mut self, h: &History, _width: u16) {
         let mut style = self.theme.as_style(Meaning::Base);
         let mut row_highlighted = false;
-        if !self.alternate_highlight && (self.y as usize + self.state.offset == self.state.selected)
+        if !self.alternate_highlight
+            && (usize::conv(self.y) + self.state.offset == self.state.selected)
         {
             row_highlighted = true;
             // if not applying alternative highlighting to the whole row, color the command
@@ -323,7 +325,7 @@ impl DrawState<'_> {
         // Calculate the available width for the command text.
         // `self.x` is already past the indicator and any preceding columns,
         // so the remaining width is how far we can draw.
-        let avail = (self.list_area.width.saturating_sub(self.x)) as usize;
+        let avail = usize::conv(self.list_area.width.saturating_sub(self.x));
 
         // Truncate long commands from the middle to show both start and end,
         // so users can identify commands even in narrow terminals (issue #3596).
@@ -356,7 +358,7 @@ impl DrawState<'_> {
     fn datetime(&mut self, h: &History, width: u16) {
         let style = self.theme.as_style(Meaning::Annotation);
         let formatted = h.timestamp.to_offset(self.tz).display().ymd_hm().to_string();
-        let w = width as usize;
+        let w = usize::conv(width);
         let display = formatted.pad_ellipsize(
             Measure::Columns(w),
             Pos::End,
@@ -369,7 +371,7 @@ impl DrawState<'_> {
     /// Render the directory column (working directory, truncated)
     fn directory(&mut self, h: &History, width: u16) {
         let style = self.theme.as_style(Meaning::Annotation);
-        let w = width as usize;
+        let w = usize::conv(width);
         let cwd = &h.cwd;
         // Elide from the left with "…" so the leaf directory stays visible;
         // pad to the column width when it already fits.
@@ -385,7 +387,7 @@ impl DrawState<'_> {
     /// Render the host column (just the hostname)
     fn host(&mut self, h: &History, width: u16) {
         let style = self.theme.as_style(Meaning::Annotation);
-        let w = width as usize;
+        let w = usize::conv(width);
         // Database stores hostname as "hostname:username"
         let host = h.cmd_origin.host().into_inner();
         let display =
@@ -396,7 +398,7 @@ impl DrawState<'_> {
     /// Render the user column
     fn user(&mut self, h: &History, width: u16) {
         let style = self.theme.as_style(Meaning::Annotation);
-        let w = width as usize;
+        let w = usize::conv(width);
         // Database stores hostname as "hostname:username"
         let user = h.cmd_origin.user().into_inner();
         let display =
@@ -411,7 +413,7 @@ impl DrawState<'_> {
         } else {
             self.theme.as_style(Meaning::AlertError)
         };
-        let w = width as usize;
+        let w = usize::conv(width);
         let display = format!("{:>w$}", h.exit);
         self.draw(&display, Style::from_crossterm(style));
     }
@@ -425,12 +427,13 @@ impl DrawState<'_> {
             self.list_area.bottom() - self.y - 1
         };
 
-        if self.alternate_highlight && (self.y as usize + self.state.offset == self.state.selected)
+        if self.alternate_highlight
+            && (usize::conv(self.y) + self.state.offset == self.state.selected)
         {
             style = style.add_modifier(Modifier::REVERSED);
         }
 
-        let w = (self.list_area.width - self.x) as usize;
+        let w = usize::conv(self.list_area.width - self.x);
         self.x += self.buf.set_stringn(cx, cy, s, w, style).0 - cx;
     }
 }

--- a/crates/atuin/src/command/client/search/inspector.rs
+++ b/crates/atuin/src/command/client/search/inspector.rs
@@ -4,6 +4,7 @@ use atuin_client::history::{History, HistoryStats};
 use atuin_client::settings::Settings;
 use atuin_common::string::EscapeNonPrintablePosixExt as _;
 use atuin_common::time::{DurationExt, UtcOffsetSpec};
+use easy_cast::Conv;
 use ratatui::Frame;
 use ratatui::backend::FromCrossterm;
 use ratatui::layout::Rect;
@@ -16,12 +17,11 @@ use time::macros::format_description;
 use super::super::theme::{Meaning, Theme};
 use super::interactive::{Compactness, to_compactness};
 
-#[allow(clippy::cast_sign_loss)]
 fn u64_or_zero(num: i64) -> u64 {
     if num < 0 {
         0
     } else {
-        num as u64
+        u64::conv(num)
     }
 }
 

--- a/crates/atuin/src/command/client/search/interactive.rs
+++ b/crates/atuin/src/command/client/search/interactive.rs
@@ -12,6 +12,7 @@ use atuin_client::settings::{
 };
 use atuin_common::shell::Shell;
 use atuin_common::string::EscapeNonPrintablePosixExt as _;
+use easy_cast::Conv;
 use eyre::Result;
 use futures_util::FutureExt;
 use ratatui::backend::{CrosstermBackend, FromCrossterm};
@@ -659,7 +660,7 @@ impl State {
             }
             Action::AcceptNth(n) => {
                 self.accept = true;
-                InputAction::Accept(self.results_state.selected() + *n as usize)
+                InputAction::Accept(self.results_state.selected() + usize::conv(*n))
             }
             Action::ReturnSelection => {
                 if self.tab_index == 1 {
@@ -668,7 +669,7 @@ impl State {
                 InputAction::Accept(self.results_state.selected())
             }
             Action::ReturnSelectionNth(n) => {
-                InputAction::Accept(self.results_state.selected() + *n as usize)
+                InputAction::Accept(self.results_state.selected() + usize::conv(*n))
             }
             Action::Copy => InputAction::Copy(self.results_state.selected()),
             Action::Delete => InputAction::Delete(self.results_state.selected()),
@@ -773,10 +774,10 @@ impl State {
             && tab_index == 0
             && !results.is_empty()
         {
-            let length_current_cmd = results[selected].command.width() as u16;
+            let length_current_cmd = u16::conv(results[selected].command.width());
             // calculate the number of newlines in the command
             let num_newlines =
-                results[selected].command.chars().filter(|&c| c == '\n').count() as u16;
+                u16::conv(results[selected].command.chars().filter(|&c| c == '\n').count());
             if num_newlines > 0 {
                 std::cmp::min(
                     settings.max_preview_height,
@@ -784,7 +785,7 @@ impl State {
                         .command
                         .split('\n')
                         .map(|line| {
-                            (line.len() as u16 + preview_width - 1 - border_size)
+                            (u16::conv(line.len()) + preview_width - 1 - border_size)
                                 / (preview_width - border_size)
                         })
                         .sum(),
@@ -812,7 +813,7 @@ impl State {
                     v.command
                         .split('\n')
                         .map(|line| {
-                            (line.len() as u16 + preview_width - 1 - border_size)
+                            (u16::conv(line.len()) + preview_width - 1 - border_size)
                                 / (preview_width - border_size)
                         })
                         .sum(),
@@ -1105,7 +1106,6 @@ impl State {
                 preview_chunk.width.into(),
                 theme,
             );
-            #[allow(clippy::cast_possible_truncation)]
             let prefix_width = settings
                 .ui
                 .columns
@@ -1113,9 +1113,8 @@ impl State {
                 .take_while(|col| !col.expand)
                 .map(|col| col.width + 1)
                 .sum::<u16>()
-                + " > ".len() as u16;
-            #[allow(clippy::cast_possible_truncation)]
-            let min_prefix_width = "[ SRCH: FULLTXT ] ".len() as u16;
+                + u16::conv(" > ".len());
+            let min_prefix_width = u16::conv("[ SRCH: FULLTXT ] ".len());
             self.draw_preview(
                 f,
                 style,
@@ -1128,7 +1127,7 @@ impl State {
         }
     }
 
-    #[allow(clippy::cast_possible_truncation, clippy::too_many_arguments)]
+    #[allow(clippy::too_many_arguments)]
     fn draw_preview(
         &self,
         f: &mut Frame,
@@ -1152,7 +1151,7 @@ impl State {
         };
         f.set_cursor_position((
             // Put cursor past the end of the input text
-            input_chunk.x + extra_width as u16 + prefix_width + cursor_offset,
+            input_chunk.x + u16::conv(extra_width) + prefix_width + cursor_offset,
             input_chunk.y + cursor_offset,
         ));
     }
@@ -1525,15 +1524,15 @@ fn fetch_screen_state(socket_path: &str) -> Option<SavedScreen> {
     let cursor_col = u16::from_be_bytes([data[6], data[7]]);
 
     // Parse length-prefixed rows
-    let mut rows_data = Vec::with_capacity(rows as usize);
+    let mut rows_data = Vec::with_capacity(usize::conv(rows));
     let mut offset = 8;
     while offset + 4 <= data.len() {
-        let row_len = u32::from_be_bytes([
+        let row_len = usize::conv(u32::from_be_bytes([
             data[offset],
             data[offset + 1],
             data[offset + 2],
             data[offset + 3],
-        ]) as usize;
+        ]));
         offset += 4;
         if offset + row_len > data.len() {
             break;
@@ -1564,7 +1563,7 @@ fn restore_popup_area(saved: &SavedScreen, popup_rect: Rect, scroll_offset: u16)
 
     for dy in 0..popup_rect.height {
         let target_row = popup_rect.y + dy;
-        let source_row = (target_row + scroll_offset) as usize;
+        let source_row = usize::conv(target_row + scroll_offset);
 
         // Clear only the popup region. The server-side rows_formatted() skips
         // default cells (spaces with default attributes) using cursor jumps, so
@@ -1577,7 +1576,7 @@ fn restore_popup_area(saved: &SavedScreen, popup_rect: Rect, scroll_offset: u16)
             MoveTo(popup_rect.x, target_row),
             ratatui::crossterm::style::SetAttribute(ratatui::crossterm::style::Attribute::Reset),
         );
-        let _ = write!(stdout, "{:width$}", "", width = popup_rect.width as usize);
+        let _ = write!(stdout, "{:width$}", "", width = usize::conv(popup_rect.width));
         let _ = execute!(stdout, MoveTo(popup_rect.x, target_row));
 
         if let Some(row_bytes) = saved.rows_data.get(source_row) {
@@ -1796,7 +1795,7 @@ pub async fn history(
         );
         for row in popup_rect.y..popup_rect.y.saturating_add(popup_rect.height) {
             let _ = queue!(raw_stdout, MoveTo(popup_rect.x, row));
-            let _ = write!(raw_stdout, "{:width$}", "", width = popup_rect.width as usize);
+            let _ = write!(raw_stdout, "{:width$}", "", width = usize::conv(popup_rect.width));
         }
         let _ = raw_stdout.flush();
     }

--- a/crates/atuin/src/command/client/search/interactive.rs
+++ b/crates/atuin/src/command/client/search/interactive.rs
@@ -758,7 +758,6 @@ impl State {
         }
     }
 
-    #[allow(clippy::cast_possible_truncation)]
     #[allow(clippy::bool_to_int_with_if)]
     fn calc_preview_height(
         settings: &Settings,
@@ -1705,7 +1704,7 @@ fn compute_popup_placement(
 
 // for now, it works. But it'd be great if it were more easily readable, and
 // modular. I'd like to add some more stats and stuff at some point
-#[allow(clippy::cast_possible_truncation, clippy::too_many_lines, clippy::cognitive_complexity)]
+#[allow(clippy::too_many_lines, clippy::cognitive_complexity)]
 pub async fn history(
     query: &[String],
     settings: &Settings,

--- a/crates/atuin/src/command/client/search/syntax.rs
+++ b/crates/atuin/src/command/client/search/syntax.rs
@@ -3,6 +3,7 @@
 //! build (see the note in Cargo.toml), commands are left unhighlighted.
 
 use atuin_client::theme::Meaning;
+use easy_cast::Conv;
 
 /// Style every byte of `cmd` with a `Syntax*` meaning, parsing with the
 /// grammar for the entry's shell. Anything unrecognized (plain arguments,
@@ -137,7 +138,7 @@ fn highlight_powershell(node: tree_sitter::Node, src: &[u8], meanings: &mut [Mea
 
     while let Some((m, capture_index)) = captures.next() {
         let capture = m.captures[*capture_index];
-        let capture_name = HIGHLIGHTS_QUERY.capture_names()[capture.index as usize];
+        let capture_name = HIGHLIGHTS_QUERY.capture_names()[usize::conv(capture.index)];
 
         let meaning = match capture_name {
             "base" => Meaning::Base,

--- a/crates/atuin/src/command/client/sync.rs
+++ b/crates/atuin/src/command/client/sync.rs
@@ -6,6 +6,7 @@ use atuin_client::settings::Settings;
 use atuin_common::encryption::paseto_v4;
 use atuin_domain::record::RecordTag;
 use clap::Subcommand;
+use easy_cast::Conv;
 use eyre::{Result, WrapErr};
 use tracing::instrument;
 
@@ -101,8 +102,7 @@ async fn run(settings: &Settings, force: bool, db: &Sqlite, store: SqliteStore) 
     let history_length = db.history_count(true).await?;
     let store_history_length = store.len_tag(&RecordTag::History).await?;
 
-    #[allow(clippy::cast_sign_loss)]
-    if history_length as u64 > store_history_length {
+    if u64::conv(history_length) > store_history_length {
         println!("{history_length} in history index, but {store_history_length} in history store");
         println!("Running automatic history store init...");
 

--- a/crates/atuin/src/print_error.rs
+++ b/crates/atuin/src/print_error.rs
@@ -3,6 +3,7 @@ use std::io::IsTerminal;
 use atuin_client::record::sync::SyncError;
 use colored::Colorize;
 use crossterm::terminal;
+use easy_cast::Conv;
 
 /// Print a prominent error to stderr. Colored and box-bordered when stderr is
 /// a TTY, plain "Error: ..." header otherwise. The description is word-wrapped
@@ -10,7 +11,7 @@ use crossterm::terminal;
 pub fn print_error(title: &str, description: &str) {
     let is_tty = std::io::stderr().is_terminal();
     let width = if is_tty {
-        terminal::size().map_or(80, |(w, _)| w as usize)
+        terminal::size().map_or(80, |(w, _)| usize::conv(w))
     } else {
         80
     }


### PR DESCRIPTION
Use the `easy-cast` crate instead of primitive `as` casts.

### The problem

In Rust, primitive `as` casts like `x as u64` **silently overflow/truncate** if the number cannot fit in the destination type. This is in contrast to operations like addition that panic in debug mode.

`easy-cast` behaves like an `as` cast in release mode **with no performance overhead or behavior changes**, but panics on overflow in debug mode. This helps catch bugs—the same as Rust's rationale for making integer arithmetic panic on overflow in debug mode.

### Risk profile

This change should be low-risk. In release mode, **there is no behavior change**. In debug mode, if we get a panic, that will indicate that we have a programming error or need to add proper error handling.

### If we get a panic in debug mode

If we get a panic in debug mode from an overflowing conversion, it's a sign that either:

* We have a logic bug in our code.
* We need to add proper error handling for overflow.
* We explicitly desire wrapping behavior but haven't made that clear, so we should add a comment and change back to `as`.

`easy-cast` will help uncover places where we need to make these changes.

### How to use `easy-cast`

There are two traits, `Conv` and `Cast`. `Conv` is like `From` and `Cast` is like `Into`:

```rust
use easy_cast::{Cast, Conv};
let x = u32::conv(u64::MAX); // panics in debug, truncates in release
let x: u32 = u64::MAX.cast(); // exact same thing, just written differently (like `into` vs `from`)
```