### PR TITLE
feat(daemon): Daemon owns History Deletion

### DIFF
--- a/crates/atuin-common/src/string.rs
+++ b/crates/atuin-common/src/string.rs
@@ -1,5 +1,6 @@
 //! String-related utilities and extension traits.
 
+use std::borrow::Cow;
 use std::fmt::{self, Write as _};
 
 #[cfg(feature = "unicode")]
@@ -15,6 +16,7 @@ pub mod trim;
 mod buffer;
 mod escape_non_printable_posix_ext;
 mod non_nul_str;
+mod normalize;
 
 #[cfg(feature = "unicode")]
 pub use align::{AlignExt, Alignment};
@@ -23,7 +25,38 @@ pub use buffer::BoundedBuffer;
 pub use ellipsis::EllipsizeExt;
 pub use escape_non_printable_posix_ext::EscapeNonPrintablePosixExt;
 pub use non_nul_str::{ContainsNul, NonNulStr};
+pub use normalize::normalize;
 pub use trim::TrimExt;
+
+pub trait TruncateCharsExt: AsRef<str> {
+    fn truncate_chars(&self, max_chars: usize) -> &str {
+        let s = self.as_ref();
+        if s.len() <= max_chars {
+            return s;
+        }
+
+        match s.char_indices().nth(max_chars) {
+            Some((end, _)) => &s[..end],
+            None => s,
+        }
+    }
+}
+
+impl<T: AsRef<str> + ?Sized> TruncateCharsExt for T {}
+
+/// Extension trait adding diacritic normalization to string slices.
+pub trait NormalizeDiacriticsExt: AsRef<str> {
+    /// Normalize Latin diacritics to their ASCII equivalents (`é` -> `e`).
+    fn normalize_diacritics(&self) -> Cow<'_, str> {
+        let s = self.as_ref();
+        if s.is_ascii() || !s.chars().any(|c| normalize(c) != c) {
+            return Cow::Borrowed(s);
+        }
+        Cow::Owned(s.chars().map(normalize).collect())
+    }
+}
+
+impl<T: AsRef<str> + ?Sized> NormalizeDiacriticsExt for T {}
 
 /// Extension trait for [`Url`] to render a `Debug` representation with any
 /// password redacted.
@@ -84,7 +117,45 @@ mod tests {
     use rstest::rstest;
     use url::Url;
 
-    use super::FormatSafeUrlExt;
+    use super::{FormatSafeUrlExt, NormalizeDiacriticsExt, TruncateCharsExt};
+
+    #[rstest]
+    #[case::empty("", "")]
+    #[case::ascii_unchanged("hello world", "hello world")]
+    #[case::accented("café", "cafe")]
+    #[case::keeps_unmappable("naïve Æ", "naive Æ")] // ï -> i, but Æ has no single-ASCII mapping
+    #[case::position_preserved("élève", "eleve")]
+    fn normalizes_diacritics(#[case] input: &str, #[case] expected: &str) {
+        assert_eq!(input.normalize_diacritics(), expected);
+    }
+
+    #[rstest]
+    #[case::empty("")]
+    #[case::plain_ascii("just ascii text")]
+    #[case::unmappable("日本語")]
+    fn normalize_diacritics_borrows_when_unchanged(#[case] input: &str) {
+        assert!(matches!(input.normalize_diacritics(), std::borrow::Cow::Borrowed(_)));
+    }
+
+    #[rstest]
+    #[case::under_budget("hello", 10, "hello")]
+    #[case::exact_budget("hello", 5, "hello")]
+    #[case::over_budget("hello", 3, "hel")] // codespell:ignore hel
+    #[case::zero("hello", 0, "")]
+    #[case::empty("", 5, "")]
+    #[case::multibyte_cut("café", 3, "caf")] // never splits a multibyte char; codespell:ignore caf
+    #[case::multibyte_kept("café", 4, "café")]
+    fn truncates_by_char_count(#[case] input: &str, #[case] max: usize, #[case] expected: &str) {
+        let out = input.truncate_chars(max);
+        assert_eq!(out, expected);
+        assert!(out.chars().count() <= max);
+    }
+
+    #[test]
+    fn truncate_chars_returns_the_original_slice_when_it_fits() {
+        let s = "borrow me";
+        assert!(std::ptr::eq(s.truncate_chars(100), s));
+    }
 
     struct Safe<'a>(&'a Url);
 

--- a/crates/atuin-common/src/string.rs
+++ b/crates/atuin-common/src/string.rs
@@ -16,6 +16,8 @@ pub mod trim;
 mod buffer;
 mod escape_non_printable_posix_ext;
 mod non_nul_str;
+
+#[allow(clippy::manual_range_contains, clippy::must_use_candidate, reason = "vendored file")]
 mod normalize;
 
 #[cfg(feature = "unicode")]

--- a/crates/atuin-common/src/string/normalize.rs
+++ b/crates/atuin-common/src/string/normalize.rs
@@ -8,8 +8,6 @@
 //! covered by MPL-2.0 (<https://mozilla.org/MPL/2.0/>) independently of the
 //! crate's license.
 
-#![allow(clippy::manual_range_contains, clippy::must_use_candidate, reason = "vendored file")]
-
 /// Normalize a Unicode character by converting Latin characters which are variants
 /// of ASCII characters to their latin equivalent.
 ///

--- a/crates/atuin-common/src/string/normalize.rs
+++ b/crates/atuin-common/src/string/normalize.rs
@@ -8,6 +8,8 @@
 //! covered by MPL-2.0 (<https://mozilla.org/MPL/2.0/>) independently of the
 //! crate's license.
 
+#![allow(clippy::manual_range_contains, clippy::must_use_candidate, reason = "vendored file")]
+
 /// Normalize a Unicode character by converting Latin characters which are variants
 /// of ASCII characters to their latin equivalent.
 ///

--- a/crates/atuin-daemon/proto/control.proto
+++ b/crates/atuin-daemon/proto/control.proto
@@ -9,8 +9,6 @@ service Control {
 }
 
 message SendEventRequest {
-  reserved 1, 2; // previously history_pruned / history_deleted, now handled via DeleteHistory RPC
-
   oneof event {
     // Request immediate sync
     ForceSyncEvent force_sync = 3;

--- a/crates/atuin-daemon/proto/control.proto
+++ b/crates/atuin-daemon/proto/control.proto
@@ -9,13 +9,9 @@ service Control {
 }
 
 message SendEventRequest {
+  reserved 1, 2; // previously history_pruned / history_deleted, now handled via DeleteHistory RPC
+
   oneof event {
-    // History was pruned - search index needs full rebuild
-    HistoryPrunedEvent history_pruned = 1;
-
-    // Specific history items were deleted
-    HistoryDeletedEvent history_deleted = 2;
-
     // Request immediate sync
     ForceSyncEvent force_sync = 3;
 
@@ -36,17 +32,8 @@ message SendEventResponse {
 
 // Individual event message types
 
-message HistoryPrunedEvent {
-  // No fields needed - just signals that pruning happened
-}
-
 message HistoryRebuiltEvent {
   // No fields needed - just signals that rebuilding happened
-}
-
-message HistoryDeletedEvent {
-  // IDs of deleted history items (UUIDs as strings)
-  repeated string ids = 1;
 }
 
 message ForceSyncEvent {

--- a/crates/atuin-daemon/proto/history.proto
+++ b/crates/atuin-daemon/proto/history.proto
@@ -63,6 +63,18 @@ message CancelHistoryReply {
   uint32 protocol = 2;
 }
 
+message DeleteHistoryRequest {
+  // History entries to delete, by id.
+  repeated HistoryId ids = 1;
+}
+
+message DeleteHistoryReply {
+  // Number of entries processed for deletion.
+  uint64 deleted = 1;
+  string version = 2;
+  uint32 protocol = 3;
+}
+
 // Do **not** change this RPC, ever. Updating the daemon **requires** this RPC to be stable.
 message StatusRequest {}
 
@@ -123,6 +135,7 @@ service History {
   rpc StartHistory(StartHistoryRequest) returns (StartHistoryReply);
   rpc EndHistory(EndHistoryRequest) returns (EndHistoryReply);
   rpc CancelHistory(CancelHistoryRequest) returns (CancelHistoryReply);
+  rpc DeleteHistory(DeleteHistoryRequest) returns (DeleteHistoryReply);
   rpc TailHistory(TailHistoryRequest) returns (stream TailHistoryReply);
   // Do **not** change this RPC, ever. Updating the daemon **requires** this RPC to be stable.
   rpc Status(StatusRequest) returns (StatusReply);

--- a/crates/atuin-daemon/src/client.rs
+++ b/crates/atuin-daemon/src/client.rs
@@ -19,15 +19,14 @@ use tracing::{Level, instrument, span};
 
 use crate::control::control_client::ControlClient as ControlServiceClient;
 use crate::control::{
-    ForceSyncEvent, HistoryDeletedEvent, HistoryPrunedEvent, HistoryRebuiltEvent, SendEventRequest,
-    SettingsReloadedEvent, ShutdownEvent,
+    ForceSyncEvent, HistoryRebuiltEvent, SendEventRequest, SettingsReloadedEvent, ShutdownEvent,
 };
 use crate::events::DaemonEvent;
 use crate::grpc::history::pb::history_client::HistoryClient as HistoryServiceClient;
 use crate::grpc::history::pb::{
-    AuthorKind, CancelHistoryReply, CancelHistoryRequest, EndHistoryReply, EndHistoryRequest,
-    ShutdownRequest, StartHistoryReply, StartHistoryRequest, StatusReply, StatusRequest,
-    TailHistoryReply, TailHistoryRequest,
+    AuthorKind, CancelHistoryReply, CancelHistoryRequest, DeleteHistoryReply, DeleteHistoryRequest,
+    EndHistoryReply, EndHistoryRequest, ShutdownRequest, StartHistoryReply, StartHistoryRequest,
+    StatusReply, StatusRequest, TailHistoryReply, TailHistoryRequest,
 };
 use crate::search::search_client::SearchClient as SearchServiceClient;
 use crate::search::{
@@ -161,6 +160,16 @@ impl HistoryClient {
             .client
             .cancel_history(CancelHistoryRequest {
                 id: Some(id.into()),
+            })
+            .await?
+            .into_inner())
+    }
+
+    pub async fn delete_history(&mut self, ids: Vec<HistoryId>) -> Result<DeleteHistoryReply> {
+        Ok(self
+            .client
+            .delete_history(DeleteHistoryRequest {
+                ids: ids.into_iter().map(Into::into).collect(),
             })
             .await?
             .into_inner())
@@ -474,7 +483,7 @@ impl ControlClient {
 
     /// Send an event to the daemon.
     pub async fn send_event(&mut self, event: DaemonEvent) -> Result<()> {
-        let proto_event = daemon_event_to_proto(event);
+        let proto_event = daemon_event_to_proto(&event);
         let request = SendEventRequest {
             event: Some(proto_event),
         };
@@ -484,15 +493,11 @@ impl ControlClient {
 }
 
 /// Convert a daemon event to its proto representation.
-fn daemon_event_to_proto(event: DaemonEvent) -> crate::control::send_event_request::Event {
+fn daemon_event_to_proto(event: &DaemonEvent) -> crate::control::send_event_request::Event {
     use crate::control::send_event_request::Event;
 
     match event {
-        DaemonEvent::HistoryPruned => Event::HistoryPruned(HistoryPrunedEvent {}),
         DaemonEvent::HistoryRebuilt => Event::HistoryRebuilt(HistoryRebuiltEvent {}),
-        DaemonEvent::HistoryDeleted { ids } => Event::HistoryDeleted(HistoryDeletedEvent {
-            ids: ids.into_iter().map(|id| id.to_string()).collect(),
-        }),
         DaemonEvent::ForceSync => Event::ForceSync(ForceSyncEvent {}),
         DaemonEvent::SettingsReloaded => Event::SettingsReloaded(SettingsReloadedEvent {}),
         DaemonEvent::ShutdownRequested => Event::Shutdown(ShutdownEvent {}),
@@ -520,11 +525,8 @@ fn daemon_event_to_proto(event: DaemonEvent) -> crate::control::send_event_reque
 /// # Example
 ///
 /// ```ignore
-/// // After pruning history
-/// emit_event(DaemonEvent::HistoryPruned).await?;
-///
-/// // After deleting specific history items
-/// emit_event(DaemonEvent::HistoryDeleted { ids: vec![...] }).await?;
+/// // After history was rebuilt
+/// emit_event(DaemonEvent::HistoryRebuilt).await?;
 ///
 /// // Request immediate sync
 /// emit_event(DaemonEvent::ForceSync).await?;

--- a/crates/atuin-daemon/src/components/search.rs
+++ b/crates/atuin-daemon/src/components/search.rs
@@ -117,31 +117,6 @@ impl SearchComponent {
     pub fn index(&self) -> Arc<RwLock<SearchIndex>> {
         self.index.clone()
     }
-
-    /// Rebuild the entire search index from the database without updating the frecency map.
-    async fn rebuild_index_only(&self) {
-        let Some(handle) = self.handle.as_ref() else {
-            error!("Component not initialized");
-            return;
-        };
-        info!("Rebuilding search index from database");
-
-        // TODO(#4052): This is inherently racy -- any add_history operations added between this
-        //              .read() and the subsequent .write() are completely discarded from the new
-        //              index.
-        let shells = self.index.read().await.shells.clone();
-        let search = handle.settings().await.search.clone();
-        let new_index = match SearchIndex::from_db(shells, handle.history_db(), &search).await {
-            Ok(new_index) => new_index,
-            Err(e) => {
-                error!("Failed to rebuild search index: {e}");
-                return;
-            }
-        };
-
-        info!("Search index rebuild complete; {} unique commands", new_index.command_count());
-        *self.index.write().await = new_index;
-    }
 }
 
 impl Default for SearchComponent {
@@ -209,7 +184,27 @@ impl Component for SearchComponent {
             }
             DaemonEvent::HistoryRebuilt => {
                 info!("History store rebuilt, rebuilding search index");
-                self.rebuild_index_only().await;
+
+                let Some(handle) = self.handle.as_ref() else {
+                    error!("Component not initialized");
+                    return Ok(());
+                };
+
+                // TODO(#4052): This is inherently racy -- any add_history operations added between
+                //              this .read() and the subsequent .write() are completely discarded
+                //              from the new index.
+                let shells = self.index.read().await.shells.clone();
+                let search = handle.settings().await.search.clone();
+                match SearchIndex::from_db(shells, handle.history_db(), &search).await {
+                    Ok(new_index) => {
+                        info!(
+                            "Search index rebuild complete; {} unique commands",
+                            new_index.command_count()
+                        );
+                        *self.index.write().await = new_index;
+                    }
+                    Err(e) => error!("Failed to rebuild search index: {e}"),
+                }
             }
             DaemonEvent::SettingsReloaded => {
                 if let Some(handle) = self.handle.as_ref() {

--- a/crates/atuin-daemon/src/components/search.rs
+++ b/crates/atuin-daemon/src/components/search.rs
@@ -157,6 +157,9 @@ impl SearchComponent {
         info!("Rebuilding search index from database");
 
         // Create a new index
+        // TODO(#4052): This is inherently racy -- any add_history operations added between this
+        //              .read() and the subsequent .write() are completely discarded from the new
+        //              index.
         let new_index = SearchIndex::new(self.index.read().await.shells.clone());
         if build_index_only(async || &new_index, handle).await.is_err() {
             return;
@@ -181,6 +184,9 @@ impl Component for SearchComponent {
     async fn start(&mut self, handle: DaemonHandle) -> Result<()> {
         self.handle = Some(handle.clone());
 
+        // TODO(#4052): This is inherently racy -- any add_history operations added between this
+        //              .read() and the subsequent .write() are completely discarded from the new
+        //              index.
         // Spawn background task to load history into index
         let index = self.index.clone();
         let handle_for_loader = handle.clone();
@@ -341,6 +347,9 @@ impl SearchSvc for SearchGrpcService {
 
                 // An empty list in `SearchRequest::shells` means "all".
                 let shells = OrFilter::from_list(search_req.shells).unwrap_or_default();
+                // TODO(#4052): This is inherently racy -- any add_history operations added between
+                //              this .maybe_rebuild_index() and the subsequent .write() are
+                //              completely discarded from the new index.
                 let index = match this.maybe_rebuild_index(shells).await {
                     Ok(Some(new_index)) => {
                         let mut guard = this.index.write().await;
@@ -387,6 +396,9 @@ impl SearchSvc for SearchGrpcService {
         request: Request<PrepareIndexRequest>,
     ) -> Result<Response<PrepareIndexResponse>, Status> {
         // Same as `SearchRequest::shells` -- empty list means "all".
+        // TODO(#4052): This is inherently racy -- any add_history operations added between this
+        //              .maybe_rebuild_index() and the subsequent .write() are completely discarded
+        //              from the new index.
         let shells = OrFilter::from_list(request.into_inner().shells).unwrap_or_default();
         if let Some(index) = self
             .maybe_rebuild_index(shells)

--- a/crates/atuin-daemon/src/components/search.rs
+++ b/crates/atuin-daemon/src/components/search.rs
@@ -225,14 +225,8 @@ impl Component for SearchComponent {
                 let histories = handle.history_db().load_active(ids.iter().copied()).await?;
                 self.index.read().await.add_histories(&histories);
             }
-            DaemonEvent::HistoryPruned | DaemonEvent::HistoryRebuilt => {
-                info!("History store pruned or rebuilt, rebuilding search index");
-                self.rebuild_index_only().await;
-            }
-            DaemonEvent::HistoryDeleted { ids } => {
-                info!(count = ids.len(), "History deleted, rebuilding search index");
-                // For now, just rebuild the entire index. A more efficient implementation
-                // would remove specific items from the index.
+            DaemonEvent::HistoryRebuilt => {
+                info!("History store rebuilt, rebuilding search index");
                 self.rebuild_index_only().await;
             }
             DaemonEvent::SettingsReloaded => {

--- a/crates/atuin-daemon/src/components/search.rs
+++ b/crates/atuin-daemon/src/components/search.rs
@@ -357,7 +357,10 @@ impl SearchSvc for SearchGrpcService {
                 // Perform the search
                 let history_ids: Vec<Vec<u8>> =
                     span!(Level::TRACE, "daemon_search_query", %query, query_id).in_scope(|| {
-                        index.search(&query, &index_filter, RESULTS_LIMIT).map(Vec::from).collect()
+                        index
+                            .search(&query, &index_filter, RESULTS_LIMIT)
+                            .map(|id| id.into_bytes().to_vec())
+                            .collect()
                     });
                 drop(index);
 

--- a/crates/atuin-daemon/src/components/search.rs
+++ b/crates/atuin-daemon/src/components/search.rs
@@ -3,7 +3,6 @@
 //! Provides fuzzy search over command history using the Nucleo search library
 //! with frecency-based ranking and dynamic filtering.
 
-use std::ops::Deref;
 use std::pin::{Pin, pin};
 use std::sync::Arc;
 
@@ -30,50 +29,29 @@ const FRECENCY_REFRESH_INTERVAL_SECS: u64 = 60;
 
 /// Build the search index without building the frecency map.
 ///
-/// `index` is a closure to support both shared `RwLock` indices and owned indices:
-///
-/// * Owned: `async || &my_owned_index`
-/// * Shared: `|| my_rwlock_index.read()`
-///
-/// In the shared case, this ensures that the lock isn't held while this function does expensive
-/// computation.
+/// The read guard is re-acquired per page rather than held across the whole load, so concurrent
+/// index operations aren't blocked while this does its expensive work.
 #[instrument(skip_all, level = Level::TRACE)]
-async fn build_index_only<F, R>(index: F, handle: &DaemonHandle) -> Result<(), ()>
-where
-    F: Fn() -> R,
-    R: Future<Output: Deref<Target = SearchIndex>>,
-{
+async fn build_index_only(index: &RwLock<SearchIndex>, handle: &DaemonHandle) -> Result<(), ()> {
     info!("Loading history into search index; page size = {}", SearchIndex::HISTORY_LOAD_PAGE_SIZE);
     let mut pages = pin!(SearchIndex::history_pages(handle.history_db()));
     while let Some(histories) =
         pages.try_next().await.map_err(|e| error!("Failed to load history: {e}"))?
     {
         info!("Loading {} history entries into search index", histories.len());
-        index().await.add_histories(&histories);
+        index.read().await.add_histories(&histories);
     }
 
-    info!("History load complete; {} unique commands indexed", index().await.command_count());
+    info!("History load complete; {} unique commands indexed", index.read().await.command_count());
     Ok(())
 }
 
 /// Build the frecency map.
-///
-/// `index` is a closure to support both shared `RwLock` indices and owned indices:
-///
-/// * Owned: `async || &my_owned_index`
-/// * Shared: `|| my_rwlock_index.read()`
-///
-/// In the shared case, this ensures that the lock isn't held while this function does expensive
-/// computation.
 #[instrument(skip_all, level = Level::TRACE)]
-async fn build_frecency<F, R>(index: F, handle: &DaemonHandle)
-where
-    F: Fn() -> R,
-    R: Future<Output: Deref<Target = SearchIndex>>,
-{
+async fn build_frecency(index: &RwLock<SearchIndex>, handle: &DaemonHandle) {
     {
         let settings = handle.settings().await;
-        index().await.rebuild_frecency(&settings.search);
+        index.read().await.rebuild_frecency(&settings.search);
     }
     info!("Frecency map built");
 }
@@ -148,8 +126,8 @@ impl Component for SearchComponent {
             let shells =
                 handle_for_loader.settings().await.search.shells.to_filter().to_vec_filter();
             index.write().await.shells = shells;
-            if build_index_only(|| index.read(), &handle_for_loader).await.is_ok() {
-                build_frecency(|| index.read(), &handle_for_loader).await;
+            if build_index_only(&index, &handle_for_loader).await.is_ok() {
+                build_frecency(&index, &handle_for_loader).await;
             }
         }));
 
@@ -162,7 +140,7 @@ impl Component for SearchComponent {
             loop {
                 interval.tick().await;
                 trace!("Refreshing frecency map");
-                build_frecency(|| index_for_frecency.read(), &handle).await;
+                build_frecency(&index_for_frecency, &handle).await;
             }
         }));
 
@@ -209,7 +187,7 @@ impl Component for SearchComponent {
             DaemonEvent::SettingsReloaded => {
                 if let Some(handle) = self.handle.as_ref() {
                     info!("Rebuilding frecency map after settings update");
-                    build_frecency(|| self.index.read(), handle).await;
+                    build_frecency(&self.index, handle).await;
                 }
             }
             // Events we don't care about

--- a/crates/atuin-daemon/src/components/search.rs
+++ b/crates/atuin-daemon/src/components/search.rs
@@ -4,12 +4,13 @@
 //! with frecency-based ranking and dynamic filtering.
 
 use std::ops::Deref;
-use std::pin::Pin;
+use std::pin::{Pin, pin};
 use std::sync::Arc;
 
 use atuin_common::filter::OrFilter;
 use atuin_common::path::DisplayRichExt;
 use eyre::Result;
+use futures::TryStreamExt;
 use tokio::sync::RwLock;
 use tokio_stream::Stream;
 use tonic::{Request, Response, Status, Streaming};
@@ -23,7 +24,6 @@ use crate::search::{
     SearchRequest, SearchResponse,
 };
 
-const PAGE_SIZE: usize = 5000;
 const RESULTS_LIMIT: u32 = 200;
 /// How often to rebuild the frecency map (in seconds).
 const FRECENCY_REFRESH_INTERVAL_SECS: u64 = 60;
@@ -43,28 +43,17 @@ where
     F: Fn() -> R,
     R: Future<Output: Deref<Target = SearchIndex>>,
 {
-    info!("Loading history into search index; page size = {}", PAGE_SIZE);
-    let db = handle.history_db();
-    let mut pager = db.all_paged(PAGE_SIZE, false, true);
-    loop {
-        match pager.next().await {
-            Ok(Some(histories)) => {
-                info!("Loading {} history entries into search index", histories.len());
-                index().await.add_histories(&histories);
-            }
-            Ok(None) => {
-                info!(
-                    "History load complete; {} unique commands indexed",
-                    index().await.command_count()
-                );
-                return Ok(());
-            }
-            Err(e) => {
-                error!("Failed to load history: {}", e);
-                return Err(());
-            }
-        }
+    info!("Loading history into search index; page size = {}", SearchIndex::HISTORY_LOAD_PAGE_SIZE);
+    let mut pages = pin!(SearchIndex::history_pages(handle.history_db()));
+    while let Some(histories) =
+        pages.try_next().await.map_err(|e| error!("Failed to load history: {e}"))?
+    {
+        info!("Loading {} history entries into search index", histories.len());
+        index().await.add_histories(&histories);
     }
+
+    info!("History load complete; {} unique commands indexed", index().await.command_count());
+    Ok(())
 }
 
 /// Build the frecency map.
@@ -87,25 +76,6 @@ where
         index().await.rebuild_frecency(&settings.search);
     }
     info!("Frecency map built");
-}
-
-/// Build the search index and frecency map.
-///
-/// `index` is a closure to support both shared `RwLock` indices and owned indices:
-///
-/// * Owned: `async || &my_owned_index`
-/// * Shared: `|| my_rwlock_index.read()`
-///
-/// In the shared case, this ensures that the lock isn't held while this function does expensive
-/// computation.
-async fn build_index<F, R>(index: F, handle: &DaemonHandle) -> Result<(), ()>
-where
-    F: Fn() -> R,
-    R: Future<Output: Deref<Target = SearchIndex>>,
-{
-    build_index_only(&index, handle).await?;
-    build_frecency(index, handle).await;
-    Ok(())
 }
 
 /// Search component - provides fuzzy search over command history.
@@ -156,14 +126,18 @@ impl SearchComponent {
         };
         info!("Rebuilding search index from database");
 
-        // Create a new index
         // TODO(#4052): This is inherently racy -- any add_history operations added between this
         //              .read() and the subsequent .write() are completely discarded from the new
         //              index.
-        let new_index = SearchIndex::new(self.index.read().await.shells.clone());
-        if build_index_only(async || &new_index, handle).await.is_err() {
-            return;
-        }
+        let shells = self.index.read().await.shells.clone();
+        let search = handle.settings().await.search.clone();
+        let new_index = match SearchIndex::from_db(shells, handle.history_db(), &search).await {
+            Ok(new_index) => new_index,
+            Err(e) => {
+                error!("Failed to rebuild search index: {e}");
+                return;
+            }
+        };
 
         info!("Search index rebuild complete; {} unique commands", new_index.command_count());
         *self.index.write().await = new_index;
@@ -199,7 +173,9 @@ impl Component for SearchComponent {
             let shells =
                 handle_for_loader.settings().await.search.shells.to_filter().to_vec_filter();
             index.write().await.shells = shells;
-            let _ = build_index(|| index.read(), &handle_for_loader).await;
+            if build_index_only(|| index.read(), &handle_for_loader).await.is_ok() {
+                build_frecency(|| index.read(), &handle_for_loader).await;
+            }
         }));
 
         // Spawn background task to periodically refresh frecency
@@ -294,8 +270,10 @@ impl SearchGrpcService {
 
         info!("Rebuilding search index from database after shell filter change");
 
-        let new_index = SearchIndex::new(shells);
-        build_index(async || &new_index, &self.handle).await?;
+        let search = self.handle.settings().await.search.clone();
+        let new_index = SearchIndex::from_db(shells, self.handle.history_db(), &search)
+            .await
+            .map_err(|e| error!("Failed to rebuild search index: {e}"))?;
 
         info!("Search index rebuild complete; {} unique commands", new_index.command_count());
         Ok(Some(new_index))

--- a/crates/atuin-daemon/src/components/search.rs
+++ b/crates/atuin-daemon/src/components/search.rs
@@ -27,35 +27,6 @@ const RESULTS_LIMIT: u32 = 200;
 /// How often to rebuild the frecency map (in seconds).
 const FRECENCY_REFRESH_INTERVAL_SECS: u64 = 60;
 
-/// Build the search index without building the frecency map.
-///
-/// The read guard is re-acquired per page rather than held across the whole load, so concurrent
-/// index operations aren't blocked while this does its expensive work.
-#[instrument(skip_all, level = Level::TRACE)]
-async fn build_index_only(index: &RwLock<SearchIndex>, handle: &DaemonHandle) -> Result<(), ()> {
-    info!("Loading history into search index; page size = {}", SearchIndex::HISTORY_LOAD_PAGE_SIZE);
-    let mut pages = pin!(SearchIndex::history_pages(handle.history_db()));
-    while let Some(histories) =
-        pages.try_next().await.map_err(|e| error!("Failed to load history: {e}"))?
-    {
-        info!("Loading {} history entries into search index", histories.len());
-        index.read().await.add_histories(&histories);
-    }
-
-    info!("History load complete; {} unique commands indexed", index.read().await.command_count());
-    Ok(())
-}
-
-/// Build the frecency map.
-#[instrument(skip_all, level = Level::TRACE)]
-async fn build_frecency(index: &RwLock<SearchIndex>, handle: &DaemonHandle) {
-    {
-        let settings = handle.settings().await;
-        index.read().await.rebuild_frecency(&settings.search);
-    }
-    info!("Frecency map built");
-}
-
 /// Search component - provides fuzzy search over command history.
 ///
 /// This component:
@@ -95,6 +66,42 @@ impl SearchComponent {
     pub fn index(&self) -> Arc<RwLock<SearchIndex>> {
         self.index.clone()
     }
+
+    #[instrument(skip_all, level = Level::TRACE)]
+    async fn rebuild_frecency(handle: &DaemonHandle, index: &RwLock<SearchIndex>) {
+        let settings = handle.settings().await;
+        index.read().await.rebuild_frecency(&settings.search);
+    }
+
+    /// Rebuild the search index from the database, then its frecency map.
+    ///
+    /// The read guard is re-acquired per page rather than held across the whole load, so concurrent
+    /// index operations aren't blocked while this does its expensive work.
+    #[instrument(skip_all, level = Level::TRACE)]
+    async fn rebuild_index(
+        handle: &DaemonHandle,
+        index: &RwLock<SearchIndex>,
+    ) -> Result<(), eyre::Error> {
+        info!(
+            "Loading history into search index; page size = {}",
+            SearchIndex::HISTORY_LOAD_PAGE_SIZE
+        );
+        let mut pages = pin!(SearchIndex::history_pages(handle.history_db()));
+        while let Some(histories) =
+            pages.try_next().await.inspect_err(|e| error!("Failed to load history: {e}"))?
+        {
+            info!("Loading {} history entries into search index", histories.len());
+            index.read().await.add_histories(&histories);
+        }
+
+        info!(
+            "History load complete; {} unique commands indexed",
+            index.read().await.command_count()
+        );
+
+        Self::rebuild_frecency(handle, index).await;
+        Ok(())
+    }
 }
 
 impl Default for SearchComponent {
@@ -126,12 +133,13 @@ impl Component for SearchComponent {
             let shells =
                 handle_for_loader.settings().await.search.shells.to_filter().to_vec_filter();
             index.write().await.shells = shells;
-            if build_index_only(&index, &handle_for_loader).await.is_ok() {
-                build_frecency(&index, &handle_for_loader).await;
-            }
+            let _ = Self::rebuild_index(&handle_for_loader, &index).await.inspect_err(|err| {
+                error!(?err, "failed to rebuild the index.");
+            });
         }));
 
         // Spawn background task to periodically refresh frecency
+        let handle_for_frecency = handle;
         let index_for_frecency = self.index.clone();
         self.frecency_handle = Some(tokio::spawn(async move {
             let mut interval = tokio::time::interval(std::time::Duration::from_secs(
@@ -140,7 +148,7 @@ impl Component for SearchComponent {
             loop {
                 interval.tick().await;
                 trace!("Refreshing frecency map");
-                build_frecency(&index_for_frecency, &handle).await;
+                Self::rebuild_frecency(&handle_for_frecency, &index_for_frecency).await;
             }
         }));
 
@@ -187,7 +195,7 @@ impl Component for SearchComponent {
             DaemonEvent::SettingsReloaded => {
                 if let Some(handle) = self.handle.as_ref() {
                     info!("Rebuilding frecency map after settings update");
-                    build_frecency(&self.index, handle).await;
+                    Self::rebuild_frecency(handle, &self.index).await;
                 }
             }
             // Events we don't care about

--- a/crates/atuin-daemon/src/control/service.rs
+++ b/crates/atuin-daemon/src/control/service.rs
@@ -57,11 +57,7 @@ impl Control for ControlService {
 /// Convert a proto event to a daemon event.
 fn proto_event_to_daemon_event(event: Event) -> DaemonEvent {
     match event {
-        Event::HistoryPruned(_) => DaemonEvent::HistoryPruned,
         Event::HistoryRebuilt(_) => DaemonEvent::HistoryRebuilt,
-        Event::HistoryDeleted(e) => DaemonEvent::HistoryDeleted {
-            ids: e.ids.iter().filter_map(|id| id.parse().ok()).collect(),
-        },
         Event::ForceSync(_) => DaemonEvent::ForceSync,
         Event::SettingsReloaded(_) => DaemonEvent::SettingsReloaded,
         Event::Shutdown(_) => DaemonEvent::ShutdownRequested,

--- a/crates/atuin-daemon/src/daemon.rs
+++ b/crates/atuin-daemon/src/daemon.rs
@@ -70,7 +70,7 @@ pub struct DaemonState {
 ///
 /// ```ignore
 /// // Emit an event
-/// handle.emit(DaemonEvent::HistoryPruned);
+/// handle.emit(DaemonEvent::HistoryRebuilt);
 ///
 /// // Access settings
 /// let settings = handle.settings().await;

--- a/crates/atuin-daemon/src/events.rs
+++ b/crates/atuin-daemon/src/events.rs
@@ -42,23 +42,10 @@ pub enum DaemonEvent {
     ForceSync,
 
     // ---- External commands ----
-    /// History was pruned - search index needs a full rebuild.
-    ///
-    /// Emitted when the user runs `atuin history prune` or similar.
-    HistoryPruned,
-
     /// History was rebuilt - search index needs a full rebuild.
     ///
     /// Emitted when the user runs `atuin store rebuild history` or similar.
     HistoryRebuilt,
-
-    /// Specific history items were deleted.
-    ///
-    /// The search component should remove these from its index.
-    HistoryDeleted {
-        /// IDs of the deleted history entries.
-        ids: Vec<HistoryId>,
-    },
 
     /// Settings have changed, components should reload if needed.
     SettingsReloaded,

--- a/crates/atuin-daemon/src/grpc/history/mod.rs
+++ b/crates/atuin-daemon/src/grpc/history/mod.rs
@@ -329,7 +329,8 @@ impl GrpcService for Service {
         let ids: Vec<HistoryId> =
             request.into_inner().into_history_ids().collect::<Result<Vec<_>, _>>()?;
 
-        let deleted = self.journal.delete(ids).await?;
+        let search_settings = self.daemon_handle.settings().await.search.clone();
+        let deleted = self.journal.delete(ids, &search_settings).await?;
 
         Ok(Response::new(DeleteHistoryReply {
             deleted: deleted.cast(),

--- a/crates/atuin-daemon/src/grpc/history/mod.rs
+++ b/crates/atuin-daemon/src/grpc/history/mod.rs
@@ -322,9 +322,8 @@ impl GrpcService for Service {
         &self,
         request: Request<DeleteHistoryRequest>,
     ) -> Result<Response<DeleteHistoryReply>, Status> {
-        // Unfortunately we need the Result type here, and since `try_history_ids` returns an
-        // iterator of `Result`s, we need to collect it. [`HistoryJournal::delete`] needs to accept
-        // validated and correct HistoryIds.
+        // Unfortunately we need to collect here, and since `try_history_ids` returns an iterator of
+        // `Result`s. [`HistoryJournal::delete`] needs to accept validated and correct HistoryIds.
         let ids: Vec<HistoryId> =
             request.into_inner().try_history_ids().collect::<Result<Vec<_>, _>>()?;
 

--- a/crates/atuin-daemon/src/grpc/history/mod.rs
+++ b/crates/atuin-daemon/src/grpc/history/mod.rs
@@ -322,7 +322,11 @@ impl GrpcService for Service {
         &self,
         request: Request<DeleteHistoryRequest>,
     ) -> Result<Response<DeleteHistoryReply>, Status> {
-        let ids: Vec<HistoryId> = request.into_inner().try_into()?;
+        // Unfortunately we need the Result type here, and since `try_history_ids` returns an
+        // iterator of `Result`s, we need to collect it. [`HistoryJournal::delete`] needs to accept
+        // validated and correct HistoryIds.
+        let ids: Vec<HistoryId> =
+            request.into_inner().try_history_ids().collect::<Result<Vec<_>, _>>()?;
 
         let deleted = self.journal.delete(ids).await?;
 

--- a/crates/atuin-daemon/src/grpc/history/mod.rs
+++ b/crates/atuin-daemon/src/grpc/history/mod.rs
@@ -5,6 +5,7 @@ use std::sync::Arc;
 
 use atuin_client::history::{History, HistoryId};
 use atuin_common::time::OffsetDateTimeExt;
+use easy_cast::Cast;
 use futures::StreamExt;
 use time::OffsetDateTime;
 use tokio_stream::Stream;
@@ -15,9 +16,10 @@ use tracing::{Level, instrument};
 use crate::DaemonHandle;
 use crate::grpc::history::pb::history_server::History as GrpcService;
 use crate::grpc::history::pb::{
-    CancelHistoryReply, CancelHistoryRequest, EndHistoryReply, EndHistoryRequest, Lagged,
-    ShutdownReply, ShutdownRequest, StartHistoryReply, StartHistoryRequest, StatusReply,
-    StatusRequest, TailHistoryEvent, TailHistoryReply, TailHistoryRequest,
+    CancelHistoryReply, CancelHistoryRequest, DeleteHistoryReply, DeleteHistoryRequest,
+    EndHistoryReply, EndHistoryRequest, Lagged, ShutdownReply, ShutdownRequest, StartHistoryReply,
+    StartHistoryRequest, StatusReply, StatusRequest, TailHistoryEvent, TailHistoryReply,
+    TailHistoryRequest,
 };
 use crate::history_journal::HistoryJournal;
 
@@ -310,6 +312,22 @@ impl GrpcService for Service {
 
         Ok(Response::new(CancelHistoryReply {
             // TODO(markovejnovic): Pull this from one constant, well-defined spot.
+            version: env!("CARGO_PKG_VERSION").to_string(),
+            protocol: DAEMON_PROTOCOL_VERSION,
+        }))
+    }
+
+    #[instrument(skip_all, level = Level::TRACE)]
+    async fn delete_history(
+        &self,
+        request: Request<DeleteHistoryRequest>,
+    ) -> Result<Response<DeleteHistoryReply>, Status> {
+        let ids: Vec<HistoryId> = request.into_inner().try_into()?;
+
+        let deleted = self.journal.delete(ids).await?;
+
+        Ok(Response::new(DeleteHistoryReply {
+            deleted: deleted.cast(),
             version: env!("CARGO_PKG_VERSION").to_string(),
             protocol: DAEMON_PROTOCOL_VERSION,
         }))

--- a/crates/atuin-daemon/src/grpc/history/mod.rs
+++ b/crates/atuin-daemon/src/grpc/history/mod.rs
@@ -322,10 +322,12 @@ impl GrpcService for Service {
         &self,
         request: Request<DeleteHistoryRequest>,
     ) -> Result<Response<DeleteHistoryReply>, Status> {
-        // Unfortunately we need to collect here, and since `try_history_ids` returns an iterator of
-        // `Result`s. [`HistoryJournal::delete`] needs to accept validated and correct HistoryIds.
+        // We collect here to validate every id up front: `into_history_ids` yields an iterator of
+        // `Result`s, and [`HistoryJournal::delete`] needs validated, correct HistoryIds. Consuming
+        // the request (rather than borrowing + cloning each proto id) keeps this to a single
+        // allocation, and a malformed request deletes nothing.
         let ids: Vec<HistoryId> =
-            request.into_inner().try_history_ids().collect::<Result<Vec<_>, _>>()?;
+            request.into_inner().into_history_ids().collect::<Result<Vec<_>, _>>()?;
 
         let deleted = self.journal.delete(ids).await?;
 

--- a/crates/atuin-daemon/src/grpc/history/pb.rs
+++ b/crates/atuin-daemon/src/grpc/history/pb.rs
@@ -1,6 +1,7 @@
 //! Model conversion utilities for the `history` gRPC protobuf.
 mod codegen {
     #![allow(clippy::must_use_candidate, reason = "prost-generated code")]
+    #![allow(clippy::derive_partial_eq_without_eq, reason = "prost-generated code")]
     tonic::include_proto!("history");
 }
 
@@ -18,7 +19,9 @@ use tonic::Status;
 
 use crate::grpc::common::pb as common;
 use crate::grpc::common::pb::Uuid;
-use crate::history_journal::{CmdCancelError, CmdEvent, CmdFinishError, GetCmdInFlightError};
+use crate::history_journal::{
+    CmdCancelError, CmdDeleteError, CmdEvent, CmdFinishError, GetCmdInFlightError,
+};
 
 impl From<DomainHistoryId> for HistoryId {
     fn from(value: DomainHistoryId) -> Self {
@@ -174,6 +177,14 @@ impl TryFrom<CancelHistoryRequest> for DomainHistoryId {
     }
 }
 
+impl TryFrom<DeleteHistoryRequest> for Vec<DomainHistoryId> {
+    type Error = IdParseError;
+
+    fn try_from(value: DeleteHistoryRequest) -> Result<Self, Self::Error> {
+        value.ids.into_iter().map(DomainHistoryId::try_from).collect()
+    }
+}
+
 /// Map a single journal event to its tail-stream reply.
 impl From<CmdEvent> for TailHistoryEvent {
     fn from(event: CmdEvent) -> Self {
@@ -203,6 +214,16 @@ impl From<CmdCancelError> for Status {
     }
 }
 
+impl From<CmdDeleteError> for Status {
+    fn from(value: CmdDeleteError) -> Self {
+        match value {
+            CmdDeleteError::HistoryStoreFailed(_) | CmdDeleteError::HistoryDbFailed(_) => {
+                Self::internal(value.to_string())
+            }
+        }
+    }
+}
+
 impl From<GetCmdInFlightError> for Status {
     fn from(value: GetCmdInFlightError) -> Self {
         match value {
@@ -218,7 +239,7 @@ invalid_argument_errors!(
     CancelHistoryRequestParseError,
 );
 
-versioned_messages!(StartHistoryReply, EndHistoryReply, CancelHistoryReply);
+versioned_messages!(StartHistoryReply, EndHistoryReply, CancelHistoryReply, DeleteHistoryReply);
 
 #[cfg(test)]
 mod tests {

--- a/crates/atuin-daemon/src/grpc/history/pb.rs
+++ b/crates/atuin-daemon/src/grpc/history/pb.rs
@@ -177,11 +177,9 @@ impl TryFrom<CancelHistoryRequest> for DomainHistoryId {
     }
 }
 
-impl TryFrom<DeleteHistoryRequest> for Vec<DomainHistoryId> {
-    type Error = IdParseError;
-
-    fn try_from(value: DeleteHistoryRequest) -> Result<Self, Self::Error> {
-        value.ids.into_iter().map(DomainHistoryId::try_from).collect()
+impl DeleteHistoryRequest {
+    pub fn try_history_ids(&self) -> impl Iterator<Item = Result<DomainHistoryId, IdParseError>> {
+        self.ids.iter().map(|id| DomainHistoryId::try_from(id.clone()))
     }
 }
 

--- a/crates/atuin-daemon/src/grpc/history/pb.rs
+++ b/crates/atuin-daemon/src/grpc/history/pb.rs
@@ -178,8 +178,8 @@ impl TryFrom<CancelHistoryRequest> for DomainHistoryId {
 }
 
 impl DeleteHistoryRequest {
-    pub fn try_history_ids(&self) -> impl Iterator<Item = Result<DomainHistoryId, IdParseError>> {
-        self.ids.iter().map(|id| DomainHistoryId::try_from(id.clone()))
+    pub fn into_history_ids(self) -> impl Iterator<Item = Result<DomainHistoryId, IdParseError>> {
+        self.ids.into_iter().map(DomainHistoryId::try_from)
     }
 }
 

--- a/crates/atuin-daemon/src/history_journal.rs
+++ b/crates/atuin-daemon/src/history_journal.rs
@@ -233,10 +233,13 @@ impl HistoryJournal {
             duration = Empty,
         );
 
-        self.active_cmds.insert(id, InFlightCmd {
-            history: history.clone(),
-            span,
-        });
+        self.active_cmds.insert(
+            id,
+            InFlightCmd {
+                history: history.clone(),
+                span,
+            },
+        );
         let _ = self.broadcast.send(CmdEvent::Started(history));
         id
     }
@@ -311,6 +314,9 @@ impl HistoryJournal {
             tracing::warn!("packing failed: {e}");
         }
 
+        // TODO(#4052): This is inherently racy -- any add_history operations added between this
+        //              .read() and the subsequent .write() are completely discarded from the new
+        //              index.
         self.search_index.read().await.add_history(&history);
 
         if self.broadcast.receiver_count() > 0 {

--- a/crates/atuin-daemon/src/history_journal.rs
+++ b/crates/atuin-daemon/src/history_journal.rs
@@ -399,6 +399,16 @@ impl HistoryJournal {
         match rebuilt {
             Ok(new_index) => *self.search_index.write().await = new_index,
             Err(e) => {
+                // TODO(markovejnovic): This is obviously incorrect behavior, keeping the previous
+                //                      index is almost certainly wrong, however, is the legacy
+                //                      behavior we had.
+                //
+                //                      Arguably, we could completely delete the index/crash the
+                //                      daemon, since at this point, Atuin is as good as useless.
+                //
+                //                      We could also just mark the index as hot garbo and have the
+                //                      next request attempt to rebuild it. Not sure why the next
+                //                      request would succeed but a retry is always good.
                 tracing::error!("failed to reload search index; keeping previous index: {e}");
             }
         }

--- a/crates/atuin-daemon/src/history_journal.rs
+++ b/crates/atuin-daemon/src/history_journal.rs
@@ -358,7 +358,7 @@ impl HistoryJournal {
         //
         // This happens as a result of the fact that [`HistoryJournal`] might be tracking started,
         // but not finished commands. These get cancelled via [`HistoryJournal::cancel`].
-        let delete_records = || async {
+        let delete_records = async || {
             let mut deleted: usize = 0;
             let mut record_ids = Vec::new();
             for id in ids {

--- a/crates/atuin-daemon/src/history_journal.rs
+++ b/crates/atuin-daemon/src/history_journal.rs
@@ -97,8 +97,6 @@ pub struct HistoryJournal {
     active_cmds: DashMap<HistoryId, InFlightCmd>,
 
     /// We hold a reference to the search index which allows us to add a new history record into it.
-    ///
-    /// Do note that the [`tokio::sync::RwLock`] is only ever used in reader mode.
     search_index: Arc<tokio::sync::RwLock<SearchIndex>>,
 
     /// Just like the search_index, we need to notify the SemanticComponent of added history.
@@ -117,6 +115,15 @@ pub enum CmdFinishError {
     #[error("storing into history store failed: {0}")]
     HistoryStoreFailed(eyre::Report),
     #[error("storing into history db failed: {0}")]
+    HistoryDbFailed(eyre::Report),
+}
+
+/// Errors returned by [`HistoryJournal::delete`].
+#[derive(Debug, thiserror::Error)]
+pub enum CmdDeleteError {
+    #[error("deleting from history store failed: {0}")]
+    HistoryStoreFailed(eyre::Report),
+    #[error("applying deletion to history db failed: {0}")]
     HistoryDbFailed(eyre::Report),
 }
 
@@ -327,6 +334,70 @@ impl HistoryJournal {
         let _ = self.broadcast.send(CmdEvent::Cancelled(cmd.history));
 
         Ok(())
+    }
+
+    /// Delete the given history entries from Atuin's memory completely.
+    ///
+    /// Returns how many history entries Atuin forgot.
+    pub async fn delete(
+        &self,
+        ids: impl IntoIterator<Item = HistoryId>,
+    ) -> Result<usize, CmdDeleteError> {
+        // Remove records from the record store.
+        //
+        // This returns a tuple where the first element is the total number of history elements that
+        // were erased from Atuin's memory, and the second element is a vector of [`RecordId`]s that
+        // must be subsequently removed from the history database via [`HistoryStore::build_all`].
+        // Note the passed database argument.
+        //
+        // Furthermore, note that `.0 != .1.len()`, because there may very well be history entries
+        // that atuin has forgotten about that were never in the record store.
+        //
+        // This happens as a result of the fact that [`HistoryJournal`] might be tracking started,
+        // but not finished commands. These get cancelled via [`HistoryJournal::cancel`].
+        let delete_records = || async {
+            let mut deleted: usize = 0;
+            let mut record_ids = Vec::new();
+            for id in ids {
+                if let Some((_id, cmd)) = self.active_cmds.remove(&id) {
+                    let _ = self.broadcast.send(CmdEvent::Cancelled(cmd.history));
+                    deleted += 1;
+                    continue;
+                }
+
+                match self.history_store.delete(id).await {
+                    Ok((record_id, _)) => {
+                        record_ids.push(record_id);
+                        deleted += 1;
+                    }
+                    Err(e) => {
+                        return Err(CmdDeleteError::HistoryStoreFailed(e));
+                    }
+                }
+            }
+
+            Ok((deleted, record_ids))
+        };
+
+        let (deleted, record_ids) = delete_records().await?;
+        if record_ids.is_empty() {
+            return Ok(deleted);
+        }
+
+        self.history_store
+            .build_all(&self.history_db, &record_ids)
+            .await
+            .map_err(CmdDeleteError::HistoryDbFailed)?;
+
+        let rebuilt = self.search_index.read().await.rebuild(&self.history_db).await;
+        match rebuilt {
+            Ok(new_index) => *self.search_index.write().await = new_index,
+            Err(e) => {
+                tracing::error!("failed to reload search index; keeping previous index: {e}");
+            }
+        }
+
+        Ok(deleted)
     }
 
     /// Create a new stream of [`CmdEvent`] objects.

--- a/crates/atuin-daemon/src/history_journal.rs
+++ b/crates/atuin-daemon/src/history_journal.rs
@@ -36,6 +36,7 @@ use atuin_client::database::Sqlite as HistoryDatabase;
 use atuin_client::history::store::HistoryStore;
 use atuin_client::history::{History, HistoryId};
 use atuin_client::packfile;
+use atuin_client::settings::Search;
 use atuin_domain::caps::{CapClient, PackfileCap};
 use atuin_domain::record::{RecordId, RecordIdx, RecordSeriesKey, RecordTag};
 use dashmap::DashMap;
@@ -341,10 +342,14 @@ impl HistoryJournal {
 
     /// Delete the given history entries from Atuin's memory completely.
     ///
+    /// `search_settings` is needed to rebuild the search index's frecency map after the deletion,
+    /// so the swapped-in index has correct rankings immediately rather than after the next refresh.
+    ///
     /// Returns how many history entries Atuin forgot.
     pub async fn delete(
         &self,
         ids: impl IntoIterator<Item = HistoryId>,
+        search_settings: &Search,
     ) -> Result<usize, CmdDeleteError> {
         // Remove records from the record store.
         //
@@ -392,7 +397,8 @@ impl HistoryJournal {
             .await
             .map_err(CmdDeleteError::HistoryDbFailed)?;
 
-        let rebuilt = self.search_index.read().await.rebuild(&self.history_db).await;
+        let rebuilt =
+            self.search_index.read().await.rebuild(&self.history_db, search_settings).await;
         match rebuilt {
             Ok(new_index) => *self.search_index.write().await = new_index,
             Err(e) => {

--- a/crates/atuin-daemon/src/history_journal.rs
+++ b/crates/atuin-daemon/src/history_journal.rs
@@ -233,13 +233,10 @@ impl HistoryJournal {
             duration = Empty,
         );
 
-        self.active_cmds.insert(
-            id,
-            InFlightCmd {
-                history: history.clone(),
-                span,
-            },
-        );
+        self.active_cmds.insert(id, InFlightCmd {
+            history: history.clone(),
+            span,
+        });
         let _ = self.broadcast.send(CmdEvent::Started(history));
         id
     }

--- a/crates/atuin-daemon/src/history_journal.rs
+++ b/crates/atuin-daemon/src/history_journal.rs
@@ -397,8 +397,10 @@ impl HistoryJournal {
             .await
             .map_err(CmdDeleteError::HistoryDbFailed)?;
 
-        let rebuilt =
-            self.search_index.read().await.rebuild(&self.history_db, search_settings).await;
+        // Clone the shell filter and drop the read guard before the (full) reload, so the scan
+        // doesn't hold the search-index lock across the database load.
+        let shells = self.search_index.read().await.shells.clone();
+        let rebuilt = SearchIndex::from_db(shells, &self.history_db, search_settings).await;
         match rebuilt {
             Ok(new_index) => *self.search_index.write().await = new_index,
             Err(e) => {

--- a/crates/atuin-daemon/src/lib.rs
+++ b/crates/atuin-daemon/src/lib.rs
@@ -28,7 +28,8 @@ pub use components::{SearchComponent, SemanticComponent, SyncComponent};
 pub use daemon::{AnyComponent, Daemon, DaemonBuilder, DaemonHandle};
 pub use events::DaemonEvent;
 pub use history_journal::{
-    CmdCancelError, CmdEvent, CmdFinishError, FinishedCmd, GetCmdInFlightError, HistoryJournal,
+    CmdCancelError, CmdDeleteError, CmdEvent, CmdFinishError, FinishedCmd, GetCmdInFlightError,
+    HistoryJournal,
 };
 
 /// Boot the daemon using the new component-based architecture.

--- a/crates/atuin-daemon/src/search/index.rs
+++ b/crates/atuin-daemon/src/search/index.rs
@@ -394,16 +394,6 @@ impl SearchIndex {
         Ok(new_index)
     }
 
-    /// Take the existing [`SearchIndex`], clone it without the data, and populate it with new data
-    /// from the given `db`.
-    pub async fn rebuild(
-        &self,
-        db: &Sqlite,
-        search_settings: &Search,
-    ) -> Result<Self, LoadFromDbError> {
-        Self::from_db(self.shells.clone(), db, search_settings).await
-    }
-
     /// Number of history rows loaded per page when (re)building an index from the database.
     pub const HISTORY_LOAD_PAGE_SIZE: usize = 5000;
 

--- a/crates/atuin-daemon/src/search/index.rs
+++ b/crates/atuin-daemon/src/search/index.rs
@@ -382,7 +382,7 @@ impl SearchIndex {
 
     /// Take the existing [`SearchIndex`], clone it without the data, and populate it with new data
     /// from the given `db`.
-    pub(crate) async fn rebuild(&self, db: &Sqlite) -> Result<Self, LoadFromDbError> {
+    pub async fn rebuild(&self, db: &Sqlite) -> Result<Self, LoadFromDbError> {
         let shells = self.shells.clone();
         let new_index = Self::new(shells);
         new_index.load_from_db(db).await?;
@@ -390,7 +390,7 @@ impl SearchIndex {
     }
 
     /// Load every history entry from `db` into this index.
-    pub(crate) async fn load_from_db(&self, db: &Sqlite) -> Result<(), LoadFromDbError> {
+    pub async fn load_from_db(&self, db: &Sqlite) -> Result<(), LoadFromDbError> {
         /// Number of history rows loaded per page when (re)building an index from the database.
         const INDEX_LOAD_PAGE_SIZE: usize = 5000;
 

--- a/crates/atuin-daemon/src/search/index.rs
+++ b/crates/atuin-daemon/src/search/index.rs
@@ -12,6 +12,7 @@ use std::cmp::Ordering;
 use std::collections::HashSet;
 use std::sync::Arc;
 
+use atuin_client::database::Sqlite;
 use atuin_client::history::History;
 use atuin_client::settings::Search;
 use atuin_common::filter::OrFilter;
@@ -24,7 +25,12 @@ use time::OffsetDateTime;
 use tracing::{Level, instrument};
 use uuid::Uuid;
 
-use super::normalize_diacritics;
+/// Failure to (re)build a [`SearchIndex`] from the history database.
+#[derive(Debug, thiserror::Error)]
+#[error("failed to load history from the database: {0}")]
+pub struct LoadFromDbError(eyre::Report);
+
+use atuin_common::string::NormalizeDiacriticsExt;
 
 /// Parse a UUID string into a 16-byte array.
 /// Returns None if the string is not a valid UUID.
@@ -274,14 +280,15 @@ type FrecencyMap = Arc<Vec<u32>>;
 struct HaystackEntry {
     /// The original text of the entry.
     pub original: Arc<str>,
-    /// The [normalized](normalize_diacritics) version of the text, with diacritics removed.
+    /// The [normalized](NormalizeDiacriticsExt::normalize_diacritics) version of the text, with
+    /// diacritics removed.
     pub normalized: Arc<str>,
 }
 
 impl HaystackEntry {
     /// Create a new [`HaystackEntry`] from an [`Arc<str>`].
     pub fn new(text: Arc<str>) -> Self {
-        let normalized = match normalize_diacritics(&text) {
+        let normalized = match text.normalize_diacritics() {
             Cow::Borrowed(_) => text.clone(),
             Cow::Owned(normalized) => normalized.into(),
         };
@@ -375,6 +382,30 @@ impl SearchIndex {
         }
     }
 
+    /// Take the existing [`SearchIndex`], clone it without the data, and populate it with new data
+    /// from the given `db`.
+    pub(crate) async fn rebuild(&self, db: &Sqlite) -> Result<Self, LoadFromDbError> {
+        let shells = self.shells.clone();
+        let new_index = Self::new(shells);
+        new_index.load_from_db(db).await?;
+        Ok(new_index)
+    }
+
+    /// Load every history entry from `db` into this index.
+    pub(crate) async fn load_from_db(&self, db: &Sqlite) -> Result<(), LoadFromDbError> {
+        /// Number of history rows loaded per page when (re)building an index from the database.
+        const INDEX_LOAD_PAGE_SIZE: usize = 5000;
+
+        let mut pager = db.all_paged(INDEX_LOAD_PAGE_SIZE, false, true);
+        loop {
+            match pager.next().await {
+                Ok(Some(histories)) => self.add_histories(&histories),
+                Ok(None) => return Ok(()),
+                Err(e) => return Err(LoadFromDbError(e.into())),
+            }
+        }
+    }
+
     /// Add a history entry to the index.
     ///
     /// If the command already exists, updates its invocation data.
@@ -441,7 +472,7 @@ impl SearchIndex {
         let query = super::truncate_query(query);
         // Match accent-insensitively: the haystack side is normalized in
         // add_history, so an accented query must be normalized too
-        let query = normalize_diacritics(query);
+        let query = query.normalize_diacritics();
 
         let haystack = self.haystack.read();
         let filter = filter_mode.compile(&self.interner);

--- a/crates/atuin-daemon/src/search/index.rs
+++ b/crates/atuin-daemon/src/search/index.rs
@@ -13,7 +13,7 @@ use std::collections::HashSet;
 use std::sync::Arc;
 
 use atuin_client::database::Sqlite;
-use atuin_client::history::History;
+use atuin_client::history::{History, HistoryId};
 use atuin_client::settings::Search;
 use atuin_common::filter::OrFilter;
 use atuin_common::path::DisplayRichExt;
@@ -35,7 +35,7 @@ use atuin_common::string::NormalizeDiacriticsExt;
 /// Parse a UUID string into a 16-byte array.
 /// Returns None if the string is not a valid UUID.
 fn parse_uuid_bytes(s: &str) -> Option<[u8; 16]> {
-    Uuid::parse_str(s).ok().map(|u| *u.as_bytes())
+    Uuid::parse_str(s).ok().map(Uuid::into_bytes)
 }
 
 /// Pre-computed frecency data for O(1) lookup.
@@ -110,8 +110,8 @@ impl FrecencyData {
 /// Data for a unique command.
 #[derive(Debug)]
 pub struct CommandData {
-    /// History ID of the most recent invocation (16-byte UUID).
-    most_recent_id: [u8; 16],
+    /// History ID of the most recent invocation.
+    most_recent_id: HistoryId,
     /// Timestamp of the most recent invocation.
     most_recent_timestamp: i64,
     /// Pre-computed global frecency.
@@ -143,7 +143,6 @@ impl CommandData {
             return None;
         };
 
-        let history_id = history.id.into_bytes();
         let session = parse_uuid_bytes(&history.session)?;
         let timestamp = history.timestamp.unix_timestamp();
 
@@ -155,7 +154,7 @@ impl CommandData {
         global_frecency.record_use(timestamp);
 
         Some(Self {
-            most_recent_id: history_id,
+            most_recent_id: history.id,
             most_recent_timestamp: timestamp,
             global_frecency,
             directories: HashSet::from([dir_key]),
@@ -168,7 +167,6 @@ impl CommandData {
     /// Add an invocation from a history entry.
     /// Returns false if the history entry has invalid UUIDs.
     pub fn add_invocation(&mut self, history: &History, interner: &ThreadedRodeo) -> bool {
-        let history_id = history.id.into_bytes();
         let Some(session) = parse_uuid_bytes(&history.session) else {
             return false;
         };
@@ -187,7 +185,7 @@ impl CommandData {
 
         // Update most recent if this invocation is newer
         if timestamp > self.most_recent_timestamp {
-            self.most_recent_id = history_id;
+            self.most_recent_id = history.id;
             self.most_recent_timestamp = timestamp;
         }
 
@@ -195,7 +193,7 @@ impl CommandData {
     }
 
     /// Get the most recent history ID for this command.
-    pub fn most_recent_id(&self) -> [u8; 16] {
+    pub fn most_recent_id(&self) -> HistoryId {
         self.most_recent_id
     }
 
@@ -465,7 +463,7 @@ impl SearchIndex {
         query: &str,
         filter_mode: &IndexFilterMode,
         limit: u32,
-    ) -> impl Iterator<Item = [u8; 16]> {
+    ) -> impl Iterator<Item = HistoryId> {
         // Get precomputed frecency map (may be None if not yet computed)
         let frecency_map = self.frecency_map.read().clone();
 

--- a/crates/atuin-daemon/src/search/index.rs
+++ b/crates/atuin-daemon/src/search/index.rs
@@ -10,6 +10,7 @@
 use std::borrow::Cow;
 use std::cmp::Ordering;
 use std::collections::HashSet;
+use std::pin::pin;
 use std::sync::Arc;
 
 use atuin_client::database::Sqlite;
@@ -19,6 +20,7 @@ use atuin_common::filter::OrFilter;
 use atuin_common::path::DisplayRichExt;
 use dashmap::DashMap;
 use easy_cast::Conv;
+use futures::{Stream, TryStreamExt, stream};
 use lasso::{Spur, ThreadedRodeo};
 use parking_lot::RwLock;
 use time::OffsetDateTime;
@@ -380,28 +382,52 @@ impl SearchIndex {
         }
     }
 
-    /// Take the existing [`SearchIndex`], clone it without the data, and populate it with new data
-    /// from the given `db`.
-    pub async fn rebuild(&self, db: &Sqlite) -> Result<Self, LoadFromDbError> {
-        let shells = self.shells.clone();
+    /// Build a fresh index for `shells`, populated from `db` and with its frecency map ready.
+    pub async fn from_db(
+        shells: OrFilter<Vec<String>>,
+        db: &Sqlite,
+        search_settings: &Search,
+    ) -> Result<Self, LoadFromDbError> {
         let new_index = Self::new(shells);
         new_index.load_from_db(db).await?;
+        new_index.rebuild_frecency(search_settings);
         Ok(new_index)
     }
 
+    /// Take the existing [`SearchIndex`], clone it without the data, and populate it with new data
+    /// from the given `db`.
+    pub async fn rebuild(
+        &self,
+        db: &Sqlite,
+        search_settings: &Search,
+    ) -> Result<Self, LoadFromDbError> {
+        Self::from_db(self.shells.clone(), db, search_settings).await
+    }
+
+    /// Number of history rows loaded per page when (re)building an index from the database.
+    pub const HISTORY_LOAD_PAGE_SIZE: usize = 5000;
+
     /// Load every history entry from `db` into this index.
     pub async fn load_from_db(&self, db: &Sqlite) -> Result<(), LoadFromDbError> {
-        /// Number of history rows loaded per page when (re)building an index from the database.
-        const INDEX_LOAD_PAGE_SIZE: usize = 5000;
-
-        let mut pager = db.all_paged(INDEX_LOAD_PAGE_SIZE, false, true);
-        loop {
-            match pager.next().await {
-                Ok(Some(histories)) => self.add_histories(&histories),
-                Ok(None) => return Ok(()),
-                Err(e) => return Err(LoadFromDbError(e.into())),
-            }
+        let mut pages = pin!(Self::history_pages(db));
+        while let Some(histories) = pages.try_next().await? {
+            self.add_histories(&histories);
         }
+        Ok(())
+    }
+
+    /// Stream every history entry in `db`, one page at a time.
+    pub fn history_pages(db: &Sqlite) -> impl Stream<Item = Result<Vec<History>, LoadFromDbError>> {
+        stream::try_unfold(
+            db.all_paged(Self::HISTORY_LOAD_PAGE_SIZE, false, true),
+            |mut pager| async move {
+                match pager.next().await {
+                    Ok(Some(histories)) => Ok(Some((histories, pager))),
+                    Ok(None) => Ok(None),
+                    Err(e) => Err(LoadFromDbError(e.into())),
+                }
+            },
+        )
     }
 
     /// Add a history entry to the index.

--- a/crates/atuin-daemon/src/search/mod.rs
+++ b/crates/atuin-daemon/src/search/mod.rs
@@ -2,11 +2,7 @@
 //!
 //! This module provides fuzzy search over command history using frizbee.
 
-use std::borrow::Cow;
-
 mod index;
-#[allow(clippy::manual_range_contains, reason = "this is a vendored file")]
-mod normalize;
 
 // Include the generated proto code
 mod proto {
@@ -26,25 +22,8 @@ const MAX_QUERY_LEN: usize = 512;
 /// client-side highlighting) must apply this.
 #[must_use]
 pub fn truncate_query(query: &str) -> &str {
-    // O(1) happy path -- query cannot exceed `MAX_QUERY_LEN` chars if it doesn't even have that
-    // many bytes.
-    if query.len() <= MAX_QUERY_LEN {
-        return query;
-    }
-    match query.char_indices().nth(MAX_QUERY_LEN) {
-        Some((end, _)) => &query[..end],
-        None => query,
-    }
-}
-
-/// Normalize Latin diacritics to their ASCII equivalents (`é` → `e`) so unaccented queries match
-/// accented history entries. Maps char to char so char positions are preserved.
-pub fn normalize_diacritics(s: &str) -> Cow<'_, str> {
-    use normalize::normalize;
-    if s.is_ascii() || !s.chars().any(|c| normalize(c) != c) {
-        return Cow::Borrowed(s);
-    }
-    Cow::Owned(s.chars().map(normalize).collect())
+    use atuin_common::string::TruncateCharsExt;
+    query.truncate_chars(MAX_QUERY_LEN)
 }
 
 // Re-export the index and related types

--- a/crates/atuin-daemon/tests/lifecycle.rs
+++ b/crates/atuin-daemon/tests/lifecycle.rs
@@ -384,7 +384,8 @@ mod unix {
 
         assert_eq!(search_index.read().await.command_count(), 2);
 
-        let deleted = journal.delete([id_a]).await.unwrap();
+        let deleted =
+            journal.delete([id_a], &atuin_client::settings::Search::default()).await.unwrap();
         assert_eq!(deleted, 1);
 
         let index = search_index.read().await;

--- a/crates/atuin-daemon/tests/lifecycle.rs
+++ b/crates/atuin-daemon/tests/lifecycle.rs
@@ -275,4 +275,121 @@ mod unix {
         let result = client.status().await;
         assert!(result.is_err());
     }
+
+    #[rstest]
+    #[tokio::test]
+    async fn test_delete_history_removes_entry(
+        #[future] daemon: (HistoryClient, DaemonHandle, TempDir),
+    ) {
+        use atuin_client::history::History;
+
+        let (mut client, _handle, _tmp) = daemon.await;
+
+        let history: History = History::daemon()
+            .timestamp(time::OffsetDateTime::now_utc())
+            .command("echo delete-me".to_string())
+            .cwd("/tmp".to_string())
+            .session(uuid::Uuid::new_v4().to_string())
+            .cmd_origin(atuin_domain::record::CmdOrigin::try_from("test-host:test-user").unwrap())
+            .shell("bash")
+            .build()
+            .into();
+
+        let start = client.start_history(history).await.unwrap();
+        let id: HistoryId = start.id.unwrap().try_into().unwrap();
+        client.end_history(id, Some(Duration::from_millis(1)), 0).await.unwrap();
+
+        let reply = client.delete_history(vec![id]).await.unwrap();
+        assert_eq!(reply.deleted, 1);
+        assert_eq!(reply.protocol, 2);
+
+        // Deleting an already-deleted id still succeeds (idempotent), counting the record write.
+        let reply = client.delete_history(vec![id]).await.unwrap();
+        assert_eq!(reply.deleted, 1);
+    }
+
+    #[tokio::test]
+    async fn journal_delete_removes_entry_and_rebuilds_index() {
+        use std::sync::Arc;
+        use std::time::Duration;
+
+        use atuin_client::database::Sqlite;
+        use atuin_client::history::History;
+        use atuin_client::history::store::HistoryStore;
+        use atuin_client::record::sqlite_store::SqliteStore;
+        use atuin_client::settings::{Settings, init_meta_config_for_testing};
+        use atuin_daemon::search::{IndexFilterMode, SearchIndex};
+        use atuin_daemon::{HistoryJournal, SemanticComponent};
+        use tokio::sync::RwLock;
+
+        let tmp = tempfile::tempdir().unwrap();
+        let db_path = tmp.path().join("history.db");
+        let record_path = tmp.path().join("records.db");
+        let key_path = tmp.path().join("key");
+        let meta_path = tmp.path().join("meta.db");
+        init_meta_config_for_testing(meta_path.to_str().unwrap(), 5.0);
+
+        let settings: Settings = Settings::builder()
+            .unwrap()
+            .set_override("db_path", db_path.to_str().unwrap())
+            .unwrap()
+            .set_override("record_store_path", record_path.to_str().unwrap())
+            .unwrap()
+            .set_override("key_path", key_path.to_str().unwrap())
+            .unwrap()
+            .set_override("meta.db_path", meta_path.to_str().unwrap())
+            .unwrap()
+            .build()
+            .unwrap()
+            .try_deserialize()
+            .unwrap();
+
+        let history_db = Sqlite::new(&db_path, Duration::from_secs(5)).await.unwrap();
+        let store = SqliteStore::new(&record_path, Duration::from_secs(5)).await.unwrap();
+        let key =
+            atuin_common::encryption::paseto_v4::Key::try_load_or_generate(&key_path).unwrap();
+        let host_id = Settings::host_id().await.unwrap();
+        let caps = atuin_client::api_client::caps_client(&settings).unwrap();
+
+        let search_index = Arc::new(RwLock::new(SearchIndex::default()));
+        let history_store = HistoryStore::new(store.clone(), host_id, key);
+        let journal = HistoryJournal::new(
+            caps,
+            history_store,
+            history_db.clone(),
+            SemanticComponent::new(),
+            search_index.clone(),
+        );
+
+        // Two distinct commands. Sessions MUST be valid UUIDs or the index skips them.
+        let mk = |cmd: &str| -> History {
+            History::daemon()
+                .timestamp(time::OffsetDateTime::now_utc())
+                .command(cmd.to_string())
+                .cwd("/tmp".to_string())
+                .session(uuid::Uuid::new_v4().to_string())
+                .cmd_origin(
+                    atuin_domain::record::CmdOrigin::try_from("test-host:test-user").unwrap(),
+                )
+                .shell("bash")
+                .build()
+                .into()
+        };
+        let ha = mk("delete_me");
+        let hb = mk("keep_me");
+        let id_a = journal.start_cmd(ha);
+        journal.finish(id_a, 0, Duration::from_millis(1)).await.unwrap();
+        let id_b = journal.start_cmd(hb);
+        journal.finish(id_b, 0, Duration::from_millis(1)).await.unwrap();
+
+        assert_eq!(search_index.read().await.command_count(), 2);
+
+        let deleted = journal.delete([id_a]).await.unwrap();
+        assert_eq!(deleted, 1);
+
+        let index = search_index.read().await;
+        assert_eq!(index.command_count(), 1, "index should be rebuilt without the deleted command");
+        assert_eq!(index.search("delete_me", &IndexFilterMode::Global, 10).count(), 0);
+        assert_eq!(index.search("keep_me", &IndexFilterMode::Global, 10).count(), 1);
+    }
 }

--- a/crates/atuin-pty-proxy/src/runtime.rs
+++ b/crates/atuin-pty-proxy/src/runtime.rs
@@ -66,6 +66,7 @@ fn run(options: RuntimeOptions) -> eyre::Result<()> {
     // umask the user launched us with. Applied in the child between fork and
     // exec, so the proxy's own umask stays restrictive.
     if let Some(mask) = options.child_umask {
+        #[allow(clippy::cast_possible_truncation)]
         cmd.umask(Some(mask as _));
     }
 

--- a/crates/atuin-pty-proxy/src/runtime.rs
+++ b/crates/atuin-pty-proxy/src/runtime.rs
@@ -66,7 +66,10 @@ fn run(options: RuntimeOptions) -> eyre::Result<()> {
     // umask the user launched us with. Applied in the child between fork and
     // exec, so the proxy's own umask stays restrictive.
     if let Some(mask) = options.child_umask {
-        #[allow(clippy::cast_possible_truncation)]
+        #[allow(
+            clippy::cast_possible_truncation,
+            reason = "mode_t is u16 on macOS and u32 on Linux. nop on linux, narrowing on macOS."
+        )]
         cmd.umask(Some(mask as _));
     }
 
@@ -77,10 +80,15 @@ fn run(options: RuntimeOptions) -> eyre::Result<()> {
     let mut pty_writer = pair.master.take_writer().map_err(|e| eyre::eyre!("{e:#}"))?;
 
     let (msg_tx, msg_rx) = mpsc::sync_channel::<Msg>(64);
-    let _parser_handle = screen::spawn_parser_thread(rows, cols, msg_rx, screen::ParserOptions {
-        sink: options.command_capture_sink,
-        debug_osc133: options.debug_osc133,
-    });
+    let _parser_handle = screen::spawn_parser_thread(
+        rows,
+        cols,
+        msg_rx,
+        screen::ParserOptions {
+            sink: options.command_capture_sink,
+            debug_osc133: options.debug_osc133,
+        },
+    );
     if let Some(path) = &sock_path {
         screen::spawn_socket_server(path.clone(), msg_tx.clone());
     }

--- a/crates/atuin-pty-proxy/src/runtime.rs
+++ b/crates/atuin-pty-proxy/src/runtime.rs
@@ -80,15 +80,10 @@ fn run(options: RuntimeOptions) -> eyre::Result<()> {
     let mut pty_writer = pair.master.take_writer().map_err(|e| eyre::eyre!("{e:#}"))?;
 
     let (msg_tx, msg_rx) = mpsc::sync_channel::<Msg>(64);
-    let _parser_handle = screen::spawn_parser_thread(
-        rows,
-        cols,
-        msg_rx,
-        screen::ParserOptions {
-            sink: options.command_capture_sink,
-            debug_osc133: options.debug_osc133,
-        },
-    );
+    let _parser_handle = screen::spawn_parser_thread(rows, cols, msg_rx, screen::ParserOptions {
+        sink: options.command_capture_sink,
+        debug_osc133: options.debug_osc133,
+    });
     if let Some(path) = &sock_path {
         screen::spawn_socket_server(path.clone(), msg_tx.clone());
     }

--- a/crates/atuin/src/command/client/daemon.rs
+++ b/crates/atuin/src/command/client/daemon.rs
@@ -493,6 +493,13 @@ pub async fn cancel_history(settings: &Settings, id: HistoryId) -> Result<()> {
     Ok(())
 }
 
+pub async fn delete_history(settings: &Settings, ids: Vec<HistoryId>) -> Result<u64> {
+    let reply =
+        try_with_restart(settings, async |client, ids| client.delete_history(ids).await, ids)
+            .await?;
+    Ok(reply.deleted)
+}
+
 /// Emit a daemon event, auto-starting the daemon if it is not running.
 ///
 /// If the daemon is not reachable and `daemon.autostart` is enabled, this

--- a/crates/atuin/src/command/client/history.rs
+++ b/crates/atuin/src/command/client/history.rs
@@ -32,8 +32,6 @@ use time::OffsetDateTime;
 use tracing::{debug, instrument, warn};
 
 #[cfg(feature = "daemon")]
-use super::daemon as daemon_cmd;
-#[cfg(feature = "daemon")]
 use super::daemon;
 
 #[derive(Subcommand, Debug)]
@@ -619,6 +617,30 @@ pub(super) async fn end_history_entry(
     handle_end(&db, store, history_store, settings, id, exit, duration).await
 }
 
+/// Delete history entries, routing through the daemon when it owns the store.
+///
+/// When `daemon.enabled`, the daemon performs the deletion and updates its in-memory search index;
+/// otherwise (or if the daemon is unreachable) we delete directly via the record store and rebuild
+/// the affected rows locally.
+#[cfg_attr(not(feature = "daemon"), allow(unused_variables))]
+pub(super) async fn delete_history_entries(
+    settings: &Settings,
+    history_store: &HistoryStore,
+    db: &Sqlite,
+    entries: impl IntoIterator<Item = History>,
+) -> Result<()> {
+    #[cfg(feature = "daemon")]
+    if settings.daemon.enabled {
+        let ids: Vec<HistoryId> = entries.into_iter().map(|h| h.id).collect();
+        daemon::delete_history(settings, ids).await?;
+        return Ok(());
+    }
+
+    let ids = history_store.delete_entries(entries).await?;
+    history_store.build_all(db, &ids).await?;
+    Ok(())
+}
+
 #[cfg(feature = "daemon")]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 enum TailKind {
@@ -1011,14 +1033,11 @@ impl Cmd {
             let host_id = Settings::host_id().await?;
             let history_store = HistoryStore::new(store.clone(), host_id, encryption_key);
 
-            for entry in matches {
+            for entry in &matches {
                 eprintln!("deleting {}", entry.id);
-                let (id, _) = history_store.delete(entry.id).await?;
-                history_store.build_all(db, &[id]).await?;
             }
 
-            #[cfg(feature = "daemon")]
-            daemon_cmd::emit_event(settings, atuin_daemon::DaemonEvent::HistoryPruned).await;
+            delete_history_entries(settings, &history_store, db, matches).await?;
         }
         Ok(())
     }
@@ -1066,18 +1085,11 @@ impl Cmd {
             let host_id = Settings::host_id().await?;
             let history_store = HistoryStore::new(store.clone(), host_id, encryption_key);
 
-            #[cfg(feature = "daemon")]
-            let ids = matches.iter().map(|h| h.id).collect::<Vec<_>>();
-
-            for entry in matches {
+            for entry in &matches {
                 eprintln!("deleting {}", entry.id);
-                let (id, _) = history_store.delete(entry.id).await?;
-                history_store.build_all(db, &[id]).await?;
             }
 
-            #[cfg(feature = "daemon")]
-            daemon_cmd::emit_event(settings, atuin_daemon::DaemonEvent::HistoryDeleted { ids })
-                .await;
+            delete_history_entries(settings, &history_store, db, matches).await?;
         }
         Ok(())
     }

--- a/crates/atuin/src/command/client/search.rs
+++ b/crates/atuin/src/command/client/search.rs
@@ -294,8 +294,8 @@ impl Cmd {
                         eprintln!("deleting {}", entry.id);
                     }
 
-                    let ids = history_store.delete_entries(entries).await?;
-                    history_store.build_all(&db, &ids).await?;
+                    super::history::delete_history_entries(settings, &history_store, &db, entries)
+                        .await?;
 
                     entries = run_non_interactive(settings, opt_filter, &query, &db).await?;
                 }

--- a/crates/atuin/src/command/client/search/engines/daemon.rs
+++ b/crates/atuin/src/command/client/search/engines/daemon.rs
@@ -1,8 +1,9 @@
 use atuin_client::database::{DbSearchMode, OptFilters, Sqlite};
 use atuin_client::history::{History, HistoryId, all_user_author_filter};
 use atuin_client::settings::Settings;
+use atuin_common::string::NormalizeDiacriticsExt;
 use atuin_daemon::client::{SearchClient, SearchParams};
-use atuin_daemon::search::{normalize_diacritics, truncate_query};
+use atuin_daemon::search::truncate_query;
 use easy_cast::Conv;
 use eyre::Result;
 use tracing::{Level, debug, instrument, span};
@@ -240,8 +241,8 @@ impl SearchEngine for Search {
         // Mirror the daemon's query handling: truncate before frizbee sees
         // the query (a long enough atom panics Matcher::from_query) and
         // normalize diacritics so highlighting agrees with matching
-        let search_input = normalize_diacritics(truncate_query(search_input));
-        let matchable = normalize_diacritics(command);
+        let search_input = truncate_query(search_input).normalize_diacritics();
+        let matchable = command.normalize_diacritics();
 
         let config = frizbee::Config::default().casing(frizbee::CaseMatching::Smart);
         let mut matcher = frizbee::Matcher::from_query(&search_input, &config);

--- a/crates/atuin/src/command/client/search/interactive.rs
+++ b/crates/atuin/src/command/client/search/interactive.rs
@@ -1939,8 +1939,13 @@ pub async fn history(
 
                                 let entry = results.remove(index);
 
-                                let ids = history_store.delete_entries([entry]).await?;
-                                history_store.build_all(&db, &ids).await?;
+                                crate::command::client::history::delete_history_entries(
+                                    settings,
+                                    history_store,
+                                    &db,
+                                    [entry],
+                                )
+                                .await?;
 
                                 app.tab_index  = 0;
                             },
@@ -1963,8 +1968,13 @@ pub async fn history(
                                     )
                                 ).await?;
 
-                                let ids = history_store.delete_entries(all_matching).await?;
-                                history_store.build_all(&db, &ids).await?;
+                                crate::command::client::history::delete_history_entries(
+                                    settings,
+                                    history_store,
+                                    &db,
+                                    all_matching,
+                                )
+                                .await?;
 
                                 app.results_len = results.len();
                                 app.results_state = ListState::default();


### PR DESCRIPTION
This PR removes some slightly janky events we've had in the daemon. Historically we had:

- the client do deletions and then **notify** the daemon that deletions have happened and that it needs to rebuild its index.

Now:

- the client asks the daemon to perform the deletions.
- removes HistoryDeleted and HistoryPruned events.

Some bug-fixes/feature improvements that happened:

- Historically, the daemon forgot to cancel in flight commands on history delete. Now it does!
- **`atuin search --delete` forgot to notify the daemon to refresh the index** -- now it does!
- Added some short-circuiting to avoid rebuilding the index if not necessary (now we have some extra info in the daemon that enables that).

Why: We're slowly inching towards having the daemon own the majority of the lifecycle.

## To Do

- [ ] Run a bunch of smoke tests
- [ ] Reviews =)