### PR TITLE
fix(pty-proxy): make PTY proxy aware of other PTYs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -632,9 +632,13 @@ dependencies = [
  "crossterm",
  "easy-cast",
  "eyre",
+ "parking_lot",
  "portable-pty",
  "rstest",
+ "rustix",
  "signal-hook",
+ "tempfile",
+ "thiserror 2.0.19",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -111,7 +111,7 @@ rmp = "0.8.14"
 rpassword = "7.0"
 rstest = "0.26.1"
 runtime-format = "0.1.3"
-rustix = { version = "1.1.4", features = ["process", "fs"] }
+rustix = { version = "1.1.4", features = ["process", "fs", "pty", "termios", "stdio"] }
 rusty_paserk = { version = "0.5.0", default-features = false, features = ["v4", "serde"] }
 # rusty_paserk 0.5.0 (latest) requires rusty_paseto 0.8.0 unfortunately
 rusty_paseto = { version = "0.8.0", default-features = false }

--- a/crates/atuin-client/src/settings.rs
+++ b/crates/atuin-client/src/settings.rs
@@ -1581,6 +1581,7 @@ impl Settings {
                     .unwrap_or_else(|| config::Value::new(None, config::ValueKind::Boolean(false))),
             )?
             .set_default("no_mouse", false)?
+            .set_default("pty_proxy.enabled", false)?
             .add_source(Environment::with_prefix("atuin").prefix_separator("_").separator("__")))
     }
 

--- a/crates/atuin-common/src/encryption/paseto_v4.rs
+++ b/crates/atuin-common/src/encryption/paseto_v4.rs
@@ -3,7 +3,7 @@
 //! See [`encrypt_sync`] for the encryption description.
 use std::array::TryFromSliceError;
 use std::fs;
-use std::io::{Read, Write};
+use std::io::Write;
 use std::path::Path;
 
 use base64::Engine;
@@ -65,8 +65,14 @@ pub enum KeyFileLoadingError {
 pub enum KeyFileStoringError {
     #[error("the given key path already exists")]
     AlreadyExists,
+
     #[error("unexpected io error: {_0}")]
     Io(#[from] std::io::Error),
+
+    /// This error will essentially never happen in practice. It requires
+    /// `/path/to/.key.atuin-tmp.{i}` to exist for *every* `i` up to `usize::MAX`.
+    #[error("all temporary file paths are in use")]
+    TempFilesExhausted,
 }
 
 #[derive(Debug, Error)]
@@ -76,6 +82,11 @@ pub enum KeyFileLoadOrGenerateError {
 
     #[error("unexpected io error: {_0}")]
     Io(#[from] std::io::Error),
+
+    /// See comment on [`KeyFileStoringError::TempFilesExhausted`] -- this error will essentially
+    /// never happen.
+    #[error("failed to create key: all temporary file paths are in use")]
+    TempFilesExhausted,
 }
 
 /// A type which contains a [`Key`] encoded as a B64 string. See [`Key::encode`] for more details.
@@ -232,21 +243,74 @@ impl Key {
     ///
     /// Refuses to overwrite a file that already exists.
     pub fn try_write_path(&self, path: &Path) -> Result<(), KeyFileStoringError> {
-        if path.exists() {
-            // We could try to load the path real fast and check whether the contents are the same
-            // as to what the user wants -- save them an error handling if we can:
-            let mut data = String::new();
-            fs::File::open(path)?.read_to_string(&mut data)?;
-            if data == self.encode().dangerously_leak_secret() {
-                return Ok(());
-            }
+        use std::io::{Error, ErrorKind};
 
-            return Err(KeyFileStoringError::AlreadyExists);
+        // To avoid race conditions, this function:
+        //
+        // 1. Creates a temporary file in the same directory as `path`, but with `.` prepended to
+        //    the filename, and `.atuin-tmp.{i}` appended. `i` starts at 0 and is incremented until
+        //    we find a path that doesn't exist yet.
+        //
+        //    For example, `/path/to/key` -> `/path/to/.key.atuin-tmp.0`.
+        //
+        // 2. Writes the key to the temporary path.
+        //
+        // 3. Hardlinks the temporary path to the real key path (`path`). Hardlinking will fail if
+        //    the destination already exists, which is what we want.
+        //
+        // 4. Removes the temporary file.
+
+        let dir = path.parent().ok_or(Error::from(ErrorKind::IsADirectory))?;
+        let name = path.file_name().ok_or(Error::from(ErrorKind::IsADirectory))?;
+        let base_tmp_name: std::ffi::OsString = [".".as_ref(), name].into_iter().collect();
+
+        let mut i: usize = 0;
+        match loop {
+            let mut tmp_path = dir.join(&base_tmp_name);
+            tmp_path.add_extension(format!("atuin-tmp.{i}"));
+
+            // `tmp_path` is first so it gets dropped after `tmp_file`. `tmp_path` is a
+            // `RemoveOnDropPath` so it will remove the file when dropped, but this will fail on
+            // Windows if the file is still open.
+            let (tmp_path, mut tmp_file) =
+                match fs::OpenOptions::new().write(true).create_new(true).open(&tmp_path) {
+                    Ok(file) => (crate::fs::RemoveOnDropPath(tmp_path), file),
+                    Err(e) if e.kind() == ErrorKind::AlreadyExists => {
+                        // This error will essentially never happen in practice. It requires
+                        // `/path/to/.key.atuin-tmp.{i}` to exist for *every* `i` up to
+                        // `usize::MAX`.
+                        i = i.checked_add(1).ok_or(KeyFileStoringError::TempFilesExhausted)?;
+                        continue;
+                    }
+                    Err(e) => return Err(e.into()),
+                };
+
+            tmp_file.write_all(self.encode().dangerously_leak_secret().as_bytes())?;
+            tmp_file.sync_all()?;
+            drop(tmp_file);
+            break std::fs::hard_link(&tmp_path, path);
+        } {
+            Ok(()) => return Ok(()),
+            Err(e) if e.kind() == ErrorKind::AlreadyExists => {
+                return Err(KeyFileStoringError::AlreadyExists);
+            }
+            Err(e) if e.kind() == ErrorKind::Unsupported => {}
+            Err(e) => return Err(e.into()),
         }
 
-        let mut file = fs::File::create(path)?;
+        // Hardlinks are unsupported. This is unlikely but can happen on FAT32/exFAT filesystems.
+        // Fall back to creating the file and then writing to it. This has the possibility of a race
+        // condition where another process could observe a partially written key file, but it is
+        // better than unconditionally failing to create the key file. In any case we are careful
+        // not to overwrite an existing key file.
+        let mut file = match std::fs::OpenOptions::new().write(true).create_new(true).open(path) {
+            Ok(file) => file,
+            Err(e) if e.kind() == ErrorKind::AlreadyExists => {
+                return Err(KeyFileStoringError::AlreadyExists);
+            }
+            Err(e) => return Err(e.into()),
+        };
         file.write_all(self.encode().dangerously_leak_secret().as_bytes())?;
-
         Ok(())
     }
 
@@ -254,6 +318,10 @@ impl Key {
     ///
     /// Unlike [`Self::try_write_path`], this deliberately overwrites an existing key.
     pub fn overwrite_path(&self, path: &Path) -> std::io::Result<()> {
+        // TODO(taylordotfish): This has a race condition where another process can observe a
+        // partially written key file. We should write to a temp file, similar to
+        // `Self::try_write_path`, and then use `rename` to move it to the key path (not `hardlink`
+        // because we do want it to overwrite an existing key).
         let mut file = fs::File::create(path)?;
         file.write_all(self.encode().dangerously_leak_secret().as_bytes())?;
 
@@ -286,6 +354,9 @@ impl Key {
                             }
                         }),
                     Err(KeyFileStoringError::Io(io)) => Err(io.into()),
+                    Err(KeyFileStoringError::TempFilesExhausted) => {
+                        Err(KeyFileLoadOrGenerateError::TempFilesExhausted)
+                    }
                 }
             }
             Err(KeyFileLoadingError::Io(io)) => Err(io.into()),
@@ -745,5 +816,60 @@ mod test {
         assert_eq!(Key::try_load_from_path(&path).unwrap(), new);
 
         let _ = fs::remove_dir_all(&dir);
+    }
+
+    #[rstest]
+    fn concurrent_generation_yields_one_complete_key() {
+        // `try_write_path` used to create the key file and only then write the key into it, so a
+        // concurrent reader could observe a zero-length file and fail with
+        // `KeyDecodingError::EmptyKey`. Nothing in shell startup creates the key, so the first
+        // writers really are concurrent in practice: the backgrounded `atuin history end` hook and
+        // a foreground `atuin search`.
+        const THREADS: usize = 8;
+        const ROUNDS: usize = 100;
+
+        for round in 0..ROUNDS {
+            let dir = tempfile::tempdir().expect("create temp dir");
+            let path = dir.path().join("key");
+            let barrier = std::sync::Barrier::new(THREADS);
+
+            let keys: Vec<Key> = std::thread::scope(|scope| {
+                let threads: Vec<_> = (0..THREADS)
+                    .map(|_| {
+                        scope.spawn(|| {
+                            barrier.wait();
+                            Key::try_load_or_generate(&path)
+                                .unwrap_or_else(|e| panic!("round {round}: {e}"))
+                        })
+                    })
+                    .collect();
+                threads.into_iter().map(|t| t.join().expect("thread panicked")).collect()
+            });
+
+            // Every racer must end up holding the one key that actually landed on disk; a racer
+            // that kept a key the file does not have would encrypt records nothing can decrypt.
+            let stored = Key::try_load_from_path(&path).expect("key file is readable");
+            for (i, key) in keys.iter().enumerate() {
+                assert_eq!(
+                    *key, stored,
+                    "round {round}: thread {i} kept a key that is not on disk"
+                );
+            }
+        }
+    }
+
+    #[rstest]
+    fn try_write_path_leaves_no_temporary_files() {
+        let dir = tempfile::tempdir().expect("create temp dir");
+        let path = dir.path().join("key");
+
+        Key::from([0x33u8; 32]).try_write_path(&path).expect("write creates the key");
+
+        let mut names: Vec<String> = fs::read_dir(dir.path())
+            .expect("read temp dir")
+            .map(|entry| entry.expect("dir entry").file_name().to_string_lossy().into_owned())
+            .collect();
+        names.sort();
+        assert_eq!(names, ["key"], "the temporary file was left behind");
     }
 }

--- a/crates/atuin-common/src/fs.rs
+++ b/crates/atuin-common/src/fs.rs
@@ -1,8 +1,10 @@
 use std::path::{Path, PathBuf};
 
 /// A path that is removed when this type is dropped.
+#[derive(derive_more::AsRef)]
 pub struct RemoveOnDropPath<P: AsRef<Path> = PathBuf>(
     /// The path to the file.
+    #[as_ref(Path)]
     pub P,
 );
 
@@ -12,16 +14,12 @@ impl<P: AsRef<Path>> Drop for RemoveOnDropPath<P> {
     }
 }
 
+// Not using `derive_more` for this as it would require adding a `P: Deref<Target = Path>` bound to
+// the struct.
 impl<P: AsRef<Path>> std::ops::Deref for RemoveOnDropPath<P> {
     type Target = Path;
 
     fn deref(&self) -> &Self::Target {
         self.0.as_ref()
-    }
-}
-
-impl<P: AsRef<Path>> AsRef<Path> for RemoveOnDropPath<P> {
-    fn as_ref(&self) -> &Path {
-        self
     }
 }

--- a/crates/atuin-common/src/fs.rs
+++ b/crates/atuin-common/src/fs.rs
@@ -1,0 +1,27 @@
+use std::path::{Path, PathBuf};
+
+/// A path that is removed when this type is dropped.
+pub struct RemoveOnDropPath<P: AsRef<Path> = PathBuf>(
+    /// The path to the file.
+    pub P,
+);
+
+impl<P: AsRef<Path>> Drop for RemoveOnDropPath<P> {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_file(&self.0);
+    }
+}
+
+impl<P: AsRef<Path>> std::ops::Deref for RemoveOnDropPath<P> {
+    type Target = Path;
+
+    fn deref(&self) -> &Self::Target {
+        self.0.as_ref()
+    }
+}
+
+impl<P: AsRef<Path>> AsRef<Path> for RemoveOnDropPath<P> {
+    fn as_ref(&self) -> &Path {
+        self
+    }
+}

--- a/crates/atuin-common/src/fs.rs
+++ b/crates/atuin-common/src/fs.rs
@@ -1,16 +1,22 @@
 use std::path::{Path, PathBuf};
 
 /// A path that is removed when this type is dropped.
-#[derive(derive_more::AsRef)]
 pub struct RemoveOnDropPath<P: AsRef<Path> = PathBuf>(
     /// The path to the file.
-    #[as_ref(Path)]
     pub P,
 );
 
 impl<P: AsRef<Path>> Drop for RemoveOnDropPath<P> {
     fn drop(&mut self) {
         let _ = std::fs::remove_file(&self.0);
+    }
+}
+
+// Not using `derive_more` as it causes Clippy to emit an incorrect "this trait bound is already
+// specified in the where clause" warning.
+impl<P: AsRef<Path>> AsRef<Path> for RemoveOnDropPath<P> {
+    fn as_ref(&self) -> &Path {
+        self
     }
 }
 

--- a/crates/atuin-common/src/lib.rs
+++ b/crates/atuin-common/src/lib.rs
@@ -7,6 +7,7 @@ pub mod db;
 pub mod docs;
 pub mod encryption;
 pub mod filter;
+pub mod fs;
 pub mod futures;
 pub mod logs;
 #[cfg(feature = "os")]

--- a/crates/atuin-common/src/os/unix.rs
+++ b/crates/atuin-common/src/os/unix.rs
@@ -1,6 +1,7 @@
 //! Unix-specific utilities.
 
 pub mod process;
+pub mod tty;
 
 use std::path::{Path, PathBuf};
 

--- a/crates/atuin-common/src/os/unix/tty.rs
+++ b/crates/atuin-common/src/os/unix/tty.rs
@@ -1,0 +1,175 @@
+//! TTY-related utilities.
+
+use std::os::fd::{AsFd, BorrowedFd};
+
+use rustix::fs::Dev;
+
+/// A unique identifier for a terminal device.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct TtyId {
+    /// Which filesystem the terminal lives on.
+    ///
+    /// Corresponds to `st_dev` in `struct stat`.
+    pub dev: Dev,
+
+    /// The device ID of the terminal.
+    ///
+    /// Corresponds to `st_rdev` in `struct stat`.
+    pub rdev: Dev,
+}
+
+impl TtyId {
+    /// Get the terminal ID of a file descriptor.
+    ///
+    /// Returns [`None`] if the file is not a terminal.
+    #[must_use]
+    pub fn from_fd(fd: impl AsFd) -> Option<Self> {
+        let fd = fd.as_fd();
+        if !rustix::termios::isatty(fd) {
+            return None;
+        }
+        let stat = rustix::fs::fstat(fd).ok()?;
+        Some(Self {
+            dev: stat.st_dev,
+            rdev: stat.st_rdev,
+        })
+    }
+
+    /// Get the ID of the terminal that this process is attached to.
+    ///
+    /// Returns [`None`] if none of this process's standard file descriptors are attached to a
+    /// terminal.
+    #[must_use]
+    pub fn current() -> Option<Self> {
+        use rustix::stdio::{stderr, stdin, stdout};
+        first_tty_id([stdin(), stdout(), stderr()])
+    }
+}
+
+/// Get the ID of the first FD in `fds` that is a terminal.
+fn first_tty_id<'a>(fds: impl IntoIterator<Item = BorrowedFd<'a>>) -> Option<TtyId> {
+    fds.into_iter().find_map(TtyId::from_fd)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::ffi::OsStr;
+    use std::fs::File;
+    use std::os::unix::ffi::OsStrExt;
+    use std::path::PathBuf;
+
+    use rstest::{fixture, rstest};
+    use rustix::pty::{OpenptFlags, grantpt, openpt, ptsname, unlockpt};
+
+    use super::*;
+
+    /// Open a fresh pty pair, returning the master, the slave, and the slave's path.
+    #[fixture]
+    fn pty() -> (File, File, PathBuf) {
+        let master = openpt(OpenptFlags::RDWR | OpenptFlags::NOCTTY).unwrap();
+        grantpt(&master).unwrap();
+        unlockpt(&master).unwrap();
+        let name = ptsname(&master, Vec::new()).unwrap();
+        let path = PathBuf::from(OsStr::from_bytes(name.as_bytes()));
+        let slave = File::options().read(true).write(true).open(&path).unwrap();
+        (File::from(master), slave, path)
+    }
+
+    #[rstest]
+    fn from_fd_of_a_pty_matches_a_stat_of_its_path(pty: (File, File, PathBuf)) {
+        use std::os::unix::fs::MetadataExt;
+
+        let (_master, slave, path) = pty;
+        let meta = std::fs::metadata(&path).unwrap();
+
+        let id = TtyId::from_fd(&slave).expect("a pty slave is a terminal");
+
+        // `Dev` is already u64 on Linux but is narrower on macOS, so the conversion is not
+        // redundant everywhere it compiles.
+        #[allow(clippy::useless_conversion, reason = "Dev is not u64 on every platform")]
+        {
+            assert_eq!(u64::try_from(id.dev).unwrap(), meta.dev());
+            assert_eq!(u64::try_from(id.rdev).unwrap(), meta.rdev());
+        }
+    }
+
+    /// Serialises the tests that swap this process's stdin.
+    static STDIN_LOCK: parking_lot::Mutex<()> = parking_lot::Mutex::new(());
+
+    /// Replace stdin with `fd` for as long as the returned guard lives.
+    fn with_stdin(fd: BorrowedFd<'_>) -> impl Drop {
+        struct Restore {
+            saved: std::os::fd::OwnedFd,
+            _lock: parking_lot::MutexGuard<'static, ()>,
+        }
+        impl Drop for Restore {
+            fn drop(&mut self) {
+                rustix::stdio::dup2_stdin(&self.saved).unwrap();
+            }
+        }
+        let lock = STDIN_LOCK.lock();
+        let saved = rustix::io::dup(std::io::stdin()).unwrap();
+        rustix::stdio::dup2_stdin(fd).unwrap();
+        Restore { saved, _lock: lock }
+    }
+
+    #[rstest]
+    fn current_finds_the_terminal_on_stdin(pty: (File, File, PathBuf)) {
+        let (_master, slave, _path) = pty;
+        let expected = TtyId::from_fd(&slave).unwrap();
+
+        let found = {
+            let _stdin = with_stdin(slave.as_fd());
+            TtyId::current()
+        };
+
+        assert_eq!(found, Some(expected));
+    }
+
+    #[rstest]
+    fn dev_null_is_not_a_terminal() {
+        // /dev/null is a character device, so a check based on the file type alone would
+        // wrongly accept it.
+        let devnull = File::open("/dev/null").unwrap();
+        assert_eq!(TtyId::from_fd(&devnull), None);
+    }
+
+    #[rstest]
+    fn first_tty_id_skips_non_terminals(pty: (File, File, PathBuf)) {
+        // Mirrors `atuin search -i </dev/null >/dev/null`, where only stderr is left on the tty.
+        let (_master, slave, _path) = pty;
+        let devnull = File::open("/dev/null").unwrap();
+        let expected = TtyId::from_fd(&slave).unwrap();
+
+        let found = first_tty_id([devnull.as_fd(), devnull.as_fd(), slave.as_fd()]);
+
+        assert_eq!(found, Some(expected));
+    }
+
+    #[rstest]
+    fn first_tty_id_returns_the_earliest_terminal(
+        #[from(pty)] first: (File, File, PathBuf),
+        #[from(pty)] second: (File, File, PathBuf),
+    ) {
+        let (_master_a, slave_a, _path_a) = first;
+        let (_master_b, slave_b, _path_b) = second;
+        let expected = TtyId::from_fd(&slave_a).unwrap();
+        assert_ne!(TtyId::from_fd(&slave_b), Some(expected), "the two ptys must differ");
+
+        let found = first_tty_id([slave_a.as_fd(), slave_b.as_fd()]);
+
+        assert_eq!(found, Some(expected));
+    }
+
+    #[rstest]
+    fn first_tty_id_is_none_when_nothing_is_a_terminal() {
+        // The case we deliberately do not handle: with every standard fd redirected there is no
+        // way to tell which terminal we belong to, so the pty proxy is not used.
+        let devnull = File::open("/dev/null").unwrap();
+        let regular = tempfile::NamedTempFile::new().unwrap();
+
+        let found = first_tty_id([devnull.as_fd(), regular.as_file().as_fd(), devnull.as_fd()]);
+
+        assert_eq!(found, None);
+    }
+}

--- a/crates/atuin-common/src/os/unix/tty.rs
+++ b/crates/atuin-common/src/os/unix/tty.rs
@@ -1,6 +1,6 @@
 //! TTY-related utilities.
 
-use std::os::fd::{AsFd, BorrowedFd};
+use std::os::fd::AsFd;
 
 use rustix::fs::Dev;
 
@@ -42,13 +42,8 @@ impl TtyId {
     #[must_use]
     pub fn current() -> Option<Self> {
         use rustix::stdio::{stderr, stdin, stdout};
-        first_tty_id([stdin(), stdout(), stderr()])
+        [stdin(), stdout(), stderr()].into_iter().find_map(Self::from_fd)
     }
-}
-
-/// Get the ID of the first FD in `fds` that is a terminal.
-fn first_tty_id<'a>(fds: impl IntoIterator<Item = BorrowedFd<'a>>) -> Option<TtyId> {
-    fds.into_iter().find_map(TtyId::from_fd)
 }
 
 #[cfg(test)]
@@ -97,7 +92,7 @@ mod tests {
     static STDIN_LOCK: parking_lot::Mutex<()> = parking_lot::Mutex::new(());
 
     /// Replace stdin with `fd` for as long as the returned guard lives.
-    fn with_stdin(fd: BorrowedFd<'_>) -> impl Drop {
+    fn with_stdin(fd: std::os::fd::BorrowedFd<'_>) -> impl Drop {
         struct Restore {
             saved: std::os::fd::OwnedFd,
             _lock: parking_lot::MutexGuard<'static, ()>,
@@ -132,44 +127,5 @@ mod tests {
         // wrongly accept it.
         let devnull = File::open("/dev/null").unwrap();
         assert_eq!(TtyId::from_fd(&devnull), None);
-    }
-
-    #[rstest]
-    fn first_tty_id_skips_non_terminals(pty: (File, File, PathBuf)) {
-        // Mirrors `atuin search -i </dev/null >/dev/null`, where only stderr is left on the tty.
-        let (_master, slave, _path) = pty;
-        let devnull = File::open("/dev/null").unwrap();
-        let expected = TtyId::from_fd(&slave).unwrap();
-
-        let found = first_tty_id([devnull.as_fd(), devnull.as_fd(), slave.as_fd()]);
-
-        assert_eq!(found, Some(expected));
-    }
-
-    #[rstest]
-    fn first_tty_id_returns_the_earliest_terminal(
-        #[from(pty)] first: (File, File, PathBuf),
-        #[from(pty)] second: (File, File, PathBuf),
-    ) {
-        let (_master_a, slave_a, _path_a) = first;
-        let (_master_b, slave_b, _path_b) = second;
-        let expected = TtyId::from_fd(&slave_a).unwrap();
-        assert_ne!(TtyId::from_fd(&slave_b), Some(expected), "the two ptys must differ");
-
-        let found = first_tty_id([slave_a.as_fd(), slave_b.as_fd()]);
-
-        assert_eq!(found, Some(expected));
-    }
-
-    #[rstest]
-    fn first_tty_id_is_none_when_nothing_is_a_terminal() {
-        // The case we deliberately do not handle: with every standard fd redirected there is no
-        // way to tell which terminal we belong to, so the pty proxy is not used.
-        let devnull = File::open("/dev/null").unwrap();
-        let regular = tempfile::NamedTempFile::new().unwrap();
-
-        let found = first_tty_id([devnull.as_fd(), regular.as_file().as_fd(), devnull.as_fd()]);
-
-        assert_eq!(found, None);
     }
 }

--- a/crates/atuin-common/src/os/unix/tty.rs
+++ b/crates/atuin-common/src/os/unix/tty.rs
@@ -86,10 +86,10 @@ mod tests {
 
         // `Dev` is already u64 on Linux but is narrower on macOS, so the conversion is not
         // redundant everywhere it compiles.
-        #[allow(clippy::useless_conversion, reason = "Dev is not u64 on every platform")]
+        #[allow(clippy::unnecessary_cast, reason = "Dev is not u64 on every platform")]
         {
-            assert_eq!(u64::try_from(id.dev).unwrap(), meta.dev());
-            assert_eq!(u64::try_from(id.rdev).unwrap(), meta.rdev());
+            assert_eq!(id.dev as u64, meta.dev());
+            assert_eq!(id.rdev as u64, meta.rdev());
         }
     }
 

--- a/crates/atuin-daemon/tests/history_delete.rs
+++ b/crates/atuin-daemon/tests/history_delete.rs
@@ -242,7 +242,7 @@ async fn deletion_survives_restart_and_rebuild(#[future(awt)] env: TestEnv) {
 #[rstest]
 #[tokio::test]
 async fn delete_failure_keeps_rows_until_retry() {
-    let env = TestEnv::builder().db_timeout(Duration::from_millis(200)).build().await;
+    let env = TestEnv::builder().build().await;
     let mut client = env.history_client().await;
     let a = env.record(&mut client, "echo a").await;
     let b = env.record(&mut client, "echo b").await;
@@ -266,7 +266,7 @@ async fn delete_failure_keeps_rows_until_retry() {
 #[case::record_store_down(false)]
 #[tokio::test]
 async fn failed_finish_keeps_the_command_in_flight(#[case] lock_history_db: bool) {
-    let env = TestEnv::builder().db_timeout(Duration::from_millis(200)).build().await;
+    let env = TestEnv::builder().build().await;
     let id = env.journal.start_cmd(history("echo flaky"));
 
     let lock = if lock_history_db {

--- a/crates/atuin-pty-proxy/Cargo.toml
+++ b/crates/atuin-pty-proxy/Cargo.toml
@@ -23,9 +23,13 @@ crossterm = { workspace = true }
 eyre = { workspace = true }
 portable-pty = { workspace = true }
 signal-hook = { workspace = true }
+thiserror = { workspace = true }
 
 [dev-dependencies]
+parking_lot = { workspace = true }
 rstest = { workspace = true }
+rustix = { workspace = true }
+tempfile = { workspace = true }
 
 [lints]
 workspace = true

--- a/crates/atuin-pty-proxy/src/lib.rs
+++ b/crates/atuin-pty-proxy/src/lib.rs
@@ -15,6 +15,8 @@ mod screen;
 pub use capture::{CommandCapture, CommandCaptureSink};
 #[cfg(unix)]
 pub use pty_proxy::{PtyProxy, Shell, init_script};
+#[cfg(unix)]
+pub use screen::{is_pty_proxy_child, parent_socket_path};
 
 #[cfg(not(unix))]
 #[allow(dead_code)]

--- a/crates/atuin-pty-proxy/src/pty_proxy.rs
+++ b/crates/atuin-pty-proxy/src/pty_proxy.rs
@@ -98,7 +98,7 @@ impl PtyProxy {
 impl Init {
     fn run(self) -> Result<(), String> {
         let shell = detect_shell(self.shell)?;
-        let script = render_init(shell);
+        let script = init_script(shell);
         print!("{script}");
         Ok(())
     }
@@ -146,96 +146,98 @@ fn env_flag(name: &str) -> bool {
 
 /// Shell code that re-execs the current shell inside `atuin pty-proxy`.
 ///
-/// Guarded by `ATUIN_PTY_PROXY_ACTIVE`, so it is safe to emit more than once
-/// per shell startup: whichever copy runs first wins and the rest no-op. This
-/// lets `atuin init` embed the preamble (via the `pty_proxy.enabled` setting)
-/// without conflicting with an existing standalone `atuin pty-proxy init`
-/// line in shell config.
+/// Safe to emit more than once: the script checks whether a PTY proxy has already been spawned and
+/// won't spawn another. This lets `atuin init` embed the preamble (via the `pty_proxy.enabled`
+/// setting) without conflicting with an existing standalone `atuin pty-proxy init` line in shell
+/// config.
 #[must_use]
 pub fn init_script(shell: Shell) -> &'static str {
-    render_init(shell)
+    match shell {
+        Shell::Bash | Shell::Zsh => BASH_ZSH_INIT,
+        Shell::Fish => FISH_INIT,
+        Shell::Nu => NU_INIT,
+    }
 }
 
-fn render_init(shell: Shell) -> &'static str {
-    // Each shell embeds its own interpreter path in the `--shell` argument so
-    // `atuin pty-proxy` spawns the same binary that sourced the init, rather
-    // than resolving via $PATH (which can pick the wrong installation when the
-    // user has, for instance, both /usr/bin/bash and /opt/homebrew/bin/bash).
-    match shell {
-        Shell::Bash | Shell::Zsh => {
-            r#"if [[ "$-" == *i* ]] && [[ -t 0 ]] && [[ -t 1 ]]; then
-  _atuin_pty_proxy_tmux_current="${TMUX:-}"
-  _atuin_pty_proxy_tmux_previous="${ATUIN_PTY_PROXY_TMUX:-}"
+/// Preamble for Bash and Zsh.
+///
+/// Each shell embeds its own interpreter path in the `--shell` argument so `atuin pty-proxy`
+/// spawns the same binary that sourced the init, rather than resolving via `$PATH` (which can
+/// pick the wrong installation when the user has, for instance, both `/usr/bin/bash` and
+/// `/opt/homebrew/bin/bash`).
+const BASH_ZSH_INIT: &str = r#"if [[ "$-" == *i* ]] && [[ -t 0 ]] && [[ -t 1 ]] &&
+  [[ -z ${__atuin_pty_proxy_owns_tty-} ]]
+then
+  __atuin_pty_proxy_owns_tty=0
 
-  if [[ -z "${ATUIN_PTY_PROXY_ACTIVE:-}" ]] || [[ "$_atuin_pty_proxy_tmux_current" != "$_atuin_pty_proxy_tmux_previous" ]]; then
-    export ATUIN_PTY_PROXY_ACTIVE=1
-    export ATUIN_PTY_PROXY_TMUX="$_atuin_pty_proxy_tmux_current"
-    if [[ -n "${BASH_VERSION:-}" ]]; then
-      exec atuin pty-proxy --shell "$BASH"
-    elif [[ -n "${ZSH_VERSION:-}" ]]; then
-      # Prefer ZSH_ARGZERO (zsh 5.3+) — it preserves the path zsh was
-      # invoked with — and fall back to PATH lookup otherwise. Login shells
-      # set argv[0] to "-zsh", and ZSH_ARGZERO keeps that leading dash, so
-      # strip it (${var#-}) before passing the path along.
-      _atuin_pty_proxy_zsh="${ZSH_ARGZERO:-$(command -v zsh)}"
-      exec atuin pty-proxy --shell "${_atuin_pty_proxy_zsh#-}"
-    else
-      exec atuin pty-proxy
-    fi
+  # Check whether this terminal is already running in an Atuin PTY proxy.
+  __atuin_pty_proxy_answer=$(atuin __internal pty-proxy-active 2>/dev/null)
+  if [[ $? -ne 0 ]]; then
+    :
+  elif [[ $__atuin_pty_proxy_answer = 1 ]]; then
+    __atuin_pty_proxy_owns_tty=1
+  elif [[ -n ${ATUIN_PTY_PROXY_FAILED-} ]]; then
+    # If the PTY proxy failed to spawn its server, stop here instead of endlessly
+    # trying to spawn more proxies.
+    :
+  elif [[ -n "${BASH_VERSION:-}" ]]; then
+    exec atuin pty-proxy --shell "$BASH"
+  elif [[ -n "${ZSH_VERSION:-}" ]]; then
+    # Prefer ZSH_ARGZERO (zsh 5.3+) -- it preserves the path zsh was
+    # invoked with -- and fall back to PATH lookup otherwise. Login shells
+    # set argv[0] to "-zsh", and ZSH_ARGZERO keeps that leading dash, so
+    # strip it (${var#-}) before passing it along.
+    _atuin_pty_proxy_zsh="${ZSH_ARGZERO:-$(command -v zsh)}"
+    exec atuin pty-proxy --shell "${_atuin_pty_proxy_zsh#-}"
+  else
+    exec atuin pty-proxy
   fi
-
-  unset _atuin_pty_proxy_tmux_current _atuin_pty_proxy_tmux_previous
+  unset __atuin_pty_proxy_answer
 fi
-"#
-        }
-        Shell::Fish => {
-            r#"if status is-interactive; and test -t 0; and test -t 1
-    set -l _atuin_pty_proxy_tmux_current ""
-    if set -q TMUX
-        set _atuin_pty_proxy_tmux_current "$TMUX"
-    end
+"#;
 
-    set -l _atuin_pty_proxy_tmux_previous ""
-    if set -q ATUIN_PTY_PROXY_TMUX
-        set _atuin_pty_proxy_tmux_previous "$ATUIN_PTY_PROXY_TMUX"
-    end
+/// Preamble for fish.
+const FISH_INIT: &str = r#"if status is-interactive; and test -t 0; and test -t 1
+    and not set -q __atuin_pty_proxy_owns_tty
 
-    if not set -q ATUIN_PTY_PROXY_ACTIVE
-        set -gx ATUIN_PTY_PROXY_ACTIVE 1
-        set -gx ATUIN_PTY_PROXY_TMUX "$_atuin_pty_proxy_tmux_current"
-        exec atuin pty-proxy --shell (status fish-path)
-    else if test "$_atuin_pty_proxy_tmux_current" != "$_atuin_pty_proxy_tmux_previous"
-        set -gx ATUIN_PTY_PROXY_ACTIVE 1
-        set -gx ATUIN_PTY_PROXY_TMUX "$_atuin_pty_proxy_tmux_current"
+    set -g __atuin_pty_proxy_owns_tty 0
+    set -l __atuin_pty_proxy_answer (atuin __internal pty-proxy-active 2>/dev/null)
+    set -l __atuin_pty_proxy_status $status
+
+    if test $__atuin_pty_proxy_status -ne 0
+    else if test "$__atuin_pty_proxy_answer" = 1
+        set -g __atuin_pty_proxy_owns_tty 1
+    else if not set -q ATUIN_PTY_PROXY_FAILED
         exec atuin pty-proxy --shell (status fish-path)
     end
 end
-"#
-        }
-        // Nushell cannot dynamically source the output of `atuin init nu`,
-        // so we only output the pty-proxy preamble here. Users must also set up
-        // `atuin init nu` separately.
-        Shell::Nu => {
-            r#"if (is-terminal --stdin) and (is-terminal --stdout) {
-    let tmux_current = ($env.TMUX? | default "")
-    let tmux_previous = ($env.ATUIN_PTY_PROXY_TMUX? | default "")
+"#;
 
-    if (($env.ATUIN_PTY_PROXY_ACTIVE? | default "") | is-empty) or ($tmux_current != $tmux_previous) {
-        $env.ATUIN_PTY_PROXY_ACTIVE = "1"
-        $env.ATUIN_PTY_PROXY_TMUX = $tmux_current
+/// Preamble for Nushell.
+///
+/// Nushell cannot dynamically source the output of `atuin init nu`, so only the pty-proxy
+/// preamble is emitted here; users must also set up `atuin init nu` separately.
+const NU_INIT: &str = r#"if (is-terminal --stdin) and (is-terminal --stdout) and ('__atuin_pty_proxy' not-in $env) {
+    # Use a record rather than a plain string so the variable doesn't get exported
+    # to child processes -- we want each child shell to perform its own detection.
+    $env.__atuin_pty_proxy = { owns_tty: false }
+
+    let atuin_proxy_check = (do -i { atuin __internal pty-proxy-active } | complete)
+
+    if $atuin_proxy_check.exit_code != 0 {
+    } else if ($atuin_proxy_check.stdout | str trim) == "1" {
+        $env.__atuin_pty_proxy = { owns_tty: true }
+    } else if ('ATUIN_PTY_PROXY_FAILED' not-in $env) {
         exec atuin pty-proxy --shell $nu.current-exe
     }
 }
-"#
-        }
-    }
-}
+"#;
 
 #[cfg(test)]
 mod tests {
     use rstest::rstest;
 
-    use super::{Shell, render_init, shell_from_name};
+    use super::{Shell, init_script, shell_from_name};
 
     #[rstest]
     #[case::zsh_abs_path("/bin/zsh", Shell::Zsh)]
@@ -250,50 +252,54 @@ mod tests {
     fn every_init_execs_pty_proxy(
         #[values(Shell::Zsh, Shell::Bash, Shell::Fish, Shell::Nu)] shell: Shell,
     ) {
-        assert!(render_init(shell).contains("exec atuin pty-proxy"));
+        assert!(init_script(shell).contains("exec atuin pty-proxy"));
     }
 
     #[rstest]
-    fn posix_init_uses_exec_and_tmux_guard() {
-        let script = render_init(Shell::Bash);
-        assert!(script.contains("ATUIN_PTY_PROXY_TMUX"));
-        assert!(!script.contains("eval \"$(atuin init bash)\""));
+    fn every_init_asks_atuin_whether_this_terminal_has_a_proxy(
+        #[values(Shell::Zsh, Shell::Bash, Shell::Fish, Shell::Nu)] shell: Shell,
+    ) {
+        assert!(init_script(shell).contains("__internal pty-proxy-active"));
+    }
+
+    #[rstest]
+    fn every_init_stops_when_the_proxy_says_it_failed(
+        #[values(Shell::Zsh, Shell::Bash, Shell::Fish, Shell::Nu)] shell: Shell,
+    ) {
+        let script = init_script(shell);
+        assert!(script.contains("ATUIN_PTY_PROXY_FAILED"));
+    }
+
+    #[rstest]
+    #[case(Shell::Bash, r#"[[ -z "${__atuin_pty_proxy_owns_tty:-}" ]]"#)]
+    #[case(Shell::Fish, "not set -q __atuin_pty_proxy_owns_tty")]
+    #[case(Shell::Nu, "'__atuin_pty_proxy' not-in $env")]
+    fn init_no_ops_when_emitted_twice(#[case] shell: Shell, #[case] guard: &str) {
+        // `atuin init` embeds the preamble, and users may also still have a standalone
+        // `atuin pty-proxy init` line. Whichever copy runs first decides; the second must not
+        // repeat the check.
+        assert!(init_script(shell).contains(guard), "{shell:?} repeats the check");
     }
 
     #[rstest]
     fn posix_init_has_no_double_braces() {
-        let script = render_init(Shell::Bash);
+        let script = init_script(Shell::Bash);
         assert!(!script.contains("${{"), "double braces in bash init script");
     }
 
     #[rstest]
     fn init_scripts_forward_shell_path() {
-        let posix = render_init(Shell::Bash);
+        let posix = init_script(Shell::Bash);
         assert!(posix.contains(r#"exec atuin pty-proxy --shell "$BASH""#));
         // zsh: capture ZSH_ARGZERO (with PATH fallback), then strip the
         // leading dash present on login shells before forwarding the path.
         assert!(posix.contains(r#"_atuin_pty_proxy_zsh="${ZSH_ARGZERO:-$(command -v zsh)}""#));
         assert!(posix.contains(r#"exec atuin pty-proxy --shell "${_atuin_pty_proxy_zsh#-}""#));
 
-        let fish = render_init(Shell::Fish);
+        let fish = init_script(Shell::Fish);
         assert!(fish.contains("exec atuin pty-proxy --shell (status fish-path)"));
 
-        let nu = render_init(Shell::Nu);
+        let nu = init_script(Shell::Nu);
         assert!(nu.contains("exec atuin pty-proxy --shell $nu.current-exe"));
-    }
-
-    #[rstest]
-    fn fish_init_uses_source() {
-        let script = render_init(Shell::Fish);
-        assert!(!script.contains("atuin init fish | source"));
-    }
-
-    #[rstest]
-    fn nu_init_uses_exec_and_tty_guard() {
-        let script = render_init(Shell::Nu);
-        assert!(script.contains("ATUIN_PTY_PROXY_TMUX"));
-        assert!(script.contains("is-terminal --stdin"));
-        assert!(script.contains("is-terminal --stdout"));
-        assert!(script.contains("ATUIN_PTY_PROXY_ACTIVE"));
     }
 }

--- a/crates/atuin-pty-proxy/src/pty_proxy.rs
+++ b/crates/atuin-pty-proxy/src/pty_proxy.rs
@@ -171,8 +171,7 @@ then
   __atuin_pty_proxy_owns_tty=0
 
   # Check whether this terminal is already running in an Atuin PTY proxy.
-  __atuin_pty_proxy_answer=$(atuin __internal pty-proxy-active 2>/dev/null)
-  if [[ $? -ne 0 ]]; then
+  if ! __atuin_pty_proxy_answer=$(atuin __internal pty-proxy-active 2>/dev/null); then
     :
   elif [[ $__atuin_pty_proxy_answer = 1 ]]; then
     __atuin_pty_proxy_owns_tty=1

--- a/crates/atuin-pty-proxy/src/pty_proxy.rs
+++ b/crates/atuin-pty-proxy/src/pty_proxy.rs
@@ -273,7 +273,7 @@ mod tests {
     }
 
     #[rstest]
-    #[case(Shell::Bash, r#"[[ -z "${__atuin_pty_proxy_owns_tty:-}" ]]"#)]
+    #[case(Shell::Bash, r#"[[ -z ${__atuin_pty_proxy_owns_tty-} ]]"#)]
     #[case(Shell::Fish, "not set -q __atuin_pty_proxy_owns_tty")]
     #[case(Shell::Nu, "'__atuin_pty_proxy' not-in $env")]
     fn init_no_ops_when_emitted_twice(#[case] shell: Shell, #[case] guard: &str) {

--- a/crates/atuin-pty-proxy/src/pty_proxy.rs
+++ b/crates/atuin-pty-proxy/src/pty_proxy.rs
@@ -197,7 +197,10 @@ fi
 "#;
 
 /// Preamble for fish.
-const FISH_INIT: &str = r#"if status is-interactive; and test -t 0; and test -t 1
+// Unlike other shells, we only test whether stdout is a tty rather than also checking stdin,
+// because we instruct users to pipe `atuin init fish` to `source`, which puts the script itself
+// on stdin, making it necessarily not a tty.
+const FISH_INIT: &str = r#"if status is-interactive; and test -t 1
     and not set -q __atuin_pty_proxy_owns_tty
 
     set -g __atuin_pty_proxy_owns_tty 0

--- a/crates/atuin-pty-proxy/src/pty_proxy.rs
+++ b/crates/atuin-pty-proxy/src/pty_proxy.rs
@@ -273,7 +273,7 @@ mod tests {
     }
 
     #[rstest]
-    #[case(Shell::Bash, r#"[[ -z ${__atuin_pty_proxy_owns_tty-} ]]"#)]
+    #[case(Shell::Bash, "[[ -z ${__atuin_pty_proxy_owns_tty-} ]]")]
     #[case(Shell::Fish, "not set -q __atuin_pty_proxy_owns_tty")]
     #[case(Shell::Nu, "'__atuin_pty_proxy' not-in $env")]
     fn init_no_ops_when_emitted_twice(#[case] shell: Shell, #[case] guard: &str) {

--- a/crates/atuin-pty-proxy/src/runtime.rs
+++ b/crates/atuin-pty-proxy/src/runtime.rs
@@ -38,6 +38,8 @@ enum InitError {
 /// the server failed to initialize), this sets `ATUIN_PTY_PROXY_FAILED` to stop the child shell
 /// from endlessly trying to spawn additional PTY proxies.
 fn set_child_env(cmd: &mut CommandBuilder, socket_path: Option<&std::path::Path>) {
+    cmd.env("ATUIN_PTY_PROXY_ACTIVE", "1");
+
     if let Some(path) = socket_path {
         cmd.env("ATUIN_PTY_PROXY_SOCKET", path);
         cmd.env_remove("ATUIN_PTY_PROXY_FAILED");

--- a/crates/atuin-pty-proxy/src/runtime.rs
+++ b/crates/atuin-pty-proxy/src/runtime.rs
@@ -1,12 +1,13 @@
 use std::io::{Read, Write};
 use std::sync::mpsc;
 
+use atuin_common::os::unix::tty::TtyId;
 use crossterm::terminal;
 use portable_pty::{CommandBuilder, PtySize, native_pty_system};
 
 use crate::debug::{Osc133DebugHighlighter, RESET};
 use crate::pty_proxy::RuntimeOptions;
-use crate::screen::{self, Msg};
+use crate::screen::{self, Msg, SocketServer};
 
 pub fn main(options: RuntimeOptions) {
     if let Err(e) = run(options) {
@@ -16,9 +17,38 @@ pub fn main(options: RuntimeOptions) {
     }
 }
 
+/// An error that occurred while setting up the PTY server.
+#[derive(Debug, thiserror::Error)]
+enum InitError {
+    #[error("failed to get path to terminal")]
+    GetPath,
+    #[error("failed to open terminal: {0}")]
+    Open(std::io::Error),
+    #[error("file is not a terminal")]
+    NotATerminal,
+    #[error("failed to create socket: {0}")]
+    CreateSocket(atuin_common::os::unix::SecureTempDirError),
+    #[error("failed to bind socket: {0}")]
+    BindSocket(std::io::Error),
+}
+
+/// Set the appropriate proxy-related environment variables in the PTY child.
+///
+/// This sets `ATUIN_PTY_PROXY_SOCKET` to the socket path, or, if `socket_path` is [`None`] (because
+/// the server failed to initialize), this sets `ATUIN_PTY_PROXY_FAILED` to stop the child shell
+/// from endlessly trying to spawn additional PTY proxies.
+fn set_child_env(cmd: &mut CommandBuilder, socket_path: Option<&std::path::Path>) {
+    if let Some(path) = socket_path {
+        cmd.env("ATUIN_PTY_PROXY_SOCKET", path);
+        cmd.env_remove("ATUIN_PTY_PROXY_FAILED");
+    } else {
+        cmd.env_remove("ATUIN_PTY_PROXY_SOCKET");
+        cmd.env("ATUIN_PTY_PROXY_FAILED", "1");
+    }
+}
+
 fn run(options: RuntimeOptions) -> eyre::Result<()> {
     let (cols, rows) = terminal::size()?;
-
     let pty_system = native_pty_system();
     let pair = pty_system
         .openpty(PtySize {
@@ -29,18 +59,44 @@ fn run(options: RuntimeOptions) -> eyre::Result<()> {
         })
         .map_err(|e| eyre::eyre!("{e:#}"))?;
 
-    let sock_path = match screen::socket_path() {
-        Ok(path) => {
-            let _ = std::fs::remove_file(&path);
-            Some(path)
-        }
-        Err(e) => {
-            // If creating the socket fails, print the error and continue rather than returning it,
-            // so the user still gets a shell. This is the same behavior as when binding the socket
-            // fails in `screen::spawn_socket_server`.
-            eprintln!("atuin pty-proxy: failed to create socket: {e}");
-            None
-        }
+    // The PTY proxy server and the path of its socket.
+    let server_and_path: Option<(SocketServer, atuin_common::fs::RemoveOnDropPath)> = pair
+        .master
+        .tty_name()
+        .ok_or(InitError::GetPath)
+        .and_then(|tty_name| {
+            // portable-pty doesn't give us access to the child FD, so we have to open it by path.
+            let tty_fd = std::fs::File::open(&tty_name).map_err(InitError::Open)?;
+            let tty_id = TtyId::from_fd(tty_fd).ok_or(InitError::NotATerminal)?;
+            let socket_path = screen::socket_path(tty_id).map_err(InitError::CreateSocket)?;
+
+            // A previous proxy on this PTY may have died without cleaning up. Its socket is
+            // definitely no longer in use (otherwise we wouldn't have been given its PTY), so
+            // delete it.
+            let _ = std::fs::remove_file(&socket_path);
+            let server = SocketServer::new(&socket_path).map_err(InitError::BindSocket)?;
+            let path = atuin_common::fs::RemoveOnDropPath(socket_path);
+            Ok::<_, InitError>((server, path))
+        })
+        .map_err(|e| {
+            // If we're unable to initialize the PTY server (e.g., failed to create the socket),
+            // print the error and continue rather than returning it, so the user still gets a
+            // shell.
+            eprintln!("atuin pty-proxy: failed to initialize server: {e}");
+        })
+        .ok();
+
+    let (msg_tx, msg_rx) = mpsc::sync_channel::<Msg>(64);
+    let _parser_handle = screen::spawn_parser_thread(rows, cols, msg_rx, screen::ParserOptions {
+        sink: options.command_capture_sink,
+        debug_osc133: options.debug_osc133,
+    });
+
+    let socket_path = if let Some((server, path)) = server_and_path {
+        server.spawn(msg_tx.clone());
+        Some(path)
+    } else {
+        None
     };
 
     let mut cmd = match options.shell {
@@ -55,12 +111,7 @@ fn run(options: RuntimeOptions) -> eyre::Result<()> {
     if let Some(ref path) = options.shell {
         cmd.env("SHELL", path);
     }
-    if let Some(path) = &sock_path {
-        cmd.env("ATUIN_PTY_PROXY_SOCKET", path);
-    } else {
-        cmd.env_remove("ATUIN_PTY_PROXY_SOCKET");
-    }
-    cmd.env("ATUIN_PTY_PROXY_ACTIVE", "1");
+    set_child_env(&mut cmd, socket_path.as_deref());
     // Atuin sets a restrictive process-wide umask on startup to protect the
     // files it creates. The shell must not inherit it (#3695) — restore the
     // umask the user launched us with. Applied in the child between fork and
@@ -79,14 +130,6 @@ fn run(options: RuntimeOptions) -> eyre::Result<()> {
     let mut pty_reader = pair.master.try_clone_reader().map_err(|e| eyre::eyre!("{e:#}"))?;
     let mut pty_writer = pair.master.take_writer().map_err(|e| eyre::eyre!("{e:#}"))?;
 
-    let (msg_tx, msg_rx) = mpsc::sync_channel::<Msg>(64);
-    let _parser_handle = screen::spawn_parser_thread(rows, cols, msg_rx, screen::ParserOptions {
-        sink: options.command_capture_sink,
-        debug_osc133: options.debug_osc133,
-    });
-    if let Some(path) = &sock_path {
-        screen::spawn_socket_server(path.clone(), msg_tx.clone());
-    }
     spawn_resize_handler(pair.master, msg_tx.clone())?;
     terminal::enable_raw_mode()?;
 
@@ -143,10 +186,7 @@ fn run(options: RuntimeOptions) -> eyre::Result<()> {
     let _ = stdout_thread.join();
 
     let _ = terminal::disable_raw_mode();
-    if let Some(path) = &sock_path {
-        let _ = std::fs::remove_file(path);
-    }
-
+    drop(socket_path); // delete the socket
     std::process::exit(process_exit_code(status.exit_code()));
 }
 
@@ -182,10 +222,13 @@ fn process_exit_code(code: u32) -> i32 {
 
 #[cfg(test)]
 mod tests {
+    use std::ffi::OsStr;
+    use std::path::Path;
+
     use easy_cast::Conv;
     use rstest::rstest;
 
-    use super::process_exit_code;
+    use super::{CommandBuilder, process_exit_code, set_child_env};
 
     #[rstest]
     #[case::zero(0, 0)]
@@ -194,5 +237,28 @@ mod tests {
     #[case::overflow_defaults_to_one(u32::conv(i32::MAX) + 1, 1)]
     fn maps_exit_code(#[case] input: u32, #[case] expected: i32) {
         assert_eq!(process_exit_code(input), expected);
+    }
+
+    #[rstest]
+    fn a_proxy_without_a_socket_tells_its_shell_not_to_start_another() {
+        // The shell cannot detect a proxy that has no socket, so it would exec a replacement
+        // that fails in exactly the same way, forever.
+        let mut cmd = CommandBuilder::new("true");
+
+        set_child_env(&mut cmd, None);
+
+        assert_eq!(cmd.get_env("ATUIN_PTY_PROXY_FAILED"), Some(OsStr::new("1")));
+    }
+
+    #[rstest]
+    fn a_working_proxy_clears_an_inherited_failed_flag() {
+        // An outer proxy that failed exports the flag. A working proxy nested below it -- in a
+        // multiplexer pane, say -- must not pass that verdict on to its own shell.
+        let mut cmd = CommandBuilder::new("true");
+        cmd.env("ATUIN_PTY_PROXY_FAILED", "1");
+
+        set_child_env(&mut cmd, Some(Path::new("/tmp/atuin-test/pty-proxy-1-2-3.sock")));
+
+        assert_eq!(cmd.get_env("ATUIN_PTY_PROXY_FAILED"), None);
     }
 }

--- a/crates/atuin-pty-proxy/src/screen.rs
+++ b/crates/atuin-pty-proxy/src/screen.rs
@@ -159,7 +159,7 @@ pub struct SocketServer {
 impl SocketServer {
     /// Create a new socket server.
     ///
-    /// The server will start running once [`spawn`] is called.
+    /// The server will start running once [`Self::spawn`] is called.
     pub fn new(path: &std::path::Path) -> std::io::Result<Self> {
         Ok(Self {
             listener: UnixListener::bind(path)?,

--- a/crates/atuin-pty-proxy/src/screen.rs
+++ b/crates/atuin-pty-proxy/src/screen.rs
@@ -5,6 +5,7 @@ use std::path::PathBuf;
 use std::sync::mpsc::{self, Receiver, SyncSender};
 use std::thread::JoinHandle;
 
+use atuin_common::os::unix::tty::TtyId;
 use atuin_common::os::unix::{SecureTempDirError, create_secure_temp_dir};
 use easy_cast::Conv;
 
@@ -20,11 +21,47 @@ pub enum Msg {
     ScreenRequest(mpsc::Sender<Vec<u8>>),
 }
 
-pub fn socket_path() -> Result<PathBuf, SecureTempDirError> {
+/// The path to the PTY proxy socket for the given terminal.
+pub fn socket_path(tty_id: TtyId) -> Result<PathBuf, SecureTempDirError> {
+    Ok(socket_dir()?.join(socket_name(tty_id)))
+}
+
+/// The name of the PTY proxy socket for the given terminal.
+#[must_use]
+fn socket_name(tty_id: TtyId) -> String {
+    format!("pty-proxy-{}-{}.sock", tty_id.dev, tty_id.rdev)
+}
+
+/// The directory in which PTY proxy sockets are stored.
+fn socket_dir() -> Result<PathBuf, SecureTempDirError> {
     let uid = atuin_common::os::unix::uid();
     let dir = atuin_common::os::unix::tmp_dir().join(format!("atuin-{uid}"));
-    let dir = create_secure_temp_dir(dir)?;
-    Ok(dir.join(format!("pty-proxy-{}.sock", std::process::id())))
+    create_secure_temp_dir(dir)
+}
+
+/// The socket path of the PTY proxy that this process is running in.
+///
+/// This process must be directly running inside an Atuin PTY proxy -- that is, its terminal must be
+/// the child PTY created by the PTY proxy. Otherwise, this function will return [`None`].
+#[must_use]
+pub fn parent_socket_path() -> Option<PathBuf> {
+    live_socket(socket_dir().ok()?, TtyId::current()?)
+}
+
+/// Whether this process is running directly inside an Atuin PTY proxy.
+///
+/// To qualify, this process's terminal must be the child PTY created by the PTY proxy. If there is
+/// another PTY in between (e.g., from tmux or screen), this will return false.
+#[must_use]
+pub fn is_pty_proxy_child() -> bool {
+    parent_socket_path().is_some()
+}
+
+/// Check whether `socket_dir` contains a live socket corresponding to `tty_id`.
+fn live_socket(mut socket_dir: PathBuf, tty: TtyId) -> Option<PathBuf> {
+    socket_dir.push(socket_name(tty));
+    std::os::unix::net::UnixStream::connect(&socket_dir).ok()?;
+    Some(socket_dir)
 }
 
 pub struct ParserOptions {
@@ -114,23 +151,30 @@ pub fn spawn_parser_thread(
     })
 }
 
-pub fn spawn_socket_server(sock_path: PathBuf, screen_tx: SyncSender<Msg>) {
-    std::thread::spawn(move || {
-        let listener = match UnixListener::bind(&sock_path) {
-            Ok(l) => l,
-            Err(e) => {
-                eprintln!("atuin pty-proxy: failed to bind socket: {e}");
-                return;
-            }
-        };
+/// The PTY proxy server.
+pub struct SocketServer {
+    listener: UnixListener,
+}
 
-        for stream in listener.incoming() {
+impl SocketServer {
+    /// Create a new socket server.
+    ///
+    /// The server will start running once [`spawn`] is called.
+    pub fn new(path: &std::path::Path) -> std::io::Result<Self> {
+        Ok(Self {
+            listener: UnixListener::bind(path)?,
+        })
+    }
+
+    /// Start running the socket server on the current thread.
+    pub fn run(self, msg_tx: &SyncSender<Msg>) {
+        for stream in self.listener.incoming() {
             let Ok(mut stream) = stream else {
                 break;
             };
 
             let (reply_tx, reply_rx) = mpsc::channel();
-            if screen_tx.send(Msg::ScreenRequest(reply_tx)).is_err() {
+            if msg_tx.send(Msg::ScreenRequest(reply_tx)).is_err() {
                 break;
             }
             if let Ok(data) = reply_rx.recv() {
@@ -138,7 +182,12 @@ pub fn spawn_socket_server(sock_path: PathBuf, screen_tx: SyncSender<Msg>) {
                 let _ = stream.flush();
             }
         }
-    });
+    }
+
+    /// Start running the socket server on a new thread.
+    pub fn spawn(self, msg_tx: SyncSender<Msg>) -> std::thread::JoinHandle<()> {
+        std::thread::spawn(move || self.run(&msg_tx))
+    }
 }
 
 /// Wire format written to the Unix socket:
@@ -182,6 +231,7 @@ mod tests {
 
     use atuin_client::history::HistoryId;
     use rstest::{fixture, rstest};
+    use tempfile::TempDir;
 
     use super::*;
     use crate::capture::CommandCapture;
@@ -192,6 +242,157 @@ mod tests {
 
     fn hid(s: &str) -> HistoryId {
         s.parse().expect("valid history id")
+    }
+
+    /// Terminals that differ in either half of their identity must not share a socket name.
+    #[rstest]
+    // Two panes of a multiplexer are different ptys on the same devpts mount.
+    #[case::same_mount_other_pty(TtyId { dev: 24, rdev: 12 }, TtyId { dev: 24, rdev: 19 })]
+    // A container gets its own devpts, where pts numbering restarts from zero. Without the
+    // filesystem id in the name, its /dev/pts/0 would collide with the host's.
+    #[case::same_pty_other_mount(TtyId { dev: 24, rdev: 0 }, TtyId { dev: 31, rdev: 0 })]
+    fn socket_names_differ(#[case] one: TtyId, #[case] other: TtyId) {
+        assert_ne!(socket_name(one), socket_name(other));
+    }
+
+    #[rstest]
+    fn socket_name_is_built_from_both_halves_of_the_identity() {
+        let tty = TtyId {
+            dev: 24,
+            rdev: 34828,
+        };
+
+        assert_eq!(socket_name(tty), "pty-proxy-24-34828.sock");
+    }
+
+    #[rstest]
+    fn a_bound_socket_accepts_connections_before_anything_accepts_them(dir: TempDir) {
+        // The proxy binds before spawning the shell so that the shell can never observe a
+        // missing socket. That only works if `listen` has already happened when `SocketServer::new`
+        // returns: a client connecting into the backlog must succeed with nobody accepting yet.
+        let path = dir.path().join("pty-proxy-1-2-3.sock");
+
+        let server = SocketServer::new(&path).unwrap();
+
+        std::os::unix::net::UnixStream::connect(&path)
+            .expect("a connection must succeed on a bound socket with no accept loop running");
+        drop(server);
+    }
+
+    #[rstest]
+    fn a_listening_proxy_socket_is_found(dir: TempDir) {
+        let tty = TtyId { dev: 24, rdev: 12 };
+        let path = dir.path().join(socket_name(tty));
+        let _server = SocketServer::new(&path).unwrap();
+
+        assert_eq!(live_socket(dir.path().to_path_buf(), tty), Some(path));
+    }
+
+    #[rstest]
+    fn a_stale_socket_file_is_not_a_live_proxy(dir: TempDir) {
+        // A proxy killed with SIGKILL never runs its cleanup, so the file outlives it. Because
+        // the kernel reissues the lowest free pts index, a later terminal can legitimately have
+        // the same identity -- and must not be fooled into thinking it is proxied.
+        let tty = TtyId { dev: 24, rdev: 12 };
+        let path = dir.path().join(socket_name(tty));
+        let server = SocketServer::new(&path).unwrap();
+        drop(server);
+        assert!(path.exists(), "dropping a listener must leave the file behind");
+
+        assert_eq!(live_socket(dir.path().to_path_buf(), tty), None);
+    }
+
+    #[rstest]
+    fn no_socket_means_no_proxy(dir: TempDir) {
+        let tty = TtyId { dev: 24, rdev: 12 };
+
+        assert_eq!(live_socket(dir.path().to_path_buf(), tty), None);
+    }
+
+    /// Open a fresh pty pair, returning the master, the slave, and the slave's path.
+    #[fixture]
+    fn pty() -> (std::fs::File, std::fs::File, std::path::PathBuf) {
+        use std::os::unix::ffi::OsStrExt;
+
+        use rustix::pty::{OpenptFlags, grantpt, openpt, ptsname, unlockpt};
+
+        let master = openpt(OpenptFlags::RDWR | OpenptFlags::NOCTTY).unwrap();
+        grantpt(&master).unwrap();
+        unlockpt(&master).unwrap();
+        let name = ptsname(&master, Vec::new()).unwrap();
+        let path = std::path::PathBuf::from(std::ffi::OsStr::from_bytes(name.as_bytes()));
+        let slave = std::fs::File::options().read(true).write(true).open(&path).unwrap();
+        (std::fs::File::from(master), slave, path)
+    }
+
+    /// Serialises the tests that swap this process's stdin.
+    static STDIN_LOCK: parking_lot::Mutex<()> = parking_lot::Mutex::new(());
+
+    /// Replace stdin with `fd` for as long as the returned guard lives.
+    fn with_stdin(fd: std::os::fd::BorrowedFd<'_>) -> impl Drop {
+        struct Restore {
+            saved: std::os::fd::OwnedFd,
+            _lock: parking_lot::MutexGuard<'static, ()>,
+        }
+        impl Drop for Restore {
+            fn drop(&mut self) {
+                rustix::stdio::dup2_stdin(&self.saved).unwrap();
+            }
+        }
+        let lock = STDIN_LOCK.lock();
+        let saved = rustix::io::dup(std::io::stdin()).unwrap();
+        rustix::stdio::dup2_stdin(fd).unwrap();
+        Restore { saved, _lock: lock }
+    }
+
+    /// A directory to hold proxy sockets, removed when the test ends.
+    #[fixture]
+    fn dir() -> TempDir {
+        tempfile::tempdir().unwrap()
+    }
+
+    /// Bind a socket for a proxy attached to `tty`, as the proxy itself would.
+    fn proxy_listening_on(dir: &std::path::Path, tty: TtyId) -> SocketServer {
+        SocketServer::new(&dir.join(socket_name(tty))).unwrap()
+    }
+
+    #[rstest]
+    fn a_shell_in_the_proxys_own_pty_is_attached(
+        dir: TempDir,
+        pty: (std::fs::File, std::fs::File, std::path::PathBuf),
+    ) {
+        use std::os::fd::AsFd;
+
+        let (_master, slave, _path) = pty;
+        let _proxy = proxy_listening_on(dir.path(), TtyId::from_fd(&slave).unwrap());
+
+        let attached = {
+            let _stdin = with_stdin(slave.as_fd());
+            live_socket(dir.path().to_path_buf(), TtyId::current().unwrap()).is_some()
+        };
+
+        assert!(attached);
+    }
+
+    #[rstest]
+    fn a_shell_in_a_pty_nested_inside_the_proxy_is_not_attached(
+        dir: TempDir,
+        #[from(pty)] proxy_pty: (std::fs::File, std::fs::File, std::path::PathBuf),
+        // tmux allocates a fresh pty for the pane; the proxy is still running around it.
+        #[from(pty)] pane_pty: (std::fs::File, std::fs::File, std::path::PathBuf),
+    ) {
+        use std::os::fd::AsFd;
+
+        let (_master, proxy_slave, _path) = proxy_pty;
+        let _proxy = proxy_listening_on(dir.path(), TtyId::from_fd(&proxy_slave).unwrap());
+        let (_pane_master, pane_slave, _pane_path) = pane_pty;
+
+        let attached = {
+            let _stdin = with_stdin(pane_slave.as_fd());
+            live_socket(dir.path().to_path_buf(), TtyId::current().unwrap()).is_some()
+        };
+
+        assert!(!attached, "a multiplexer pane is a different terminal from the proxy's own");
     }
 
     /// Get the `rows` and `cols` values from an [`encode_screen`] blob.

--- a/crates/atuin-pty-proxy/src/screen.rs
+++ b/crates/atuin-pty-proxy/src/screen.rs
@@ -58,6 +58,8 @@ pub fn is_pty_proxy_child() -> bool {
 }
 
 /// Check whether `socket_dir` contains a live socket corresponding to `tty_id`.
+///
+/// If so, returns the path to the socket.
 fn live_socket(mut socket_dir: PathBuf, tty: TtyId) -> Option<PathBuf> {
     socket_dir.push(socket_name(tty));
     std::os::unix::net::UnixStream::connect(&socket_dir).ok()?;

--- a/crates/atuin/src/command/client.rs
+++ b/crates/atuin/src/command/client.rs
@@ -169,44 +169,66 @@ impl Cmd {
         }
 
         #[cfg(feature = "ai")]
-        let mut runtime = if matches!(&self, Self::Ai(_)) {
+        let use_multi_thread_runtime = matches!(&self, Self::Ai(_));
+        #[cfg(not(feature = "ai"))]
+        let use_multi_thread_runtime = false;
+
+        let Some(future) = self.run_inner()? else {
+            // The command was handled synchronously; return.
+            return Ok(());
+        };
+
+        let runtime = if use_multi_thread_runtime {
             tokio::runtime::Builder::new_multi_thread()
         } else {
             tokio::runtime::Builder::new_current_thread()
+        }
+        .enable_all()
+        .build()
+        .unwrap();
+
+        let res = runtime.block_on(future);
+        runtime.shutdown_timeout(std::time::Duration::from_millis(50));
+        res
+    }
+
+    /// Run the command, returning a future for commands that require async.
+    ///
+    /// If the command was able to be handled synchronously, returns `Ok(None)`. Otherwise, returns
+    /// `Ok(Some(future))` where `future` will run the command when awaited. Returns `Err` on error.
+    fn run_inner(self) -> Result<Option<impl Future<Output = Result<()>>>> {
+        let run_internal = if let Self::Internal(cmd) = &self {
+            match cmd.run() {
+                Some(func) => Some(func),
+                None => return Ok(None),
+            }
+        } else {
+            None
         };
 
-        #[cfg(not(feature = "ai"))]
-        let mut runtime = tokio::runtime::Builder::new_current_thread();
-
-        let runtime = runtime.enable_all().build().unwrap();
-
-        // For non-history commands, we want to initialize logging and the theme manager before
-        // doing anything else. History commands are performance-sensitive and run before and after
-        // every shell command, so we want to skip any unnecessary initialization for them.
         let settings = Settings::new().wrap_err("could not load client settings")?;
         let _logging = self
             .log_config(&settings)
             .map(|c| LogCtx::try_enable("atuin", &c))
             .transpose()
             .wrap_err("failed to enable logging")?;
-        let theme_manager = theme::ThemeManager::new(settings.theme.debug, None);
-        let res = runtime.block_on(self.run_inner(settings, theme_manager));
 
-        runtime.shutdown_timeout(std::time::Duration::from_millis(50));
-
-        res
+        Ok(Some(async {
+            if let Some(func) = run_internal {
+                func(settings).await
+            } else {
+                self.run_async(settings).await
+            }
+        }))
     }
 
     #[allow(clippy::too_many_lines)]
     // `atuin_ai::commands::run` is not `Send` because `eye_declare` holds a `StdoutLock` across
     // await points.
     #[allow(clippy::future_not_send)]
-    async fn run_inner(
-        self,
-        mut settings: Settings,
-        mut theme_manager: theme::ThemeManager,
-    ) -> Result<()> {
+    async fn run_async(self, mut settings: Settings) -> Result<()> {
         tracing::trace!(command = ?self, "client command");
+        let mut theme_manager = theme::ThemeManager::new(settings.theme.debug, None);
 
         // Skip initializing any databases for history
         // This is a pretty hot path, as it runs before and after every single command the user
@@ -219,7 +241,6 @@ impl Cmd {
             #[cfg(feature = "self-update")]
             Self::Update(update) => return update.run(&settings).await,
             Self::Config(config) => return config.run(&settings).await,
-            Self::Internal(cmd) => return cmd.run(&settings).await,
             Self::InternalDecoy => {
                 eprintln!("error: this command is not meant to be accessed directly");
                 std::process::exit(1);

--- a/crates/atuin/src/command/client/history.rs
+++ b/crates/atuin/src/command/client/history.rs
@@ -1233,7 +1233,8 @@ impl Cmd {
 
     fn logs_enabled(&self) -> bool {
         match self {
-            // Enable logs if not invoked from a shell hook.
+            // Enable logs if not invoked from a shell hook. History commands invoked from shell
+            // hooks are performance-sensitive, so we want to skip any unnecessary initialization.
             Self::Start { hook, .. } | Self::End { hook, .. } => !*hook,
             _ => true,
         }

--- a/crates/atuin/src/command/client/init.rs
+++ b/crates/atuin/src/command/client/init.rs
@@ -133,12 +133,11 @@ impl Cmd {
         }
     }
 
-    /// When `pty_proxy.enabled` is set, prepend the pty-proxy exec preamble
-    /// to the init script so the shell re-execs itself inside
-    /// `atuin pty-proxy` — no separate `atuin pty-proxy init` line needed in
-    /// shell config. The preamble is guarded by `ATUIN_PTY_PROXY_ACTIVE`, so
-    /// users who still have the standalone line keep working: whichever copy
-    /// runs first wins and the other no-ops.
+    /// When `pty_proxy.enabled` is set, prepend the pty-proxy exec preamble to the init script so
+    /// the shell re-execs itself inside `atuin pty-proxy` — no separate `atuin pty-proxy init` line
+    /// needed in shell config. The preamble checks whether a PTY proxy has already been spawned and
+    /// won't spawn another, so users who still have the standalone line keep working: whichever
+    /// copy runs first wins and the other no-ops.
     #[cfg(all(feature = "pty-proxy", unix))]
     fn pty_proxy_init(&self, settings: &Settings) {
         if !settings.pty_proxy.enabled {

--- a/crates/atuin/src/command/client/internal.rs
+++ b/crates/atuin/src/command/client/internal.rs
@@ -2,26 +2,45 @@
 
 use atuin_client::settings::Settings;
 use atuin_common::logs::LogConfig;
-use tracing::instrument;
 
 #[derive(clap::Subcommand, Debug)]
 pub enum Cmd {
     PrepareSearchIndex,
+    /// Check whether the current terminal belongs to a live PTY proxy.
+    ///
+    /// Prints `0` or `1` to stdout. This command is used by shell hooks to determine whether the
+    /// PTY proxy is in use.
+    PtyProxyActive,
 }
 
 impl Cmd {
-    #[instrument(level = "trace", skip_all, err)]
-    pub async fn run(self, settings: &Settings) -> eyre::Result<()> {
+    /// Run this command.
+    ///
+    /// If the command was able to be handled synchronously, this method returns [`None`].
+    /// Otherwise, it returns an async function that, when called, will run the command.
+    pub fn run(&self) -> Option<impl AsyncFnOnce(Settings) -> eyre::Result<()> + use<>> {
         match self {
-            Self::PrepareSearchIndex => super::search::prepare_index(settings).await,
+            Self::PrepareSearchIndex => {
+                Some(async |settings| super::search::prepare_index(&settings).await)
+            }
+            Self::PtyProxyActive => {
+                #[cfg(all(unix, feature = "pty-proxy"))]
+                let is_proxy_child = atuin_pty_proxy::is_pty_proxy_child();
+                #[cfg(not(all(unix, feature = "pty-proxy")))]
+                let is_proxy_child = false;
+
+                println!("{}", u8::from(is_proxy_child));
+                None
+            }
         }
     }
 
     pub fn log_config(&self) -> Option<LogConfig> {
         match self {
-            // This command is called from the shell hooks with no stdout/stderr; there's no point
-            // in initializing logging.
-            Self::PrepareSearchIndex => None,
+            // These commands are called from the shell hooks with no stderr; there's no point in
+            // initializing logging. Also, commands that are handled synchronously
+            // (pty-proxy-active) are run before logging is even initialized.
+            Self::PrepareSearchIndex | Self::PtyProxyActive => None,
         }
     }
 }

--- a/crates/atuin/src/command/client/search.rs
+++ b/crates/atuin/src/command/client/search.rs
@@ -355,6 +355,7 @@ async fn run_non_interactive(
     Ok(results)
 }
 
+#[instrument(level = "trace", skip_all, err)]
 pub async fn prepare_index(settings: &Settings) -> Result<()> {
     use engines::AnySearchEngine;
     #[cfg(feature = "daemon")]

--- a/crates/atuin/src/command/client/search/interactive.rs
+++ b/crates/atuin/src/command/client/search/interactive.rs
@@ -1490,9 +1490,10 @@ struct SavedScreen {
     rows_data: Vec<Vec<u8>>,
 }
 
-/// Connect to atuin pty-proxy's Unix socket and fetch the current screen state.
+/// Fetch the current screen state from the given PTY proxy socket.
 ///
 /// The wire format is:
+///
 /// ```text
 /// [rows: u16 BE][cols: u16 BE][cursor_row: u16 BE][cursor_col: u16 BE]
 /// [row_0_len: u32 BE][row_0_bytes...]
@@ -1500,7 +1501,7 @@ struct SavedScreen {
 /// ...
 /// ```
 #[cfg(unix)]
-fn fetch_screen_state(socket_path: &str) -> Option<SavedScreen> {
+fn fetch_screen_state(socket_path: &std::path::Path) -> Option<SavedScreen> {
     use std::os::unix::net::UnixStream;
 
     let mut stream = UnixStream::connect(socket_path).ok()?;
@@ -1736,9 +1737,11 @@ pub async fn history(
     // fetch the screen state and render as a centered overlay.
     #[cfg(unix)]
     let (saved_screen, popup_rect, popup_scroll_offset) = {
-        let socket_path = std::env::var("ATUIN_PTY_PROXY_SOCKET")
-            .or_else(|_| std::env::var("ATUIN_HEX_SOCKET"))
-            .ok();
+        #[cfg(feature = "pty-proxy")]
+        let socket_path = atuin_pty_proxy::parent_socket_path();
+        #[cfg(not(feature = "pty-proxy"))]
+        let socket_path = None;
+
         if let Some(ref path) = socket_path
             && inline_height > 0
         {

--- a/crates/atuin/src/command/client/search/interactive.rs
+++ b/crates/atuin/src/command/client/search/interactive.rs
@@ -1740,7 +1740,7 @@ pub async fn history(
         #[cfg(feature = "pty-proxy")]
         let socket_path = atuin_pty_proxy::parent_socket_path();
         #[cfg(not(feature = "pty-proxy"))]
-        let socket_path = None;
+        let socket_path = None::<std::path::PathBuf>;
 
         if let Some(ref path) = socket_path
             && inline_height > 0

--- a/crates/atuin/src/shell/atuin.bash
+++ b/crates/atuin/src/shell/atuin.bash
@@ -13,8 +13,9 @@ if [[ -z ${__atuin_pty_proxy_owns_tty-} ]]; then
     # so a manually started proxy still functions when `pty_proxy.enabled` is false.
     __atuin_pty_proxy_owns_tty=0
     if [[ -n ${ATUIN_PTY_PROXY_ACTIVE-} ]]; then
-        __atuin_pty_proxy_answer=$(atuin __internal pty-proxy-active 2>/dev/null)
-        if [[ $? -eq 0 ]] && [[ $__atuin_pty_proxy_answer = 1 ]]; then
+        if __atuin_pty_proxy_answer=$(atuin __internal pty-proxy-active 2>/dev/null) &&
+            [[ $__atuin_pty_proxy_answer = 1 ]]
+        then
             __atuin_pty_proxy_owns_tty=1
         fi
         unset __atuin_pty_proxy_answer

--- a/crates/atuin/src/shell/atuin.bash
+++ b/crates/atuin/src/shell/atuin.bash
@@ -8,11 +8,11 @@ fi
 ATUIN_STTY=$(stty -g)
 ATUIN_HISTORY_ID=""
 
-if [[ -z "${__atuin_pty_proxy_owns_tty:-}" ]]; then
+if [[ -z ${__atuin_pty_proxy_owns_tty-} ]]; then
     # The pty-proxy preamble also sets this variable, but make sure it's set here,
     # so a manually started proxy still functions when `pty_proxy.enabled` is false.
     __atuin_pty_proxy_owns_tty=0
-    if [[ -n "${ATUIN_PTY_PROXY_SOCKET:-}" ]]; then
+    if [[ -n ${ATUIN_PTY_PROXY_ACTIVE-} ]]; then
         __atuin_pty_proxy_answer=$(atuin __internal pty-proxy-active 2>/dev/null)
         if [[ $? -eq 0 ]] && [[ $__atuin_pty_proxy_answer = 1 ]]; then
             __atuin_pty_proxy_owns_tty=1

--- a/crates/atuin/src/shell/atuin.bash
+++ b/crates/atuin/src/shell/atuin.bash
@@ -8,15 +8,28 @@ fi
 ATUIN_STTY=$(stty -g)
 ATUIN_HISTORY_ID=""
 
+if [[ -z "${__atuin_pty_proxy_owns_tty:-}" ]]; then
+    # The pty-proxy preamble also sets this variable, but make sure it's set here,
+    # so a manually started proxy still functions when `pty_proxy.enabled` is false.
+    __atuin_pty_proxy_owns_tty=0
+    if [[ -n "${ATUIN_PTY_PROXY_SOCKET:-}" ]]; then
+        __atuin_pty_proxy_answer=$(atuin __internal pty-proxy-active 2>/dev/null)
+        if [[ $? -eq 0 ]] && [[ $__atuin_pty_proxy_answer = 1 ]]; then
+            __atuin_pty_proxy_owns_tty=1
+        fi
+        unset __atuin_pty_proxy_answer
+    fi
+fi
+
 __atuin_osc133_command_executed() {
-    [[ -n "${ATUIN_PTY_PROXY_ACTIVE:-}" ]] || return
+    [[ "${__atuin_pty_proxy_owns_tty:-0}" = 1 ]] || return
     [[ -n "${ATUIN_HISTORY_ID:-}" && "$ATUIN_HISTORY_ID" != "__bash_preexec_failure__" ]] || return
 
     printf '\033]133;C\a'
 }
 
 __atuin_osc133_command_finished() {
-    [[ -n "${ATUIN_PTY_PROXY_ACTIVE:-}" ]] || return
+    [[ "${__atuin_pty_proxy_owns_tty:-0}" = 1 ]] || return
     [[ -n "${ATUIN_HISTORY_ID:-}" && "$ATUIN_HISTORY_ID" != "__bash_preexec_failure__" ]] || return
 
     printf '\033]133;D;%s;history_id=%s\a' "$1" "$ATUIN_HISTORY_ID"
@@ -30,7 +43,7 @@ __atuin_osc133_wrap_prompt() {
     __atuin_prompt="${__atuin_prompt//$__atuin_osc133_prompt_start/}"
     __atuin_prompt="${__atuin_prompt//$__atuin_osc133_prompt_end/}"
 
-    if [[ -n "${ATUIN_PTY_PROXY_ACTIVE:-}" ]]; then
+    if [[ "${__atuin_pty_proxy_owns_tty:-0}" = 1 ]]; then
         PS1="${__atuin_osc133_prompt_start}${__atuin_prompt}${__atuin_osc133_prompt_end}"
     else
         PS1="$__atuin_prompt"

--- a/crates/atuin/src/shell/atuin.fish
+++ b/crates/atuin/src/shell/atuin.fish
@@ -4,15 +4,28 @@ if not set -q ATUIN_SESSION; or test "$ATUIN_SHLVL" != "$SHLVL"
 end
 set --erase ATUIN_HISTORY_ID
 
+if not set -q __atuin_pty_proxy_owns_tty
+    # The pty-proxy preamble also sets this variable, but make sure it's set here,
+    # so a manually started proxy still functions when `pty_proxy.enabled` is false.
+    set -g __atuin_pty_proxy_owns_tty 0
+    if set -q ATUIN_PTY_PROXY_SOCKET
+        set -l __atuin_pty_proxy_answer (atuin __internal pty-proxy-active 2>/dev/null)
+        set -l __atuin_pty_proxy_status $status
+        if test $__atuin_pty_proxy_status -eq 0; and test "$__atuin_pty_proxy_answer" = 1
+            set -g __atuin_pty_proxy_owns_tty 1
+        end
+    end
+end
+
 function _atuin_osc133_command_executed
-    set -q ATUIN_PTY_PROXY_ACTIVE; or return
+    test "$__atuin_pty_proxy_owns_tty" = 1; or return
     test -n "$ATUIN_HISTORY_ID"; or return
 
     printf '\033]133;C\a'
 end
 
 function _atuin_osc133_command_finished --argument-names exit_code
-    set -q ATUIN_PTY_PROXY_ACTIVE; or return
+    test "$__atuin_pty_proxy_owns_tty" = 1; or return
     test -n "$ATUIN_HISTORY_ID"; or return
 
     printf '\033]133;D;%s;history_id=%s\a' "$exit_code" "$ATUIN_HISTORY_ID"

--- a/crates/atuin/src/shell/atuin.fish
+++ b/crates/atuin/src/shell/atuin.fish
@@ -8,7 +8,7 @@ if not set -q __atuin_pty_proxy_owns_tty
     # The pty-proxy preamble also sets this variable, but make sure it's set here,
     # so a manually started proxy still functions when `pty_proxy.enabled` is false.
     set -g __atuin_pty_proxy_owns_tty 0
-    if set -q ATUIN_PTY_PROXY_SOCKET
+    if set -q ATUIN_PTY_PROXY_ACTIVE
         set -l __atuin_pty_proxy_answer (atuin __internal pty-proxy-active 2>/dev/null)
         set -l __atuin_pty_proxy_status $status
         if test $__atuin_pty_proxy_status -eq 0; and test "$__atuin_pty_proxy_answer" = 1

--- a/crates/atuin/src/shell/atuin.nu
+++ b/crates/atuin/src/shell/atuin.nu
@@ -19,7 +19,7 @@ if '__atuin_pty_proxy' not-in $env {
     # so a manually started proxy still functions when `pty_proxy.enabled` is false.
     # We are using a record rather than a plain string so it doesn't get exported
     # to child processes -- we want each child shell to perform its own detection.
-    $env.__atuin_pty_proxy = { owns_tty: (if 'ATUIN_PTY_PROXY_SOCKET' in $env {
+    $env.__atuin_pty_proxy = { owns_tty: (if 'ATUIN_PTY_PROXY_ACTIVE' in $env {
         do {
             let atuin_pty_proxy_check = (do -i { atuin __internal pty-proxy-active } | complete)
             $atuin_pty_proxy_check.exit_code == 0 and ($atuin_pty_proxy_check.stdout | str trim) == "1"

--- a/crates/atuin/src/shell/atuin.nu
+++ b/crates/atuin/src/shell/atuin.nu
@@ -14,8 +14,21 @@ if 'ATUIN_SESSION' not-in $env or ('ATUIN_SHLVL' not-in $env) or ($env.ATUIN_SHL
 }
 hide-env -i ATUIN_HISTORY_ID
 
+if '__atuin_pty_proxy' not-in $env {
+    # The pty-proxy preamble also sets this variable, but make sure it's set here,
+    # so a manually started proxy still functions when `pty_proxy.enabled` is false.
+    # We are using a record rather than a plain string so it doesn't get exported
+    # to child processes -- we want each child shell to perform its own detection.
+    $env.__atuin_pty_proxy = { owns_tty: (if 'ATUIN_PTY_PROXY_SOCKET' in $env {
+        do {
+            let atuin_pty_proxy_check = (do -i { atuin __internal pty-proxy-active } | complete)
+            $atuin_pty_proxy_check.exit_code == 0 and ($atuin_pty_proxy_check.stdout | str trim) == "1"
+        }
+    } else { false }) }
+}
+
 def _atuin_osc133_command_executed [] {
-    if 'ATUIN_PTY_PROXY_ACTIVE' not-in $env {
+    if not ($env.__atuin_pty_proxy?.owns_tty? | default false) {
         return
     }
     if 'ATUIN_HISTORY_ID' not-in $env or ($env.ATUIN_HISTORY_ID | is-empty) {
@@ -26,7 +39,7 @@ def _atuin_osc133_command_executed [] {
 }
 
 def _atuin_osc133_command_finished [exit_code: int] {
-    if 'ATUIN_PTY_PROXY_ACTIVE' not-in $env {
+    if not ($env.__atuin_pty_proxy?.owns_tty? | default false) {
         return
     }
     if 'ATUIN_HISTORY_ID' not-in $env or ($env.ATUIN_HISTORY_ID | is-empty) {

--- a/crates/atuin/src/shell/atuin.zsh
+++ b/crates/atuin/src/shell/atuin.zsh
@@ -33,11 +33,11 @@ if [[ -z "${ATUIN_SESSION:-}" || "${ATUIN_SHLVL:-}" != "$SHLVL" ]]; then
 fi
 ATUIN_HISTORY_ID=""
 
-if [[ -z "${__atuin_pty_proxy_owns_tty:-}" ]]; then
+if [[ -z ${__atuin_pty_proxy_owns_tty-} ]]; then
     # The pty-proxy preamble also sets this variable, but make sure it's set here,
     # so a manually started proxy still functions when `pty_proxy.enabled` is false.
     __atuin_pty_proxy_owns_tty=0
-    if [[ -n "${ATUIN_PTY_PROXY_SOCKET:-}" ]]; then
+    if [[ -n ${ATUIN_PTY_PROXY_ACTIVE-} ]]; then
         __atuin_pty_proxy_answer=$(atuin __internal pty-proxy-active 2>/dev/null)
         if [[ $? -eq 0 ]] && [[ $__atuin_pty_proxy_answer = 1 ]]; then
             __atuin_pty_proxy_owns_tty=1

--- a/crates/atuin/src/shell/atuin.zsh
+++ b/crates/atuin/src/shell/atuin.zsh
@@ -38,8 +38,9 @@ if [[ -z ${__atuin_pty_proxy_owns_tty-} ]]; then
     # so a manually started proxy still functions when `pty_proxy.enabled` is false.
     __atuin_pty_proxy_owns_tty=0
     if [[ -n ${ATUIN_PTY_PROXY_ACTIVE-} ]]; then
-        __atuin_pty_proxy_answer=$(atuin __internal pty-proxy-active 2>/dev/null)
-        if [[ $? -eq 0 ]] && [[ $__atuin_pty_proxy_answer = 1 ]]; then
+        if __atuin_pty_proxy_answer=$(atuin __internal pty-proxy-active 2>/dev/null) &&
+            [[ $__atuin_pty_proxy_answer = 1 ]]
+        then
             __atuin_pty_proxy_owns_tty=1
         fi
         unset __atuin_pty_proxy_answer

--- a/crates/atuin/src/shell/atuin.zsh
+++ b/crates/atuin/src/shell/atuin.zsh
@@ -33,15 +33,28 @@ if [[ -z "${ATUIN_SESSION:-}" || "${ATUIN_SHLVL:-}" != "$SHLVL" ]]; then
 fi
 ATUIN_HISTORY_ID=""
 
+if [[ -z "${__atuin_pty_proxy_owns_tty:-}" ]]; then
+    # The pty-proxy preamble also sets this variable, but make sure it's set here,
+    # so a manually started proxy still functions when `pty_proxy.enabled` is false.
+    __atuin_pty_proxy_owns_tty=0
+    if [[ -n "${ATUIN_PTY_PROXY_SOCKET:-}" ]]; then
+        __atuin_pty_proxy_answer=$(atuin __internal pty-proxy-active 2>/dev/null)
+        if [[ $? -eq 0 ]] && [[ $__atuin_pty_proxy_answer = 1 ]]; then
+            __atuin_pty_proxy_owns_tty=1
+        fi
+        unset __atuin_pty_proxy_answer
+    fi
+fi
+
 __atuin_osc133_command_executed() {
-    [[ -n "${ATUIN_PTY_PROXY_ACTIVE:-}" ]] || return
+    [[ "${__atuin_pty_proxy_owns_tty:-0}" = 1 ]] || return
     [[ -n "${ATUIN_HISTORY_ID:-}" ]] || return
 
     printf '\033]133;C\a'
 }
 
 __atuin_osc133_command_finished() {
-    [[ -n "${ATUIN_PTY_PROXY_ACTIVE:-}" ]] || return
+    [[ "${__atuin_pty_proxy_owns_tty:-0}" = 1 ]] || return
     [[ -n "${ATUIN_HISTORY_ID:-}" ]] || return
 
     printf '\033]133;D;%s;history_id=%s\a' "$1" "$ATUIN_HISTORY_ID"
@@ -64,7 +77,7 @@ __atuin_osc133_wrap_prompt() {
     __atuin_rprompt="${__atuin_rprompt//$__atuin_osc133_prompt_start/}"
     __atuin_rprompt="${__atuin_rprompt//$__atuin_osc133_prompt_end/}"
 
-    if [[ -n "${ATUIN_PTY_PROXY_ACTIVE:-}" ]]; then
+    if [[ "${__atuin_pty_proxy_owns_tty:-0}" = 1 ]]; then
         PROMPT="${__atuin_osc133_prompt_start}${__atuin_prompt}"
         RPROMPT="${__atuin_rprompt}${__atuin_osc133_prompt_end}"
     else

--- a/crates/atuin/tests/pty_proxy_active.rs
+++ b/crates/atuin/tests/pty_proxy_active.rs
@@ -1,0 +1,36 @@
+//! Tests for `atuin __internal pty-proxy-active`.
+
+use std::process::{Command, Output, Stdio};
+
+use rstest::{fixture, rstest};
+
+/// Run the check with every standard descriptor redirected, so the answer is deterministic:
+/// with no terminal to derive from, this process cannot belong to a proxy.
+#[fixture]
+fn output() -> Output {
+    Command::new(env!("CARGO_BIN_EXE_atuin"))
+        .args(["__internal", "pty-proxy-active"])
+        .stdin(Stdio::null())
+        .output()
+        .expect("failed to run atuin")
+}
+
+#[rstest]
+fn a_check_that_ran_exits_zero_even_when_the_answer_is_no(output: Output) {
+    // The exit status reports whether the check ran, not what it found. Shell integration relies
+    // on that distinction: an atuin too old to know this command exits non-zero, and treating
+    // that as "no proxy here" makes the shell exec a proxy whose shell repeats the mistake.
+    assert!(
+        output.status.success(),
+        "exit {:?}, stderr: {}",
+        output.status.code(),
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+#[rstest]
+fn the_answer_is_reported_on_stdout(output: Output) {
+    let answer = String::from_utf8_lossy(&output.stdout);
+
+    assert_eq!(answer.trim(), "0", "with no terminal there is no proxy to be attached to");
+}


### PR DESCRIPTION
This PR fixes rendering issues with the PTY proxy when used alongside multiplexers like `tmux` and `screen` or any other program that creates its own PTY.

### Background

Atuin's PTY proxy does not work well when used with other programs that create PTYs – particularly terminal multiplexers. Atuin has a workaround for tmux, but other programs cause serious rendering issues, as seen in #4062.

The underlying problem is that as soon as another PTY sits in between the Atuin client and PTY proxy – that of `tmux` or `screen`, for example – Atuin's prediction of the rendered state of the terminal, which it uses to restore the screen when the search UI is closed, is no longer accurate, and Atuin ends up drawing incorrect data in an incorrect position.

### The fix

This PR makes it so Atuin only connects to a PTY proxy if it is *directly* running under the PTY proxy – that is, if its terminal is the PTY proxy's terminal. If something like tmux is sitting in between, Atuin now treats this as though no PTY proxy is running at all, and (assuming `pty_proxy.enabled` is true) will spawn a new one in each tmux pane.

The underlying mechanism for the fix is a change in the PTY proxy's socket path. Previously, each socket path was made unique by inserting the PTY proxy's PID into the filename. Now, a unique, deterministic identifier corresponding to the child PTY created by the proxy is included instead. This means we no longer rely on passing the socket path in an environment variable (though this is still done for compatibility). Instead, Atuin derives the expected socket path from the ID of its own terminal and checks if there is a live socket there; if there is, we know we must be running under the PTY proxy on that socket. This check is immune to collisions from reused PTY numbers – because the path is uniquely scoped to our own terminal, it cannot be taken by someone else. The check is accomplished using a new internal command, `atuin __internal pty-proxy-active`, which has been made to be as fast as possible by skipping tokio, settings, and logging initialization.

### Testing

In addition to the unit tests, I've performed smoke testing with various combinations of nested shells and tmux sessions; everything works as expected with correct rendering.

Fixes #4062; also fixes #4078 (fish init script issue).