### PR TITLE
chore(ci): limit concurrency of workflows on same branch

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -10,6 +10,10 @@ on:
     paths-ignore:
       - "ui/**"
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 env:
   CARGO_TERM_COLOR: always
 


### PR DESCRIPTION
Limit CI concurrency so the same workflow cannot run on the same branch more than once concurrently, to avoid using up all our runners.