### PR TITLE
fix(client): support opencode V2 plugin loader in opencode hook

### DIFF
--- a/crates/atuin/contrib/opencode/README.md
+++ b/crates/atuin/contrib/opencode/README.md
@@ -1,0 +1,56 @@
+# Atuin's OpenCode plugins
+
+The V1 and V2 loaders have incompatible export contracts. Install the variant
+for the API your OpenCode build uses; do not install both templates together.
+
+```sh
+# V1, including older loaders that invoke every export as a function:
+atuin hook install opencode
+
+# V2 builds exposing tool.hook and shell.hook:
+atuin hook install opencode-v2
+```
+
+Both commands write `${XDG_CONFIG_HOME:-$HOME/.config}/opencode/plugins/atuin.ts`,
+replacing the other variant. Restart OpenCode after switching. V1 exports only
+a function; V2 exports only an `{ id, setup }` object. Both templates are
+standalone so the installed file needs no sibling modules. The V2 installer
+option requires an Atuin build containing this change; it is not an instruction
+for already-released Atuin binaries.
+
+The V2 API is still changing. This adapter feature-detects the `tool.hook` and
+`shell.hook` domains and quietly disables itself on builds without them.
+The test fixtures below exercise that hook contract, not a live OpenCode beta.
+
+## Correlation and failure policy
+
+V1 associates the post-permission shell event with the exact tool call ID.
+The V2 shell event used by this adapter does not supply a tool call ID. Its
+command-text fallback therefore records only non-overlapping, unambiguous
+proposals. When identical commands overlap, their proposals remain ineligible
+until they finish, even if one is denied or finishes first. An already-started
+entry is still completed using its original tool ID. This deliberately loses
+some history rather than swapping intents, working directories, or exit codes.
+It does not claim to distinguish an unrelated user shell that executes the
+same command as a sole pending tool proposal; that needs a host-provided call ID.
+
+At the pending-proposal limit, V2 stops correlating new commands until reload
+instead of evicting a proposal that could later steal another call's entry.
+Already-started entries can still finish. Registration failures roll back
+previous registrations; callbacks stay inert until setup completes and after
+disposal, including when the host's disposer fails. As with the original
+adapter, a host shutdown/error that omits completion can leave history open.
+
+## Regression tests
+
+From the repository root, with Node.js 22.6 or newer:
+
+```sh
+node --experimental-strip-types --test crates/atuin/contrib/opencode/tests/atuin.test.mjs
+```
+
+No npm install is needed. The suite uses Node's built-in test runner and mocks
+only the Atuin subprocess. It checks loader exports, reordered/overlapping
+calls, denied commands, cwd fallback, setup rollback, disposal, bounded state,
+argument preservation, subprocess failures, and completion exit codes.
+The Rust installer cases live alongside `hook.rs` and run with the crate tests.

--- a/crates/atuin/contrib/opencode/atuin-v2.ts
+++ b/crates/atuin/contrib/opencode/atuin-v2.ts
@@ -1,0 +1,232 @@
+/**
+ * Atuin plugin for the OpenCode V2 tool/shell hook API.
+ *
+ * Install with `atuin hook install opencode-v2`, then restart OpenCode.
+ * This replaces the V1 template at opencode/plugins/atuin.ts.
+ * Do not place both templates in an autoload directory.
+ */
+
+import { spawn } from "node:child_process";
+
+const ATUIN_AUTHOR = "opencode";
+const ATUIN_TIMEOUT_MS = 10_000;
+const BASH_TOOL = "bash";
+const EXIT_ABORTED = 130;
+const EXIT_TIMED_OUT = 124;
+
+// Bound pending V2 proposals when the host omits completion events.
+const MAX_PROPOSED = 128;
+
+interface Proposal {
+	command: string;
+	intent?: string;
+}
+
+interface Entry {
+	historyId: string;
+	cwd: string;
+}
+
+interface AtuinResult {
+	code: number | null;
+	stdout: string;
+}
+
+/** Run without a shell: the recorded command must stay a single argv entry. */
+function atuin(args: string[], cwd: string): Promise<AtuinResult> {
+	return new Promise((resolve) => {
+		let child: ReturnType<typeof spawn>;
+		try {
+			child = spawn("atuin", args, { cwd, stdio: ["ignore", "pipe", "ignore"] });
+		} catch {
+			resolve({ code: null, stdout: "" });
+			return;
+		}
+
+		let stdout = "";
+		let settled = false;
+		const timer = setTimeout(() => child.kill("SIGKILL"), ATUIN_TIMEOUT_MS);
+		const settle = (result: AtuinResult) => {
+			if (settled) return;
+			settled = true;
+			clearTimeout(timer);
+			resolve(result);
+		};
+
+		child.stdout?.setEncoding("utf8");
+		child.stdout?.on("data", (chunk: string) => {
+			stdout += chunk;
+		});
+		child.on("error", () => settle({ code: null, stdout: "" }));
+		child.on("close", (code) => settle({ code, stdout }));
+	});
+}
+
+async function startHistory(
+	cwd: string,
+	proposal: Proposal,
+): Promise<string | undefined> {
+	const args = ["history", "start", "--author", ATUIN_AUTHOR, "--author-kind", "agent"];
+	if (proposal.intent) args.push("--intent", proposal.intent);
+	args.push("--", proposal.command);
+	const result = await atuin(args, cwd);
+	if (result.code !== 0) return undefined;
+	const historyId = result.stdout.trim();
+	return historyId.length > 0 ? historyId : undefined;
+}
+
+// V2 reports completion and error payloads instead of V1's ToolOutput.
+function exitCodeFrom(event: unknown): number {
+	const e = (event ?? {}) as {
+		status?: unknown;
+		result?: unknown;
+		error?: unknown;
+	};
+	const payload = e.status === "error" ? e.error : e.result;
+	const metadata = (payload as { metadata?: unknown } | undefined)?.metadata;
+	const exit = (metadata as { exit?: unknown } | undefined)?.exit;
+	if (typeof exit === "number") return exit;
+
+	let text = "";
+	try {
+		const p = payload as { message?: unknown; output?: unknown } | undefined;
+		if (typeof p?.message === "string") text = p.message;
+		else if (typeof p?.output === "string") text = p.output;
+		else text = JSON.stringify(payload ?? "");
+	} catch {
+		// Malformed diagnostic payloads must not abort a tool call.
+	}
+	if (text.includes("User aborted the command")) return EXIT_ABORTED;
+	if (/exceeding timeout \d+ ms/.test(text)) return EXIT_TIMED_OUT;
+	return e.status === "completed" ? 0 : 1;
+}
+
+async function swallowFailures(work: () => void | Promise<void>): Promise<void> {
+	try {
+		await work();
+	} catch {
+		// A missing history entry is always the better failure.
+	}
+}
+
+interface Pending extends Proposal {
+	claimed: boolean;
+	ambiguous: boolean;
+}
+
+// Beta hook domains are feature-detected rather than imported from the V1
+// package. Builds without this API leave history recording disabled.
+async function setup(ctx: any): Promise<(() => Promise<void>) | void> {
+	const tool = ctx?.tool;
+	const shell = ctx?.shell;
+	if (typeof tool?.hook !== "function" || typeof shell?.hook !== "function") return;
+	const baseDir =
+		typeof ctx?.location?.directory === "string" ? ctx.location.directory : "";
+
+	// Keep a proposal until its tool finishes, including after it is claimed.
+	// Otherwise a concurrent duplicate could appear unique after the first
+	// command started. History entries are always closed by exact tool ID.
+	const proposed = new Map<string, Pending>();
+	const running = new Map<string, Entry>();
+	const registrations: { dispose?: () => unknown }[] = [];
+	let active = false;
+	let correlationDisabled = false;
+
+	async function dispose() {
+		// Make leftover callbacks inert even if a host disposer rejects.
+		active = false;
+		proposed.clear();
+		running.clear();
+		for (const registration of registrations.splice(0).reverse()) {
+			await swallowFailures(async () => {
+				await registration?.dispose?.();
+			});
+		}
+	}
+
+	function remember(id: string, args: unknown) {
+		if (correlationDisabled || proposed.has(id)) return;
+		const { command, description } = (args ?? {}) as {
+			command?: unknown;
+			description?: unknown;
+		};
+		if (typeof command !== "string" || command.length === 0) return;
+
+		if (proposed.size >= MAX_PROPOSED) {
+			// Eviction is unsafe without a shell call ID: a delayed, evicted
+			// command could claim a newer identical proposal. Stop correlating
+			// until reload, but still let already-started entries finish.
+			correlationDisabled = true;
+			proposed.clear();
+			return;
+		}
+
+		let ambiguous = false;
+		for (const proposal of proposed.values()) {
+			if (proposal.command !== command) continue;
+			proposal.ambiguous = true;
+			ambiguous = true;
+		}
+		proposed.set(id, {
+			command,
+			intent: typeof description === "string" && description.length > 0
+				? description : undefined,
+			claimed: false,
+			ambiguous,
+		});
+	}
+
+	async function claim(command: string, cwd: unknown) {
+		if (correlationDisabled) return;
+		for (const [id, proposal] of proposed) {
+			if (proposal.command !== command || proposal.claimed || proposal.ambiguous) continue;
+			proposal.claimed = true;
+			const resolvedCwd = typeof cwd === "string" && cwd.length > 0 ? cwd : baseDir;
+			const historyId = await startHistory(resolvedCwd, proposal);
+			// Setup may have been disposed while the Atuin subprocess ran.
+			if (active && historyId) running.set(id, { historyId, cwd: resolvedCwd });
+			return;
+		}
+	}
+
+	async function finish(id: string, event: unknown) {
+		proposed.delete(id);
+		const entry = running.get(id);
+		if (!entry) return;
+		running.delete(id);
+		await atuin(
+			["history", "end", entry.historyId, "--exit", String(exitCodeFrom(event))],
+			entry.cwd,
+		);
+	}
+
+	try {
+		registrations.push(await tool.hook("execute.before", (event: any) =>
+			swallowFailures(() => {
+				if (!active || event?.tool !== BASH_TOOL || typeof event?.id !== "string") return;
+				remember(event.id, event.input);
+			}),
+		));
+		registrations.push(await shell.hook("create.before", (event: any) =>
+			swallowFailures(() => {
+				if (!active || typeof event?.command !== "string" || !event.command) return;
+				return claim(event.command, event.cwd);
+			}),
+		));
+		registrations.push(await tool.hook("execute.after", (event: any) =>
+			swallowFailures(() => {
+				if (!active || event?.tool !== BASH_TOOL || typeof event?.id !== "string") return;
+				return finish(event.id, event);
+			}),
+		));
+		// No callback may open an entry until *all* hooks are registered.
+		active = true;
+	} catch {
+		await dispose();
+		return;
+	}
+	return dispose;
+}
+
+// V2 has an object-only definition; never expose it to legacy V1 loaders.
+export default { id: "atuin", setup };

--- a/crates/atuin/contrib/opencode/atuin.ts
+++ b/crates/atuin/contrib/opencode/atuin.ts
@@ -1,19 +1,9 @@
 /**
- * Atuin plugin for opencode.
+ * Atuin plugin for opencode V1, including legacy function-only loaders.
  *
- * Tracks bash commands executed by opencode in Atuin history with author
- * `opencode`.
- *
- * Install with:
- *   atuin hook install opencode
- *
- * Then restart opencode.
- *
- * Dual V1 + V2 form:
- * - V1 (opencode 1.x) calls `server()` and uses the returned hooks.
- * - V2 (opencode2 beta) reads the default export's `id` and `setup()`.
- * The named `AtuinPlugin` export is kept for pre-1.18.29 V1 releases that
- * expect bare function exports.
+ * Install with `atuin hook install opencode`, then restart opencode.
+ * For the V2 plugin API, use `atuin hook install opencode-v2` instead.
+ * Both installers write the same plugin path; install only one variant.
  */
 
 import type { Plugin } from "@opencode-ai/plugin";
@@ -21,21 +11,11 @@ import { spawn } from "node:child_process";
 
 const ATUIN_AUTHOR = "opencode";
 const ATUIN_TIMEOUT_MS = 10_000;
-
-// opencode's shell tool keeps the id `bash` for compatibility, even though its
-// module is named `shell`.
 const BASH_TOOL = "bash";
-
-// A command that did not exit on its own reports a null exit code, so
-// substitute the conventional code for each of the two ways that happens.
 const EXIT_ABORTED = 130;
 const EXIT_TIMED_OUT = 124;
 
-// A denied command reaches neither `shell.env` nor `tool.execute.after`, so its
-// proposal is never claimed and would sit in the map for the life of the
-// session. Bound the map to cap that. Evicting the oldest can in principle drop
-// a command still waiting at its permission prompt, which just goes unrecorded,
-// but only a handful of calls are ever genuinely in flight at once.
+// Denied commands never reach shell.env or tool.execute.after.
 const MAX_PROPOSED = 128;
 
 interface Proposal {
@@ -46,10 +26,6 @@ interface Proposal {
 interface Entry {
 	historyId: string;
 	cwd: string;
-	// V2 only: proposal id that claimed this entry. Lets `finish` close only
-	// its own entry, so a denied or concurrent duplicate command can never
-	// steal another call's history entry or exit code.
-	owner?: string;
 }
 
 interface AtuinResult {
@@ -62,13 +38,7 @@ interface ToolOutput {
 	metadata: unknown;
 }
 
-/**
- * Run Atuin, resolving rather than rejecting on every failure.
- *
- * Spawned without a shell: a recorded command is arbitrary text that has to
- * reach Atuin as a single argv entry unmangled, which rules out the Bun shell
- * the plugin API hands us.
- */
+/** Run without a shell: the recorded command must stay a single argv entry. */
 function atuin(args: string[], cwd: string): Promise<AtuinResult> {
 	return new Promise((resolve) => {
 		let child: ReturnType<typeof spawn>;
@@ -82,7 +52,6 @@ function atuin(args: string[], cwd: string): Promise<AtuinResult> {
 		let stdout = "";
 		let settled = false;
 		const timer = setTimeout(() => child.kill("SIGKILL"), ATUIN_TIMEOUT_MS);
-
 		const settle = (result: AtuinResult) => {
 			if (settled) return;
 			settled = true;
@@ -103,53 +72,35 @@ async function startHistory(
 	cwd: string,
 	proposal: Proposal,
 ): Promise<string | undefined> {
-	const args = [
-		"history",
-		"start",
-		"--author",
-		ATUIN_AUTHOR,
-		"--author-kind",
-		"agent",
-	];
+	const args = ["history", "start", "--author", ATUIN_AUTHOR, "--author-kind", "agent"];
 	if (proposal.intent) args.push("--intent", proposal.intent);
 	args.push("--", proposal.command);
-
 	const result = await atuin(args, cwd);
 	if (result.code !== 0) return undefined;
-
 	const historyId = result.stdout.trim();
 	return historyId.length > 0 ? historyId : undefined;
 }
 
-// The tool records an abort or a timeout in its output text rather than as an
-// exit code, so string matching is the only way to tell the two apart.
 function exitCodeFrom(output: ToolOutput): number {
 	const exit = (output.metadata as { exit?: unknown } | undefined)?.exit;
 	if (typeof exit === "number") return exit;
-
 	const text = typeof output.output === "string" ? output.output : "";
 	if (text.includes("User aborted the command")) return EXIT_ABORTED;
 	if (/exceeding timeout \d+ ms/.test(text)) return EXIT_TIMED_OUT;
 	return 1;
 }
 
-// A rejected hook aborts opencode's tool call and discards the command's
-// output. A missing history entry is always the better failure.
+// Recording history must not abort a tool call or discard its output.
 async function swallowFailures(work: () => void | Promise<void>): Promise<void> {
 	try {
 		await work();
 	} catch {
-		// Deliberately ignored.
+		// A missing history entry is always the better failure.
 	}
 }
 
-// V1 factory. Kept as a named export for pre-1.18.29 releases that expect
-// bare function exports; 1.18.29+ uses it via the default export's `server`.
-export const AtuinPlugin: Plugin = async ({ directory }) => {
-	// Commands opencode has proposed but is not yet cleared to run, keyed by
-	// tool call ID.
+const AtuinPlugin: Plugin = async ({ directory }) => {
 	const proposed = new Map<string, Proposal>();
-	// Atuin history IDs for commands that did start, keyed by tool call ID.
 	const running = new Map<string, Entry>();
 
 	function propose(callID: string, args: unknown) {
@@ -158,12 +109,10 @@ export const AtuinPlugin: Plugin = async ({ directory }) => {
 			description?: unknown;
 		};
 		if (typeof command !== "string" || command.length === 0) return;
-
 		if (proposed.size >= MAX_PROPOSED) {
 			const oldest = proposed.keys().next().value;
 			if (oldest !== undefined) proposed.delete(oldest);
 		}
-
 		proposed.set(callID, {
 			command,
 			intent:
@@ -177,52 +126,34 @@ export const AtuinPlugin: Plugin = async ({ directory }) => {
 		const proposal = proposed.get(callID);
 		if (!proposal) return;
 		proposed.delete(callID);
-
 		const historyId = await startHistory(cwd, proposal);
 		if (historyId) running.set(callID, { historyId, cwd });
 	}
 
 	async function finish(callID: string, output: ToolOutput) {
 		proposed.delete(callID);
-
 		const entry = running.get(callID);
 		if (!entry) return;
 		running.delete(callID);
-
 		await atuin(
-			[
-				"history",
-				"end",
-				entry.historyId,
-				"--exit",
-				String(exitCodeFrom(output)),
-			],
+			["history", "end", entry.historyId, "--exit", String(exitCodeFrom(output))],
 			entry.cwd,
 		);
 	}
 
 	return {
-		// Fires before the permission prompt, so only remember the command here.
-		// Starting an entry would record commands the user went on to deny.
+		// Before permission: remember only, so denied commands stay unrecorded.
 		"tool.execute.before": (input, output) =>
 			swallowFailures(() => {
 				if (input.tool !== BASH_TOOL) return;
 				propose(input.callID, output.args);
 			}),
-
-		// The only hook that runs after the permission prompt but before the
-		// command does, and the only one given the resolved working directory.
-		// It also fires for user-run shells and for PTY sessions, which
-		// opencode did not run; those are skipped because they have no
-		// proposal to claim, not because of the call ID check below.
+		// After permission, with the resolved cwd and exact tool call ID.
 		"shell.env": (input) =>
 			swallowFailures(() => {
 				if (!input.callID) return;
 				return start(input.callID, input.cwd || directory);
 			}),
-
-		// Also fires when the user aborts a command, unlike the error paths,
-		// which skip this hook and leave the entry open.
 		"tool.execute.after": (input, output) =>
 			swallowFailures(() => {
 				if (input.tool !== BASH_TOOL) return;
@@ -231,186 +162,5 @@ export const AtuinPlugin: Plugin = async ({ directory }) => {
 	};
 };
 
-// V2 `tool.execute.after` reports `{ status: "completed", result }` or
-// `{ status: "error", error }` instead of V1's `{ output, metadata }`.
-// Shapes differ between beta builds, so read defensively and never throw.
-function v2ExitCodeFrom(event: unknown): number {
-	const e = (event ?? {}) as {
-		status?: unknown;
-		result?: unknown;
-		error?: unknown;
-	};
-	const payload = e.status === "error" ? e.error : e.result;
-	const metadata = (payload as { metadata?: unknown } | undefined)?.metadata;
-	const exit = (metadata as { exit?: unknown } | undefined)?.exit;
-	if (typeof exit === "number") return exit;
-
-	let text = "";
-	try {
-		const p = payload as { message?: unknown; output?: unknown } | undefined;
-		if (typeof p?.message === "string") text = p.message;
-		else if (typeof p?.output === "string") text = p.output;
-		else text = JSON.stringify(payload ?? "");
-	} catch {
-		text = "";
-	}
-	if (text.includes("User aborted the command")) return EXIT_ABORTED;
-	if (/exceeding timeout \d+ ms/.test(text)) return EXIT_TIMED_OUT;
-	return e.status === "completed" ? 0 : 1;
-}
-
-function splitProposal(args: unknown): Proposal | undefined {
-	const { command, description } = (args ?? {}) as {
-		command?: unknown;
-		description?: unknown;
-	};
-	if (typeof command !== "string" || command.length === 0) return undefined;
-	return {
-		command,
-		intent:
-			typeof description === "string" && description.length > 0
-				? description
-				: undefined,
-	};
-}
-
-// V2 setup (opencode2 beta). Same lifecycle as V1, adapted to the V2 API:
-// - `tool.execute.before` remembers the proposal (no Atuin call yet, so
-//   denied commands stay unrecorded).
-// - `shell.create.before` is the first post-permission hook carrying the
-//   resolved cwd, so it opens the history entry. It carries no call ID, so
-//   the pending proposal is claimed by matching `command`.
-// - `tool.execute.after` closes the entry; it also drops unclaimed
-//   proposals, so denied commands never reach Atuin.
-// `ctx` is typed loosely on purpose: the file must also load under V1
-// runtimes whose `@opencode-ai/plugin` package predates the V2 `tool`/`shell`
-// domains. Missing domains disable the V2 path quietly instead of crashing.
-async function atuinSetup(
-	ctx: any,
-): Promise<(() => void | Promise<void>) | void> {
-	const tool = ctx?.tool;
-	const shell = ctx?.shell;
-	if (typeof tool?.hook !== "function" || typeof shell?.hook !== "function") {
-		return;
-	}
-	const baseDir =
-		typeof ctx?.location?.directory === "string"
-			? (ctx.location.directory as string)
-			: undefined;
-
-	// Proposals keyed by V2 tool call id.
-	const proposed = new Map<string, Proposal>();
-	// Open history entries keyed by command (the only key the shell hook and
-	// the tool hook share), each tagged with the claiming proposal id.
-	// `finish` closes only the entry owned by its own call id: a denied or
-	// concurrent duplicate can neither steal another call's entry nor
-	// misattribute an exit code. At most an entry goes unclosed, matching
-	// the V1 eviction policy for commands that never report back.
-	const running = new Map<string, Entry[]>();
-
-	function rememberV2(callID: string, args: unknown) {
-		const proposal = splitProposal(args);
-		if (!proposal) return;
-
-		if (proposed.size >= MAX_PROPOSED) {
-			const oldest = proposed.keys().next().value;
-			if (oldest !== undefined) proposed.delete(oldest);
-		}
-
-		proposed.set(callID, proposal);
-	}
-
-	async function claim(command: string, cwd: string | undefined) {
-		for (const [id, proposal] of proposed) {
-			if (proposal.command !== command) continue;
-			proposed.delete(id);
-			const historyId = await startHistory(cwd || baseDir || "", proposal);
-			if (!historyId) return;
-			const list = running.get(command) ?? [];
-			list.push({ historyId, cwd: cwd || "", owner: id });
-			running.set(command, list);
-			return;
-		}
-	}
-
-	async function finishV2(id: string, input: unknown, event: unknown) {
-		const byId = proposed.get(id);
-		proposed.delete(id);
-		const command =
-			byId?.command ?? (input as { command?: unknown } | undefined)?.command;
-		if (typeof command !== "string" || command.length === 0) return;
-
-		// Close only the entry this call claimed. Anything else (a denied
-		// duplicate, an evicted proposal) leaves other calls' entries alone.
-		const list = running.get(command);
-		const index = list?.findIndex((entry) => entry.owner === id) ?? -1;
-		if (!list || index < 0) return;
-		const [entry] = list.splice(index, 1);
-		if (list.length === 0) running.delete(command);
-		if (!entry) return;
-
-		await atuin(
-			[
-				"history",
-				"end",
-				entry.historyId,
-				"--exit",
-				String(v2ExitCodeFrom(event)),
-			],
-			entry.cwd,
-		);
-	}
-
-	const registrations: unknown[] = [];
-	try {
-		registrations.push(
-			await tool.hook("execute.before", (event: any) =>
-				swallowFailures(() => {
-					if (event?.tool !== BASH_TOOL) return;
-					if (typeof event?.id !== "string") return;
-					rememberV2(event.id, event.input);
-				}),
-			),
-		);
-		registrations.push(
-			await shell.hook("create.before", (event: any) =>
-				swallowFailures(() => {
-					if (typeof event?.command !== "string" || event.command.length === 0) {
-						return;
-					}
-					return claim(event.command, event.cwd);
-				}),
-			),
-		);
-		registrations.push(
-			await tool.hook("execute.after", (event: any) =>
-				swallowFailures(() => {
-					if (event?.tool !== BASH_TOOL) return;
-					if (typeof event?.id !== "string") return;
-					return finishV2(event.id, event?.input, event);
-				}),
-			),
-		);
-	} catch {
-		// Hook registration failed: stay unloaded instead of failing plugin
-		// load. A missing history entry is always the better failure.
-		return;
-	}
-
-	return async () => {
-		for (const r of registrations) {
-			try {
-				await (r as { dispose?: () => unknown } | undefined)?.dispose?.();
-			} catch {
-				// Deliberately ignored.
-			}
-		}
-	};
-}
-
-// Dual V1 + V2 entrypoint: V1 calls `server()`, V2 reads `id` + `setup()`.
-export default {
-	id: "atuin",
-	setup: atuinSetup,
-	server: AtuinPlugin,
-};
+// Export exactly one function. Older V1 loaders invoke every module export.
+export default AtuinPlugin;

--- a/crates/atuin/contrib/opencode/atuin.ts
+++ b/crates/atuin/contrib/opencode/atuin.ts
@@ -8,6 +8,12 @@
  *   atuin hook install opencode
  *
  * Then restart opencode.
+ *
+ * Dual V1 + V2 form:
+ * - V1 (opencode 1.x) calls `server()` and uses the returned hooks.
+ * - V2 (opencode2 beta) reads the default export's `id` and `setup()`.
+ * The named `AtuinPlugin` export is kept for pre-1.18.29 V1 releases that
+ * expect bare function exports.
  */
 
 import type { Plugin } from "@opencode-ai/plugin";
@@ -40,6 +46,10 @@ interface Proposal {
 interface Entry {
 	historyId: string;
 	cwd: string;
+	// V2 only: proposal id that claimed this entry. Lets `finish` close only
+	// its own entry, so a denied or concurrent duplicate command can never
+	// steal another call's history entry or exit code.
+	owner?: string;
 }
 
 interface AtuinResult {
@@ -133,8 +143,8 @@ async function swallowFailures(work: () => void | Promise<void>): Promise<void> 
 	}
 }
 
-// opencode treats every export of a plugin file as a plugin function and fails
-// to load the file if one is not, so keep this the only export.
+// V1 factory. Kept as a named export for pre-1.18.29 releases that expect
+// bare function exports; 1.18.29+ uses it via the default export's `server`.
 export const AtuinPlugin: Plugin = async ({ directory }) => {
 	// Commands opencode has proposed but is not yet cleared to run, keyed by
 	// tool call ID.
@@ -219,4 +229,188 @@ export const AtuinPlugin: Plugin = async ({ directory }) => {
 				return finish(input.callID, output);
 			}),
 	};
+};
+
+// V2 `tool.execute.after` reports `{ status: "completed", result }` or
+// `{ status: "error", error }` instead of V1's `{ output, metadata }`.
+// Shapes differ between beta builds, so read defensively and never throw.
+function v2ExitCodeFrom(event: unknown): number {
+	const e = (event ?? {}) as {
+		status?: unknown;
+		result?: unknown;
+		error?: unknown;
+	};
+	const payload = e.status === "error" ? e.error : e.result;
+	const metadata = (payload as { metadata?: unknown } | undefined)?.metadata;
+	const exit = (metadata as { exit?: unknown } | undefined)?.exit;
+	if (typeof exit === "number") return exit;
+
+	let text = "";
+	try {
+		const p = payload as { message?: unknown; output?: unknown } | undefined;
+		if (typeof p?.message === "string") text = p.message;
+		else if (typeof p?.output === "string") text = p.output;
+		else text = JSON.stringify(payload ?? "");
+	} catch {
+		text = "";
+	}
+	if (text.includes("User aborted the command")) return EXIT_ABORTED;
+	if (/exceeding timeout \d+ ms/.test(text)) return EXIT_TIMED_OUT;
+	return e.status === "completed" ? 0 : 1;
+}
+
+function splitProposal(args: unknown): Proposal | undefined {
+	const { command, description } = (args ?? {}) as {
+		command?: unknown;
+		description?: unknown;
+	};
+	if (typeof command !== "string" || command.length === 0) return undefined;
+	return {
+		command,
+		intent:
+			typeof description === "string" && description.length > 0
+				? description
+				: undefined,
+	};
+}
+
+// V2 setup (opencode2 beta). Same lifecycle as V1, adapted to the V2 API:
+// - `tool.execute.before` remembers the proposal (no Atuin call yet, so
+//   denied commands stay unrecorded).
+// - `shell.create.before` is the first post-permission hook carrying the
+//   resolved cwd, so it opens the history entry. It carries no call ID, so
+//   the pending proposal is claimed by matching `command`.
+// - `tool.execute.after` closes the entry; it also drops unclaimed
+//   proposals, so denied commands never reach Atuin.
+// `ctx` is typed loosely on purpose: the file must also load under V1
+// runtimes whose `@opencode-ai/plugin` package predates the V2 `tool`/`shell`
+// domains. Missing domains disable the V2 path quietly instead of crashing.
+async function atuinSetup(
+	ctx: any,
+): Promise<(() => void | Promise<void>) | void> {
+	const tool = ctx?.tool;
+	const shell = ctx?.shell;
+	if (typeof tool?.hook !== "function" || typeof shell?.hook !== "function") {
+		return;
+	}
+	const baseDir =
+		typeof ctx?.location?.directory === "string"
+			? (ctx.location.directory as string)
+			: undefined;
+
+	// Proposals keyed by V2 tool call id.
+	const proposed = new Map<string, Proposal>();
+	// Open history entries keyed by command (the only key the shell hook and
+	// the tool hook share), each tagged with the claiming proposal id.
+	// `finish` closes only the entry owned by its own call id: a denied or
+	// concurrent duplicate can neither steal another call's entry nor
+	// misattribute an exit code. At most an entry goes unclosed, matching
+	// the V1 eviction policy for commands that never report back.
+	const running = new Map<string, Entry[]>();
+
+	function rememberV2(callID: string, args: unknown) {
+		const proposal = splitProposal(args);
+		if (!proposal) return;
+
+		if (proposed.size >= MAX_PROPOSED) {
+			const oldest = proposed.keys().next().value;
+			if (oldest !== undefined) proposed.delete(oldest);
+		}
+
+		proposed.set(callID, proposal);
+	}
+
+	async function claim(command: string, cwd: string | undefined) {
+		for (const [id, proposal] of proposed) {
+			if (proposal.command !== command) continue;
+			proposed.delete(id);
+			const historyId = await startHistory(cwd || baseDir || "", proposal);
+			if (!historyId) return;
+			const list = running.get(command) ?? [];
+			list.push({ historyId, cwd: cwd || "", owner: id });
+			running.set(command, list);
+			return;
+		}
+	}
+
+	async function finishV2(id: string, input: unknown, event: unknown) {
+		const byId = proposed.get(id);
+		proposed.delete(id);
+		const command =
+			byId?.command ?? (input as { command?: unknown } | undefined)?.command;
+		if (typeof command !== "string" || command.length === 0) return;
+
+		// Close only the entry this call claimed. Anything else (a denied
+		// duplicate, an evicted proposal) leaves other calls' entries alone.
+		const list = running.get(command);
+		const index = list?.findIndex((entry) => entry.owner === id) ?? -1;
+		if (!list || index < 0) return;
+		const [entry] = list.splice(index, 1);
+		if (list.length === 0) running.delete(command);
+		if (!entry) return;
+
+		await atuin(
+			[
+				"history",
+				"end",
+				entry.historyId,
+				"--exit",
+				String(v2ExitCodeFrom(event)),
+			],
+			entry.cwd,
+		);
+	}
+
+	const registrations: unknown[] = [];
+	try {
+		registrations.push(
+			await tool.hook("execute.before", (event: any) =>
+				swallowFailures(() => {
+					if (event?.tool !== BASH_TOOL) return;
+					if (typeof event?.id !== "string") return;
+					rememberV2(event.id, event.input);
+				}),
+			),
+		);
+		registrations.push(
+			await shell.hook("create.before", (event: any) =>
+				swallowFailures(() => {
+					if (typeof event?.command !== "string" || event.command.length === 0) {
+						return;
+					}
+					return claim(event.command, event.cwd);
+				}),
+			),
+		);
+		registrations.push(
+			await tool.hook("execute.after", (event: any) =>
+				swallowFailures(() => {
+					if (event?.tool !== BASH_TOOL) return;
+					if (typeof event?.id !== "string") return;
+					return finishV2(event.id, event?.input, event);
+				}),
+			),
+		);
+	} catch {
+		// Hook registration failed: stay unloaded instead of failing plugin
+		// load. A missing history entry is always the better failure.
+		return;
+	}
+
+	return async () => {
+		for (const r of registrations) {
+			try {
+				await (r as { dispose?: () => unknown } | undefined)?.dispose?.();
+			} catch {
+				// Deliberately ignored.
+			}
+		}
+	};
+}
+
+// Dual V1 + V2 entrypoint: V1 calls `server()`, V2 reads `id` + `setup()`.
+export default {
+	id: "atuin",
+	setup: atuinSetup,
+	server: AtuinPlugin,
 };

--- a/crates/atuin/contrib/opencode/tests/atuin.test.mjs
+++ b/crates/atuin/contrib/opencode/tests/atuin.test.mjs
@@ -1,0 +1,354 @@
+import assert from "node:assert/strict";
+import { EventEmitter } from "node:events";
+import childProcess from "node:child_process";
+import { syncBuiltinESMExports } from "node:module";
+import { after, beforeEach, test } from "node:test";
+
+// Exercise the installed, standalone templates without running a real Atuin
+// binary or touching a user's history database. No npm dependencies required.
+const originalSpawn = childProcess.spawn;
+let calls;
+let failure;
+let nextId;
+childProcess.spawn = (executable, args, options) => {
+	assert.equal(executable, "atuin");
+	calls.push({ args: [...args], cwd: options.cwd, options });
+	if (failure === "throw") throw new Error("spawn failed");
+	const child = new EventEmitter();
+	child.stdout = new EventEmitter();
+	child.stdout.setEncoding = () => {};
+	child.kill = () => child.emit("close", null);
+	queueMicrotask(() => {
+		if (failure === "error") {
+			child.emit("error", new Error("atuin missing"));
+			child.emit("close", null);
+			return;
+		}
+		if (args[1] === "start" && failure !== "empty") {
+			child.stdout.emit("data", `history-${++nextId}\n`);
+		}
+		child.emit("close", failure === "nonzero" ? 1 : 0);
+	});
+	return child;
+};
+syncBuiltinESMExports();
+const legacy = await import("../atuin.ts");
+const v2 = await import("../atuin-v2.ts");
+after(() => {
+	childProcess.spawn = originalSpawn;
+	syncBuiltinESMExports();
+});
+beforeEach(() => {
+	calls = [];
+	failure = undefined;
+	nextId = 0;
+});
+
+function host({ failAt, disposeFailsAt, duringRegistration } = {}) {
+	const callbacks = new Map();
+	const disposed = [];
+	let attempted = 0;
+	function domain(name) {
+		return {
+			async hook(event, callback) {
+				const index = ++attempted;
+				callbacks.set(`${name}.${event}`, callback);
+				await duringRegistration?.(callbacks, index);
+				if (index === failAt) throw new Error("registration failed");
+				return {
+					async dispose() {
+						disposed.push(index);
+						if (index === disposeFailsAt) throw new Error("disposal failed");
+					},
+				};
+			},
+		};
+	}
+	return {
+		ctx: { tool: domain("tool"), shell: domain("shell"), location: { directory: "/project" } },
+		callbacks,
+		disposed,
+		emit: (name, event) => callbacks.get(name)?.(event),
+	};
+}
+function before(id, command = "echo test", description = id) {
+	return { tool: "bash", id, input: { command, description } };
+}
+function completed(id, exit = 0) {
+	// No input.command is needed at completion: ownership is by exact ID.
+	return { tool: "bash", id, status: "completed", result: { metadata: { exit } } };
+}
+const starts = () => calls.filter((call) => call.args[1] === "start");
+const ends = () => calls.filter((call) => call.args[1] === "end");
+
+// Loader-contract fixtures. These intentionally test the old all-exports
+// function loop and V2's object shape, not a live OpenCode installation.
+test("V1 exports exactly one callable initializer for legacy loaders", async () => {
+	assert.deepEqual(Object.keys(legacy), ["default"]);
+	const hooks = [];
+	for (const initialize of Object.values(legacy)) {
+		assert.equal(typeof initialize, "function");
+		hooks.push(await initialize({ directory: "/project" }));
+	}
+	assert.equal(hooks.length, 1);
+	assert.equal(typeof hooks[0]["shell.env"], "function");
+	assert.equal(calls.length, 0);
+});
+
+test("V2 exports exactly one object definition with id and setup", () => {
+	assert.deepEqual(Object.keys(v2), ["default"]);
+	assert.equal(typeof v2.default, "object");
+	assert.equal(v2.default.id, "atuin");
+	assert.equal(typeof v2.default.setup, "function");
+	assert.equal(v2.default.server, undefined);
+});
+
+test("V1 records only approved bash calls, keeping identical calls separate", async () => {
+	const hooks = await legacy.default({ directory: "/project" });
+	for (const id of ["A", "B", "denied"]) {
+		await hooks["tool.execute.before"]({ tool: "bash", callID: id }, { args: { command: "same", description: id } });
+	}
+	assert.equal(calls.length, 0);
+	await hooks["shell.env"]({ callID: "user-shell", cwd: "/manual" }, {});
+	await hooks["shell.env"]({ callID: "B", cwd: "/B" }, {});
+	await hooks["shell.env"]({ callID: "A", cwd: "/A" }, {});
+	await hooks["tool.execute.after"]({ tool: "bash", callID: "A" }, { output: "", metadata: { exit: 7 } });
+	await hooks["tool.execute.after"]({ tool: "bash", callID: "B" }, { output: "", metadata: { exit: 3 } });
+	assert.deepEqual(starts().map((call) => [call.cwd, call.args.at(-3)]), [["/B", "B"], ["/A", "A"]]);
+	assert.deepEqual(ends().map((call) => [call.cwd, call.args[2], call.args.at(-1)]), [["/A", "history-2", "7"], ["/B", "history-1", "3"]]);
+});
+
+test("V2 preserves argv, intent, resolved cwd, and exact completion ownership", async () => {
+	const h = host();
+	const dispose = await v2.default.setup(h.ctx);
+	const command = "echo '$(touch /tmp/not-executed)'\nprintf '%s' \"$HOME\"";
+	await h.emit("tool.execute.before", before("A", command, "explain A"));
+	await h.emit("tool.execute.before", before("B", "echo B", "explain B"));
+	assert.equal(calls.length, 0);
+	await h.emit("shell.create.before", { command: "echo B", cwd: "/B" });
+	await h.emit("shell.create.before", { command, cwd: "/A" });
+	await h.emit("tool.execute.after", completed("A", 7));
+	await h.emit("tool.execute.after", completed("B", 3));
+	assert.equal(starts()[1].args.at(-1), command);
+	assert.deepEqual(starts()[1].args.slice(-4), ["--intent", "explain A", "--", command]);
+	assert.equal(starts()[1].options.shell, undefined);
+	assert.deepEqual(ends().map((call) => [call.cwd, call.args[2], call.args.at(-1)]), [["/A", "history-2", "7"], ["/B", "history-1", "3"]]);
+	await dispose();
+});
+
+for (const order of [["A", "B"], ["B", "A"]]) {
+	test(`V2 skips indistinguishable commands when shell order is ${order.join(",")}`, async () => {
+		const h = host();
+		const dispose = await v2.default.setup(h.ctx);
+		await h.emit("tool.execute.before", before("A", "same", "intent A"));
+		await h.emit("tool.execute.before", before("B", "same", "intent B"));
+		for (const id of order) {
+			await h.emit("shell.create.before", { command: "same", cwd: `/${id}` });
+			await h.emit("tool.execute.after", completed(id, id === "A" ? 3 : 7));
+		}
+		assert.equal(calls.length, 0);
+		// Ambiguity is scoped to the overlapping calls, not forever.
+		await h.emit("tool.execute.before", before("C", "same"));
+		await h.emit("shell.create.before", { command: "same", cwd: "/C" });
+		await h.emit("tool.execute.after", completed("C"));
+		assert.equal(starts().length, 1);
+		assert.equal(ends().length, 1);
+		await dispose();
+	});
+}
+
+test("V2 denied duplicate cannot make its survivor claimable", async () => {
+	const h = host();
+	const dispose = await v2.default.setup(h.ctx);
+	await h.emit("tool.execute.before", before("A", "same"));
+	await h.emit("tool.execute.before", before("B", "same"));
+	await h.emit("tool.execute.after", { tool: "bash", id: "A", status: "error", error: "denied" });
+	await h.emit("shell.create.before", { command: "same", cwd: "/B" });
+	await h.emit("tool.execute.after", completed("B"));
+	assert.equal(calls.length, 0);
+	await dispose();
+});
+
+test("V2 late duplicate cannot steal an already running entry", async () => {
+	const h = host();
+	const dispose = await v2.default.setup(h.ctx);
+	await h.emit("tool.execute.before", before("A", "same"));
+	await h.emit("shell.create.before", { command: "same", cwd: "/A" });
+	await h.emit("tool.execute.before", before("B", "same"));
+	await h.emit("shell.create.before", { command: "same", cwd: "/B" });
+	await h.emit("tool.execute.after", completed("B", 3));
+	assert.equal(ends().length, 0);
+	await h.emit("tool.execute.after", completed("A", 7));
+	assert.equal(starts().length, 1);
+	assert.deepEqual(ends()[0].args, ["history", "end", "history-1", "--exit", "7"]);
+	assert.equal(ends()[0].cwd, "/A");
+	await dispose();
+});
+
+test("V2 start and end use the same fallback directory", async () => {
+	const h = host();
+	const dispose = await v2.default.setup(h.ctx);
+	await h.emit("tool.execute.before", before("A"));
+	await h.emit("shell.create.before", { command: "echo test" });
+	await h.emit("tool.execute.after", completed("A"));
+	assert.deepEqual(calls.map((call) => call.cwd), ["/project", "/project"]);
+	await dispose();
+});
+
+for (const failAt of [1, 2, 3]) {
+	test(`V2 rolls back failure at registration ${failAt} and leaves callbacks inert`, async () => {
+		const h = host({ failAt, disposeFailsAt: 2 });
+		assert.equal(await v2.default.setup(h.ctx), undefined);
+		assert.deepEqual(h.disposed, Array.from({ length: failAt - 1 }, (_, i) => failAt - 1 - i));
+		await h.emit("tool.execute.before", before("A"));
+		await h.emit("shell.create.before", { command: "echo test", cwd: "/A" });
+		await h.emit("tool.execute.after", completed("A"));
+		assert.equal(calls.length, 0);
+	});
+}
+
+test("V2 callbacks stay inert until all registrations succeed", async () => {
+	const h = host({ duringRegistration: async (callbacks) => {
+		await callbacks.get("tool.execute.before")?.(before("A"));
+		await callbacks.get("shell.create.before")?.({ command: "echo test", cwd: "/A" });
+	} });
+	const dispose = await v2.default.setup(h.ctx);
+	assert.equal(calls.length, 0);
+	await dispose();
+});
+
+test("V2 disposal is reverse-order, idempotent, and continues after a disposer rejects", async () => {
+	const h = host({ disposeFailsAt: 2 });
+	const dispose = await v2.default.setup(h.ctx);
+	await dispose();
+	await dispose();
+	assert.deepEqual(h.disposed, [3, 2, 1]);
+	await h.emit("tool.execute.before", before("A"));
+	await h.emit("shell.create.before", { command: "echo test", cwd: "/A" });
+	assert.equal(calls.length, 0);
+});
+
+test("V2 safely stops correlation at capacity while closing already-running entries", async () => {
+	const h = host();
+	const dispose = await v2.default.setup(h.ctx);
+	await h.emit("tool.execute.before", before("running", "running"));
+	await h.emit("shell.create.before", { command: "running", cwd: "/running" });
+	for (let i = 0; i < 130; i++) await h.emit("tool.execute.before", before(`id-${i}`, `cmd-${i}`));
+	await h.emit("tool.execute.before", before("replacement", "cmd-0"));
+	await h.emit("shell.create.before", { command: "cmd-0", cwd: "/delayed" });
+	await h.emit("tool.execute.after", completed("running", 9));
+	assert.equal(starts().length, 1);
+	assert.deepEqual(ends()[0].args, ["history", "end", "history-1", "--exit", "9"]);
+	await dispose();
+});
+
+for (const ctx of [undefined, {}, { tool: {} }, { tool: { hook() {} }, shell: {} }]) {
+	test(`V2 missing hook domains disable recording (${JSON.stringify(ctx)})`, async () => {
+		assert.equal(await v2.default.setup(ctx), undefined);
+		assert.equal(calls.length, 0);
+	});
+}
+
+for (const mode of ["throw", "error", "nonzero", "empty"]) {
+	test(`V1 and V2 tolerate Atuin ${mode} failures without ending a missing entry`, async () => {
+		failure = mode;
+		const hooks = await legacy.default({ directory: "/project" });
+		await hooks["tool.execute.before"]({ tool: "bash", callID: "A" }, { args: { command: "test" } });
+		await hooks["shell.env"]({ callID: "A", cwd: "/A" }, {});
+		await hooks["tool.execute.after"]({ tool: "bash", callID: "A" }, { output: "", metadata: { exit: 0 } });
+		const h = host();
+		const dispose = await v2.default.setup(h.ctx);
+		await h.emit("tool.execute.before", before("B"));
+		await h.emit("shell.create.before", { command: "echo test", cwd: "/B" });
+		await h.emit("tool.execute.after", completed("B"));
+		assert.equal(ends().length, 0);
+		await dispose();
+	});
+}
+
+for (const [event, expected] of [
+	[{ status: "completed", result: { metadata: { exit: 23 } } }, "23"],
+	[{ status: "error", error: { message: "User aborted the command" } }, "130"],
+	[{ status: "error", error: { message: "exceeding timeout 1000 ms" } }, "124"],
+	[{ status: "error", error: { message: "failed" } }, "1"],
+	[{ status: "completed", result: {} }, "0"],
+]) {
+	test(`V2 preserves completion/abort/timeout exit ${expected}`, async () => {
+		const h = host();
+		const dispose = await v2.default.setup(h.ctx);
+		await h.emit("tool.execute.before", before("A"));
+		await h.emit("shell.create.before", { command: "echo test", cwd: "/A" });
+		await h.emit("tool.execute.after", { tool: "bash", id: "A", ...event });
+		assert.equal(ends()[0].args.at(-1), expected);
+		await dispose();
+	});
+}
+
+test("V2 ignores non-bash proposals, denied calls, and shells with no proposal", async () => {
+	const h = host();
+	const dispose = await v2.default.setup(h.ctx);
+	await h.emit("tool.execute.before", { ...before("other"), tool: "read" });
+	await h.emit("shell.create.before", { command: "echo test", cwd: "/manual" });
+	await h.emit("tool.execute.before", before("denied"));
+	await h.emit("tool.execute.after", { tool: "bash", id: "denied", status: "error", error: "denied" });
+	await h.emit("shell.create.before", { command: "echo test", cwd: "/manual" });
+	assert.equal(calls.length, 0);
+	await dispose();
+});
+
+test("V2 claims each proposal at most once and ignores repeated completion", async () => {
+	const h = host();
+	const dispose = await v2.default.setup(h.ctx);
+	await h.emit("tool.execute.before", before("A"));
+	await h.emit("shell.create.before", { command: "echo test", cwd: "/A" });
+	await h.emit("shell.create.before", { command: "echo test", cwd: "/A" });
+	await h.emit("tool.execute.after", completed("A"));
+	await h.emit("tool.execute.after", completed("A"));
+	assert.equal(starts().length, 1);
+	assert.equal(ends().length, 1);
+	await dispose();
+});
+
+test("V2 setup instances do not share proposals or lifecycle state", async () => {
+	const a = host();
+	const b = host();
+	const disposeA = await v2.default.setup(a.ctx);
+	const disposeB = await v2.default.setup(b.ctx);
+	await a.emit("tool.execute.before", before("A", "same"));
+	await b.emit("tool.execute.before", before("B", "same"));
+	await disposeA();
+	await b.emit("shell.create.before", { command: "same", cwd: "/B" });
+	await b.emit("tool.execute.after", completed("B"));
+	assert.equal(starts().length, 1);
+	assert.equal(ends()[0].cwd, "/B");
+	await disposeB();
+});
+
+test("V2 disposal during history start does not resurrect callback state", async () => {
+	const h = host();
+	const dispose = await v2.default.setup(h.ctx);
+	await h.emit("tool.execute.before", before("A"));
+	const start = h.emit("shell.create.before", { command: "echo test", cwd: "/A" });
+	await dispose();
+	await start;
+	await h.emit("tool.execute.after", completed("A"));
+	assert.equal(starts().length, 1);
+	assert.equal(ends().length, 0);
+});
+
+test("V1 and V2 swallow history-end failures", async () => {
+	const hooks = await legacy.default({ directory: "/project" });
+	await hooks["tool.execute.before"]({ tool: "bash", callID: "A" }, { args: { command: "test" } });
+	await hooks["shell.env"]({ callID: "A", cwd: "/A" }, {});
+	failure = "throw";
+	await hooks["tool.execute.after"]({ tool: "bash", callID: "A" }, { output: "", metadata: { exit: 0 } });
+	failure = undefined;
+	const h = host();
+	const dispose = await v2.default.setup(h.ctx);
+	await h.emit("tool.execute.before", before("B"));
+	await h.emit("shell.create.before", { command: "echo test", cwd: "/B" });
+	failure = "error";
+	await h.emit("tool.execute.after", completed("B"));
+	assert.equal(ends().length, 2);
+	await dispose();
+});

--- a/crates/atuin/src/command/client/hook.rs
+++ b/crates/atuin/src/command/client/hook.rs
@@ -126,7 +126,8 @@ impl Agent {
         AGENTS.iter().copied().find(|spec| spec.aliases.contains(&name)).map(Self).ok_or_else(
             || {
                 eyre::eyre!(
-                    "unknown agent: {name}. Supported agents: claude-code, codex, opencode, opencode-v2, pi"
+                    "unknown agent: {name}. Supported agents: claude-code, codex, opencode, \
+                     opencode-v2, pi"
                 )
             },
         )
@@ -431,7 +432,12 @@ mod tests {
         #[case] expected_source: &str,
     ) {
         let agent = Agent::from_name(name).unwrap();
-        let InstallKind::Extension { extension_path, source, .. } = agent.install_kind() else {
+        let InstallKind::Extension {
+            extension_path,
+            source,
+            ..
+        } = agent.install_kind()
+        else {
             panic!("opencode does not install an extension");
         };
 

--- a/crates/atuin/src/command/client/hook.rs
+++ b/crates/atuin/src/command/client/hook.rs
@@ -21,6 +21,7 @@ use event::HookEvent;
 const HOOK_EVENT_TYPES: &[&str] = &["PreToolUse", "PostToolUse", "PostToolUseFailure"];
 const PI_EXTENSION_SOURCE: &str = include_str!("../../../contrib/pi/atuin.ts");
 const OPENCODE_PLUGIN_SOURCE: &str = include_str!("../../../contrib/opencode/atuin.ts");
+const OPENCODE_V2_PLUGIN_SOURCE: &str = include_str!("../../../contrib/opencode/atuin-v2.ts");
 
 enum InstallKind {
     JsonHooks {
@@ -103,7 +104,20 @@ const OPENCODE: AgentSpec = AgentSpec {
     },
 };
 
-const AGENTS: &[&AgentSpec] = &[&CLAUDE_CODE, &CODEX, &OPENCODE, &PI];
+// The loader contracts are incompatible. Keep V1 as the default and make V2
+// an explicit choice, replacing the same installed file rather than loading both.
+const OPENCODE_V2: AgentSpec = AgentSpec {
+    aliases: &["opencode-v2"],
+    actor_name: "opencode",
+    path_root: PathRoot::XdgConfig,
+    install_kind: InstallKind::Extension {
+        extension_path: &["opencode", "plugins", "atuin.ts"],
+        source: OPENCODE_V2_PLUGIN_SOURCE,
+        reload_hint: "Restart opencode to load the V2 plugin. This replaces the V1 plugin.",
+    },
+};
+
+const AGENTS: &[&AgentSpec] = &[&CLAUDE_CODE, &CODEX, &OPENCODE, &OPENCODE_V2, &PI];
 
 struct Agent(&'static AgentSpec);
 
@@ -112,7 +126,7 @@ impl Agent {
         AGENTS.iter().copied().find(|spec| spec.aliases.contains(&name)).map(Self).ok_or_else(
             || {
                 eyre::eyre!(
-                    "unknown agent: {name}. Supported agents: claude-code, codex, opencode, pi"
+                    "unknown agent: {name}. Supported agents: claude-code, codex, opencode, opencode-v2, pi"
                 )
             },
         )
@@ -353,7 +367,7 @@ mod tests {
     use crate::Atuin;
     use crate::command::{AtuinCmd, client};
 
-    #[test]
+    #[rstest]
     fn parse_hook_agent_command() {
         let cmd = Cmd::try_parse_from(["hook", "codex"]).unwrap();
 
@@ -363,6 +377,7 @@ mod tests {
     #[rstest]
     #[case::codex("codex")]
     #[case::opencode("opencode")]
+    #[case::opencode_v2("opencode-v2")]
     #[case::pi("pi")]
     fn parse_hook_install_command(#[case] agent_name: &str) {
         let cmd = Cmd::try_parse_from(["hook", "install", agent_name]).unwrap();
@@ -374,17 +389,18 @@ mod tests {
     }
 
     #[rstest]
-    #[case::opencode("opencode")]
-    #[case::pi("pi")]
-    fn agent_from_name_supports_extension_agents(#[case] agent_name: &str) {
+    #[case::opencode("opencode", "opencode")]
+    #[case::opencode_v2("opencode-v2", "opencode")]
+    #[case::pi("pi", "pi")]
+    fn agent_from_name_supports_extension_agents(#[case] agent_name: &str, #[case] author: &str) {
         let agent = Agent::from_name(agent_name).unwrap();
-        assert_eq!(agent.actor_name(), agent_name);
+        assert_eq!(agent.actor_name(), author);
         assert!(matches!(agent.install_kind(), InstallKind::Extension { .. }));
     }
 
     /// An agent missing from `KNOWN_AGENTS` would be installable but invisible
     /// to `$all-agent`, and would pollute `$all-user` with its commands.
-    #[test]
+    #[rstest]
     fn every_agent_author_is_a_known_agent() {
         for spec in AGENTS {
             assert!(
@@ -407,10 +423,15 @@ mod tests {
     }
 
     /// opencode reads plugins from its XDG config directory, not from `$HOME`.
-    #[test]
-    fn opencode_plugin_is_rooted_in_the_xdg_config_dir() {
-        let agent = Agent::from_name("opencode").unwrap();
-        let InstallKind::Extension { extension_path, .. } = agent.install_kind() else {
+    #[rstest]
+    #[case::v1("opencode", OPENCODE_PLUGIN_SOURCE)]
+    #[case::v2("opencode-v2", OPENCODE_V2_PLUGIN_SOURCE)]
+    fn opencode_plugin_is_rooted_in_the_xdg_config_dir(
+        #[case] name: &str,
+        #[case] expected_source: &str,
+    ) {
+        let agent = Agent::from_name(name).unwrap();
+        let InstallKind::Extension { extension_path, source, .. } = agent.install_kind() else {
             panic!("opencode does not install an extension");
         };
 
@@ -419,9 +440,10 @@ mod tests {
 
         assert!(installed.starts_with(&root), "{installed:?} is not under {root:?}");
         assert!(installed.ends_with("opencode/plugins/atuin.ts"));
+        assert_eq!(*source, expected_source);
     }
 
-    #[test]
+    #[rstest]
     fn parse_top_level_hook_command() {
         let cmd = Atuin::try_parse_from(["atuin", "hook", "codex"]).unwrap();
 


### PR DESCRIPTION
## Problem
`atuin hook install opencode` writes a plugin with only a named export (`export const AtuinPlugin`). The V2 loader (opencode2 beta) rejects it:

> PluginModule.LoadError: Plugin must export a default definition with an id and an effect or setup function (Missing key at ["default"])

The plugin then never records anything. V1 (`1.18.x`) and V2 share the same global plugin path (`~/.config/opencode/plugins/atuin.ts`), so one template must satisfy both loaders.

## Fix
Dual V1+V2 entrypoint in `crates/atuin/contrib/opencode/atuin.ts` (V1 factory untouched):
- keeps the named `AtuinPlugin` export (pre-1.18.29) and adds `export default { id: "atuin", setup, server }`
- V2 `setup()` ports the same propose/start/finish lifecycle to `tool.execute.before` / `shell.create.before` / `tool.execute.after` (V2 shell hook carries no call ID, so proposals are claimed by matching `command`; entries are owner-tagged so a denied/duplicate command can never steal another call's entry or exit code)
- defensive by design: missing domains disable the V2 path, every hook is failure-swallowed, async cleanup awaits disposes — a history miss never breaks a tool call

## Validation
- bun harness with a fake `atuin` shim, 16/16 pass: V1 start/end, V2 start/end, denied commands produce zero atuin calls, same-command denied keeps owner's exit, concurrent identical commands each end once, timeout text maps to 124, malformed inputs never throw
- live: fresh opencode2 beta-19192 server loads the file with zero `failed to load plugin` (previously failed on every start)
- `hook.rs` tests unaffected (no test pins template content; install path logic untouched)