### PR TITLE
fix: behavior of PTY proxy on terminal resizes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -708,9 +708,9 @@ dependencies = [
 
 [[package]]
 name = "atuin-vt100"
-version = "0.17.1"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e1ab415760f579e398bed1931668a5a6866b5c1c7cf3718c889605534a76bab"
+checksum = "4865fe19f666db926b68f57ed09b58af0a5da97ade148687c2c695fffad0765a"
 dependencies = [
  "itoa",
  "unicode-width 0.2.2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ atuin-kv = { path = "crates/atuin-kv", version = "18.21.0" }
 atuin-pty-proxy = { path = "crates/atuin-pty-proxy", version = "18.21.0", default-features = false }
 atuin-scripts = { path = "crates/atuin-scripts", version = "18.21.0" }
 atuin-server = { path = "crates/atuin-server", version = "18.21.0" }
-atuin-vt100 = "0.17"
+atuin-vt100 = "0.19"
 
 arboard = { version = "3.4", default-features = false }
 argon2 = "0.5"

--- a/crates/atuin-ai/src/tools/mod.rs
+++ b/crates/atuin-ai/src/tools/mod.rs
@@ -811,6 +811,9 @@ const PREVIEW_WIDTH: NonZeroU16 = NonZeroU16::new(120).unwrap();
 /// instead of the real output.
 fn vt100_screen_lines(screen: &vt100::Screen) -> Vec<String> {
     let (rows, cols) = screen.size();
+    let rows = rows.get();
+    let cols = cols.get();
+
     let mut lines = Vec::with_capacity(usize::conv(rows));
     for row in 0..rows {
         let mut line = String::with_capacity(usize::conv(cols));

--- a/crates/atuin-pty-proxy/src/capture.rs
+++ b/crates/atuin-pty-proxy/src/capture.rs
@@ -116,15 +116,14 @@ impl TrackerCore {
     /// buffers but not the screen. Most likely, you will not want to call this method again until
     /// you clear the screen.
     fn take_rendered(&mut self) -> RenderedOutput {
-        let scrollback = self.emulator.callbacks_mut();
-        let mut buffer = scrollback.buffer.take();
-        let mut state = std::mem::take(&mut scrollback.state);
-
-        let _ = self.emulator.screen().write_contents_formatted_basic(
-            &mut buffer,
-            vt100::capture::BasicFormattedCaptureRange::Full(&mut state),
+        let (screen, scrollback) = self.emulator.screen_and_callbacks_mut();
+        let _ = screen.write_contents_formatted_basic(
+            &mut scrollback.buffer,
+            vt100::capture::BasicFormattedCaptureRange::Full(&mut scrollback.state),
         );
 
+        let buffer = scrollback.buffer.take();
+        scrollback.state = Default::default();
         RenderedOutput {
             truncated: buffer.is_truncated(),
             data: buffer.into_data(),

--- a/crates/atuin-pty-proxy/src/capture.rs
+++ b/crates/atuin-pty-proxy/src/capture.rs
@@ -120,7 +120,10 @@ impl TrackerCore {
         let mut buffer = scrollback.buffer.take();
         let mut state = std::mem::take(&mut scrollback.state);
 
-        let _ = self.emulator.screen().write_contents_formatted_basic(&mut buffer, &mut state);
+        let _ = self.emulator.screen().write_contents_formatted_basic(
+            &mut buffer,
+            vt100::capture::BasicFormattedCaptureRange::Full(&mut state),
+        );
 
         RenderedOutput {
             truncated: buffer.is_truncated(),

--- a/crates/atuin-pty-proxy/src/screen.rs
+++ b/crates/atuin-pty-proxy/src/screen.rs
@@ -39,9 +39,24 @@ struct Parser {
 }
 
 impl Parser {
+    /// How many lines of scrollback the snapshot emulator can hold.
+    ///
+    /// Scrollback allows for better handling of terminal resizes: without scrollback, if the
+    /// terminal height shrinks and then grows again, we'll know that lines from the scrollback got
+    /// added back to the top of the terminal, but we won't actually know what they contain, so we
+    /// won't be able to restore them when the search UI is opened and closed.
+    ///
+    /// Note that there is a best-effort fallback in the case where the terminal is resized by a
+    /// larger amount than our scrollback capacity -- atuin-vt100 tracks how much scrollback there
+    /// *would* be if the capacity were unbounded, and will fall back to inserting blank rows at the
+    /// top. Compared to inserting blank rows at the bottom, which is what a terminal emulator would
+    /// do when it genuinely ran of scrollback, this maintains the correct positioning of everything
+    /// in the terminal -- otherwise our emulator would badly drift from the parent terminal.
+    const SCROLLBACK_CAPACITY: usize = 50;
+
     fn new(rows: NonZeroU16, cols: NonZeroU16, options: ParserOptions) -> Self {
         Self {
-            emulator: vt100::Parser::new(rows, cols, 0),
+            emulator: vt100::Parser::new(rows, cols, Self::SCROLLBACK_CAPACITY),
             tracker: options.sink.map(|f| CommandCaptureTracker::new(rows, cols, f)),
             highlighter: options.debug_osc133.then(Osc133DebugHighlighter::new),
         }
@@ -142,6 +157,9 @@ fn encode_screen(parser: &vt100::Parser) -> Vec<u8> {
     let screen = parser.screen();
     let (rows, cols) = screen.size();
     let (cursor_row, cursor_col) = screen.cursor_position();
+
+    let rows = rows.get();
+    let cols = cols.get();
 
     let mut buf = Vec::with_capacity(256 + (usize::from(rows) * usize::from(cols)));
     buf.extend_from_slice(&rows.to_be_bytes());

--- a/crates/atuin/src/command/client/search/interactive.rs
+++ b/crates/atuin/src/command/client/search/interactive.rs
@@ -1557,6 +1557,8 @@ fn fetch_screen_state(socket_path: &str) -> Option<SavedScreen> {
 #[cfg(unix)]
 fn restore_popup_area(saved: &SavedScreen, popup_rect: Rect, scroll_offset: u16) {
     use ratatui::crossterm::cursor::MoveTo;
+    use ratatui::crossterm::style::{Attribute, SetAttribute};
+    use ratatui::crossterm::terminal::{Clear, ClearType};
 
     let mut stdout = stdout();
 
@@ -1564,19 +1566,15 @@ fn restore_popup_area(saved: &SavedScreen, popup_rect: Rect, scroll_offset: u16)
         let target_row = popup_rect.y + dy;
         let source_row = usize::conv(target_row + scroll_offset);
 
-        // Clear only the popup region. The server-side rows_formatted() skips
-        // default cells (spaces with default attributes) using cursor jumps, so
-        // any popup content at those positions would remain if not cleared
-        // beforehand. We write `popup_rect.width` spaces instead of
-        // ClearType::CurrentLine so that only the popup area is cleared, not
-        // the entire terminal line.
+        // The snapshot from the server spans the full width of the terminal, not just the popup
+        // area, so move to the start of the line and clear the whole line before we write the row
+        // contents.
         let _ = execute!(
             stdout,
-            MoveTo(popup_rect.x, target_row),
-            ratatui::crossterm::style::SetAttribute(ratatui::crossterm::style::Attribute::Reset),
+            MoveTo(0, target_row),
+            SetAttribute(Attribute::Reset),
+            Clear(ClearType::CurrentLine),
         );
-        let _ = write!(stdout, "{:width$}", "", width = usize::conv(popup_rect.width));
-        let _ = execute!(stdout, MoveTo(popup_rect.x, target_row));
 
         if let Some(row_bytes) = saved.rows_data.get(source_row) {
             let _ = stdout.write_all(row_bytes);


### PR DESCRIPTION
* **Fixed:** When the search UI is opened and closed, every line becomes max-width, padded with spaces. This means that shrinking the terminal by just one column wraps *every* line.
* **Fixed:** When there's at least a screenful of output, if the terminal is shrunk vertically, opening and closing the UI will restore the wrong part of the screen where the UI was.
* **Fixed:** When there's at least a screenful of output plus some scrollback, if the terminal is grown vertically, the UI will be rendered at the wrong position when opened, and the wrong part of the screen will be restored when it's closed.

### Implementation details

Most of the work was in [atuin-vt100](https://github.com/atuin/vt100-rust). The relevant changes are:

* Added support for `CSI 3 J`, which clears the scrollback buffer.

* Changed the behavior of `Parser::set_size` and `Screen::set_size` when the screen height is increased. Now, the parser tracks how many rows of scrollback we *would* have if the scrollback capacity were unbounded; rows are inserted at the top of the screen until we reach this theoretical number rather than the actual length of the scrollback buffer. If we exhaust the scrollback buffer but haven't reached the theoretical length yet, we keep adding rows at the top but just make them blank. Only after we reach the theoretical scrollback length do we start adding blank rows at the bottom. This is intended to more closely match the behavior of a real terminal emulator that the parser might be emulating.

* Scrollback uses less memory when lines end with blank cells. Note that there is a technically observable change with `Screen::set_scrollback`: previously, `set_scrollback` could cause the screen to contain rows that were shorter than the screen width, if the screen used to be narrower when those rows were pushed to scrollback; this could be noticed with `Screen::cell`. Now, every row in the screen is always at least the width of the screen. Scrollback rows that are longer than the screen width can still be observed; this change does not truncate them.

* Fixed handling of triple-width Unicode characters (U+17D8). The emulator always renders wide characters in exactly two cells, but the raw Unicode width was used for certain calculations, which produced inconsistent results. Now the calculations used the actual number of cells that the character will take up. It may be worth adding true support for triple-width characters in the future, but this fix at least makes the current behavior consistent.

* `Screen::set_size` only clears each row's `wrapped` when the screen width changes. Previously, it would unconditionally clear that flag.

* `Screen::size` now returns `NonZeroU16`s.

* `Screen::set_size` resets the scroll region and scrollback offset when the size changes, matching the behavior of xterm.

* `Screen::set_size` has different behavior when the screen height changes. Previously, it would discard rows from or add rows to the bottom as needed, but this does not match most terminal emulators.

  Now, when the height is decreased, `set_size` discards rows from the bottom only until the cursor is at the bottom. Then, it pushes excess rows from the top of the screen into scrollback.

  When the height is increased, `set_size` pulls rows from scrollback into the top of the screen. If scrollback is exhausted and the new height hasn't been reached yet, blank rows are added to the bottom.

* Added `Parser::set_size`, which is like `Screen::set_size` but calls the `on_scroll` callback when a row is pushed off the top of scrollback (which is now possible due to the other `set_size` changes).

* Added `capture::basic_formatted_to_plain`, which converts a basic formatted capture (as returned by `Screen::contents_formatted_basic`) into a plain text one without allocating.

* Added `capture::basic_formatted_rows`, which splits a basic formatted capture into individual rows without allocating.

* Added `Parser::screen_and_callbacks_mut`, which returns mutable references to both the screen and callbacks object at once. This was not possible with the existing methods.