### PR TITLE
chore: sort dependencies in `Cargo.toml`s

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,6 @@
 [workspace]
-members = ["crates/*"]
-
 resolver = "2"
+members = ["crates/*"]
 exclude = ["ui/backend"]
 
 [workspace.package]
@@ -14,8 +13,6 @@ repository = "https://github.com/atuinsh/atuin"
 readme = "README.md"
 
 [workspace.dependencies]
-async-trait = "0.1.58"
-enum_dispatch = "0.3"
 atuin-ai = { path = "crates/atuin-ai", version = "18.21.0", default-features = false }
 atuin-client = { path = "crates/atuin-client", version = "18.21.0" }
 atuin-common = { path = "crates/atuin-common", version = "18.21.0" }
@@ -28,162 +25,158 @@ atuin-pty-proxy = { path = "crates/atuin-pty-proxy", version = "18.21.0", defaul
 atuin-scripts = { path = "crates/atuin-scripts", version = "18.21.0" }
 atuin-server = { path = "crates/atuin-server", version = "18.21.0" }
 atuin-vt100 = "0.17"
-frizbee = "0.12.0"
+
+arboard = { version = "3.4", default-features = false }
+argon2 = "0.5"
+async-stream = "0.3"
+async-trait = "0.1.58"
+axoupdater = "0.10"
+axum = "0.8"
 base64 = "0.22"
-crossterm = "0.29.0"
-time = { version = "0.3.47", features = [
-  "serde-human-readable",
-  "macros",
-  "local-offset",
-] }
+chrono = "0.4"
+chrono-humanize = "0.2"
 clap = { version = "4.5.7", features = ["derive"] }
+clap_complete = "4.6.1"
+clap_complete_nushell = "4.5.4"
+colored = "2.0.4"
 config = { version = "0.15.8", default-features = false, features = ["toml"] }
-derive_more = { version = "2", features = ["as_ref", "deref", "display", "error", "from", "into", "debug"] }
+crossterm = "0.29.0"
+crypto_secretbox = "0.1.1"
+daemonize = "0.5.0"
+dashmap = "6.1.0"
+derive_more = {
+    version = "2",
+    features = ["as_ref", "deref", "display", "error", "from", "into", "debug"],
+}
 directories = "6.0.0"
+divan = { version = "5.0.1", package = "codspeed-divan-compat" }
 easy-cast = "0.7.1"
+enum_dispatch = "0.3"
+eventsource-stream = "0.2"
+eye_declare = "0.6.4"
+eye_declare_engine = { version = "0.6.4", features = ["test-util"] }
 eyre = "0.6"
+frizbee = "0.12.0"
 fs-err = "3.1"
+futures = "0.3"
+futures-util = "0.3"
+getrandom = "0.4"
+glob-match = "0.2.1"
 http = "1.5"
-reqwest-middleware = "0.5"
-wiremock = "0.6"
+humantime = "2.1.0"
+hyper-util = "0.1"
+imara-diff = "0.2"
+indicatif = "0.18.0"
 interim = { version = "0.2.0", features = ["time_0_3"] }
 itertools = "0.15.0"
-rand = { version = "0.8.5", features = ["std"] }
-semver = "1.0.20"
-serde = { version = "1.0.202", features = ["derive"] }
-serde_json = "1.0.119"
-shellexpand = "3"
-tokio = { version = "1", features = ["full"] }
-tokio-util = { version = "0.7", features = ["rt"] }
-uuid = { version = "1.9", features = ["v4", "v7", "serde"] }
-whoami = "2.1.0"
-typed-builder = "0.23.2"
+lasso = { version = "0.7", features = ["multi-threaded"] }
+# Version range mirrors sqlx-sqlite's so cargo unifies both to a single
+# `links = "sqlite3"` package (one bundled SQLite).
+libsqlite3-sys = ">=0.30.1, <0.38.0"
+listenfd = "1.0.1"
+memchr = "2.7"
+metrics = "0.24"
+metrics-exporter-prometheus = { version = "0.18", default-features = false }
+minijinja = "2.9.0"
+minspan = "0.1.5"
+nix = { version = "0.30.1", features = ["signal"] }
+norm = { version = "0.1.1", features = ["fzf-v2"] }
+notify = "8"
+opentelemetry = "0.32"
+opentelemetry-otlp = "0.32"
+opentelemetry_sdk = "0.32"
+palette = { version = "0.7.5", features = ["serializing"] }
+parking_lot = "0.12.5"
+portable-pty = "0.9"
 pretty_assertions = "1.3.0"
 proptest = "1.11.0"
-parking_lot = "0.12.5"
-zeroize = "1"
+prost = "0.14"
+prost-types = "0.14"
+protox = "0.9"
+pulldown-cmark = "0.13.0"
+rand = { version = "0.8.5", features = ["std"] }
+ratatui = "0.30.0"
+ratatui-core = "0.1"
+ratatui-widgets = "0.3"
+regex = "1.10.5"
+reqwest = {
+    version = "0.13",
+    default-features = false,
+    features = ["json", "native-tls", "stream", "gzip", "zstd"],
+}
+reqwest-middleware = "0.5"
+rmcp = { version = "2.1.0", default-features = false, features = ["server", "transport-io"] }
+rmp = "0.8.14"
+rpassword = "7.0"
 rstest = "0.26.1"
-thiserror = "2"
+runtime-format = "0.1.3"
 rustix = { version = "1.1.4", features = ["process", "fs"] }
-nix = { version = "0.30.1", features = ["signal"] }
-windows-sys = { version = "0.61.2", features = ["Win32_System_Console", "Win32_System_Threading", "Win32_Foundation"] }
-tower = "0.5"
+rusty_paserk = { version = "0.5.0", default-features = false, features = ["v4", "serde"] }
+# rusty_paserk 0.5.0 (latest) requires rusty_paseto 0.8.0 unfortunately
+rusty_paseto = { version = "0.8.0", default-features = false }
+semver = "1.0.20"
+serde = { version = "1.0.202", features = ["derive"] }
+serde_bytes = "0.11"
+serde_json = "1.0.119"
+serde_regex = "1.1.0"
+serde_with = "3.8.1"
+shellexpand = "3"
+shlex = "2.0.1"
+signal-hook = "0.3"
+sql-builder = "3"
+sqlx = { version = "0.9", features = ["runtime-tokio", "time", "uuid"] }
+strum = { version = "0.27", features = ["strum_macros"] }
+strum_macros = "0.28"
+sysinfo = "0.30.7"
+tempfile = { version = "3.19" }
+thiserror = "2"
+time = { version = "0.3.47", features = ["serde-human-readable", "macros", "local-offset"] }
+tiny-bip39 = "2"
 # `release_max_level_info` compiles out trace/debug events in any build with
 # debug assertions off (release, dist, profiling). Builds that want the
 # `#[instrument(level = "trace")]` spans back must turn debug assertions on --
 # see the `profiling-traced` profile below.
 tracing = { version = "0.1", features = ["release_max_level_info"] }
-tree-sitter = "0.26.8"
-tree-sitter-bash = "0.25.1"
-crypto_secretbox = "0.1.1"
-tiny-bip39 = "2"
-tree-sitter-fish = "3.6.0"
-tree-sitter-powershell = "0.26.4"
-rmp = "0.8.14"
-ratatui = "0.30.0"
-sql-builder = "3"
-tempfile = { version = "3.19" }
-minijinja = "2.9.0"
-glob-match = "0.2.1"
-imara-diff = "0.2"
-xxhash-rust = { version = "0.8", features = ["xxh3"] }
-regex = "1.10.5"
+tokio = { version = "1", features = ["full"] }
+tokio-stream = { version = "0.1.14", features = ["net"] }
+tokio-util = { version = "0.7", features = ["rt"] }
+toml = "1.1"
 toml_edit = "0.25.4"
-url = { version = "2.5", features = ["serde"] }
-# rusty_paserk 0.5.0 (latest) requires rusty_paseto 0.8.0 unfortunately
-rusty_paseto = { version = "0.8.0", default-features = false }
-rusty_paserk = { version = "0.5.0", default-features = false, features = [
-  "v4",
-  "serde",
-] }
-strum = { version = "0.27", features = ["strum_macros"] }
-strum_macros = "0.28"
-
+tonic = "0.14"
+tonic-build = "0.14"
+tonic-prost = "0.14"
+tonic-prost-build = "0.14"
+tonic-types = "0.14"
+tower = "0.5"
+tower-http = { version = "0.6", features = ["trace"] }
 tracing-appender = "0.2.4"
 tracing-futures = { version = "0.2", features = ["futures-03"] }
-tracing-tree = "0.4"
 tracing-opentelemetry = "0.33"
-opentelemetry = "0.32"
-opentelemetry_sdk = "0.32"
-opentelemetry-otlp = "0.32"
-futures = "0.3"
-futures-util = "0.3"
-async-stream = "0.3"
-eventsource-stream = "0.2"
-pulldown-cmark = "0.13.0"
+tracing-subscriber = {
+    version = "0.3",
+    features = ["ansi", "fmt", "registry", "env-filter", "json"],
+}
+tracing-tree = "0.4"
+tree-sitter = "0.26.8"
+tree-sitter-bash = "0.25.1"
+tree-sitter-fish = "3.6.0"
+tree-sitter-powershell = "0.26.4"
 tui-textarea-2 = "0.10.2"
-unicode-width = "0.2"
+typed-builder = "0.23.2"
 unicode-segmentation = "1.11.0"
-eye_declare = "0.6.4"
-eye_declare_engine = { version = "0.6.4", features = ["test-util"] }
-ratatui-core = "0.1"
-ratatui-widgets = "0.3"
-toml = "1.1"
+unicode-width = "0.2"
+url = { version = "2.5", features = ["serde"] }
+uuid = { version = "1.9", features = ["v4", "v7", "serde"] }
+whoami = "2.1.0"
+windows-sys = {
+    version = "0.61.2",
+    features = ["Win32_System_Console", "Win32_System_Threading", "Win32_Foundation"],
+}
+wiremock = "0.6"
+xxhash-rust = { version = "0.8", features = ["xxh3"] }
 yaml-rust2 = "0.11"
-chrono = "0.4"
-chrono-humanize = "0.2"
-rmcp = { version = "2.1.0", default-features = false, features = ["server", "transport-io"] }
-humantime = "2.1.0"
-minspan = "0.1.5"
-serde_regex = "1.1.0"
-serde_with = "3.8.1"
-serde_bytes = "0.11"
-memchr = "2.7"
-notify = "8"
-indicatif = "0.18.0"
-palette = { version = "0.7.5", features = ["serializing"] }
+zeroize = "1"
 zstd = "0.13"
-divan = { version = "5.0.1", package = "codspeed-divan-compat" }
-sysinfo = "0.30.7"
-getrandom = "0.4"
-dashmap = "6.1.0"
-lasso = { version = "0.7", features = ["multi-threaded"] }
-tonic = "0.14"
-tonic-types = "0.14"
-tonic-prost = "0.14"
-tonic-build = "0.14"
-tonic-prost-build = "0.14"
-prost = "0.14"
-prost-types = "0.14"
-protox = "0.9"
-tokio-stream = { version = "0.1.14", features = ["net"] }
-hyper-util = "0.1"
-listenfd = "1.0.1"
-axum = "0.8"
-portable-pty = "0.9"
-signal-hook = "0.3"
-tower-http = { version = "0.6", features = ["trace"] }
-argon2 = "0.5"
-metrics = "0.24"
-metrics-exporter-prometheus = { version = "0.18", default-features = false }
-clap_complete = "4.6.1"
-clap_complete_nushell = "4.5.4"
-rpassword = "7.0"
-runtime-format = "0.1.3"
-colored = "2.0.4"
-norm = { version = "0.1.1", features = ["fzf-v2"] }
-shlex = "2.0.1"
-arboard = { version = "3.4", default-features = false }
-daemonize = "0.5.0"
-axoupdater = "0.10"
-
-[workspace.dependencies.tracing-subscriber]
-version = "0.3"
-features = ["ansi", "fmt", "registry", "env-filter", "json"]
-
-[workspace.dependencies.reqwest]
-version = "0.13"
-features = ["json", "native-tls", "stream", "gzip", "zstd"]
-default-features = false
-
-[workspace.dependencies.sqlx]
-version = "0.9"
-features = ["runtime-tokio", "time", "uuid"]
-
-# Version range mirrors sqlx-sqlite's so cargo unifies both to a single
-# `links = "sqlite3"` package (one bundled SQLite).
-[workspace.dependencies.libsqlite3-sys]
-version = ">=0.30.1, <0.38.0"
 
 # The profile that 'cargo dist' will build with
 [profile.dist]

--- a/crates/atuin-ai/Cargo.toml
+++ b/crates/atuin-ai/Cargo.toml
@@ -3,14 +3,13 @@ name = "atuin-ai"
 edition = "2024"
 description = "AI integration for Atuin CLI"
 
-rust-version = { workspace = true }
-version = { workspace = true }
-authors = { workspace = true }
-license = { workspace = true }
-homepage = { workspace = true }
-repository = { workspace = true }
-
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+authors.workspace = true
+homepage.workspace = true
+license.workspace = true
+readme.workspace = true
+repository.workspace = true
+rust-version.workspace = true
+version.workspace = true
 
 [features]
 default = []
@@ -19,64 +18,59 @@ tree-sitter = ["dep:tree-sitter", "dep:tree-sitter-bash", "dep:tree-sitter-fish"
 
 [dependencies]
 atuin-client = { workspace = true }
-atuin-domain = { workspace = true }
 atuin-common = { workspace = true, features = ["unicode", "ansi", "sqlite"] }
 atuin-daemon = { workspace = true }
+atuin-domain = { workspace = true }
 atuin-vt100 = { workspace = true }
-enum_dispatch = { workspace = true }
-parking_lot = { workspace = true }
-async-trait = { workspace = true }
-derive_more = { workspace = true }
-tokio = { workspace = true }
-eyre = { workspace = true }
-clap = { workspace = true, features = ["derive", "env"] }
-tracing = { workspace = true }
-tracing-subscriber = { workspace = true, features = [
-  "ansi",
-  "fmt",
-  "registry",
-  "env-filter",
-] }
-directories = { workspace = true }
-tracing-appender = { workspace = true }
-reqwest = { workspace = true }
-serde = { workspace = true }
-serde_json = { workspace = true }
-crossterm = { workspace = true, features = ["use-dev-tty", "event-stream"] }
-ratatui = { workspace = true }
-fs-err = { workspace = true }
-futures = { workspace = true }
-eventsource-stream = { workspace = true }
-pulldown-cmark = { workspace = true }
+
 async-stream = { workspace = true }
-uuid = { workspace = true }
-tui-textarea-2 = { workspace = true }
-unicode-width = { workspace = true }
-# Path dependency until eye_declare 0.6.0 publishes; then just a version.
+async-trait = { workspace = true }
+chrono = { workspace = true }
+chrono-humanize = { workspace = true }
+clap = { workspace = true, features = ["derive", "env"] }
+crossterm = { workspace = true, features = ["use-dev-tty", "event-stream"] }
+derive_more = { workspace = true }
+directories = { workspace = true }
+easy-cast = { workspace = true }
+enum_dispatch = { workspace = true }
+eventsource-stream = { workspace = true }
 eye_declare = { workspace = true }
 eye_declare_engine = { workspace = true }
+eyre = { workspace = true }
+fs-err = { workspace = true }
+futures = { workspace = true }
+glob-match = { workspace = true }
+imara-diff = { workspace = true }
+parking_lot = { workspace = true }
+pulldown-cmark = { workspace = true }
+ratatui = { workspace = true }
 ratatui-core = { workspace = true }
 ratatui-widgets = { workspace = true }
-thiserror = { workspace = true }
-glob-match = { workspace = true }
 regex = { workspace = true }
+reqwest = { workspace = true }
+rmcp = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+shellexpand = { workspace = true }
+sqlx = { workspace = true, features = ["sqlite"] }
+tempfile = { workspace = true }
+thiserror = { workspace = true }
 time = { workspace = true }
+tokio = { workspace = true }
 toml = { workspace = true }
 toml_edit = { workspace = true }
+tracing = { workspace = true }
+tracing-appender = { workspace = true }
+tracing-subscriber = { workspace = true, features = ["ansi", "fmt", "registry", "env-filter"] }
 tree-sitter = { workspace = true, optional = true }
 tree-sitter-bash = { workspace = true, optional = true }
 tree-sitter-fish = { workspace = true, optional = true }
-sqlx = { workspace = true, features = ["sqlite"] }
+tui-textarea-2 = { workspace = true }
 typed-builder = { workspace = true }
-shellexpand = { workspace = true }
-imara-diff = { workspace = true }
+unicode-width = { workspace = true }
+uuid = { workspace = true }
 xxhash-rust = { workspace = true }
 yaml-rust2 = { workspace = true }
-tempfile = { workspace = true }
-chrono = { workspace = true }
-chrono-humanize = { workspace = true }
-rmcp = { workspace = true }
-easy-cast = { workspace = true }
 
 [dev-dependencies]
 pretty_assertions = { workspace = true }

--- a/crates/atuin-client/Cargo.toml
+++ b/crates/atuin-client/Cargo.toml
@@ -4,14 +4,13 @@ edition = "2024"
 description = "client library for atuin"
 autobenches = false
 
-rust-version = { workspace = true }
-version = { workspace = true }
-authors = { workspace = true }
-license = { workspace = true }
-homepage = { workspace = true }
-repository = { workspace = true }
-
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+authors.workspace = true
+homepage.workspace = true
+license.workspace = true
+readme.workspace = true
+repository.workspace = true
+rust-version.workspace = true
+version.workspace = true
 
 [features]
 default = ["sync", "hub", "daemon"]
@@ -24,54 +23,57 @@ check-update = []
 vendored-tls = ["reqwest?/native-tls-vendored"]
 
 [dependencies]
-derive_more = { workspace = true }
-tracing = { workspace = true }
-tracing-futures = { workspace = true }
+atuin-common = { workspace = true, features = ["os", "sqlite"] }
+atuin-domain = { workspace = true }
+
+async-stream = { workspace = true }
+async-trait = { workspace = true }
 base64 = { workspace = true }
-zeroize = { workspace = true }
-time = { workspace = true, features = ["macros", "formatting", "parsing"] }
 clap = { workspace = true }
-eyre = { workspace = true }
-directories = { workspace = true }
-uuid = { workspace = true }
-whoami = { workspace = true }
-interim = { workspace = true }
 config = { workspace = true }
+derive_more = { workspace = true }
+directories = { workspace = true }
+easy-cast = { workspace = true }
+enum_dispatch = { workspace = true }
+eyre = { workspace = true }
+fs-err = { workspace = true }
+futures = { workspace = true }
+humantime = { workspace = true }
+interim = { workspace = true }
+itertools = { workspace = true }
+libsqlite3-sys = { workspace = true }
+memchr = { workspace = true }
+minspan = { workspace = true }
+notify = { workspace = true }
+rand = { workspace = true }
+regex = { workspace = true }
+semver = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
-url = { workspace = true }
-humantime = { workspace = true }
-enum_dispatch = { workspace = true }
-async-trait = { workspace = true }
-itertools = { workspace = true }
-rand = { workspace = true }
-shellexpand = { workspace = true }
-sqlx = { workspace = true, features = ["sqlite", "regexp"] }
-libsqlite3-sys = { workspace = true }
-minspan = { workspace = true }
-regex = { workspace = true }
 serde_regex = { workspace = true }
-fs-err = { workspace = true }
-sql-builder = { workspace = true }
-memchr = { workspace = true }
-typed-builder = { workspace = true }
-tokio = { workspace = true }
-semver = { workspace = true }
-thiserror = { workspace = true }
-futures = { workspace = true }
-async-stream = { workspace = true }
-notify = { workspace = true }
 serde_with = { workspace = true }
-easy-cast = { workspace = true }
+shellexpand = { workspace = true }
+sql-builder = { workspace = true }
+sqlx = { workspace = true, features = ["sqlite", "regexp"] }
+thiserror = { workspace = true }
+time = { workspace = true, features = ["macros", "formatting", "parsing"] }
+tokio = { workspace = true }
+tracing = { workspace = true }
+tracing-futures = { workspace = true }
+typed-builder = { workspace = true }
+url = { workspace = true }
+uuid = { workspace = true }
+whoami = { workspace = true }
+zeroize = { workspace = true }
 
 # encryption
-rusty_paseto = { workspace = true }
 rusty_paserk = { workspace = true }
+rusty_paseto = { workspace = true }
 
 # sync
+indicatif = { workspace = true }
 reqwest = { workspace = true, optional = true }
 reqwest-middleware = { workspace = true, optional = true, features = ["json", "query"] }
-indicatif = { workspace = true }
 tiny-bip39 = { workspace = true }
 
 # theme
@@ -84,27 +86,17 @@ strum_macros = { workspace = true }
 zstd = { workspace = true }
 serde_bytes = { workspace = true }
 
-[dependencies.atuin-common]
-workspace = true
-features = ["os", "sqlite"]
-
-[dependencies.atuin-domain]
-workspace = true
-
 [dev-dependencies]
-tokio = { workspace = true }
+# This crate's tests require the `test-utils` feature in atuin-common.
+atuin-common = { workspace = true, features = ["test-utils"] }
+divan = { workspace = true }
 pretty_assertions = { workspace = true }
 proptest = { workspace = true }
 rstest = { workspace = true }
-divan = { workspace = true }
 tempfile = { workspace = true }
+tokio = { workspace = true }
 toml = { workspace = true }
 wiremock = { workspace = true }
-
-# This crate's tests require the `test-utils` feature in atuin-common.
-[dev-dependencies.atuin-common]
-workspace = true
-features = ["test-utils"]
 
 [[bench]]
 name = "benchmarks"

--- a/crates/atuin-common/Cargo.toml
+++ b/crates/atuin-common/Cargo.toml
@@ -3,14 +3,13 @@ name = "atuin-common"
 edition = "2024"
 description = "common library for atuin"
 
-rust-version = { workspace = true }
-version = { workspace = true }
-authors = { workspace = true }
-license = { workspace = true }
-homepage = { workspace = true }
-repository = { workspace = true }
-
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+authors.workspace = true
+homepage.workspace = true
+license.workspace = true
+readme.workspace = true
+repository.workspace = true
+rust-version.workspace = true
+version.workspace = true
 
 [features]
 test-utils = ["dep:tracing-subscriber"]
@@ -22,39 +21,40 @@ sqlite = ["db", "sqlx/sqlite", "sqlx/regexp", "dep:libsqlite3-sys", "dep:tokio-u
 
 [dependencies]
 atuin-vt100 = { workspace = true, optional = true }
-derive_more = { workspace = true }
-tiny-bip39 = { workspace = true }
-crypto_secretbox = { workspace = true }
-time = { workspace = true, features = ["formatting", "parsing"] }
-serde = { workspace = true }
-serde_with = { workspace = true }
-uuid = { workspace = true }
-eyre = { workspace = true }
-url = { workspace = true }
-thiserror = { workspace = true }
-directories = { workspace = true }
-sysinfo = { workspace = true }
+
 base64 = { workspace = true }
+crypto_secretbox = { workspace = true }
+derive_more = { workspace = true }
+directories = { workspace = true }
+easy-cast = { workspace = true }
+eyre = { workspace = true }
+fs-err = { workspace = true }
+futures = { workspace = true }
 getrandom = { workspace = true }
-tracing = { workspace = true }
-tracing-subscriber = { workspace = true, optional = true }
-unicode-width = { workspace = true, optional = true }
-unicode-segmentation = { workspace = true, optional = true }
 itertools = { workspace = true }
-rusty_paseto = { workspace = true }
+libsqlite3-sys = { workspace = true, optional = true }
+parking_lot = { workspace = true }
+rmp = { workspace = true }
 rusty_paserk = { workspace = true }
+rusty_paseto = { workspace = true }
+semver = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+serde_with = { workspace = true }
+sqlx = { workspace = true, optional = true }
+sysinfo = { workspace = true }
+thiserror = { workspace = true }
+time = { workspace = true, features = ["formatting", "parsing"] }
+tiny-bip39 = { workspace = true }
 tokio = { workspace = true }
 tokio-util = { workspace = true, optional = true }
-parking_lot = { workspace = true }
-futures = { workspace = true }
-serde_json = { workspace = true }
+tracing = { workspace = true }
+tracing-subscriber = { workspace = true, optional = true }
+unicode-segmentation = { workspace = true, optional = true }
+unicode-width = { workspace = true, optional = true }
+url = { workspace = true }
+uuid = { workspace = true }
 zeroize = { workspace = true }
-rmp = { workspace = true }
-fs-err = { workspace = true }
-semver = { workspace = true }
-sqlx = { workspace = true, optional = true }
-libsqlite3-sys = { workspace = true, optional = true }
-easy-cast = { workspace = true }
 
 [target.'cfg(unix)'.dependencies]
 rustix = { workspace = true, optional = true }

--- a/crates/atuin-daemon/Cargo.toml
+++ b/crates/atuin-daemon/Cargo.toml
@@ -1,54 +1,46 @@
 [package]
 name = "atuin-daemon"
 edition = "2024"
-version = { workspace = true }
 description = "The daemon crate for Atuin"
 
 authors.workspace = true
-rust-version.workspace = true
-license.workspace = true
 homepage.workspace = true
-repository.workspace = true
+license.workspace = true
 readme.workspace = true
-
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+repository.workspace = true
+rust-version.workspace = true
+version.workspace = true
 
 [dependencies]
 atuin-client = { workspace = true }
-parking_lot = { workspace = true }
+atuin-common = { workspace = true, features = ["os"] }
 atuin-domain = { workspace = true }
-enum_dispatch = { workspace = true }
-derive_more = { workspace = true }
 atuin-dotfiles = { workspace = true }
 atuin-history = { workspace = true }
-
-time = { workspace = true }
-uuid = { workspace = true }
-tokio = { workspace = true }
-tower = { workspace = true }
-eyre = { workspace = true }
-tracing = { workspace = true }
-tracing-subscriber = { workspace = true }
-reqwest = { workspace = true }
-
 dashmap = { workspace = true }
-lasso = { workspace = true }
-tonic-types = { workspace = true }
-tonic = { workspace = true }
-tonic-prost = { workspace = true }
-prost = { workspace = true }
-prost-types = { workspace = true }
-tokio-stream = { workspace = true }
+derive_more = { workspace = true }
+easy-cast = { workspace = true }
+enum_dispatch = { workspace = true }
+eyre = { workspace = true }
+frizbee = { workspace = true }
 futures = { workspace = true }
 hyper-util = { workspace = true }
-
-rand.workspace = true
-frizbee = { workspace = true }
-easy-cast = { workspace = true }
-
-[dependencies.atuin-common]
-workspace = true
-features = ["os"]
+lasso = { workspace = true }
+parking_lot = { workspace = true }
+prost = { workspace = true }
+prost-types = { workspace = true }
+rand = { workspace = true }
+reqwest = { workspace = true }
+time = { workspace = true }
+tokio = { workspace = true }
+tokio-stream = { workspace = true }
+tonic = { workspace = true }
+tonic-prost = { workspace = true }
+tonic-types = { workspace = true }
+tower = { workspace = true }
+tracing = { workspace = true }
+tracing-subscriber = { workspace = true }
+uuid = { workspace = true }
 
 [target.'cfg(target_os = "linux")'.dependencies]
 listenfd = { workspace = true }

--- a/crates/atuin-domain/Cargo.toml
+++ b/crates/atuin-domain/Cargo.toml
@@ -3,40 +3,40 @@ name = "atuin-domain"
 edition = "2024"
 description = "Core domain and API types shared across Atuin's client, daemon, and server"
 
-rust-version = { workspace = true }
-version = { workspace = true }
-authors = { workspace = true }
-license = { workspace = true }
-homepage = { workspace = true }
-repository = { workspace = true }
-
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+authors.workspace = true
+homepage.workspace = true
+license.workspace = true
+readme.workspace = true
+repository.workspace = true
+rust-version.workspace = true
+version.workspace = true
 
 [dependencies]
-serde = { workspace = true }
 atuin-common = { workspace = true }
-whoami = { workspace = true }
-uuid = { workspace = true }
-time = { workspace = true }
-semver = { workspace = true }
-typed-builder = { workspace = true }
-derive_more = { workspace = true }
-eyre = { workspace = true }
-sqlx = { workspace = true }
-thiserror = { workspace = true }
-url = { workspace = true }
-serde_json = { workspace = true }
-reqwest = { workspace = true }
+
 async-trait = { workspace = true }
-parking_lot = { workspace = true }
-reqwest-middleware = { workspace = true }
-http = { workspace = true }
-xxhash-rust = { workspace = true }
-tokio = { workspace = true }
 axum = { workspace = true, optional = true }
+derive_more = { workspace = true }
+easy-cast = { workspace = true }
+eyre = { workspace = true }
+http = { workspace = true }
+parking_lot = { workspace = true }
+reqwest = { workspace = true }
+reqwest-middleware = { workspace = true }
+semver = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+sqlx = { workspace = true }
 strum = { workspace = true }
 strum_macros = { workspace = true }
-easy-cast = { workspace = true }
+thiserror = { workspace = true }
+time = { workspace = true }
+tokio = { workspace = true }
+typed-builder = { workspace = true }
+url = { workspace = true }
+uuid = { workspace = true }
+whoami = { workspace = true }
+xxhash-rust = { workspace = true }
 
 [features]
 # Feature-gated axum integration for the server-side capability handlers (`caps::axum`).
@@ -44,10 +44,10 @@ axum = ["dep:axum"]
 
 [dev-dependencies]
 pretty_assertions = { workspace = true }
-rstest = { workspace = true }
 proptest = { workspace = true }
-wiremock = { workspace = true }
+rstest = { workspace = true }
 tower = { workspace = true, features = ["util"] }
+wiremock = { workspace = true }
 
 [lints]
 workspace = true

--- a/crates/atuin-dotfiles/Cargo.toml
+++ b/crates/atuin-dotfiles/Cargo.toml
@@ -2,30 +2,28 @@
 name = "atuin-dotfiles"
 description = "The dotfiles crate for Atuin"
 edition = "2024"
-version = { workspace = true }
 
 authors.workspace = true
-rust-version.workspace = true
-license.workspace = true
 homepage.workspace = true
-repository.workspace = true
+license.workspace = true
 readme.workspace = true
-
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+repository.workspace = true
+rust-version.workspace = true
+version.workspace = true
 
 [dependencies]
+atuin-client = { workspace = true }
 atuin-common = { workspace = true }
 atuin-domain = { workspace = true }
-atuin-client = { workspace = true }
-derive_more = { workspace = true }
 
+crypto_secretbox = { workspace = true }
+derive_more = { workspace = true }
 eyre = { workspace = true }
+rand = { workspace = true }
+rmp = { workspace = true }
+serde = { workspace = true }
 tokio = { workspace = true }
 tracing = { workspace = true }
-rmp = { workspace = true }
-rand = { workspace = true }
-serde = { workspace = true }
-crypto_secretbox = { workspace = true }
 
 [dev-dependencies]
 rstest = { workspace = true }

--- a/crates/atuin-history/Cargo.toml
+++ b/crates/atuin-history/Cargo.toml
@@ -2,25 +2,23 @@
 name = "atuin-history"
 description = "The history crate for Atuin"
 edition = "2024"
-version = { workspace = true }
 
 authors.workspace = true
-rust-version.workspace = true
-license.workspace = true
 homepage.workspace = true
-repository.workspace = true
+license.workspace = true
 readme.workspace = true
-
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+repository.workspace = true
+rust-version.workspace = true
+version.workspace = true
 
 [dependencies]
 atuin-client = { workspace = true }
 
-time = { workspace = true }
-serde = { workspace = true }
 crossterm = { workspace = true, features = ["use-dev-tty"] }
-unicode-segmentation = { workspace = true }
 easy-cast = { workspace = true }
+serde = { workspace = true }
+time = { workspace = true }
+unicode-segmentation = { workspace = true }
 
 [dev-dependencies]
 divan = { workspace = true }

--- a/crates/atuin-kv/Cargo.toml
+++ b/crates/atuin-kv/Cargo.toml
@@ -1,33 +1,31 @@
 [package]
 name = "atuin-kv"
 edition = "2024"
-version = { workspace = true }
 description = "The kv crate for Atuin"
 
 authors.workspace = true
-rust-version.workspace = true
-license.workspace = true
 homepage.workspace = true
-repository.workspace = true
+license.workspace = true
 readme.workspace = true
-
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+repository.workspace = true
+rust-version.workspace = true
+version.workspace = true
 
 [dependencies]
 atuin-client = { workspace = true }
 atuin-common = { workspace = true, features = ["sqlite"] }
 atuin-domain = { workspace = true }
-derive_more = { workspace = true }
 
+derive_more = { workspace = true }
+eyre = { workspace = true }
+pretty_assertions = { workspace = true }
+rmp = { workspace = true }
+semver = { workspace = true }
+sqlx = { workspace = true }
+tokio = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
-rmp = { workspace = true }
-eyre = { workspace = true }
-tokio = { workspace = true }
 typed-builder = { workspace = true }
-pretty_assertions = { workspace = true }
-sqlx = { workspace = true }
-semver = { workspace = true }
 
 [dev-dependencies]
 rstest = { workspace = true }

--- a/crates/atuin-pty-proxy/Cargo.toml
+++ b/crates/atuin-pty-proxy/Cargo.toml
@@ -3,12 +3,13 @@ name = "atuin-pty-proxy"
 edition = "2024"
 description = "a PTY proxy for atuin"
 
-version = { workspace = true }
-authors = { workspace = true }
-rust-version = { workspace = true }
-license = { workspace = true }
-homepage = { workspace = true }
-repository = { workspace = true }
+authors.workspace = true
+homepage.workspace = true
+license.workspace = true
+readme.workspace = true
+repository.workspace = true
+rust-version.workspace = true
+version.workspace = true
 
 [dependencies]
 clap = { workspace = true }

--- a/crates/atuin-scripts/Cargo.toml
+++ b/crates/atuin-scripts/Cargo.toml
@@ -1,40 +1,38 @@
 [package]
 name = "atuin-scripts"
 edition = "2024"
-version = { workspace = true }
 description = "The scripts crate for Atuin"
 
 authors.workspace = true
-rust-version.workspace = true
-license.workspace = true
 homepage.workspace = true
-repository.workspace = true
+license.workspace = true
 readme.workspace = true
-
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+repository.workspace = true
+rust-version.workspace = true
+version.workspace = true
 
 [dependencies]
 atuin-client = { workspace = true }
 atuin-common = { workspace = true, features = ["sqlite"] }
 atuin-domain = { workspace = true }
-derive_more = { workspace = true }
 
-tracing = { workspace = true }
-tracing-subscriber = { workspace = true }
-rmp = { workspace = true }
-uuid = { workspace = true }
+derive_more = { workspace = true }
+easy-cast = { workspace = true }
 eyre = { workspace = true }
-tokio = { workspace = true }
-serde = { workspace = true }
-typed-builder = { workspace = true }
+minijinja = { workspace = true }
 pretty_assertions = { workspace = true }
+rmp = { workspace = true }
+semver = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
 sql-builder = { workspace = true }
 sqlx = { workspace = true }
 tempfile = { workspace = true }
-minijinja = { workspace = true }
-serde_json = { workspace = true }
-semver = { workspace = true }
-easy-cast = { workspace = true }
+tokio = { workspace = true }
+tracing = { workspace = true }
+tracing-subscriber = { workspace = true }
+typed-builder = { workspace = true }
+uuid = { workspace = true }
 
 [dev-dependencies]
 rstest = { workspace = true }

--- a/crates/atuin-server/Cargo.toml
+++ b/crates/atuin-server/Cargo.toml
@@ -3,12 +3,13 @@ name = "atuin-server"
 edition = "2024"
 description = "server library for atuin"
 
-rust-version = { workspace = true }
-version = { workspace = true }
-authors = { workspace = true }
-license = { workspace = true }
-homepage = { workspace = true }
-repository = { workspace = true }
+authors.workspace = true
+homepage.workspace = true
+license.workspace = true
+readme.workspace = true
+repository.workspace = true
+rust-version.workspace = true
+version.workspace = true
 
 [lib]
 name = "atuin_server"
@@ -27,40 +28,46 @@ vendored-tls = ["reqwest/native-tls-vendored"]
 atuin-common = { workspace = true, features = ["db"] }
 atuin-domain = { workspace = true, features = ["axum"] }
 
-tracing = { workspace = true }
-eyre = { workspace = true }
-config = { workspace = true }
-serde = { workspace = true }
-rand = { workspace = true }
-tokio = { workspace = true }
+argon2 = { workspace = true }
+async-trait = { workspace = true }
 axum = { workspace = true }
+clap = { workspace = true }
+config = { workspace = true }
+derive_more = { workspace = true }
+easy-cast = { workspace = true }
+eyre = { workspace = true }
 fs-err = { workspace = true }
+metrics = { workspace = true }
+metrics-exporter-prometheus = { workspace = true }
+rand = { workspace = true }
+reqwest = { workspace = true }
+serde = { workspace = true }
+sqlx = { workspace = true, features = ["postgres", "sqlite", "mysql", "regexp", "tls-native-tls"] }
+time = { workspace = true }
+tokio = { workspace = true }
 tower = { workspace = true }
 tower-http = { workspace = true }
-reqwest = { workspace = true }
-url = { workspace = true }
-argon2 = { workspace = true }
-metrics-exporter-prometheus = { workspace = true }
-metrics = { workspace = true }
-clap = { workspace = true }
+tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
-async-trait = { workspace = true }
-derive_more = { workspace = true }
-time = { workspace = true }
+url = { workspace = true }
 uuid = { workspace = true }
-sqlx = { workspace = true, features = ["postgres", "sqlite", "mysql", "regexp", "tls-native-tls"] }
-easy-cast = { workspace = true }
 
 # Integration tests in tests/ spin up a real server and drive it with the
 # client's api_client. atuin-client is only a dev dependency here so the client
 # binary crate stays free of server/postgres deps (see issue #2884).
 [dev-dependencies]
-atuin-client = { path = "../atuin-client", version = "18.21.0", default-features = false, features = ["sync"] }
-rstest = { workspace = true }
+# TODO(taylordotfish): in Rust 1.99 we can change this to `workspace = true`
+atuin-client = {
+    path = "../atuin-client",
+    version = "18.21.0",
+    default-features = false,
+    features = ["sync"],
+}
 futures-util = { workspace = true }
-tracing-tree = { workspace = true }
-tower = { workspace = true, features = ["util"] }
 regex = { workspace = true }
+rstest = { workspace = true }
+tower = { workspace = true, features = ["util"] }
+tracing-tree = { workspace = true }
 
 [lints]
 workspace = true

--- a/crates/atuin/Cargo.toml
+++ b/crates/atuin/Cargo.toml
@@ -4,12 +4,12 @@ edition = "2024"
 description = "atuin - magical shell history"
 readme = "./README.md"
 
-rust-version = { workspace = true }
-version = { workspace = true }
-authors = { workspace = true }
-license = { workspace = true }
-homepage = { workspace = true }
-repository = { workspace = true }
+authors.workspace = true
+homepage.workspace = true
+license.workspace = true
+repository.workspace = true
+rust-version.workspace = true
+version.workspace = true
 
 exclude = ["vendor/bash-preexec/.github", "vendor/bash-preexec/test"]
 
@@ -74,64 +74,66 @@ profiling-traced = [
 
 [dependencies]
 atuin-ai = { workspace = true, optional = true }
-# default-features = false cannot be set on a workspace-inherited dependency, and
-# atuin-client's defaults (sync/hub/daemon) are needed by its other consumers, so
-# the workspace entry keeps them on. This crate opts out via a direct path dep.
-atuin-client = { path = "../atuin-client", version = "18.21.0", optional = true, default-features = false }
+# TODO(taylordotfish): in Rust 1.99 we can change this to `workspace = true`
+atuin-client = {
+    path = "../atuin-client",
+    version = "18.21.0",
+    optional = true,
+    default-features = false,
+}
 atuin-common = { workspace = true, features = ["unicode", "os"] }
+atuin-daemon = { workspace = true, optional = true }
 atuin-domain = { workspace = true }
 atuin-dotfiles = { workspace = true }
 atuin-history = { workspace = true }
-atuin-daemon = { workspace = true, optional = true }
+atuin-kv = { workspace = true }
 atuin-pty-proxy = { workspace = true, optional = true }
 atuin-scripts = { workspace = true }
-atuin-kv = { workspace = true }
-axoupdater = { workspace = true, optional = true }
-derive_more = { workspace = true }
 
-time = { workspace = true }
-eyre = { workspace = true }
-url = { workspace = true }
-indicatif = { workspace = true }
-serde = { workspace = true }
-serde_json = { workspace = true }
-crossterm = { workspace = true, features = ["use-dev-tty"] }
-unicode-width = { workspace = true }
-itertools = { workspace = true }
-tokio = { workspace = true }
-enum_dispatch = { workspace = true }
 async-trait = { workspace = true }
-interim = { workspace = true }
+axoupdater = { workspace = true, optional = true }
 clap = { workspace = true }
 clap_complete = { workspace = true }
 clap_complete_nushell = { workspace = true }
-rpassword = { workspace = true }
-semver = { workspace = true }
-rustix = { workspace = true }
-runtime-format = { workspace = true }
-tiny-bip39 = { workspace = true }
-futures-util = { workspace = true }
 colored = { workspace = true }
-ratatui = { workspace = true }
-tracing = { workspace = true }
-tracing-subscriber = { workspace = true }
-tracing-appender = { workspace = true }
-tracing-opentelemetry = { workspace = true, optional = true }
-opentelemetry = { workspace = true, optional = true }
-opentelemetry_sdk = { workspace = true, optional = true }
-opentelemetry-otlp = { workspace = true, optional = true }
-uuid = { workspace = true }
-sysinfo = { workspace = true }
-regex = { workspace = true }
-norm = { workspace = true }
-frizbee = { workspace = true }
-tempfile = { workspace = true }
-shlex = { workspace = true }
-thiserror = { workspace = true }
+crossterm = { workspace = true, features = ["use-dev-tty"] }
+derive_more = { workspace = true }
 easy-cast = { workspace = true }
-
+enum_dispatch = { workspace = true }
+eyre = { workspace = true }
+frizbee = { workspace = true }
+futures-util = { workspace = true }
+indicatif = { workspace = true }
+interim = { workspace = true }
+itertools = { workspace = true }
+norm = { workspace = true }
+opentelemetry = { workspace = true, optional = true }
+opentelemetry-otlp = { workspace = true, optional = true }
+opentelemetry_sdk = { workspace = true, optional = true }
+ratatui = { workspace = true }
+regex = { workspace = true }
+rpassword = { workspace = true }
+runtime-format = { workspace = true }
+rustix = { workspace = true }
+semver = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+shlex = { workspace = true }
+sysinfo = { workspace = true }
+tempfile = { workspace = true }
+thiserror = { workspace = true }
+time = { workspace = true }
+tiny-bip39 = { workspace = true }
+tokio = { workspace = true }
 # settings editor with comment and relative ordering preservation
 toml_edit = { workspace = true }
+tracing = { workspace = true }
+tracing-appender = { workspace = true }
+tracing-opentelemetry = { workspace = true, optional = true }
+tracing-subscriber = { workspace = true }
+unicode-width = { workspace = true }
+url = { workspace = true }
+uuid = { workspace = true }
 
 [target.'cfg(any(target_os = "windows", target_os = "macos"))'.dependencies]
 arboard = { workspace = true, optional = true }


### PR DESCRIPTION
Sort the dependencies in every `Cargo.toml`. Also add a README to crates that don't have one, pointing to the repository's README. We already do this for some of the crates like `atuin-daemon`, `atuin-dotfiles`, and `atuin-history`.