### PR TITLE
feat: store terminal size in command captures

### DIFF
--- a/crates/atuin-ai/src/tools/mod.rs
+++ b/crates/atuin-ai/src/tools/mod.rs
@@ -1506,6 +1506,8 @@ mod tests {
             meta: Some(CommandCaptureMeta {
                 output_truncated: false,
                 output_observed_bytes: 0,
+                terminal_width: 80,
+                terminal_height: 24,
             }),
         };
         let chunked = GetCommandOutputResponse::build(capture, &[

--- a/crates/atuin-daemon/proto/history.proto
+++ b/crates/atuin-daemon/proto/history.proto
@@ -156,6 +156,10 @@ message CommandCaptureMeta {
   // Think about this example -- a command outputs "hello\rhello\rhello\rhello". What is rendered?
   // "hello". `output_observed_bytes` will be 23 -- ie. how many bytes the terminal saw.
   uint64 output_observed_bytes = 2;
+  // The width of the terminal when the command finished.
+  uint32 terminal_width = 3;
+  // The height of the terminal when the command finished.
+  uint32 terminal_height = 4;
 }
 
 // A completed command's captured output.

--- a/crates/atuin-daemon/src/client.rs
+++ b/crates/atuin-daemon/src/client.rs
@@ -202,12 +202,16 @@ impl HistoryClient {
         output: String,
         output_truncated: bool,
         output_observed_bytes: u64,
+        terminal_width: u16,
+        terminal_height: u16,
     ) -> Result<()> {
         let capture = CommandCapture {
             output,
             meta: Some(CommandCaptureMeta {
                 output_truncated,
                 output_observed_bytes,
+                terminal_width: terminal_width.into(),
+                terminal_height: terminal_height.into(),
             }),
         };
         self.client

--- a/crates/atuin-daemon/src/grpc/history/pb.rs
+++ b/crates/atuin-daemon/src/grpc/history/pb.rs
@@ -400,6 +400,8 @@ mod tests {
             meta: Some(CommandCaptureMeta {
                 output_truncated: false,
                 output_observed_bytes: u64::conv(output.len()),
+                terminal_width: 80,
+                terminal_height: 24,
             }),
         }
     }

--- a/crates/atuin-daemon/src/output_capture.rs
+++ b/crates/atuin-daemon/src/output_capture.rs
@@ -136,6 +136,8 @@ mod tests {
             meta: Some(CommandCaptureMeta {
                 output_truncated: false,
                 output_observed_bytes: u64::conv(output.len()),
+                terminal_width: 80,
+                terminal_height: 24,
             }),
         }
     }

--- a/crates/atuin-pty-proxy/src/capture.rs
+++ b/crates/atuin-pty-proxy/src/capture.rs
@@ -37,6 +37,8 @@ pub struct CommandCapture {
     pub session_id: Option<String>,
     pub output_observed_bytes: u64,
     pub output_truncated: bool,
+    pub terminal_width: u16,
+    pub terminal_height: u16,
 }
 
 /// The state of an in-progress command capture.
@@ -250,6 +252,7 @@ impl TrackerCore {
         };
 
         let state = std::mem::take(&mut self.capture);
+        let (rows, cols) = self.emulator.screen().size();
         (self.sink)(CommandCapture {
             output: state.output,
             exit_code: state.exit_code,
@@ -257,6 +260,8 @@ impl TrackerCore {
             session_id: state.session_id,
             output_observed_bytes: state.output_observed_bytes,
             output_truncated: state.output_truncated,
+            terminal_width: cols.get(),
+            terminal_height: rows.get(),
         });
     }
 
@@ -425,6 +430,8 @@ mod tests {
             session_id: Some("sess".to_string()),
             output_observed_bytes: u64::conv(b"hi\r\n".len()),
             output_truncated: false,
+            terminal_width: COLS,
+            terminal_height: ROWS,
         },
     )]
     // Only the execute and finish markers: no prompt or command line in the stream at all.
@@ -437,6 +444,8 @@ mod tests {
             session_id: Some("abcd".to_string()),
             output_observed_bytes: u64::conv(b"line one\r\n".len()),
             output_truncated: false,
+            terminal_width: COLS,
+            terminal_height: ROWS,
         },
     )]
     fn captures_a_full_command_cycle(
@@ -736,6 +745,8 @@ mod tests {
             // after it, in the unknown zone, so it was never counted to begin with.
             output_observed_bytes: u64::conv(b"line one\r\n".len()),
             output_truncated: false,
+            terminal_width: COLS,
+            terminal_height: ROWS,
         });
     }
 

--- a/crates/atuin/src/command/mod.rs
+++ b/crates/atuin/src/command/mod.rs
@@ -125,6 +125,8 @@ fn semantic_command_capture_sink() -> Option<atuin_pty_proxy::CommandCaptureSink
                         capture.output,
                         capture.output_truncated,
                         capture.output_observed_bytes,
+                        capture.terminal_width,
+                        capture.terminal_height,
                     )
                     .await;
             }


### PR DESCRIPTION
We need to know the size of the terminal (particularly the width, but we might as well store both dimensions) in order to display the output as it actually appeared on the user's terminal.