### PR TITLE
feat(mcp): make agents actually use the atuin MCP server

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -347,6 +347,8 @@ dependencies = [
  "serde_json",
  "shellexpand",
  "sqlx",
+ "strum 0.27.2",
+ "strum_macros 0.28.0",
  "tempfile",
  "thiserror 2.0.19",
  "time",

--- a/crates/atuin-ai/Cargo.toml
+++ b/crates/atuin-ai/Cargo.toml
@@ -77,6 +77,9 @@ chrono = "0.4"
 chrono-humanize = "0.2"
 rmcp = { version = "2.1.0", default-features = false, features = ["server", "transport-io"] }
 
+strum = { workspace = true }
+strum_macros = { workspace = true }
+
 [dev-dependencies]
 pretty_assertions = { workspace = true }
 rstest = { workspace = true }

--- a/crates/atuin-ai/src/context.rs
+++ b/crates/atuin-ai/src/context.rs
@@ -6,6 +6,8 @@ use atuin_client::history::History;
 use atuin_client::settings::AiCapabilities;
 use atuin_common::time::UtcOffsetExt;
 
+use crate::tools::descriptor;
+
 /// Session-scoped context for the AI chat session.
 /// Holds the API configuration and client settings needed by the event loop and stream task.
 #[derive(Clone, Debug)]
@@ -37,30 +39,49 @@ pub fn history_output_capability_available(daemon_enabled: bool) -> bool {
     cfg!(feature = "daemon") && daemon_enabled
 }
 
+/// The `client_v1_*` capability strings this client sends with every AI
+/// request to the Hub (`ai.endpoint`), which runs the model and sends back
+/// tool calls. The Hub reads the list to decide which tools it may ask this
+/// client to run: a tool whose capability string is missing here is never
+/// offered to the model. Requests are built in more than one place, but they
+/// all get their capabilities from this function — separately maintained
+/// lists could drift apart, and the model would then see different tools
+/// depending on how the user launched the AI.
+pub fn capability_strings(capabilities: &AiCapabilities, daemon_enabled: bool) -> Vec<String> {
+    // Each tool's capability string lives on its ToolDescriptor. Reuse it
+    // rather than retyping the string: the fsm later accepts or rejects the
+    // server's tool calls by comparing against those same descriptors, so a
+    // mismatched literal here would silently disable a tool.
+    let cap = |d: &descriptor::ToolDescriptor| {
+        d.capability.expect("client-side tools declare a capability").to_string()
+    };
+    let mut caps = vec!["client_invocations".to_string(), cap(descriptor::LOAD_SKILL)];
+    if capabilities.enable_history_search.unwrap_or(true) {
+        caps.push(cap(descriptor::ATUIN_HISTORY));
+        caps.push(descriptor::ATUIN_HISTORY_V2_CAPABILITY.to_string());
+    }
+    if capabilities.enable_file_tools.unwrap_or(true) {
+        caps.push(cap(descriptor::READ));
+        caps.push(cap(descriptor::EDIT));
+        caps.push(cap(descriptor::WRITE));
+    }
+    if capabilities.enable_command_execution.unwrap_or(true) {
+        caps.push(cap(descriptor::SHELL));
+    }
+    if history_output_capability_available(daemon_enabled)
+        && capabilities.enable_history_output.unwrap_or(true)
+    {
+        caps.push(cap(descriptor::ATUIN_OUTPUT));
+    }
+    if let Ok(extra) = std::env::var("ATUIN_AI__ADDITIONAL_CAPS") {
+        caps.extend(extra.split(',').map(|s| s.trim().to_string()).filter(|s| !s.is_empty()));
+    }
+    caps
+}
+
 impl AppContext {
     pub(crate) fn capabilities_as_strings(&self) -> Vec<String> {
-        let mut caps = vec!["client_invocations".to_string()];
-        if self.capabilities.enable_history_search.unwrap_or(true) {
-            caps.push("client_v1_atuin_history".to_string());
-        }
-        if self.capabilities.enable_file_tools.unwrap_or(true) {
-            caps.push("client_v1_read_file".to_string());
-            caps.push("client_v1_edit_file".to_string());
-            caps.push("client_v1_write_file".to_string());
-        }
-        if self.capabilities.enable_command_execution.unwrap_or(true) {
-            caps.push("client_v1_execute_shell_command".to_string());
-        }
-        if history_output_capability_available(self.daemon_enabled)
-            && self.capabilities.enable_history_output.unwrap_or(true)
-        {
-            caps.push("client_v1_atuin_output".to_string());
-        }
-        caps.push("client_v1_load_skill".to_string());
-        if let Ok(extra) = std::env::var("ATUIN_AI__ADDITIONAL_CAPS") {
-            caps.extend(extra.split(',').map(|s| s.trim().to_string()).filter(|s| !s.is_empty()));
-        }
-        caps
+        capability_strings(&self.capabilities, self.daemon_enabled)
     }
 }
 

--- a/crates/atuin-ai/src/mcp.rs
+++ b/crates/atuin-ai/src/mcp.rs
@@ -8,6 +8,8 @@
 //! daemon; output retrieval talks to the daemon and returns a tool error when
 //! it is not running.
 
+use std::sync::LazyLock;
+
 use atuin_client::database::Sqlite;
 use atuin_client::history::{AUTHOR_FILTER_ALL_AGENT, AUTHOR_FILTER_ALL_USER, KNOWN_AGENTS};
 use eyre::Result;
@@ -18,17 +20,55 @@ use rmcp::model::{
 use rmcp::service::RequestContext;
 use rmcp::{RoleServer, ServerHandler, ServiceExt};
 use serde_json::{Value, json};
+use strum::IntoEnumIterator;
 
-use crate::tools::{AtuinHistoryToolCall, AtuinOutputToolCall, ToolOutcome};
+use crate::tools::{
+    AtuinHistoryToolCall, AtuinOutputToolCall, DEFAULT_HISTORY_RESULTS, HistorySearchFilterMode,
+    MAX_HISTORY_RESULTS, ToolOutcome,
+};
 
 struct AtuinMcp {
     db: Sqlite,
 }
 
+/// Server-level instructions, surfaced by MCP clients (Claude Code injects
+/// them into the model's system prompt). This is the main lever for making
+/// agents reach for Atuin instead of guessing: it frames the history as the
+/// ground truth for "what actually happened in the terminal".
+const SERVER_INSTRUCTIONS: &str =
+    "\
+Atuin is the ground truth for what actually happened in the user's terminal. It records shell \
+     history from every session and machine: each command with its timestamp, working directory, \
+     exit code, and duration — including commands run by AI agents (tagged with the agent's name \
+     and intent) — and, where output capture is enabled, the full terminal output of each command.
+
+Search atuin_history instead of guessing, asking the user, or re-running things whenever past \
+     terminal activity is relevant: how the user last invoked something ('what flags did I use'), \
+     whether and when something ran and if it succeeded, why a command failed (search with \
+     only_failed: true, then read the actual error with atuin_output), or what an AI agent ran. \
+     When debugging, checking recent history early often reveals what the user already tried.
+
+When a question is about the user themselves — 'what do I use', 'how do I connect', 'what's my \
+     setup' — run one atuin_history search BEFORE searching the filesystem. It is a single cheap \
+     call, and 'it is not in the repository' is not an answer: personal habits live in shell \
+     history, not in checked-in config.
+
+Do not use `history`, ~/.bash_history, or ~/.zsh_history: they are typically empty or stale in \
+     non-interactive shells and lack exit codes and output. Atuin is the reliable source. Prefer \
+     atuin_output over re-running an expensive or side-effectful command just to see its output \
+     again.";
+
+/// The initialize result, separated from the handler so tests can assert on
+/// it without constructing a database-backed server.
+fn server_info() -> ServerInfo {
+    ServerInfo::new(ServerCapabilities::builder().enable_tools().build())
+        .with_server_info(Implementation::new("atuin", env!("CARGO_PKG_VERSION")))
+        .with_instructions(SERVER_INSTRUCTIONS)
+}
+
 impl ServerHandler for AtuinMcp {
     fn get_info(&self) -> ServerInfo {
-        ServerInfo::new(ServerCapabilities::builder().enable_tools().build())
-            .with_server_info(Implementation::new("atuin", env!("CARGO_PKG_VERSION")))
+        server_info()
     }
 
     async fn list_tools(
@@ -36,7 +76,7 @@ impl ServerHandler for AtuinMcp {
         _request: Option<PaginatedRequestParams>,
         _context: RequestContext<RoleServer>,
     ) -> Result<ListToolsResult, ErrorData> {
-        Ok(ListToolsResult::with_all_items(tool_definitions()))
+        Ok(ListToolsResult::with_all_items(TOOLS.clone()))
     }
 
     async fn call_tool(
@@ -85,8 +125,12 @@ pub async fn run(db: &Sqlite) -> Result<()> {
     Ok(())
 }
 
-/// Tool metadata for `tools/list`. The input schemas mirror what the
-/// `TryFrom<&serde_json::Value>` impls in [`crate::tools`] accept.
+/// Tool metadata for `tools/list`, built once: the schemas and descriptions
+/// are assembled from consts and the filter-mode enum, none of which change
+/// at runtime. The input schemas mirror what the `TryFrom<&serde_json::Value>`
+/// impls in [`crate::tools`] accept.
+static TOOLS: LazyLock<Vec<Tool>> = LazyLock::new(tool_definitions);
+
 fn tool_definitions() -> Vec<Tool> {
     let Value::Object(history_schema) = json!({
         "type": "object",
@@ -94,28 +138,31 @@ fn tool_definitions() -> Vec<Tool> {
             "query": {
                 "type": "string",
                 "description": "Fuzzy search query matched against past commands. \
-                    An empty string returns the most recent commands. Supports \
-                    fzf-style operators per space-separated term: ^prefix, suffix$, \
-                    'exact-substring, !negate, and r/regex/.",
+                    Prefer a few distinctive terms (e.g. 'ffmpeg av1'), not a \
+                    sentence; terms are AND-ed. An empty string returns the most \
+                    recent commands. Supports fzf-style operators per \
+                    space-separated term: ^prefix, suffix$, 'exact-substring, \
+                    !negate, and r/regex/.",
             },
             "filter_modes": {
                 "type": "array",
                 "items": {
                     "type": "string",
-                    "enum": ["global", "host", "session", "directory", "workspace"],
+                    "enum": HistorySearchFilterMode::iter().map(|m| m.as_str()).collect::<Vec<_>>(),
                 },
-                "description": "Search scope; the first entry is used. 'global' \
-                    searches all history, 'host' only commands run on this machine, \
-                    'directory' only commands run in the current working directory, \
-                    'workspace' only commands run inside the current git repository, \
-                    'session' only commands from the shell session that launched \
-                    this server (errors when it was not launched from a shell).",
+                "description": "Optional search scope; the first entry is used and \
+                    the default is 'global' (all history). 'workspace' limits to \
+                    commands run inside the current git repository, 'directory' to \
+                    the exact current working directory, 'host' to this machine, \
+                    'session' to the shell session that launched this server \
+                    (errors when it was not launched from a shell). Start global \
+                    and narrow only if results are noisy.",
             },
             "limit": {
                 "type": "integer",
                 "minimum": 1,
-                "maximum": 50,
-                "default": 10,
+                "maximum": MAX_HISTORY_RESULTS,
+                "default": DEFAULT_HISTORY_RESULTS,
                 "description": "Maximum number of results.",
             },
             "only_failed": {
@@ -136,7 +183,7 @@ fn tool_definitions() -> Vec<Tool> {
                 ),
             },
         },
-        "required": ["query", "filter_modes"],
+        "required": ["query"],
     }) else {
         unreachable!()
     };
@@ -159,8 +206,9 @@ fn tool_definitions() -> Vec<Tool> {
                 },
                 "description": "Optional [start, end] line ranges to fetch \
                     (0-based, end-inclusive). Negative indices count from the end \
-                    of the output, e.g. [-50, -1] is the last 50 lines. Defaults \
-                    to the first 1000 lines.",
+                    of the output, e.g. [[-80, -1]] is the last 80 lines — fetch \
+                    that first when investigating a failure, since errors usually \
+                    print at the end. Defaults to the first 1000 lines.",
             },
         },
         "required": ["history_id"],
@@ -171,30 +219,42 @@ fn tool_definitions() -> Vec<Tool> {
     vec![
         Tool::new(
             "atuin_history",
-            "Search the user's shell command history, recorded by Atuin. Fuzzy-matches the query \
-             against past commands and returns the most relevant entries, each with a history ID, \
-             timestamp, working directory, exit code, and duration. Commands run by AI agents are \
-             annotated with the agent's name and stated intent. Pass a history ID to atuin_output \
-             to see what a command printed.",
+            format!(
+                "Search the user's shell history, recorded by Atuin across all their terminal \
+                 sessions and machines. Each result includes the command, timestamp, working \
+                 directory, exit code, duration, and a history ID; commands run by AI agents \
+                 carry the agent's name and stated intent. Set only_failed: true when \
+                 investigating failures, and authors: [\"{AUTHOR_FILTER_ALL_AGENT}\"] to see what \
+                 agents ran. Pass a history ID to atuin_output to read what the command printed."
+            ),
             history_schema,
         )
-        .annotate(ToolAnnotations::new().read_only(true)),
+        .annotate(ToolAnnotations::with_title("Search shell history").read_only(true)),
         Tool::new(
             "atuin_output",
-            "Fetch the captured terminal output of a previously executed command, identified by a \
-             history ID from atuin_history results. Output capture requires the Atuin daemon; \
-             output is only available for recent commands captured while the daemon was running.",
+            "Read the terminal output that a previously executed command actually printed, \
+             identified by a history ID from atuin_history results. Use it to see an error \
+             exactly as the user saw it, or to re-read the output of an expensive or \
+             side-effectful command without re-running it. Output capture requires the Atuin \
+             daemon; output is only available for recent commands captured while the daemon was \
+             running.",
             output_schema,
         )
-        .annotate(ToolAnnotations::new().read_only(true)),
+        .annotate(ToolAnnotations::with_title("Read past command output").read_only(true)),
     ]
 }
 
 #[cfg(test)]
 mod tests {
+    use rstest::rstest;
+
     use super::*;
 
-    #[test]
+    /// MCP clients inject the instructions into the model's system prompt on
+    /// every session, so the block must stay small.
+    const MAX_INSTRUCTIONS_LEN: usize = 2_000;
+
+    #[rstest]
     fn tool_definitions_list_both_tools_as_read_only() {
         let tools = tool_definitions();
         let names: Vec<&str> = tools.iter().map(|t| t.name.as_ref()).collect();
@@ -204,5 +264,18 @@ mod tests {
             assert_eq!(tool.annotations.as_ref().unwrap().read_only_hint, Some(true));
             assert!(tool.input_schema.contains_key("required"));
         }
+
+        // Everything except `query` is optional — see the filter_modes
+        // comment in AtuinHistoryToolCall::try_from for why.
+        let required = tools[0].input_schema.get("required").unwrap();
+        assert_eq!(required, &json!(["query"]));
+    }
+
+    #[rstest]
+    fn server_info_carries_instructions() {
+        let instructions = server_info().instructions.expect("initialize result has instructions");
+        assert!(instructions.contains("atuin_history"));
+        assert!(instructions.contains("atuin_output"));
+        assert!(instructions.len() < MAX_INSTRUCTIONS_LEN, "instructions should stay concise");
     }
 }

--- a/crates/atuin-ai/src/stream.rs
+++ b/crates/atuin-ai/src/stream.rs
@@ -11,7 +11,7 @@ use futures::StreamExt;
 use reqwest::Url;
 use reqwest::header::USER_AGENT;
 
-use crate::context::{ClientContext, history_output_capability_available};
+use crate::context::{ClientContext, capability_strings};
 
 pub static APP_USER_AGENT: &str = concat!("atuin/", env!("CARGO_PKG_VERSION"));
 
@@ -73,26 +73,7 @@ impl ChatRequest {
         invocation_id: String,
         model: Option<String>,
     ) -> Self {
-        let mut caps = vec!["client_invocations".to_string(), "client_v1_load_skill".to_string()];
-        if capabilities.enable_history_search.unwrap_or(true) {
-            caps.push("client_v1_atuin_history".to_string());
-        }
-        if capabilities.enable_file_tools.unwrap_or(true) {
-            caps.push("client_v1_read_file".to_string());
-            caps.push("client_v1_edit_file".to_string());
-            caps.push("client_v1_write_file".to_string());
-        }
-        if capabilities.enable_command_execution.unwrap_or(true) {
-            caps.push("client_v1_execute_shell_command".to_string());
-        }
-        if history_output_capability_available(history_output_available)
-            && capabilities.enable_history_output.unwrap_or(true)
-        {
-            caps.push("client_v1_atuin_output".to_string());
-        }
-        if let Ok(extra) = std::env::var("ATUIN_AI__ADDITIONAL_CAPS") {
-            caps.extend(extra.split(',').map(|s| s.trim().to_string()).filter(|s| !s.is_empty()));
-        }
+        let caps = capability_strings(capabilities, history_output_available);
 
         Self {
             messages,

--- a/crates/atuin-ai/src/tools/descriptor.rs
+++ b/crates/atuin-ai/src/tools/descriptor.rs
@@ -20,6 +20,14 @@ pub struct ToolDescriptor {
     pub is_client: bool,
 }
 
+/// Sent in addition to [`ATUIN_HISTORY`]'s capability by clients whose
+/// `atuin_history` parser accepts a missing or null `filter_modes` (treated
+/// as a global search). Older releases error on the missing field, so the
+/// Hub must keep requiring `filter_modes` in the tool schema for any client
+/// that does not send this string — relaxing it for everyone who sends plain
+/// v1 would break those older clients.
+pub const ATUIN_HISTORY_V2_CAPABILITY: &str = "client_v2_atuin_history";
+
 // ── Client-side tool descriptors ──
 
 pub const READ: &ToolDescriptor = &ToolDescriptor {

--- a/crates/atuin-ai/src/tools/mod.rs
+++ b/crates/atuin-ai/src/tools/mod.rs
@@ -5,14 +5,25 @@ use std::str::FromStr;
 use std::time::Duration;
 
 use atuin_client::history::{AuthorPattern, HistoryId};
+use atuin_client::settings::FilterMode;
 use atuin_common::ansi;
 use atuin_common::filter::OrFilter;
 use atuin_common::time::UtcOffsetExt;
 use enum_dispatch::enum_dispatch;
 use eyre::Result;
+use strum_macros::{EnumIter, EnumString, IntoStaticStr};
 
 const DEFAULT_FILE_READ_LINES: u64 = 100;
 const MAX_FILE_READ_LINES: u64 = 1000;
+/// Page-size bounds for `atuin_history`; mirrored in the MCP schema.
+pub const DEFAULT_HISTORY_RESULTS: i64 = 10;
+pub const MAX_HISTORY_RESULTS: i64 = 50;
+/// Advice appended to `atuin_output` failures. Hedged on safety: telling the
+/// model to re-run unconditionally would invite re-executing destructive
+/// commands — the very thing output capture exists to avoid.
+const NO_OUTPUT_ADVICE: &str = "If the command is safe and cheap to repeat, re-run it to see its \
+                                output; otherwise rely on history metadata (exit code, duration) \
+                                instead.";
 
 pub mod descriptor;
 
@@ -966,7 +977,8 @@ pub struct AtuinHistoryToolCall {
     pub authors: OrFilter<Vec<AuthorPattern>>,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, EnumIter, EnumString, IntoStaticStr)]
+#[strum(serialize_all = "lowercase")]
 pub enum HistorySearchFilterMode {
     Global,
     Host,
@@ -975,8 +987,15 @@ pub enum HistorySearchFilterMode {
     Workspace,
 }
 
-impl From<&HistorySearchFilterMode> for atuin_client::settings::FilterMode {
-    fn from(mode: &HistorySearchFilterMode) -> Self {
+impl HistorySearchFilterMode {
+    #[must_use]
+    pub fn as_str(self) -> &'static str {
+        self.into()
+    }
+}
+
+impl From<HistorySearchFilterMode> for FilterMode {
+    fn from(mode: HistorySearchFilterMode) -> Self {
         match mode {
             HistorySearchFilterMode::Global => Self::Global,
             HistorySearchFilterMode::Host => Self::Host,
@@ -991,42 +1010,46 @@ impl TryFrom<&serde_json::Value> for AtuinHistoryToolCall {
     type Error = eyre::Error;
 
     fn try_from(value: &serde_json::Value) -> Result<Self, Self::Error> {
-        let filter_modes = value
-            .get("filter_modes")
-            .and_then(|v| v.as_array())
-            .ok_or(eyre::eyre!("Missing filter_modes"))?;
+        // Optional; JSON null counts as omitted because models often send
+        // null for optional params. A missing scope means a global search —
+        // evals showed that forcing the model to pick a scope on every call
+        // made it stop calling the tool at all.
+        let filter_modes = match value.get("filter_modes") {
+            None | Some(serde_json::Value::Null) => Vec::new(),
+            Some(v) => v
+                .as_array()
+                .ok_or_else(|| eyre::eyre!("filter_modes must be an array"))?
+                .iter()
+                .map(|v| {
+                    let mode = v.as_str().ok_or_else(|| eyre::eyre!("Invalid filter mode"))?;
+                    mode.parse::<HistorySearchFilterMode>()
+                        .map_err(|_| eyre::eyre!("Invalid filter mode: {mode}"))
+                })
+                .collect::<Result<Vec<HistorySearchFilterMode>>>()?,
+        };
 
-        let filter_modes = filter_modes
-            .iter()
-            .map(|v| {
-                let mode = v.as_str().ok_or(eyre::eyre!("Invalid filter mode"))?;
-                match mode {
-                    "global" => Ok(HistorySearchFilterMode::Global),
-                    "host" => Ok(HistorySearchFilterMode::Host),
-                    "session" => Ok(HistorySearchFilterMode::Session),
-                    "directory" => Ok(HistorySearchFilterMode::Directory),
-                    "workspace" => Ok(HistorySearchFilterMode::Workspace),
-                    _ => Err(eyre::eyre!("Invalid filter mode: {mode}")),
-                }
-            })
-            .collect::<Result<Vec<HistorySearchFilterMode>>>()?;
+        let query = value
+            .get("query")
+            .and_then(|v| v.as_str())
+            .ok_or_else(|| eyre::eyre!("Missing query"))?;
 
-        let query =
-            value.get("query").and_then(|v| v.as_str()).ok_or(eyre::eyre!("Missing query"))?;
-
-        let limit = value.get("limit").and_then(|v| v.as_i64()).unwrap_or(10).clamp(1, 50);
+        let limit = value
+            .get("limit")
+            .and_then(|v| v.as_i64())
+            .unwrap_or(DEFAULT_HISTORY_RESULTS)
+            .clamp(1, MAX_HISTORY_RESULTS);
 
         let only_failed = value.get("only_failed").and_then(|v| v.as_bool()).unwrap_or(false);
 
         let authors = match value.get("authors") {
             Some(authors) => authors
                 .as_array()
-                .ok_or(eyre::eyre!("authors must be an array of strings"))?
+                .ok_or_else(|| eyre::eyre!("authors must be an array of strings"))?
                 .iter()
                 .map(|v| {
                     v.as_str()
                         .map(AuthorPattern::from)
-                        .ok_or(eyre::eyre!("authors entries must be strings"))
+                        .ok_or_else(|| eyre::eyre!("authors entries must be strings"))
                 })
                 .collect::<Result<Vec<AuthorPattern>>>()?,
             None => Vec::new(),
@@ -1065,18 +1088,13 @@ impl AtuinHistoryToolCall {
             Err(e) => return ToolOutcome::Error(format!("Failed to get history context: {e}")),
         };
 
-        let filter_mode = self
-            .filter_modes
-            .first()
-            .map(atuin_client::settings::FilterMode::from)
-            .unwrap_or(atuin_client::settings::FilterMode::Global);
+        let search_mode =
+            self.filter_modes.first().copied().unwrap_or(HistorySearchFilterMode::Global);
 
         // An empty session would silently match nothing; error instead so a
         // missing $ATUIN_SESSION (e.g. MCP server launched outside a hooked
         // shell) isn't mistaken for empty history.
-        if matches!(filter_mode, atuin_client::settings::FilterMode::Session)
-            && context.session.is_empty()
-        {
+        if matches!(search_mode, HistorySearchFilterMode::Session) && context.session.is_empty() {
             return ToolOutcome::Error(
                 "Session-scoped search is unavailable: $ATUIN_SESSION is not set, so there is no \
                  shell session to scope to. Use another filter mode."
@@ -1085,33 +1103,76 @@ impl AtuinHistoryToolCall {
         }
 
         let filter_options = OptFilters {
-            limit: Some(self.limit),
+            // Fetch one row beyond the requested limit so the truncation
+            // notice appended to the results below can say "more exist" as a
+            // fact rather than a guess.
+            limit: Some(self.limit + 1),
             only_failed: self.only_failed,
             authors: self.authors.as_slice_filter(),
             ..Default::default()
         };
 
-        let results = match db
-            .search(DbSearchMode::Fuzzy, filter_mode, &context, &self.query, filter_options)
+        let mut results = match db
+            .search(DbSearchMode::Fuzzy, search_mode.into(), &context, &self.query, filter_options)
             .await
         {
             Ok(results) => results,
             Err(e) => return ToolOutcome::Error(format!("History search failed: {e}")),
         };
+        let page_size = self.limit.clamp(1, MAX_HISTORY_RESULTS) as usize;
+        let truncated = results.len() > page_size;
+        results.truncate(page_size);
 
         if results.is_empty() {
-            return ToolOutcome::Success("No matching history entries found.".to_string());
+            // An unadorned "no results" reads to the model as "this tool is
+            // useless". List which search parameters are worth loosening so
+            // its retry has somewhere to go.
+            let mut hints = Vec::new();
+            if !self.query.is_empty() {
+                hints.push("query terms are AND-ed, so try fewer or shorter terms");
+            }
+            if !matches!(search_mode, HistorySearchFilterMode::Global) {
+                hints.push("widen the scope to 'global'");
+            }
+            if self.only_failed {
+                hints.push("drop only_failed (the command may have succeeded)");
+            }
+            if !self.authors.is_all() {
+                hints.push("drop the authors filter");
+            }
+            let mut msg = format!(
+                "No history entries matched query {query:?} (scope: {scope}).",
+                query = self.query,
+                scope = search_mode.as_str(),
+            );
+            if !hints.is_empty() {
+                msg.push_str(&format!(" To find more: {}.", hints.join("; ")));
+            }
+            return ToolOutcome::Success(msg);
         }
 
         let local_offset = time::UtcOffset::local_or_utc();
 
-        let formatted: Vec<String> = results
+        let mut formatted: Vec<String> = results
             .iter()
             .enumerate()
             .map(|(i, history)| {
                 crate::history_format::format_history_search_result(i + 1, history, local_offset)
             })
             .collect();
+
+        if truncated {
+            // The parser clamps `limit` to MAX_HISTORY_RESULTS, so a model
+            // that retries with a larger limit at the cap would just get the
+            // identical page back; only suggest raising it below the cap.
+            let advice = if self.limit < MAX_HISTORY_RESULTS {
+                "Refine the query or raise `limit` to see others."
+            } else {
+                "That is the maximum page size; refine the query to narrow them."
+            };
+            formatted
+                .push(format!("[Showing the first {page_size} matches; more exist. {advice}]"));
+        }
 
         ToolOutcome::Success(formatted.join("\n"))
     }
@@ -1206,7 +1267,12 @@ impl AtuinOutputToolCall {
 
         let mut client = match atuin_daemon::SemanticClient::from_settings(&settings).await {
             Ok(client) => client,
-            Err(e) => return ToolOutcome::Error(format!("Failed to connect to Atuin daemon: {e}")),
+            Err(e) => {
+                return ToolOutcome::Error(format!(
+                    "Captured output is unavailable: could not connect to the Atuin daemon ({e}). \
+                     History search still works. {NO_OUTPUT_ADVICE}"
+                ));
+            }
         };
 
         let history_id = self.history_id;
@@ -1217,7 +1283,9 @@ impl AtuinOutputToolCall {
 
         if !response.found {
             return ToolOutcome::Success(format!(
-                "No captured output found for history ID {history_id}."
+                "No captured output found for history ID {history_id}. Output is only captured \
+                 for commands run in an Atuin-enabled terminal while the daemon was running; \
+                 older output may also have been dropped. {NO_OUTPUT_ADVICE}"
             ));
         }
 
@@ -1316,12 +1384,31 @@ mod tests {
 
     // ── Cross-platform tests ──
 
-    #[test]
-    fn atuin_history_filters_are_optional() {
-        let input = serde_json::json!({
-            "query": "cargo",
-            "filter_modes": ["global"],
-        });
+    #[rstest]
+    #[case::omitted(serde_json::json!({ "query": "cargo" }))]
+    #[case::null(serde_json::json!({ "query": "cargo", "filter_modes": null }))]
+    fn atuin_history_filter_modes_are_optional(#[case] input: serde_json::Value) {
+        let call = AtuinHistoryToolCall::try_from(&input).unwrap();
+        assert!(call.filter_modes.is_empty());
+    }
+
+    #[rstest]
+    fn filter_mode_names_round_trip() {
+        use strum::IntoEnumIterator;
+        for mode in HistorySearchFilterMode::iter() {
+            assert_eq!(mode.as_str().parse::<HistorySearchFilterMode>(), Ok(mode));
+        }
+    }
+
+    #[rstest]
+    fn atuin_history_filter_modes_reject_non_arrays() {
+        let input = serde_json::json!({ "query": "cargo", "filter_modes": "global" });
+        assert!(AtuinHistoryToolCall::try_from(&input).is_err());
+    }
+
+    #[rstest]
+    fn atuin_history_author_and_failure_filters_parse() {
+        let input = serde_json::json!({ "query": "cargo" });
 
         let call = AtuinHistoryToolCall::try_from(&input).unwrap();
         assert!(!call.only_failed);
@@ -1329,7 +1416,6 @@ mod tests {
 
         let input = serde_json::json!({
             "query": "cargo",
-            "filter_modes": ["global"],
             "only_failed": true,
             "authors": ["$all-agent"],
         });

--- a/crates/atuin-ai/src/tools/mod.rs
+++ b/crates/atuin-ai/src/tools/mod.rs
@@ -1119,7 +1119,9 @@ impl AtuinHistoryToolCall {
             Ok(results) => results,
             Err(e) => return ToolOutcome::Error(format!("History search failed: {e}")),
         };
-        let page_size = self.limit.clamp(1, MAX_HISTORY_RESULTS) as usize;
+        // The clamp keeps this in 1..=MAX_HISTORY_RESULTS, so the conversion
+        // never fails; the fallback only exists to keep it infallible.
+        let page_size = usize::try_from(self.limit.clamp(1, MAX_HISTORY_RESULTS)).unwrap_or(1);
         let truncated = results.len() > page_size;
         results.truncate(page_size);
 

--- a/crates/atuin-ai/src/tui/view/mod.rs
+++ b/crates/atuin-ai/src/tui/view/mod.rs
@@ -558,23 +558,14 @@ fn history_search_row(is_first: bool, details: &ToolCallDetails) -> AnyElement<'
     group_row_view(is_first, &details.status, content)
 }
 
-fn filter_mode_label(mode: &HistorySearchFilterMode) -> &'static str {
-    match mode {
-        HistorySearchFilterMode::Global => "global",
-        HistorySearchFilterMode::Host => "host",
-        HistorySearchFilterMode::Session => "session",
-        HistorySearchFilterMode::Directory => "directory",
-        HistorySearchFilterMode::Workspace => "workspace",
-    }
-}
-
 /// Format a list of filter modes as `"(global, workspace)"`, or an empty
 /// string if the list is empty.
 fn format_filter_modes(modes: &[HistorySearchFilterMode]) -> String {
     if modes.is_empty() {
         return String::new();
     }
-    let parts: Vec<&'static str> = modes.iter().map(filter_mode_label).collect();
+    let parts: Vec<&'static str> =
+        modes.iter().copied().map(HistorySearchFilterMode::as_str).collect();
     format!("({})", parts.join(", "))
 }
 

--- a/docs/docs/ai/mcp.md
+++ b/docs/docs/ai/mcp.md
@@ -43,7 +43,7 @@ Searches your shell history, using the same fuzzy matching as the search TUI. Ea
 
 Searches can be narrowed down in a few ways:
 
-- **Filter mode**: the same scopes as [interactive search](../guide/advanced-usage.md) — `global`, `host`, `directory`, `workspace`, or `session`. The `directory` and `workspace` scopes are relative to the directory your MCP client launched the server in, which for most editors is your project directory.
+- **Filter mode**: the same scopes as [interactive search](../guide/advanced-usage.md) — `global` (the default), `host`, `directory`, `workspace`, or `session`. The `directory` and `workspace` scopes are relative to the directory your MCP client launched the server in, which for most editors is your project directory.
 - **Failed commands only**: return only commands that exited with a non-zero exit code.
 - **Author**: filter to commands you ran yourself, commands run by AI agents, or commands run by one specific agent. See [AI Agent Hooks](../guide/agent-hooks.md) for how Atuin records agent-run commands.
 


### PR DESCRIPTION
Add server instructions (injected into the client's system prompt), trigger-focused tool descriptions, an optional `filter_mode`, and empty/error results that say what to try next.

Measured with headless Claude Code (sonnet) on seeded history DBs, before → after:

| Suite                       | atuin used   | correct      |
|-----------------------------|--------------|--------------|
| v1 suite (244 rows)         | 55% → 100%   | 52% → 100%   |
| coding (21.8k rows)         | 36% → 92%    | 47% → 89%    |
| devops (21.8k rows)         | 56% → 100%   | 47% → 100%   |
| agent-heavy coding (34k)    | 38% → 88%    | 50% → 96%    |
| agent-heavy devops (34k)    | 62% → 100%   | 62% → 100%   |
| config-shaped questions     | 50% → 75%    | 58% → 88%    |

Across the two large suites (124 runs per side):

- output tokens/task: **−32%**
- wall time: **−25%**
- turns: **−11%**
- cost: **−5%**
- control over-trigger: 0/44 runs

*"atuin used"* = the run made at least one `atuin_history` / `atuin_output` call.
*"correct"* = the answer matched the scenario's planted ground truth (all of its regexes, e.g. the exact port or flag).

_**Important caveat**_: this testing ran on synthetic data, on a single model only. While it feels like an improvement and early data suggests so, more thorough testing is required before we can draw real conclusions

<!-- Thank you for making a PR! Bug fixes are always welcome, but if you're adding a new feature or changing an existing one, we'd really appreciate if you open an issue, post on the forum, or drop in on Discord -->. 

## Checks

- [ ] I am happy for maintainers to push small adjustments to this PR, to speed up the review cycle
- [ ] I have checked that there are no existing pull requests for the same thing