### PR TITLE
chore: enable Clippy cast warnings

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -219,12 +219,11 @@ borrow_as_ptr = "warn"
 branches_sharing_code = "warn"
 case_sensitive_file_extension_comparisons = "warn"
 cast_lossless = "warn"
-# TODO(markovejnovic): These could be enabled in a separate PR, but we should
-# first try using easy_cast.
-#cast_possible_truncation = "warn"
-#cast_possible_wrap = "warn"
+cast_possible_truncation = "warn"
+cast_possible_wrap = "warn"
+cast_sign_loss = "warn"
+# TODO(markovejnovic): This could be enabled in a separate PR.
 #cast_precision_loss = "warn"
-#cast_sign_loss = "warn"
 clear_with_drain = "warn"
 cloned_instead_of_copied = "warn"
 collapsible_else_if = "warn"

--- a/crates/atuin-ai/src/tui/view/mod.rs
+++ b/crates/atuin-ai/src/tui/view/mod.rs
@@ -6,7 +6,7 @@
 //! app's keymap, not here — elements are display-only.
 
 use atuin_common::path::DisplayRichExt;
-use easy_cast::{Cast, Conv};
+use easy_cast::{Cast, CastTo, Conv, Nearest};
 use eye_declare::{
     AnyElement, Element, ElementExt, Fluent, Markdown, MarkdownStyles, Spinner, col, empty,
     markdown, row, spinner, text, viewport,
@@ -161,7 +161,7 @@ fn format_elapsed(elapsed: std::time::Duration) -> String {
     if secs < 10.0 {
         format!("{secs:.1} seconds")
     } else if secs < 60.0 {
-        format!("{} seconds", secs.round() as u64)
+        format!("{secs:.0} seconds")
     } else {
         let total = elapsed.as_secs();
         format!("{}m {:02}s", total / 60, total % 60)
@@ -799,10 +799,11 @@ pub fn status_bar_view(
         return left.any();
     };
 
-    let filled = ((pct / 100.0).clamp(0.0, 1.0) * USAGE_BAR_WIDTH as f64).round() as usize;
+    let filled: usize =
+        ((pct / 100.0).clamp(0.0, 1.0) * f64::conv(USAGE_BAR_WIDTH)).cast_to(Nearest);
     let bar_filled = "█".repeat(filled);
     let bar_empty = "░".repeat(USAGE_BAR_WIDTH - filled);
-    let pct_text = format!(" {}%", pct.round() as i64);
+    let pct_text = format!(" {pct:.0}%");
     let resets_text = resets_in
         .map(|d| format!(" · resets in {} ", crate::usage::format_reset_delta(d)))
         .unwrap_or_default();

--- a/crates/atuin-client/src/database.rs
+++ b/crates/atuin-client/src/database.rs
@@ -8,7 +8,7 @@ use atuin_common::filter::{self, OrFilter};
 use atuin_common::time::OffsetDateTimeExt;
 use atuin_common::{db, utils};
 use atuin_domain::record::{CmdOrigin, UNKNOWN_USER};
-use easy_cast::Conv;
+use easy_cast::{CastTo, Conv, Nearest, Trunc};
 use itertools::Itertools;
 use sql_builder::bind::Bind;
 use sql_builder::{SqlBuilder, SqlName, esc, quote};
@@ -1029,13 +1029,13 @@ impl Sqlite {
         )?;
 
         let duration_over_time =
-            duration_over_time.iter().map(|f| (f.0.clone(), f.1.round() as i64)).collect();
+            duration_over_time.iter().map(|f| (f.0.clone(), f.1.cast_to(Nearest))).collect();
 
         Ok(HistoryStats {
             next,
             previous: prev,
             total: u64::conv(total.0),
-            average_duration: average.0 as u64,
+            average_duration: average.0.cast_to(Trunc),
             exits,
             day_of_week,
             duration_over_time,

--- a/crates/atuin-client/src/import/resh.rs
+++ b/crates/atuin-client/src/import/resh.rs
@@ -5,6 +5,7 @@ use atuin_common::time::OffsetDateTimeExt;
 use atuin_common::utils::uuid_v7;
 use atuin_domain::record::{CmdHost, CmdOrigin, CmdUser};
 use directories::UserDirs;
+use easy_cast::{CastTo, Floor, Nearest};
 use eyre::{Result, eyre};
 use serde::Deserialize;
 use time::OffsetDateTime;
@@ -106,18 +107,14 @@ impl Importer for Resh {
                 continue;
             };
 
-            #[allow(clippy::cast_possible_truncation)]
-            let start = {
-                let secs = entry.realtime_before.floor() as i64;
-                let nanosecs = (entry.realtime_before.fract() * 1_000_000_000_f64).round() as i64;
-                OffsetDateTime::from_timespec(i128::from(secs), i128::from(nanosecs))
+            let try_to_time = |realtime: f64| {
+                let secs: i64 = realtime.try_cast_to(Floor).ok()?;
+                let nanosecs: i64 =
+                    (realtime.fract() * 1_000_000_000_f64).try_cast_to(Nearest).ok()?;
+                OffsetDateTime::from_timespec(i128::from(secs), i128::from(nanosecs)).ok()
             };
-            #[allow(clippy::cast_possible_truncation)]
-            let end = {
-                let secs = entry.realtime_after.floor() as i64;
-                let nanosecs = (entry.realtime_after.fract() * 1_000_000_000_f64).round() as i64;
-                OffsetDateTime::from_timespec(i128::from(secs), i128::from(nanosecs))
-            };
+            let start = try_to_time(entry.realtime_before);
+            let end = try_to_time(entry.realtime_after);
 
             // a corrupt entry must not abort the whole import. only report a duration when
             // both ends are representable - measuring against the epoch sentinel would
@@ -125,10 +122,12 @@ impl Importer for Resh {
             // can also make realtime_after precede realtime_before; a negative duration is
             // just as meaningless as an unrepresentable one, so it falls back the same way
             let duration = match (start, end) {
-                (Ok(start), Ok(end)) => match i64::try_from((end - start).whole_nanoseconds()) {
-                    Ok(nanos) if nanos >= 0 => nanos,
-                    _ => HistoryImported::DEFAULT_DURATION,
-                },
+                (Some(start), Some(end)) => {
+                    match i64::try_from((end - start).whole_nanoseconds()) {
+                        Ok(nanos) if nanos >= 0 => nanos,
+                        _ => HistoryImported::DEFAULT_DURATION,
+                    }
+                }
                 _ => HistoryImported::DEFAULT_DURATION,
             };
             let timestamp = start.unwrap_or(OffsetDateTime::UNIX_EPOCH);

--- a/crates/atuin-client/src/import/xonsh.rs
+++ b/crates/atuin-client/src/import/xonsh.rs
@@ -6,6 +6,7 @@ use async_trait::async_trait;
 use atuin_common::time::OffsetDateTimeExt;
 use atuin_domain::record::CmdOrigin;
 use directories::BaseDirs;
+use easy_cast::{CastTo, Trunc};
 use eyre::{Result, eyre};
 use serde::Deserialize;
 use time::OffsetDateTime;
@@ -91,8 +92,13 @@ fn load_session(path: &Path) -> Result<Option<HistoryData>> {
     // if there are commands in this session, replace the existing UUIDv4
     // with a UUIDv7 generated from the timestamp of the first command
     if let Some(cmd) = hist_file.data.cmds.first() {
-        let seconds = cmd.ts.0.trunc() as u64;
-        let nanos = (cmd.ts.0.fract() * 1_000_000_000_f64) as u32;
+        #[expect(
+            clippy::cast_possible_truncation,
+            clippy::cast_sign_loss,
+            reason = "only used for creating a UUID -- saturating is ok"
+        )]
+        let (seconds, nanos) =
+            (cmd.ts.0.trunc() as u64, (cmd.ts.0.fract() * 1_000_000_000_f64) as u32);
         let ts = Timestamp::from_unix(NoContext, seconds, nanos);
         hist_file.data.sessionid = Uuid::new_v7(ts).to_string();
     }
@@ -124,16 +130,20 @@ impl Importer for Xonsh {
         for session in self.sessions {
             for cmd in session.cmds {
                 let (start, end) = cmd.ts;
-                let ts_nanos = (start * 1_000_000_000_f64) as i128;
-                let timestamp =
-                    OffsetDateTime::from_unix_nanos(ts_nanos).unwrap_or(OffsetDateTime::UNIX_EPOCH);
+                let timestamp = (start * 1_000_000_000_f64)
+                    .try_cast_to(Trunc)
+                    .ok()
+                    .and_then(|nanos: i128| OffsetDateTime::from_unix_nanos(nanos).ok())
+                    .unwrap_or(OffsetDateTime::UNIX_EPOCH);
 
-                let duration = (end - start) * 1_000_000_000_f64;
+                let duration = ((end - start) * 1_000_000_000_f64)
+                    .try_cast_to(Trunc)
+                    .unwrap_or(HistoryImported::DEFAULT_DURATION);
 
                 let entry = History::import()
                     .shell("xonsh")
                     .timestamp(timestamp)
-                    .duration(duration.trunc() as i64)
+                    .duration(duration)
                     .exit(cmd.rtn.unwrap_or(HistoryImported::DEFAULT_EXIT))
                     .command(cmd.inp.trim())
                     .cwd(cmd.cwd)

--- a/crates/atuin-client/src/import/xonsh_sqlite.rs
+++ b/crates/atuin-client/src/import/xonsh_sqlite.rs
@@ -6,7 +6,7 @@ use atuin_common::db;
 use atuin_common::time::OffsetDateTimeExt;
 use atuin_domain::record::CmdOrigin;
 use directories::BaseDirs;
-use easy_cast::Conv;
+use easy_cast::{CastTo, Conv, Trunc};
 use eyre::{Result, eyre};
 use futures::TryStreamExt;
 use sqlx::sqlite::SqlitePool;
@@ -32,20 +32,31 @@ struct HistDbEntry {
 
 impl HistDbEntry {
     fn into_hist_with_cmd_origin(self, cmd_origin: CmdOrigin) -> History {
-        let ts_nanos = (self.tsb * 1_000_000_000_f64) as i128;
-        let timestamp =
-            OffsetDateTime::from_unix_nanos(ts_nanos).unwrap_or(OffsetDateTime::UNIX_EPOCH);
+        let timestamp = (self.tsb * 1_000_000_000_f64)
+            .try_cast_to(Trunc)
+            .ok()
+            .and_then(|nanos: i128| OffsetDateTime::from_unix_nanos(nanos).ok())
+            .unwrap_or(OffsetDateTime::UNIX_EPOCH);
 
-        let session_ts_seconds = self.session_start.trunc() as u64;
-        let session_ts_nanos = (self.session_start.fract() * 1_000_000_000_f64) as u32;
+        #[expect(
+            clippy::cast_possible_truncation,
+            clippy::cast_sign_loss,
+            reason = "only used for creating a UUID -- saturating is ok"
+        )]
+        let (session_ts_seconds, session_ts_nanos) = (
+            self.session_start.trunc() as u64,
+            (self.session_start.fract() * 1_000_000_000_f64) as u32,
+        );
         let session_ts = Timestamp::from_unix(NoContext, session_ts_seconds, session_ts_nanos);
         let session_id = Uuid::new_v7(session_ts).to_string();
-        let duration = (self.tse - self.tsb) * 1_000_000_000_f64;
+        let duration = ((self.tse - self.tsb) * 1_000_000_000_f64)
+            .try_cast_to(Trunc)
+            .unwrap_or(HistoryImported::DEFAULT_DURATION);
 
         History::import()
             .shell("xonsh")
             .timestamp(timestamp)
-            .duration(duration.trunc() as i64)
+            .duration(duration)
             .exit(self.rtn.unwrap_or(HistoryImported::DEFAULT_EXIT))
             .command(self.inp)
             .cwd(self.cwd)

--- a/crates/atuin-daemon/src/components/sync.rs
+++ b/crates/atuin-daemon/src/components/sync.rs
@@ -253,11 +253,10 @@ async fn do_sync_tick(
                 new_interval = max_interval;
             }
 
-            *ticker = time::interval_at(
-                tokio::time::Instant::now() + Duration::from_secs(new_interval as u64),
-                time::Duration::from_secs(new_interval as u64),
-            );
-            ticker.reset_after(time::Duration::from_secs(new_interval as u64));
+            let backoff =
+                Duration::try_from_secs_f64(new_interval).unwrap_or_else(|_| ticker.period());
+            *ticker = time::interval_at(tokio::time::Instant::now() + backoff, backoff);
+            ticker.reset_after(backoff);
             ticker.set_missed_tick_behavior(MissedTickBehavior::Skip);
 
             tracing::error!("backing off, next sync tick in {new_interval}");

--- a/crates/atuin-daemon/src/search/index.rs
+++ b/crates/atuin-daemon/src/search/index.rs
@@ -90,7 +90,14 @@ impl FrecencyData {
         let frequency_score = (f64::from(self.count).ln() * 20.0).min(100.0);
 
         // Apply multipliers and combine scores, then round to u32
-        ((recency_score * recency_mul) + (frequency_score * frequency_mul)).round() as u32
+        #[expect(
+            clippy::cast_possible_truncation,
+            clippy::cast_sign_loss,
+            reason = "frecency is used for ordering only -- saturating is ok"
+        )]
+        {
+            ((recency_score * recency_mul) + (frequency_score * frequency_mul)).round() as u32
+        }
     }
 }
 
@@ -558,7 +565,14 @@ impl SearchIndex {
                         let frecency =
                             data.global_frecency.compute(now, recency_mul, frequency_mul);
                         // Apply overall frecency multiplier and round to u32
-                        (f64::from(frecency) * frecency_mul).round() as u32
+                        #[allow(
+                            clippy::cast_possible_truncation,
+                            clippy::cast_sign_loss,
+                            reason = "frecency is used for ordering only -- saturating is ok"
+                        )]
+                        {
+                            (f64::from(frecency) * frecency_mul).round() as u32
+                        }
                     })
                 })
                 .collect()


### PR DESCRIPTION
Enable warnings about `as` casts in Clippy, now that we've changed most of them to `easy-cast`.

Clippy also warns about `<float> as <int>` casts even though these saturate, which, imo, is not as much of a problem as truncation/wrapping. It's not possible to warn only about `<int> as <int>` casts, so this PR updates the `<float> as <int>` casts as well:

* Ones where we were already clamping within the destination type's range have been changed to `easy_cast::ConvTo`.
* There were several where the saturating behavior of the cast was sufficient but not necessary for our purposes. All it did was make the integer out of range for a second conversion, where we would then fall back to a default value. These have been changed to use `try_cast_to` with the same fallback as before.
* There were some where we could avoid the cast by using a different library method.
* For the remaining ones where saturating was intended, an `#[expect]` attribute has been added to them.