### PR TITLE
fix: do not try to decrypt plaintext records

### DIFF
--- a/crates/atuin-client/src/record/sqlite_store.rs
+++ b/crates/atuin-client/src/record/sqlite_store.rs
@@ -385,6 +385,10 @@ impl SqliteStore {
         let re_encrypted = all
             .into_iter()
             .map(|record| {
+                if record.tag.is_plaintext() {
+                    return Ok(record);
+                }
+
                 let data = paseto_v4::reencrypt_sync(&record.data, old_key, new_key)?;
                 Ok(record.with_data(data))
             })
@@ -418,7 +422,10 @@ impl SqliteStore {
     pub async fn verify(&self, key: &paseto_v4::Key) -> Result<()> {
         let all = self.load_all().await?;
 
-        all.into_iter().map(|record| record.decrypt(key)).collect::<Result<Vec<_>>>()?;
+        all.into_iter()
+            .filter(|record| !record.tag.is_plaintext())
+            .map(|record| record.decrypt(key))
+            .collect::<Result<Vec<_>>>()?;
 
         Ok(())
     }
@@ -430,6 +437,10 @@ impl SqliteStore {
         let all = self.load_all().await?;
 
         for record in &all {
+            if record.tag.is_plaintext() {
+                continue;
+            }
+
             match record.clone().decrypt(key) {
                 Ok(_) => {}
                 Err(_) => {
@@ -674,5 +685,49 @@ mod tests {
                 .unwrap(),
             10
         );
+    }
+
+    #[rstest]
+    #[tokio::test]
+    async fn verify_purge_and_rekey_skip_plaintext_packfile_manifests(
+        #[future(awt)] store: SqliteStore,
+    ) {
+        let key = paseto_v4::Key::new_os_random();
+        let host = HostId(uuid_v7());
+
+        let history = Record::builder()
+            .host(Host::new(host))
+            .version(RecordVersion::V1)
+            .tag(RecordTag::History)
+            .idx(0)
+            .data(DecryptedData(b"history".to_vec()))
+            .build()
+            .encrypt(&key);
+
+        // Packfile manifests are plaintext with an empty cek, as written by the packer.
+        let manifest = Record::builder()
+            .host(Host::new(host))
+            .version(RecordVersion::V1)
+            .tag(RecordTag::Packfile)
+            .idx(0)
+            .data(paseto_v4::EncryptedData {
+                raw: "001{}".into(),
+                cek: String::new(),
+            })
+            .build();
+
+        store.push(&history).await.unwrap();
+        store.push(&manifest).await.unwrap();
+
+        store.verify(&key).await.expect("verify should skip packfile manifests");
+
+        store.purge(&key).await.expect("purge should skip packfile manifests");
+        assert_eq!(store.len_all().await.unwrap(), 2, "purge must not delete the manifest");
+
+        let new_key = paseto_v4::Key::new_os_random();
+        store.re_encrypt(&key, &new_key).await.expect("rekey should skip packfile manifests");
+        assert_eq!(store.get(manifest.id).await.unwrap(), manifest, "manifest must be untouched");
+        store.get(history.id).await.unwrap().decrypt(&new_key).expect("history was rekeyed");
+        store.verify(&new_key).await.unwrap();
     }
 }

--- a/crates/atuin-client/src/record/sync/mod.rs
+++ b/crates/atuin-client/src/record/sync/mod.rs
@@ -208,9 +208,9 @@ impl SyncEngine {
             .flat_map(|(host, tags)| {
                 tags.keys().map(move |tag| RecordSeriesKey::new(*host, tag.clone()))
             })
-            // Note we have to skip `Packfile`s here because packfiles _aren't_ actually encrypted,
-            // so using the default CEK would fail decryption.
-            .find(|series| series.tag != RecordTag::Packfile);
+            // Plaintext series (packfile manifests) would fail decryption with any key, so they
+            // can't be used to check whether the local key matches the remote.
+            .find(|series| !series.tag.is_plaintext());
 
         let series = sample?;
 

--- a/crates/atuin-domain/src/record/tag.rs
+++ b/crates/atuin-domain/src/record/tag.rs
@@ -37,6 +37,24 @@ impl RecordTag {
         self.as_ref()
     }
 
+    /// Whether records with this tag are stored as plaintext rather than encrypted.
+    ///
+    /// Packfile manifests only describe a range of records and carry no secrets, so they are
+    /// written without a cek. Everything else is encrypted with the user's key.
+    #[must_use]
+    pub fn is_plaintext(&self) -> bool {
+        // Exhaustive on purpose: a new tag must decide whether it is encrypted.
+        match self {
+            Self::Packfile => true,
+            Self::History
+            | Self::Kv
+            | Self::Script
+            | Self::DotfilesVar
+            | Self::ConfigShellAlias
+            | Self::Other(_) => false,
+        }
+    }
+
     fn variant_rank(&self) -> u8 {
         match self {
             Self::History => 0,


### PR DESCRIPTION
Introduces is_plaintext to the RecordTag type, which can be called to check if a record is plaintext or not. This is used for store verification, re-encryption, etc.

Resolves #4056

<!-- Thank you for making a PR! Bug fixes are always welcome, but if you're adding a new feature or changing an existing one, we'd really appreciate if you open an issue, post on the forum, or drop in on Discord -->

## Checks
- [ ] I am happy for maintainers to push small adjustments to this PR, to speed up the review cycle
- [ ] I have checked that there are no existing pull requests for the same thing
