### PR TITLE
feat: rework inspector and add output view

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -55,6 +55,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "ansi-to-tui"
+version = "8.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e42366bb9d958f042bf58f0a85e1b2d091997c1257ca49bddd7e4827aadc65fd"
+dependencies = [
+ "nom 8.0.0",
+ "ratatui-core",
+ "smallvec",
+ "thiserror 2.0.19",
+]
+
+[[package]]
 name = "anstream"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -244,6 +256,7 @@ checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 name = "atuin"
 version = "18.21.0"
 dependencies = [
+ "ansi-to-tui",
  "arboard",
  "async-trait",
  "atuin-ai",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ atuin-scripts = { path = "crates/atuin-scripts", version = "18.21.0" }
 atuin-server = { path = "crates/atuin-server", version = "18.21.0" }
 atuin-vt100 = "0.19"
 
+ansi-to-tui = { version = "8.0.1", default-features = false }
 arboard = { version = "3.4", default-features = false }
 argon2 = "0.5"
 async-stream = "0.3"

--- a/crates/atuin-client/src/database.rs
+++ b/crates/atuin-client/src/database.rs
@@ -864,6 +864,43 @@ impl Sqlite {
         Ok(res)
     }
 
+    /// A bounded window of undeduplicated occurrences of this exact command, or its session.
+    /// Includes up to 100 entries on either side; callers can re-center when reaching an edge.
+    /// Ordering includes the ID so equal timestamps remain stable while browsing.
+    pub async fn inspector_history(
+        &self,
+        history: &History,
+        session: bool,
+    ) -> Result<Vec<History>> {
+        // Imported entries may have no session. Do not group unrelated imports together.
+        if session && history.session.is_empty() {
+            return Ok(vec![history.clone()]);
+        }
+        let (field, value) = if session {
+            ("session", history.session.as_str())
+        } else {
+            ("command", history.command.as_str())
+        };
+        let query = format!(
+            "select {HISTORY_COLUMNS} from (select {HISTORY_COLUMNS} from history where {field} = \
+             ?1
+             and deleted_at is null and (timestamp, id) <= (?2, ?3)
+             order by timestamp desc, id desc limit 101)
+             union all
+             select {HISTORY_COLUMNS} from (select {HISTORY_COLUMNS} from history where {field} = \
+             ?1
+             and deleted_at is null and (timestamp, id) > (?2, ?3)
+             order by timestamp, id limit 100)
+             order by timestamp, id"
+        );
+        db::query_as::<_, History>(sqlx::AssertSqlSafe(query.as_str()))
+            .bind(value)
+            .bind(i64::conv(history.timestamp.unix_timestamp_nanos()))
+            .bind(history.id)
+            .fetch_all(self.sqlite.pool())
+            .await
+    }
+
     #[instrument(level = "trace", skip_all, err)]
     pub async fn all_with_count(&self) -> Result<Vec<(History, i32)>> {
         debug!("listing history");
@@ -935,33 +972,22 @@ impl Sqlite {
 
     #[instrument(level = "trace", skip_all, fields(id = ?h.id), err)]
     pub async fn stats(&self, h: &History) -> Result<HistoryStats> {
-        // We select the previous in the session by time. Excluding deleted
-        // history matches every other read path, and lets the query use the
-        // partial (session, timestamp) index.
-        let mut prev = SqlBuilder::select_from("history");
-        prev.field(HISTORY_COLUMNS)
-            .and_where("timestamp < ?1")
-            .and_where("session = ?2")
-            .and_where_is_null("deleted_at")
-            .order_by("timestamp", true)
-            .limit(1);
-
-        let mut next = SqlBuilder::select_from("history");
-        next.field(HISTORY_COLUMNS)
-            .and_where("timestamp > ?1")
-            .and_where("session = ?2")
-            .and_where_is_null("deleted_at")
-            .order_by("timestamp", false)
-            .limit(1);
-
         let mut total = SqlBuilder::select_from("history");
-        total.field("count(1)").and_where("command = ?1");
+        total.field("count(1)").and_where("command = ?1").and_where_is_null("deleted_at");
 
         let mut average = SqlBuilder::select_from("history");
-        average.field("avg(duration)").and_where("command = ?1");
+        average
+            .field("coalesce(avg(duration), 0.0)")
+            .and_where("command = ?1")
+            .and_where_is_null("deleted_at")
+            .and_where("duration >= 0");
 
         let mut exits = SqlBuilder::select_from("history");
-        exits.fields(&["exit", "count(1) as count"]).and_where("command = ?1").group_by("exit");
+        exits
+            .fields(&["exit", "count(1) as count"])
+            .and_where("command = ?1")
+            .and_where_is_null("deleted_at")
+            .group_by("exit");
 
         // rewrite the following with sqlbuilder
         let mut day_of_week = SqlBuilder::select_from("history");
@@ -971,6 +997,7 @@ impl Sqlite {
                 "count(1) as count",
             ])
             .and_where("command = ?1")
+            .and_where_is_null("deleted_at")
             .group_by("day_of_week");
 
         // Intentionally format the string with 01 hardcoded. We want the average runtime for the
@@ -984,13 +1011,13 @@ impl Sqlite {
                 "avg(duration) as duration",
             ])
             .and_where("command = ?1")
+            .and_where_is_null("deleted_at")
+            .and_where("duration >= 0")
             .group_by("month_year")
             .having("duration > 0");
 
-        let prev = prev.sql().expect("issue in stats previous query");
-        let next = next.sql().expect("issue in stats next query");
-        let total = total.sql().expect("issue in stats average query");
-        let average = average.sql().expect("issue in stats previous query");
+        let total = total.sql().expect("issue in stats total query");
+        let average = average.sql().expect("issue in stats average query");
         let exits = exits.sql().expect("issue in stats exits query");
         let day_of_week = day_of_week.sql().expect("issue in stats day of week query");
         let duration_over_time =
@@ -998,23 +1025,13 @@ impl Sqlite {
 
         // The queries are all independent, so run them concurrently on the pool.
         #[allow(clippy::type_complexity)]
-        let (prev, next, total, average, exits, day_of_week, duration_over_time): (
-            _,
-            _,
+        let (total, average, exits, day_of_week, duration_over_time): (
             (i64,),
             (f64,),
             Vec<(i64, i64)>,
             Vec<(String, i64)>,
             Vec<(String, f64)>,
         ) = tokio::try_join!(
-            db::query_as::<_, History>(sqlx::AssertSqlSafe(prev))
-                .bind(i64::conv(h.timestamp.unix_timestamp_nanos()))
-                .bind(&h.session)
-                .fetch_optional(self.sqlite.pool()),
-            db::query_as::<_, History>(sqlx::AssertSqlSafe(next))
-                .bind(i64::conv(h.timestamp.unix_timestamp_nanos()))
-                .bind(&h.session)
-                .fetch_optional(self.sqlite.pool()),
             db::query_as(sqlx::AssertSqlSafe(total)).bind(&h.command).fetch_one(self.sqlite.pool()),
             db::query_as(sqlx::AssertSqlSafe(average))
                 .bind(&h.command)
@@ -1032,8 +1049,6 @@ impl Sqlite {
             duration_over_time.iter().map(|f| (f.0.clone(), f.1.cast_to(Nearest))).collect();
 
         Ok(HistoryStats {
-            next,
-            previous: prev,
             total: u64::conv(total.0),
             average_duration: average.0.cast_to(Trunc),
             exits,
@@ -1289,6 +1304,105 @@ mod test {
     #[fixture]
     async fn empty_db() -> Sqlite {
         Sqlite::in_memory(test_local_timeout()).await.unwrap()
+    }
+
+    #[rstest]
+    #[tokio::test]
+    async fn inspector_history_preserves_occurrences_and_scope(#[future] empty_db: Sqlite) {
+        let db = empty_db.await;
+        let mut entries = Vec::new();
+        for (command, session, deleted) in [
+            ("echo 'λ'", "one", false),
+            ("pwd", "one", false),
+            ("echo 'λ'", "two", false),
+            ("echo 'λ'", "one", true),
+            ("echo 'λ' suffix", "two", false),
+        ] {
+            let mut entry: History = History::capture()
+                .timestamp(OffsetDateTime::UNIX_EPOCH)
+                .command(command)
+                .cwd("/tmp")
+                .build()
+                .into();
+            entry.session = session.into();
+            entry.cwd = format!("/tmp/{}", entries.len());
+            if deleted {
+                entry.deleted_at = Some(OffsetDateTime::UNIX_EPOCH);
+            }
+            db.save(&entry).await.unwrap();
+            entries.push(entry);
+        }
+        let runs = db.inspector_history(&entries[0], false).await.unwrap();
+        assert_eq!(runs.len(), 2);
+        assert!(runs.iter().all(|entry| entry.command == "echo 'λ'"));
+        assert!(runs.iter().any(|entry| entry.id == entries[2].id));
+        assert!(runs.windows(2).all(|pair| pair[0].id.to_string() < pair[1].id.to_string()));
+        let session = db.inspector_history(&entries[0], true).await.unwrap();
+        assert_eq!(session.len(), 2);
+        assert!(session.iter().all(|entry| entry.session == "one"));
+        assert!(session.iter().any(|entry| entry.command == "pwd"));
+    }
+
+    #[rstest]
+    #[tokio::test]
+    async fn inspector_stats_match_live_runs(#[future] empty_db: Sqlite) {
+        let db = empty_db.await;
+        let mut selected = None;
+        for (i, (duration, exit, deleted)) in [
+            (1_000_000_000, 0, false),
+            (3_000_000_000, 1, false),
+            (-1, -1, false),
+            (90_000_000_000, 1, true),
+        ]
+        .into_iter()
+        .enumerate()
+        {
+            let mut entry: History = History::capture()
+                .timestamp(OffsetDateTime::UNIX_EPOCH + time::Duration::seconds(i64::conv(i)))
+                .command("echo stats")
+                .cwd("/tmp")
+                .build()
+                .into();
+            entry.duration = duration;
+            entry.exit = exit;
+            if deleted {
+                entry.deleted_at = Some(OffsetDateTime::UNIX_EPOCH);
+            }
+            db.save(&entry).await.unwrap();
+            if selected.is_none() {
+                selected = Some(entry);
+            }
+        }
+        let stats = db.stats(&selected.unwrap()).await.unwrap();
+        assert_eq!(stats.total, 3);
+        assert_eq!(stats.average_duration, 2_000_000_000);
+        assert_eq!(stats.exits.iter().map(|(_, count)| count).sum::<i64>(), 3);
+        assert_eq!(stats.day_of_week.iter().map(|(_, count)| count).sum::<i64>(), 3);
+        assert_eq!(stats.duration_over_time[0].1, 2_000_000_000);
+    }
+
+    #[rstest]
+    #[tokio::test]
+    async fn inspector_history_window_can_recenter(#[future] empty_db: Sqlite) {
+        let db = empty_db.await;
+        let mut entries = Vec::new();
+        for second in 0..250 {
+            let entry: History = History::capture()
+                .timestamp(OffsetDateTime::UNIX_EPOCH + time::Duration::seconds(second))
+                .command("ls")
+                .cwd("/tmp")
+                .build()
+                .into();
+            db.save(&entry).await.unwrap();
+            entries.push(entry);
+        }
+        let middle = db.inspector_history(&entries[125], false).await.unwrap();
+        assert_eq!(middle.len(), 201);
+        assert_eq!(middle[100].id, entries[125].id);
+        let next = db.inspector_history(middle.last().unwrap(), false).await.unwrap();
+        assert_eq!(next.last().unwrap().id, entries[249].id);
+        let previous = db.inspector_history(&middle[0], false).await.unwrap();
+        assert_eq!(previous[0].id, entries[0].id);
     }
 
     async fn assert_search_eq(

--- a/crates/atuin-client/src/database.rs
+++ b/crates/atuin-client/src/database.rs
@@ -864,37 +864,51 @@ impl Sqlite {
         Ok(res)
     }
 
-    /// A bounded window of undeduplicated occurrences of this exact command, or its session.
+    /// A bounded window of undeduplicated occurrences of this exact command.
     /// Includes up to 100 entries on either side; callers can re-center when reaching an edge.
     /// Ordering includes the ID so equal timestamps remain stable while browsing.
-    pub async fn inspector_history(
-        &self,
-        history: &History,
-        session: bool,
-    ) -> Result<Vec<History>> {
-        // Imported entries may have no session. Do not group unrelated imports together.
-        if session && history.session.is_empty() {
-            return Ok(vec![history.clone()]);
-        }
-        let (field, value) = if session {
-            ("session", history.session.as_str())
-        } else {
-            ("command", history.command.as_str())
-        };
+    pub async fn inspector_runs(&self, history: &History) -> Result<Vec<History>> {
         let query = format!(
-            "select {HISTORY_COLUMNS} from (select {HISTORY_COLUMNS} from history where {field} = \
-             ?1
-             and deleted_at is null and (timestamp, id) <= (?2, ?3)
-             order by timestamp desc, id desc limit 101)
+            "select {HISTORY_COLUMNS} from (
+                 select {HISTORY_COLUMNS} from history
+                 where command = ?1 and deleted_at is null and (timestamp, id) <= (?2, ?3)
+                 order by timestamp desc, id desc limit 101)
              union all
-             select {HISTORY_COLUMNS} from (select {HISTORY_COLUMNS} from history where {field} = \
-             ?1
-             and deleted_at is null and (timestamp, id) > (?2, ?3)
-             order by timestamp, id limit 100)
+             select {HISTORY_COLUMNS} from (
+                 select {HISTORY_COLUMNS} from history
+                 where command = ?1 and deleted_at is null and (timestamp, id) > (?2, ?3)
+                 order by timestamp, id limit 100)
              order by timestamp, id"
         );
         db::query_as::<_, History>(sqlx::AssertSqlSafe(query.as_str()))
-            .bind(value)
+            .bind(&history.command)
+            .bind(i64::conv(history.timestamp.unix_timestamp_nanos()))
+            .bind(history.id)
+            .fetch_all(self.sqlite.pool())
+            .await
+    }
+
+    /// A window of entries in this session, bounded and ordered as in [`Self::inspector_runs`].
+    pub async fn inspector_session(&self, history: &History) -> Result<Vec<History>> {
+        // Imported entries may have no session. Do not group unrelated imports together.
+        if history.session.is_empty() {
+            return Ok(vec![history.clone()]);
+        }
+
+        let query = format!(
+            "select {HISTORY_COLUMNS} from (
+                 select {HISTORY_COLUMNS} from history
+                 where session = ?1 and deleted_at is null and (timestamp, id) <= (?2, ?3)
+                 order by timestamp desc, id desc limit 101)
+             union all
+             select {HISTORY_COLUMNS} from (
+                 select {HISTORY_COLUMNS} from history
+                 where session = ?1 and deleted_at is null and (timestamp, id) > (?2, ?3)
+                 order by timestamp, id limit 100)
+             order by timestamp, id"
+        );
+        db::query_as::<_, History>(sqlx::AssertSqlSafe(query.as_str()))
+            .bind(&history.session)
             .bind(i64::conv(history.timestamp.unix_timestamp_nanos()))
             .bind(history.id)
             .fetch_all(self.sqlite.pool())
@@ -1317,6 +1331,8 @@ mod test {
             ("echo 'λ'", "two", false),
             ("echo 'λ'", "one", true),
             ("echo 'λ' suffix", "two", false),
+            ("imported", "", false),
+            ("another import", "", false),
         ] {
             let mut entry: History = History::capture()
                 .timestamp(OffsetDateTime::UNIX_EPOCH)
@@ -1332,15 +1348,16 @@ mod test {
             db.save(&entry).await.unwrap();
             entries.push(entry);
         }
-        let runs = db.inspector_history(&entries[0], false).await.unwrap();
+        let runs = db.inspector_runs(&entries[0]).await.unwrap();
         assert_eq!(runs.len(), 2);
         assert!(runs.iter().all(|entry| entry.command == "echo 'λ'"));
         assert!(runs.iter().any(|entry| entry.id == entries[2].id));
         assert!(runs.windows(2).all(|pair| pair[0].id.to_string() < pair[1].id.to_string()));
-        let session = db.inspector_history(&entries[0], true).await.unwrap();
+        let session = db.inspector_session(&entries[0]).await.unwrap();
         assert_eq!(session.len(), 2);
         assert!(session.iter().all(|entry| entry.session == "one"));
         assert!(session.iter().any(|entry| entry.command == "pwd"));
+        assert_eq!(db.inspector_session(&entries[5]).await.unwrap(), vec![entries[5].clone()]);
     }
 
     #[rstest]
@@ -1383,26 +1400,24 @@ mod test {
 
     #[rstest]
     #[tokio::test]
-    async fn inspector_history_window_can_recenter(#[future] empty_db: Sqlite) {
+    async fn inspector_windows_are_bounded(#[future] empty_db: Sqlite) {
         let db = empty_db.await;
         let mut entries = Vec::new();
         for second in 0..250 {
-            let entry: History = History::capture()
+            let mut entry: History = History::capture()
                 .timestamp(OffsetDateTime::UNIX_EPOCH + time::Duration::seconds(second))
                 .command("ls")
                 .cwd("/tmp")
                 .build()
                 .into();
+            entry.session = "window".into();
             db.save(&entry).await.unwrap();
             entries.push(entry);
         }
-        let middle = db.inspector_history(&entries[125], false).await.unwrap();
+        let middle = db.inspector_runs(&entries[125]).await.unwrap();
         assert_eq!(middle.len(), 201);
         assert_eq!(middle[100].id, entries[125].id);
-        let next = db.inspector_history(middle.last().unwrap(), false).await.unwrap();
-        assert_eq!(next.last().unwrap().id, entries[249].id);
-        let previous = db.inspector_history(&middle[0], false).await.unwrap();
-        assert_eq!(previous[0].id, entries[0].id);
+        assert_eq!(db.inspector_session(&entries[125]).await.unwrap(), middle);
     }
 
     async fn assert_search_eq(

--- a/crates/atuin-client/src/history.rs
+++ b/crates/atuin-client/src/history.rs
@@ -333,12 +333,6 @@ pub struct History {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct HistoryStats {
-    /// The command that was ran after this one in the session
-    pub next: Option<History>,
-    ///
-    /// The command that was ran before this one in the session
-    pub previous: Option<History>,
-
     /// How many times has this command been ran?
     pub total: u64,
 
@@ -779,7 +773,7 @@ mod tests {
     /// The SQL author filter derives its recognised-kind list from [`AuthorKind::VARIANTS`] while
     /// Rust decoding goes through [`AuthorKind::from_repr`]; a value present in one but not the
     /// other would split the two classifiers, so pin them to agree over the whole u8 range.
-    #[test]
+    #[rstest]
     fn author_kind_variants_and_from_repr_agree() {
         for value in 0..=u8::MAX {
             assert_eq!(
@@ -836,14 +830,14 @@ mod tests {
         assert!(author_matches_filters(&ellie, users.as_slice_filter()));
     }
 
-    #[test]
+    #[rstest]
     fn an_all_author_filter_matches_everyone() {
         let all = OrFilter::all();
         assert!(author_matches_filters(&entry("pi", "raspberry:ellie", None), all));
         assert!(author_matches_filters(&entry("ellie", "raspberry:ellie", None), all));
     }
 
-    #[test]
+    #[rstest]
     fn the_all_user_filter_excludes_agents() {
         let filter = all_user_author_filter();
         assert!(!author_matches_filters(&entry("pi", "raspberry:ellie", None), filter));
@@ -1011,7 +1005,7 @@ mod tests {
     /// A V2 record from before `author_kind` was appended: same version, one field short. New
     /// fields are only read when the encoded array is long enough to hold them, so this must still
     /// decode rather than error or misread the missing field.
-    #[test]
+    #[rstest]
     fn deserialize_v2_written_without_author_kind() {
         let history = History {
             author_kind: Some(AuthorKind::Agent),

--- a/crates/atuin/Cargo.toml
+++ b/crates/atuin/Cargo.toml
@@ -86,10 +86,12 @@ atuin-daemon = { workspace = true, optional = true }
 atuin-domain = { workspace = true }
 atuin-dotfiles = { workspace = true }
 atuin-history = { workspace = true }
+atuin-vt100 = { workspace = true }
 atuin-kv = { workspace = true }
 atuin-pty-proxy = { workspace = true, optional = true }
 atuin-scripts = { workspace = true }
 
+ansi-to-tui = { workspace = true }
 async-trait = { workspace = true }
 axoupdater = { workspace = true, optional = true }
 clap = { workspace = true }
@@ -166,7 +168,6 @@ toml_edit = { workspace = true, features = ["serde"] }
 
 # for the PTY e2e tests (tests/e2e_pty.rs)
 [target.'cfg(unix)'.dev-dependencies]
-atuin-vt100 = { workspace = true }
 nix-pty = { package = "nix", version = "0.28", features = ["term"] }
 portable-pty = "0.9"
 

--- a/crates/atuin/src/command/client/search/inspector.rs
+++ b/crates/atuin/src/command/client/search/inspector.rs
@@ -69,8 +69,89 @@ fn monthly_durations(durations: &[(String, i64)]) -> Vec<(time::Date, i64)> {
     durations
 }
 
+/// Formatted once when the database statistics change, independent of viewport size.
+pub struct Stats {
+    metrics: [(&'static str, String); 3],
+    exits: Vec<Bar<'static>>,
+    exit_width: u16,
+    weekdays: [Vec<Bar<'static>>; 2],
+    months: Vec<Bar<'static>>,
+}
+
+impl From<HistoryStats> for Stats {
+    fn from(mut stats: HistoryStats) -> Self {
+        let metrics = [
+            ("Total runs", stats.total.to_string()),
+            ("Success rate¹", success_rate(&stats)),
+            ("Avg runtime", Duration::from_nanos(stats.average_duration).display().to_string()),
+        ];
+
+        let exit_width = if stats.exits.iter().any(|(exit, _)| *exit < 0) {
+            7
+        } else {
+            4
+        };
+        stats.exits.sort_by_key(|(exit, _)| *exit);
+        let exits = stats
+            .exits
+            .iter()
+            .map(|(exit, count)| {
+                Bar::default()
+                    .label(if *exit < 0 {
+                        "Unknown".into()
+                    } else {
+                        exit.to_string()
+                    })
+                    .value(u64::try_from(*count).unwrap_or(0))
+            })
+            .collect();
+
+        let mut days = [0; 7];
+        for (day, count) in &stats.day_of_week {
+            if let Ok(index) = day.parse::<usize>()
+                && let Some(value) = days.get_mut(index)
+            {
+                *value = u64::try_from(*count).unwrap_or(0);
+            }
+        }
+        let weekdays = [["S", "M", "T", "W", "T", "F", "S"], [
+            "Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat",
+        ]]
+        .map(|labels| {
+            labels
+                .into_iter()
+                .zip(days)
+                .map(|(label, count)| Bar::default().label(label).value(count))
+                .collect()
+        });
+
+        let months = monthly_durations(&stats.duration_over_time)
+            .into_iter()
+            .map(|(date, duration)| {
+                Bar::default()
+                    .label(date.format(format_description!("[month]/[year]")).unwrap_or_default())
+                    .value(u64::try_from(duration).unwrap_or(0))
+                    .text_value(
+                        Duration::saturating_from_nanos_i64(duration)
+                            .display()
+                            .largest_unit()
+                            .to_string(),
+                    )
+            })
+            .collect();
+
+        Self {
+            metrics,
+            exits,
+            exit_width,
+            weekdays,
+            months,
+        }
+    }
+}
+
 /// Aggregate-only: occurrence metadata and command context belong in Runs.
-pub fn draw(f: &mut Frame<'_>, area: Rect, stats: &HistoryStats, theme: &Theme) {
+pub fn draw(f: &mut Frame<'_>, area: Rect, stats: &Stats, theme: &Theme) {
     let styles = Styles {
         base: Style::from_crossterm(theme.as_style(Meaning::Base)),
         muted: Style::from_crossterm(theme.as_style(Meaning::Annotation)),
@@ -87,11 +168,7 @@ pub fn draw(f: &mut Frame<'_>, area: Rect, stats: &HistoryStats, theme: &Theme) 
         Constraint::Min(0),
     ])
     .split(area);
-    let metrics = [
-        ("Total runs", stats.total.to_string()),
-        ("Success rate¹", success_rate(stats)),
-        ("Avg runtime", Duration::from_nanos(stats.average_duration).display().to_string()),
-    ];
+    let metrics = &stats.metrics;
     if compact {
         let lines: Vec<_> = metrics
             .iter()
@@ -106,9 +183,9 @@ pub fn draw(f: &mut Frame<'_>, area: Rect, stats: &HistoryStats, theme: &Theme) 
         f.render_widget(Paragraph::new("¹ Known exits only").style(styles.muted), areas[1]);
     } else {
         let cards = Layout::horizontal([Constraint::Fill(1); 3]).split(areas[0]);
-        for ((label, value), card) in metrics.into_iter().zip(cards.iter()) {
+        for ((label, value), card) in metrics.iter().zip(cards.iter()) {
             f.render_widget(
-                Paragraph::new(value)
+                Paragraph::new(value.as_str())
                     .style(styles.important)
                     .block(panel(format!(" {label} "), styles).padding(Padding::horizontal(1))),
                 *card,
@@ -139,38 +216,21 @@ fn chart(
     );
 }
 
-fn draw_charts(f: &mut Frame<'_>, area: Rect, stats: &HistoryStats, styles: Styles) {
+fn draw_charts(f: &mut Frame<'_>, area: Rect, stats: &Stats, styles: Styles) {
     let areas = Layout::vertical([Constraint::Fill(1), Constraint::Fill(1), Constraint::Length(1)])
         .split(area);
     let top = Layout::horizontal([Constraint::Fill(1); 2]).split(areas[0]);
 
-    let mut exits = stats.exits.clone();
-    exits.sort_by_key(|(exit, _)| *exit);
-    let exit_width = if exits.iter().any(|(exit, _)| *exit < 0) {
-        7
-    } else {
-        4
-    };
+    let exits = &stats.exits;
+    let exit_width = stats.exit_width;
     let capacity = usize::from(top[0].width.saturating_sub(2) / (exit_width + 1));
-    let exit_bars: Vec<_> = exits
-        .iter()
-        .take(capacity)
-        .map(|(exit, count)| {
-            Bar::default()
-                .label(if *exit < 0 {
-                    "Unknown".into()
-                } else {
-                    exit.to_string()
-                })
-                .value(u64::try_from(*count).unwrap_or(0))
-        })
-        .collect();
+    let exit_bars = &exits[..capacity.min(exits.len())];
     let title = if exits.len() > capacity {
         format!(" Exit codes · {capacity}/{} shown ", exits.len())
     } else {
         " Exit codes ".into()
     };
-    chart(f, top[0], title, &exit_bars, exit_width, styles);
+    chart(f, top[0], title, exit_bars, exit_width, styles);
 
     // Single-character weekday labels let all seven days fit in a narrow terminal.
     let day_width = if top[1].width >= 30 {
@@ -178,42 +238,12 @@ fn draw_charts(f: &mut Frame<'_>, area: Rect, stats: &HistoryStats, styles: Styl
     } else {
         1
     };
-    let days = if day_width == 3 {
-        ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"]
-    } else {
-        ["S", "M", "T", "W", "T", "F", "S"]
-    };
-    let day_bars: Vec<_> = days
-        .iter()
-        .enumerate()
-        .map(|(i, day)| {
-            let count = stats
-                .day_of_week
-                .iter()
-                .find(|(d, _)| d == &i.to_string())
-                .map_or(0, |(_, count)| *count);
-            Bar::default().label(*day).value(u64::try_from(count).unwrap_or(0))
-        })
-        .collect();
-    chart(f, top[1], " Runs by weekday (UTC) ".into(), &day_bars, day_width, styles);
+    let day_bars = &stats.weekdays[usize::from(day_width == 3)];
+    chart(f, top[1], " Runs by weekday (UTC) ".into(), day_bars, day_width, styles);
 
-    let months = monthly_durations(&stats.duration_over_time);
+    let months = &stats.months;
     let capacity = usize::from(areas[1].width.saturating_sub(2) / 8);
-    let bars: Vec<_> = months
-        .iter()
-        .skip(months.len().saturating_sub(capacity))
-        .map(|(date, duration)| {
-            Bar::default()
-                .label(date.format(format_description!("[month]/[year]")).unwrap_or_default())
-                .value(u64::try_from(*duration).unwrap_or(0))
-                .text_value(
-                    Duration::saturating_from_nanos_i64(*duration)
-                        .display()
-                        .largest_unit()
-                        .to_string(),
-                )
-        })
-        .collect();
+    let bars = &months[months.len().saturating_sub(capacity)..];
     let title = if months.len() > capacity {
         format!(" Mean runtime / month · latest {capacity} of {} ", months.len())
     } else {
@@ -227,7 +257,7 @@ fn draw_charts(f: &mut Frame<'_>, area: Rect, stats: &HistoryStats, styles: Styl
             areas[1],
         );
     } else {
-        chart(f, areas[1], title, &bars, 7, styles);
+        chart(f, areas[1], title, bars, 7, styles);
     }
 
     f.render_widget(Paragraph::new("¹ Known exits only").style(styles.muted), areas[2]);
@@ -286,6 +316,7 @@ mod tests {
         #[case] width: u16,
         #[case] height: u16,
     ) {
+        let stats = Stats::from(stats);
         let mut terminal = Terminal::new(TestBackend::new(width, height)).unwrap();
         let mut themes = ThemeManager::new(Some(true), Some(String::new()));
         let theme = themes.load_theme("(none)", None);
@@ -323,6 +354,7 @@ mod tests {
         stats.total = 0;
         stats.exits.clear();
         stats.duration_over_time.clear();
+        let stats = Stats::from(stats);
         let mut terminal = Terminal::new(TestBackend::new(width, height)).unwrap();
         let mut themes = ThemeManager::new(Some(true), Some(String::new()));
         let theme = themes.load_theme("(none)", None);

--- a/crates/atuin/src/command/client/search/inspector.rs
+++ b/crates/atuin/src/command/client/search/inspector.rs
@@ -34,21 +34,18 @@ fn panel(title: impl Into<Line<'static>>, styles: Styles) -> Block<'static> {
 
 /// Unknown exit codes (negative sentinel values) are not failures or successes.
 fn success_rate(stats: &HistoryStats) -> String {
-    let (success, known) = stats.exits.iter().filter(|(exit, _)| *exit >= 0).fold(
-        (0_u128, 0_u128),
-        |(success, known), (exit, count)| {
-            let count = u128::try_from(*count).unwrap_or(0);
-            (
-                success
-                    + if *exit == 0 {
-                        count
-                    } else {
-                        0
-                    },
-                known + count,
-            )
-        },
-    );
+    let (mut success, mut known) = (0_u128, 0_u128);
+    for &(exit, count) in &stats.exits {
+        if exit < 0 {
+            continue;
+        }
+        let count = u128::try_from(count).unwrap_or(0);
+        known += count;
+        if exit == 0 {
+            success += count;
+        }
+    }
+
     if known == 0 {
         return "—".into();
     }
@@ -265,9 +262,6 @@ fn draw_charts(f: &mut Frame<'_>, area: Rect, stats: &Stats, styles: Styles) {
 
 #[cfg(test)]
 mod tests {
-    use atuin_client::theme::ThemeManager;
-    use ratatui::Terminal;
-    use ratatui::backend::TestBackend;
     use rstest::{fixture, rstest};
 
     use super::*;
@@ -305,59 +299,5 @@ mod tests {
         let months = monthly_durations(&stats.duration_over_time);
         assert!(months[0].0 < months[1].0);
         assert_eq!(months[0].1, 1_000_000_000);
-    }
-
-    #[rstest]
-    #[case(100, 30)]
-    #[case(80, 24)]
-    #[case(40, 6)]
-    fn stats_show_aggregates_not_occurrence_details(
-        stats: HistoryStats,
-        #[case] width: u16,
-        #[case] height: u16,
-    ) {
-        let stats = Stats::from(stats);
-        let mut terminal = Terminal::new(TestBackend::new(width, height)).unwrap();
-        let mut themes = ThemeManager::new(Some(true), Some(String::new()));
-        let theme = themes.load_theme("(none)", None);
-        terminal.draw(|f| draw(f, f.area(), &stats, theme)).unwrap();
-        let text: String = terminal
-            .backend()
-            .buffer()
-            .content()
-            .iter()
-            .map(ratatui::buffer::Cell::symbol)
-            .collect();
-        for expected in ["Total runs", "Success rate", "75.0%", "Avg runtime"] {
-            assert!(text.contains(expected), "missing {expected}: {text}");
-        }
-        for removed in
-            ["Previous command", "Next command", "Directory", "Selected run", "Command stats"]
-        {
-            assert!(!text.contains(removed));
-        }
-        if height >= 16 {
-            assert!(text.contains("Exit codes"));
-            assert!(text.contains("Mean runtime / month"));
-        }
-        assert!(!text.contains('\0'));
-    }
-
-    #[rstest]
-    #[case(1, 1)]
-    #[case(20, 5)]
-    fn empty_stats_fit_small_terminals(
-        mut stats: HistoryStats,
-        #[case] width: u16,
-        #[case] height: u16,
-    ) {
-        stats.total = 0;
-        stats.exits.clear();
-        stats.duration_over_time.clear();
-        let stats = Stats::from(stats);
-        let mut terminal = Terminal::new(TestBackend::new(width, height)).unwrap();
-        let mut themes = ThemeManager::new(Some(true), Some(String::new()));
-        let theme = themes.load_theme("(none)", None);
-        terminal.draw(|f| draw(f, f.area(), &stats, theme)).unwrap();
     }
 }

--- a/crates/atuin/src/command/client/search/inspector.rs
+++ b/crates/atuin/src/command/client/search/inspector.rs
@@ -143,6 +143,7 @@ fn draw_charts(f: &mut Frame<'_>, area: Rect, stats: &HistoryStats, styles: Styl
     let areas = Layout::vertical([Constraint::Fill(1), Constraint::Fill(1), Constraint::Length(1)])
         .split(area);
     let top = Layout::horizontal([Constraint::Fill(1); 2]).split(areas[0]);
+
     let mut exits = stats.exits.clone();
     exits.sort_by_key(|(exit, _)| *exit);
     let exit_width = if exits.iter().any(|(exit, _)| *exit < 0) {
@@ -170,6 +171,7 @@ fn draw_charts(f: &mut Frame<'_>, area: Rect, stats: &HistoryStats, styles: Styl
         " Exit codes ".into()
     };
     chart(f, top[0], title, &exit_bars, exit_width, styles);
+
     // Single-character weekday labels let all seven days fit in a narrow terminal.
     let day_width = if top[1].width >= 30 {
         3
@@ -194,6 +196,7 @@ fn draw_charts(f: &mut Frame<'_>, area: Rect, stats: &HistoryStats, styles: Styl
         })
         .collect();
     chart(f, top[1], " Runs by weekday (UTC) ".into(), &day_bars, day_width, styles);
+
     let months = monthly_durations(&stats.duration_over_time);
     let capacity = usize::from(areas[1].width.saturating_sub(2) / 8);
     let bars: Vec<_> = months
@@ -226,6 +229,7 @@ fn draw_charts(f: &mut Frame<'_>, area: Rect, stats: &HistoryStats, styles: Styl
     } else {
         chart(f, areas[1], title, &bars, 7, styles);
     }
+
     f.render_widget(Paragraph::new("¹ Known exits only").style(styles.muted), areas[2]);
 }
 

--- a/crates/atuin/src/command/client/search/inspector.rs
+++ b/crates/atuin/src/command/client/search/inspector.rs
@@ -1,453 +1,327 @@
+pub(super) mod bindings;
+pub mod browser;
+mod output;
+
 use std::time::Duration;
 
-use atuin_client::history::{History, HistoryStats};
-use atuin_client::settings::Settings;
-use atuin_common::string::EscapeNonPrintablePosixExt as _;
-use atuin_common::time::{DurationExt, UtcOffsetSpec};
-use easy_cast::Conv;
+use atuin_client::history::HistoryStats;
+use atuin_common::time::DurationExt as _;
 use ratatui::Frame;
-use ratatui::backend::FromCrossterm;
-use ratatui::layout::Rect;
-use ratatui::prelude::{Constraint, Direction, Layout};
-use ratatui::style::Style;
-use ratatui::text::{Span, Text};
-use ratatui::widgets::{Bar, BarChart, BarGroup, Block, Borders, Padding, Paragraph, Row, Table};
+use ratatui::backend::FromCrossterm as _;
+use ratatui::layout::{Constraint, Layout, Rect};
+use ratatui::style::{Modifier, Style};
+use ratatui::text::{Line, Span};
+use ratatui::widgets::{Bar, BarChart, BarGroup, Block, BorderType, Borders, Padding, Paragraph};
 use time::macros::format_description;
 
 use super::super::theme::{Meaning, Theme};
-use super::interactive::{Compactness, to_compactness};
 
-fn u64_or_zero(num: i64) -> u64 {
-    if num < 0 {
-        0
-    } else {
-        u64::conv(num)
-    }
+#[derive(Clone, Copy)]
+struct Styles {
+    base: Style,
+    muted: Style,
+    important: Style,
 }
 
-pub fn draw_commands(
-    f: &mut Frame<'_>,
-    parent: Rect,
-    history: &History,
-    stats: &HistoryStats,
-    compact: bool,
-    theme: &Theme,
-) {
-    let commands = Layout::default()
-        .direction(if compact {
-            Direction::Vertical
-        } else {
-            Direction::Horizontal
-        })
-        .constraints(if compact {
-            [Constraint::Length(1), Constraint::Length(1), Constraint::Min(0)]
-        } else {
-            [Constraint::Ratio(1, 4), Constraint::Ratio(1, 2), Constraint::Ratio(1, 4)]
-        })
-        .split(parent);
-
-    let command = Paragraph::new(Text::from(Span::styled(
-        history.command.escape_non_printable(),
-        Style::from_crossterm(theme.as_style(Meaning::Important)),
-    )))
-    .block(if compact {
-        Block::new()
-            .borders(Borders::NONE)
-            .style(Style::from_crossterm(theme.as_style(Meaning::Base)))
-    } else {
-        Block::new()
-            .borders(Borders::ALL)
-            .style(Style::from_crossterm(theme.as_style(Meaning::Base)))
-            .title("Command")
-            .padding(Padding::horizontal(1))
-    });
-
-    let previous = Paragraph::new(stats.previous.clone().map_or_else(
-        || "[No previous command]".to_string(),
-        |prev| prev.command.escape_non_printable().into_owned(),
-    ))
-    .block(if compact {
-        Block::new()
-            .borders(Borders::NONE)
-            .style(Style::from_crossterm(theme.as_style(Meaning::Annotation)))
-    } else {
-        Block::new()
-            .borders(Borders::ALL)
-            .style(Style::from_crossterm(theme.as_style(Meaning::Annotation)))
-            .title("Previous command")
-            .padding(Padding::horizontal(1))
-    });
-
-    // Add [] around blank text, as when this is shown in a list
-    // compacted, it makes it more obviously control text.
-    let next = Paragraph::new(stats.next.clone().map_or_else(
-        || "[No next command]".to_string(),
-        |next| next.command.escape_non_printable().into_owned(),
-    ))
-    .block(if compact {
-        Block::new()
-            .borders(Borders::NONE)
-            .style(Style::from_crossterm(theme.as_style(Meaning::Annotation)))
-    } else {
-        Block::new()
-            .borders(Borders::ALL)
-            .title("Next command")
-            .padding(Padding::horizontal(1))
-            .style(Style::from_crossterm(theme.as_style(Meaning::Annotation)))
-    });
-
-    f.render_widget(previous, commands[0]);
-    f.render_widget(command, commands[1]);
-    f.render_widget(next, commands[2]);
+fn panel(title: impl Into<Line<'static>>, styles: Styles) -> Block<'static> {
+    Block::default()
+        .borders(Borders::ALL)
+        .border_type(BorderType::Rounded)
+        .border_style(styles.muted)
+        .title_style(styles.important)
+        .title(title)
 }
 
-pub fn draw_stats_table(
-    f: &mut Frame<'_>,
-    parent: Rect,
-    history: &History,
-    tz: UtcOffsetSpec,
-    stats: &HistoryStats,
-    theme: &Theme,
-) {
-    let duration = Duration::saturating_from_nanos_i64(history.duration);
-    let avg_duration = Duration::from_nanos(stats.average_duration);
-    let host = history.cmd_origin.host().into_inner();
-    let user = history.cmd_origin.user().into_inner();
-
-    let rows = [
-        Row::new(vec!["Host".to_string(), host.to_string()]),
-        Row::new(vec!["User".to_string(), user.to_string()]),
-        Row::new(vec!["Time".to_string(), history.timestamp.to_offset(tz.0).to_string()]),
-        Row::new(vec!["Duration".to_string(), duration.display().largest_unit().to_string()]),
-        Row::new(vec![
-            "Avg duration".to_string(),
-            avg_duration.display().largest_unit().to_string(),
-        ]),
-        Row::new(vec!["Exit".to_string(), history.exit.to_string()]),
-        Row::new(vec!["Directory".to_string(), history.cwd.clone()]),
-        Row::new(vec!["Intent".to_string(), history.intent.clone().unwrap_or_default()]),
-        Row::new(vec!["Session".to_string(), history.session.clone()]),
-        Row::new(vec!["Total runs".to_string(), stats.total.to_string()]),
-    ];
-
-    let widths = [Constraint::Ratio(1, 5), Constraint::Ratio(4, 5)];
-
-    let table = Table::new(rows, widths).column_spacing(1).block(
-        Block::default()
-            .title("Command stats")
-            .borders(Borders::ALL)
-            .style(Style::from_crossterm(theme.as_style(Meaning::Base)))
-            .padding(Padding::vertical(1)),
-    );
-
-    f.render_widget(table, parent);
-}
-
-fn num_to_day(num: &str) -> String {
-    match num {
-        "0" => "Sunday".to_string(),
-        "1" => "Monday".to_string(),
-        "2" => "Tuesday".to_string(),
-        "3" => "Wednesday".to_string(),
-        "4" => "Thursday".to_string(),
-        "5" => "Friday".to_string(),
-        "6" => "Saturday".to_string(),
-        _ => "Invalid day".to_string(),
-    }
-}
-
-fn sort_duration_over_time(durations: &[(String, i64)]) -> Vec<(String, i64)> {
-    let format = format_description!("[day]-[month]-[year]");
-    let output = format_description!("[month]/[year repr:last_two]");
-
-    let mut durations: Vec<(time::Date, i64)> = durations
-        .iter()
-        .map(|d| {
+/// Unknown exit codes (negative sentinel values) are not failures or successes.
+fn success_rate(stats: &HistoryStats) -> String {
+    let (success, known) = stats.exits.iter().filter(|(exit, _)| *exit >= 0).fold(
+        (0_u128, 0_u128),
+        |(success, known), (exit, count)| {
+            let count = u128::try_from(*count).unwrap_or(0);
             (
-                time::Date::parse(d.0.as_str(), &format).expect("invalid date string from sqlite"),
-                d.1,
+                success
+                    + if *exit == 0 {
+                        count
+                    } else {
+                        0
+                    },
+                known + count,
             )
+        },
+    );
+    if known == 0 {
+        return "—".into();
+    }
+    let tenths = (success * 1000 + known / 2) / known;
+    format!("{}.{:01}%", tenths / 10, tenths % 10)
+}
+
+fn monthly_durations(durations: &[(String, i64)]) -> Vec<(time::Date, i64)> {
+    let mut durations: Vec<_> = durations
+        .iter()
+        .filter_map(|(date, duration)| {
+            time::Date::parse(date, format_description!("[day]-[month]-[year]"))
+                .ok()
+                .map(|date| (date, *duration))
         })
         .collect();
-
-    durations.sort_by_key(|a| a.0);
-
+    durations.sort_by_key(|(date, _)| *date);
     durations
-        .iter()
-        .map(|(date, duration)| {
-            (date.format(output).expect("failed to format sqlite date"), *duration)
-        })
-        .collect()
 }
 
-fn draw_stats_charts(f: &mut Frame<'_>, parent: Rect, stats: &HistoryStats, theme: &Theme) {
-    let exits: Vec<Bar> = stats
-        .exits
-        .iter()
-        .map(|(exit, count)| Bar::default().label(exit.to_string()).value(u64_or_zero(*count)))
-        .collect();
-
-    let exits = BarChart::default()
-        .block(
-            Block::default()
-                .title("Exit code distribution")
-                .style(Style::from_crossterm(theme.as_style(Meaning::Base)))
-                .borders(Borders::ALL),
-        )
-        .bar_width(3)
-        .bar_gap(1)
-        .bar_style(Style::default())
-        .value_style(Style::default())
-        .label_style(Style::default())
-        .data(BarGroup::default().bars(&exits));
-
-    let day_of_week: Vec<Bar> = stats
-        .day_of_week
-        .iter()
-        .map(|(day, count)| {
-            Bar::default().label(num_to_day(day.as_str())).value(u64_or_zero(*count))
-        })
-        .collect();
-
-    let day_of_week = BarChart::default()
-        .block(
-            Block::default()
-                .title("Runs per day")
-                .style(Style::from_crossterm(theme.as_style(Meaning::Base)))
-                .borders(Borders::ALL),
-        )
-        .bar_width(3)
-        .bar_gap(1)
-        .bar_style(Style::default())
-        .value_style(Style::default())
-        .label_style(Style::default())
-        .data(BarGroup::default().bars(&day_of_week));
-
-    let duration_over_time = sort_duration_over_time(&stats.duration_over_time);
-    let duration_over_time: Vec<Bar> = duration_over_time
-        .iter()
-        .map(|(date, duration)| {
-            let d = Duration::saturating_from_nanos_i64(*duration);
-            Bar::default()
-                .label(date.clone())
-                .value(u64_or_zero(*duration))
-                .text_value(d.display().largest_unit().to_string())
-        })
-        .collect();
-
-    let duration_over_time = BarChart::default()
-        .block(
-            Block::default()
-                .title("Duration over time")
-                .style(Style::from_crossterm(theme.as_style(Meaning::Base)))
-                .borders(Borders::ALL),
-        )
-        .bar_width(5)
-        .bar_gap(1)
-        .bar_style(Style::default())
-        .value_style(Style::default())
-        .label_style(Style::default())
-        .data(BarGroup::default().bars(&duration_over_time));
-
-    let layout = Layout::default()
-        .direction(Direction::Vertical)
-        .constraints([Constraint::Ratio(1, 3), Constraint::Ratio(1, 3), Constraint::Ratio(1, 3)])
-        .split(parent);
-
-    f.render_widget(exits, layout[0]);
-    f.render_widget(day_of_week, layout[1]);
-    f.render_widget(duration_over_time, layout[2]);
-}
-
-pub fn draw(
-    f: &mut Frame<'_>,
-    chunk: Rect,
-    history: &History,
-    stats: &HistoryStats,
-    settings: &Settings,
-    theme: &Theme,
-    tz: UtcOffsetSpec,
-) {
-    let compactness = to_compactness(f, settings);
-
-    match compactness {
-        Compactness::Ultracompact => draw_ultracompact(f, chunk, history, stats, theme),
-        _ => draw_full(f, chunk, history, stats, theme, tz),
+/// Aggregate-only: occurrence metadata and command context belong in Runs.
+pub fn draw(f: &mut Frame<'_>, area: Rect, stats: &HistoryStats, theme: &Theme) {
+    let styles = Styles {
+        base: Style::from_crossterm(theme.as_style(Meaning::Base)),
+        muted: Style::from_crossterm(theme.as_style(Meaning::Annotation)),
+        important: Style::from_crossterm(theme.as_style(Meaning::Important))
+            .add_modifier(Modifier::BOLD),
+    };
+    let compact = area.height < 16 || area.width < 50;
+    let areas = Layout::vertical([
+        Constraint::Length(if compact {
+            3
+        } else {
+            4
+        }),
+        Constraint::Min(0),
+    ])
+    .split(area);
+    let metrics = [
+        ("Total runs", stats.total.to_string()),
+        ("Success rate¹", success_rate(stats)),
+        ("Avg runtime", Duration::from_nanos(stats.average_duration).display().to_string()),
+    ];
+    if compact {
+        let lines: Vec<_> = metrics
+            .iter()
+            .map(|(label, value)| {
+                Line::from(vec![
+                    Span::styled(format!("{label}  "), styles.muted),
+                    Span::styled(value.as_str(), styles.important),
+                ])
+            })
+            .collect();
+        f.render_widget(Paragraph::new(lines), areas[0]);
+        f.render_widget(Paragraph::new("¹ Known exits only").style(styles.muted), areas[1]);
+    } else {
+        let cards = Layout::horizontal([Constraint::Fill(1); 3]).split(areas[0]);
+        for ((label, value), card) in metrics.into_iter().zip(cards.iter()) {
+            f.render_widget(
+                Paragraph::new(value)
+                    .style(styles.important)
+                    .block(panel(format!(" {label} "), styles).padding(Padding::horizontal(1))),
+                *card,
+            );
+        }
+        draw_charts(f, areas[1], stats, styles);
     }
 }
 
-pub fn draw_ultracompact(
+fn chart(
     f: &mut Frame<'_>,
-    chunk: Rect,
-    history: &History,
-    stats: &HistoryStats,
-    theme: &Theme,
+    area: Rect,
+    title: String,
+    bars: &[Bar<'_>],
+    width: u16,
+    styles: Styles,
 ) {
-    draw_commands(f, chunk, history, stats, true, theme);
+    f.render_widget(
+        BarChart::default()
+            .block(panel(title, styles))
+            .bar_width(width)
+            .bar_gap(1)
+            .bar_style(styles.important)
+            .value_style(styles.base)
+            .label_style(styles.muted)
+            .data(BarGroup::default().bars(bars)),
+        area,
+    );
 }
 
-pub fn draw_full(
-    f: &mut Frame<'_>,
-    chunk: Rect,
-    history: &History,
-    stats: &HistoryStats,
-    theme: &Theme,
-    tz: UtcOffsetSpec,
-) {
-    let vert_layout = Layout::default()
-        .direction(Direction::Vertical)
-        .constraints([Constraint::Ratio(1, 5), Constraint::Ratio(4, 5)])
-        .split(chunk);
-
-    let stats_layout = Layout::default()
-        .direction(Direction::Horizontal)
-        .constraints([Constraint::Ratio(1, 3), Constraint::Ratio(2, 3)])
-        .split(vert_layout[1]);
-
-    draw_commands(f, vert_layout[0], history, stats, false, theme);
-    draw_stats_table(f, stats_layout[0], history, tz, stats, theme);
-    draw_stats_charts(f, stats_layout[1], stats, theme);
+fn draw_charts(f: &mut Frame<'_>, area: Rect, stats: &HistoryStats, styles: Styles) {
+    let areas = Layout::vertical([Constraint::Fill(1), Constraint::Fill(1), Constraint::Length(1)])
+        .split(area);
+    let top = Layout::horizontal([Constraint::Fill(1); 2]).split(areas[0]);
+    let mut exits = stats.exits.clone();
+    exits.sort_by_key(|(exit, _)| *exit);
+    let exit_width = if exits.iter().any(|(exit, _)| *exit < 0) {
+        7
+    } else {
+        4
+    };
+    let capacity = usize::from(top[0].width.saturating_sub(2) / (exit_width + 1));
+    let exit_bars: Vec<_> = exits
+        .iter()
+        .take(capacity)
+        .map(|(exit, count)| {
+            Bar::default()
+                .label(if *exit < 0 {
+                    "Unknown".into()
+                } else {
+                    exit.to_string()
+                })
+                .value(u64::try_from(*count).unwrap_or(0))
+        })
+        .collect();
+    let title = if exits.len() > capacity {
+        format!(" Exit codes · {capacity}/{} shown ", exits.len())
+    } else {
+        " Exit codes ".into()
+    };
+    chart(f, top[0], title, &exit_bars, exit_width, styles);
+    // Single-character weekday labels let all seven days fit in a narrow terminal.
+    let day_width = if top[1].width >= 30 {
+        3
+    } else {
+        1
+    };
+    let days = if day_width == 3 {
+        ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"]
+    } else {
+        ["S", "M", "T", "W", "T", "F", "S"]
+    };
+    let day_bars: Vec<_> = days
+        .iter()
+        .enumerate()
+        .map(|(i, day)| {
+            let count = stats
+                .day_of_week
+                .iter()
+                .find(|(d, _)| d == &i.to_string())
+                .map_or(0, |(_, count)| *count);
+            Bar::default().label(*day).value(u64::try_from(count).unwrap_or(0))
+        })
+        .collect();
+    chart(f, top[1], " Runs by weekday (UTC) ".into(), &day_bars, day_width, styles);
+    let months = monthly_durations(&stats.duration_over_time);
+    let capacity = usize::from(areas[1].width.saturating_sub(2) / 8);
+    let bars: Vec<_> = months
+        .iter()
+        .skip(months.len().saturating_sub(capacity))
+        .map(|(date, duration)| {
+            Bar::default()
+                .label(date.format(format_description!("[month]/[year]")).unwrap_or_default())
+                .value(u64::try_from(*duration).unwrap_or(0))
+                .text_value(
+                    Duration::saturating_from_nanos_i64(*duration)
+                        .display()
+                        .largest_unit()
+                        .to_string(),
+                )
+        })
+        .collect();
+    let title = if months.len() > capacity {
+        format!(" Mean runtime / month · latest {capacity} of {} ", months.len())
+    } else {
+        " Mean runtime / month ".into()
+    };
+    if bars.is_empty() {
+        f.render_widget(
+            Paragraph::new("No runtime samples yet")
+                .style(styles.muted)
+                .block(panel(title, styles)),
+            areas[1],
+        );
+    } else {
+        chart(f, areas[1], title, &bars, 7, styles);
+    }
+    f.render_widget(Paragraph::new("¹ Known exits only").style(styles.muted), areas[2]);
 }
 
 #[cfg(test)]
 mod tests {
-    use atuin_client::history::{History, HistoryStats};
     use atuin_client::theme::ThemeManager;
-    use atuin_domain::record::CmdOrigin;
+    use ratatui::Terminal;
     use ratatui::backend::TestBackend;
-    use ratatui::prelude::*;
-    use rstest::*;
-    use time::OffsetDateTime;
+    use rstest::{fixture, rstest};
 
-    use super::draw_ultracompact;
+    use super::*;
 
     #[fixture]
-    fn mock_history_stats() -> (History, HistoryStats) {
-        let history = History {
-            id: "018f011c-9a0a-7000-8000-000000000001".parse().unwrap(),
-            timestamp: OffsetDateTime::now_utc(),
-            duration: 3,
-            exit: 0,
-            command: "/bin/cmd".to_string(),
-            cwd: "/toot".to_string(),
-            session: "sesh1".to_string(),
-            #[allow(deprecated)]
-            cmd_origin: CmdOrigin::parse_lenient("hostn"),
-            author: "hostn".to_string(),
-            intent: None,
-            deleted_at: None,
-            shell: None,
-            author_kind: None,
-        };
-        let next = History {
-            id: "018f011c-9a0a-7000-8000-000000000002".parse().unwrap(),
-            timestamp: OffsetDateTime::now_utc(),
-            duration: 2,
-            exit: 0,
-            command: "/bin/cmd -os".to_string(),
-            cwd: "/toot".to_string(),
-            session: "sesh1".to_string(),
-            #[allow(deprecated)]
-            cmd_origin: CmdOrigin::parse_lenient("hostn"),
-            author: "hostn".to_string(),
-            intent: None,
-            deleted_at: None,
-            shell: Some("bash".into()),
-            author_kind: None,
-        };
-        let prev = History {
-            id: "018f011c-9a0a-7000-8000-000000000003".parse().unwrap(),
-            timestamp: OffsetDateTime::now_utc(),
-            duration: 1,
-            exit: 0,
-            command: "/bin/cmd -a".to_string(),
-            cwd: "/toot".to_string(),
-            session: "sesh1".to_string(),
-            #[allow(deprecated)]
-            cmd_origin: CmdOrigin::parse_lenient("hostn"),
-            author: "hostn".to_string(),
-            intent: None,
-            deleted_at: None,
-            shell: Some("nu".into()),
-            author_kind: None,
-        };
-        let stats = HistoryStats {
-            next: Some(next),
-            previous: Some(prev),
-            total: 2,
-            average_duration: 3,
-            exits: Vec::new(),
-            day_of_week: Vec::new(),
-            duration_over_time: Vec::new(),
-        };
-        (history, stats)
-    }
-
-    #[fixture]
-    fn theme_manager() -> ThemeManager {
-        ThemeManager::new(Some(true), Some(String::new()))
-    }
-
-    #[fixture]
-    fn terminal(
-        #[default(22u16)] w: u16,
-        #[default(5u16)] h: u16,
-    ) -> (Terminal<TestBackend>, Rect) {
-        let t = Terminal::new(TestBackend::new(w, h)).expect("Could not create terminal");
-        let r = Rect::new(0, 0, w, h);
-        (t, r)
-    }
-
-    #[rstest]
-    fn test_output_looks_correct_for_ultracompact(
-        mock_history_stats: (History, HistoryStats),
-        mut theme_manager: ThemeManager,
-        #[from(terminal)] (mut terminal, chunk): (Terminal<TestBackend>, Rect),
-    ) {
-        let (history, stats) = mock_history_stats;
-        let prev = stats.previous.clone().unwrap();
-        let next = stats.next.clone().unwrap();
-
-        let theme = theme_manager.load_theme("(none)", None);
-        let _ = terminal.draw(|f| draw_ultracompact(f, chunk, &history, &stats, theme));
-        let mut lines = ["                      "; 5].map(Line::from);
-        for (n, entry) in [prev, history, next].iter().enumerate() {
-            let mut l = lines[n].to_string();
-            l.replace_range(0..entry.command.len(), &entry.command);
-            lines[n] = Line::from(l);
+    fn stats() -> HistoryStats {
+        HistoryStats {
+            total: 10,
+            average_duration: 2_000_000_000,
+            exits: vec![(-1, 2), (0, 6), (1, 2)],
+            day_of_week: vec![("0".into(), 4), ("2".into(), 6)],
+            duration_over_time: vec![
+                ("01-02-2026".into(), 2_000_000_000),
+                ("01-12-2025".into(), 1_000_000_000),
+            ],
         }
-
-        terminal.backend().assert_buffer_lines(lines);
     }
 
     #[rstest]
-    fn control_chars_are_escaped_in_commands(
-        mock_history_stats: (History, HistoryStats),
-        mut theme_manager: ThemeManager,
-        #[from(terminal)]
-        #[with(40u16, 8u16)]
-        (mut terminal, chunk): (Terminal<TestBackend>, Rect),
+    #[case(vec![(0, 6), (1, 2), (-1, 2)], "75.0%")]
+    #[case(vec![(-1, 10)], "—")]
+    #[case(vec![], "—")]
+    #[case(vec![(0, 1), (1, 2)], "33.3%")]
+    fn success_uses_only_known_exits(
+        mut stats: HistoryStats,
+        #[case] exits: Vec<(i64, i64)>,
+        #[case] expected: &str,
     ) {
-        let (mut history, mut stats) = mock_history_stats;
+        stats.exits = exits;
+        assert_eq!(success_rate(&stats), expected);
+    }
 
-        // Inject a NUL byte into the current and neighbouring commands
-        history.command = "echo\0hi".to_string();
-        stats.previous.as_mut().unwrap().command = "prev\0cmd".to_string();
-        stats.next.as_mut().unwrap().command = "next\0cmd".to_string();
+    #[rstest]
+    fn months_are_chronological(stats: HistoryStats) {
+        let months = monthly_durations(&stats.duration_over_time);
+        assert!(months[0].0 < months[1].0);
+        assert_eq!(months[0].1, 1_000_000_000);
+    }
 
-        let theme = theme_manager.load_theme("(none)", None);
-        let _ = terminal.draw(|f| draw_ultracompact(f, chunk, &history, &stats, theme));
-
-        let rendered: String = terminal
+    #[rstest]
+    #[case(100, 30)]
+    #[case(80, 24)]
+    #[case(40, 6)]
+    fn stats_show_aggregates_not_occurrence_details(
+        stats: HistoryStats,
+        #[case] width: u16,
+        #[case] height: u16,
+    ) {
+        let mut terminal = Terminal::new(TestBackend::new(width, height)).unwrap();
+        let mut themes = ThemeManager::new(Some(true), Some(String::new()));
+        let theme = themes.load_theme("(none)", None);
+        terminal.draw(|f| draw(f, f.area(), &stats, theme)).unwrap();
+        let text: String = terminal
             .backend()
             .buffer()
             .content()
             .iter()
             .map(ratatui::buffer::Cell::symbol)
             .collect();
+        for expected in ["Total runs", "Success rate", "75.0%", "Avg runtime"] {
+            assert!(text.contains(expected), "missing {expected}: {text}");
+        }
+        for removed in
+            ["Previous command", "Next command", "Directory", "Selected run", "Command stats"]
+        {
+            assert!(!text.contains(removed));
+        }
+        if height >= 16 {
+            assert!(text.contains("Exit codes"));
+            assert!(text.contains("Mean runtime / month"));
+        }
+        assert!(!text.contains('\0'));
+    }
 
-        // NUL is shown as caret notation ^@, never as a raw NUL byte
-        assert!(rendered.contains("^@"), "expected caret-escaped NUL (^@) in rendered output");
-        assert!(!rendered.contains('\u{0000}'), "raw NUL byte leaked to the terminal");
+    #[rstest]
+    #[case(1, 1)]
+    #[case(20, 5)]
+    fn empty_stats_fit_small_terminals(
+        mut stats: HistoryStats,
+        #[case] width: u16,
+        #[case] height: u16,
+    ) {
+        stats.total = 0;
+        stats.exits.clear();
+        stats.duration_over_time.clear();
+        let mut terminal = Terminal::new(TestBackend::new(width, height)).unwrap();
+        let mut themes = ThemeManager::new(Some(true), Some(String::new()));
+        let theme = themes.load_theme("(none)", None);
+        terminal.draw(|f| draw(f, f.area(), &stats, theme)).unwrap();
     }
 }

--- a/crates/atuin/src/command/client/search/inspector/bindings.rs
+++ b/crates/atuin/src/command/client/search/inspector/bindings.rs
@@ -20,6 +20,7 @@ impl Bindings {
                 })
             })
             .collect();
+
         bindings.sort_by(|(_, a), (_, b)| (a.len(), a).cmp(&(b.len(), b)));
         Self(bindings)
     }
@@ -43,6 +44,7 @@ impl Bindings {
             Action::ScrollToBottom => "end",
             _ => "",
         };
+
         self.0
             .iter()
             .find(|(a, key)| a == action && key == preferred)

--- a/crates/atuin/src/command/client/search/inspector/bindings.rs
+++ b/crates/atuin/src/command/client/search/inspector/bindings.rs
@@ -1,0 +1,105 @@
+use super::super::keybindings::{Action, EvalContext, Keymap};
+
+/// Resolved bindings for this frame, shared by the view selector and footer.
+#[derive(Default)]
+pub struct Bindings(Vec<(Action, String)>);
+
+impl Bindings {
+    pub fn new(keymap: &Keymap, context: &EvalContext) -> Self {
+        let mut bindings: Vec<_> = keymap
+            .bindings
+            .keys()
+            .filter_map(|key| {
+                keymap.resolve(key, context).map(|action| {
+                    let action = match action {
+                        Action::SelectPrevious => Action::InspectPrevious,
+                        Action::SelectNext => Action::InspectNext,
+                        action => action,
+                    };
+                    (action, key.to_string())
+                })
+            })
+            .collect();
+        bindings.sort_by(|(_, a), (_, b)| (a.len(), a).cmp(&(b.len(), b)));
+        Self(bindings)
+    }
+
+    pub fn key(&self, action: &Action) -> Option<&str> {
+        // Prefer familiar defaults when several keys do the same thing, but never
+        // advertise a default that has been remapped or disabled by a condition.
+        let preferred = match action {
+            Action::InspectOutput => "enter",
+            Action::InspectPrevious => "up",
+            Action::InspectNext => "down",
+            Action::InspectRuns => "r",
+            Action::InspectSession => "s",
+            Action::InspectStats => "t",
+            Action::ReturnSelection => "tab",
+            Action::Exit => "esc",
+            Action::Delete => "ctrl-d",
+            Action::ScrollPageUp => "pageup",
+            Action::ScrollPageDown => "pagedown",
+            Action::ScrollToTop => "home",
+            Action::ScrollToBottom => "end",
+            _ => "",
+        };
+        self.0
+            .iter()
+            .find(|(a, key)| a == action && key == preferred)
+            .or_else(|| self.0.iter().find(|(a, _)| a == action))
+            .map(|(_, key)| key.as_str())
+    }
+
+    pub fn group(&self, actions: &[Action]) -> String {
+        actions
+            .iter()
+            .filter_map(|action| self.key(action))
+            .map(|key| match key {
+                "up" => "↑",
+                "down" => "↓",
+                "pageup" => "pgup",
+                "pagedown" => "pgdn",
+                key => key,
+            })
+            .collect::<Vec<_>>()
+            .join("/")
+    }
+
+    pub fn title(&self, name: &str, action: &Action) -> String {
+        self.key(action).map_or_else(|| name.into(), |key| format!("[{key}] {name}"))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use rstest::rstest;
+
+    use super::*;
+    use crate::command::client::search::keybindings::{ConditionAtom, KeyInput, KeyRule};
+
+    #[rstest]
+    fn remapped_and_conditional_keys() {
+        let context = EvalContext {
+            cursor_position: 0,
+            input_width: 0,
+            input_byte_len: 0,
+            selected_index: 0,
+            results_len: 2,
+            original_input_empty: false,
+            has_context: false,
+        };
+        let mut keymap = Keymap::new();
+        keymap.bind(KeyInput::parse("enter").unwrap(), Action::Noop);
+        keymap.bind(KeyInput::parse("x").unwrap(), Action::InspectOutput);
+        keymap.bind(KeyInput::parse("S").unwrap(), Action::InspectSession);
+        keymap.bind_conditional(KeyInput::parse("down").unwrap(), vec![KeyRule::when(
+            ConditionAtom::ListAtEnd,
+            Action::SelectNext,
+        )]);
+        let bindings = Bindings::new(&keymap, &context);
+        assert_eq!(bindings.key(&Action::InspectOutput), Some("x"));
+        assert_eq!(bindings.title("Session", &Action::InspectSession), "[S] Session");
+        assert_eq!(bindings.title("Runs", &Action::InspectRuns), "Runs");
+        assert!(bindings.key(&Action::InspectNext).is_none());
+    }
+}

--- a/crates/atuin/src/command/client/search/inspector/bindings.rs
+++ b/crates/atuin/src/command/client/search/inspector/bindings.rs
@@ -1,8 +1,11 @@
 use super::super::keybindings::{Action, EvalContext, Keymap};
 
-/// Resolved bindings for this frame, shared by the view selector and footer.
+/// Resolved bindings shared by the view selector and footer.
 #[derive(Default)]
-pub struct Bindings(Vec<(Action, String)>);
+pub struct Bindings {
+    keys: Vec<(Action, String)>,
+    context: Option<EvalContext>,
+}
 
 impl Bindings {
     pub fn new(keymap: &Keymap, context: &EvalContext) -> Self {
@@ -22,7 +25,17 @@ impl Bindings {
             .collect();
 
         bindings.sort_by(|(_, a), (_, b)| (a.len(), a).cmp(&(b.len(), b)));
-        Self(bindings)
+        Self {
+            keys: bindings,
+            context: Some(*context),
+        }
+    }
+
+    /// The keymap is fixed for the search session; only conditions can change.
+    pub fn update(&mut self, keymap: &Keymap, context: &EvalContext) {
+        if self.context.as_ref() != Some(context) {
+            *self = Self::new(keymap, context);
+        }
     }
 
     pub fn key(&self, action: &Action) -> Option<&str> {
@@ -45,10 +58,10 @@ impl Bindings {
             _ => "",
         };
 
-        self.0
+        self.keys
             .iter()
             .find(|(a, key)| a == action && key == preferred)
-            .or_else(|| self.0.iter().find(|(a, _)| a == action))
+            .or_else(|| self.keys.iter().find(|(a, _)| a == action))
             .map(|(_, key)| key.as_str())
     }
 
@@ -81,7 +94,7 @@ mod tests {
 
     #[rstest]
     fn remapped_and_conditional_keys() {
-        let context = EvalContext {
+        let mut context = EvalContext {
             cursor_position: 0,
             input_width: 0,
             input_byte_len: 0,
@@ -98,10 +111,23 @@ mod tests {
             ConditionAtom::ListAtEnd,
             Action::SelectNext,
         )]);
-        let bindings = Bindings::new(&keymap, &context);
+        let mut bindings = Bindings::default();
+        bindings.update(&keymap, &context);
         assert_eq!(bindings.key(&Action::InspectOutput), Some("x"));
         assert_eq!(bindings.title("Session", &Action::InspectSession), "[S] Session");
         assert_eq!(bindings.title("Runs", &Action::InspectRuns), "Runs");
+        assert!(bindings.key(&Action::InspectNext).is_none());
+
+        let keys = bindings.keys.as_ptr();
+        bindings.update(&keymap, &context);
+        assert_eq!(bindings.keys.as_ptr(), keys);
+
+        context.selected_index = 1;
+        bindings.update(&keymap, &context);
+        assert_eq!(bindings.key(&Action::InspectNext), Some("down"));
+
+        context.selected_index = 0;
+        bindings.update(&keymap, &context);
         assert!(bindings.key(&Action::InspectNext).is_none());
     }
 }

--- a/crates/atuin/src/command/client/search/inspector/browser.rs
+++ b/crates/atuin/src/command/client/search/inspector/browser.rs
@@ -168,11 +168,7 @@ impl Browser {
         }
         .max(1);
 
-        self.output_scroll = if next {
-            self.output_scroll.saturating_add(amount).min(self.output_max_scroll)
-        } else {
-            self.output_scroll.saturating_sub(amount)
-        };
+        self.scroll_output(next, amount);
     }
 
     pub fn scroll_output_edge(&mut self, end: bool) {
@@ -183,11 +179,11 @@ impl Browser {
         };
     }
 
-    pub fn scroll_output(&mut self, next: bool) {
+    pub fn scroll_output(&mut self, next: bool, amount: usize) {
         self.output_scroll = if next {
-            self.output_scroll.saturating_add(1).min(self.output_max_scroll)
+            self.output_scroll.saturating_add(amount).min(self.output_max_scroll)
         } else {
-            self.output_scroll.saturating_sub(1)
+            self.output_scroll.saturating_sub(amount)
         };
     }
 
@@ -217,9 +213,13 @@ impl Browser {
         if self.scope.as_ref() != Some(&(self.view, scope.clone()))
             || (at_edge && self.window_for != Some(selected.id))
         {
-            self.entries = db
-                .inspector_history(selected, self.view == View::Session)
-                .await?
+            let entries = if self.view == View::Session {
+                db.inspector_session(selected).await?
+            } else {
+                db.inspector_runs(selected).await?
+            };
+
+            self.entries = entries
                 .into_iter()
                 .rev()
                 .map(|entry| Run::new(&entry, self.view == View::Session, settings))
@@ -682,40 +682,6 @@ mod tests {
     }
 
     #[rstest]
-    #[case(View::Runs, "Directory")]
-    #[case(View::Session, "Command")]
-    fn list_shows_occurrence_metadata(
-        mut history: History,
-        #[case] view: View,
-        #[case] heading: &str,
-    ) {
-        history.cwd = "/tmp/example".into();
-        history.exit = 42;
-        history.duration = 2_000_000_000;
-        let mut browser = Browser {
-            view,
-            entries: vec![Run::new(&history, view == View::Session, &Settings::utc())],
-            ..Browser::default()
-        };
-        browser.table.select(Some(0));
-        let mut terminal = Terminal::new(TestBackend::new(80, 12)).unwrap();
-        let mut themes = ThemeManager::new(Some(true), Some(String::new()));
-        let theme = themes.load_theme("(none)", None);
-        browser.prepare(&history, &Settings::utc(), theme);
-        terminal.draw(|f| browser.draw(f, f.area(), theme, &bindings())).unwrap();
-        let rendered: String = terminal
-            .backend()
-            .buffer()
-            .content()
-            .iter()
-            .map(ratatui::buffer::Cell::symbol)
-            .collect();
-        for text in [heading, "1970-01-01", "42", "2s", "/tmp/example"] {
-            assert!(rendered.contains(text), "missing {text} in {rendered}");
-        }
-    }
-
-    #[rstest]
     #[case("echo hello", 80, 24, 1)]
     #[case("echo first\necho second", 80, 24, 2)]
     #[case("a long command that wraps across lines", 12, 24, 2)]
@@ -743,17 +709,6 @@ mod tests {
                 assert_eq!(rest.height, height - rows - 1);
             })
             .unwrap();
-        let rendered: String = terminal
-            .backend()
-            .buffer()
-            .content()
-            .iter()
-            .map(ratatui::buffer::Cell::symbol)
-            .collect();
-        assert!(!rendered.contains('╭'));
-        assert!(rendered.contains("[r] Runs"));
-        assert_eq!(terminal.backend().buffer()[(0, 1)].symbol(), "c");
-        assert!(rendered.contains("cmd: "));
     }
 
     #[rstest]
@@ -824,7 +779,6 @@ mod tests {
     #[rstest]
     #[case(20, 5)]
     #[case(80, 24)]
-    #[case(120, 40)]
     fn output_wraps_and_scrolls_to_the_end(
         history: History,
         #[case] width: u16,
@@ -864,45 +818,24 @@ mod tests {
             assert_ne!(cell.bg, Color::Blue);
             assert_ne!(cell.fg, Color::Red);
         }
-        if height >= 10 {
-            assert!(
-                browser.output_page_size >= usize::from(height - 5),
-                "output should get almost the whole viewport"
-            );
-        }
-        for _ in 0..6000 {
-            browser.scroll_output(true);
-        }
+        browser.scroll_output(true, usize::MAX);
         terminal.draw(|f| browser.draw(f, f.area(), theme, &bindings())).unwrap();
-        let rendered: String = terminal
+        let end = terminal
             .backend()
             .buffer()
             .content()
             .iter()
-            .map(ratatui::buffer::Cell::symbol)
-            .collect();
-        assert!(rendered.contains("THE END"));
-        assert!(!rendered.contains('\x1b'));
-        let end = terminal.backend().buffer().content().iter().find(|c| c.symbol() == "T").unwrap();
+            .find(|c| c.symbol() == "T")
+            .expect("last output row should be visible");
         assert_eq!(end.fg, Color::Reset);
         assert_eq!(end.bg, Color::Reset);
         assert!(end.modifier.is_empty());
-        assert!(
-            terminal
-                .backend()
-                .buffer()
-                .content()
-                .iter()
-                .any(|c| c.symbol() == "x" && c.fg == ratatui::style::Color::Red)
-        );
         assert_eq!(browser.output_scroll, browser.output_max_scroll);
         assert_eq!(
             browser.list_position(),
             (browser.output_max_scroll, browser.output_max_scroll + 1)
         );
-        for _ in 0..6000 {
-            browser.scroll_output(false);
-        }
+        browser.scroll_output(false, usize::MAX);
         assert_eq!(browser.output_scroll, 0);
         browser.back_from_output();
         terminal.draw(|f| browser.draw(f, f.area(), theme, &bindings())).unwrap();

--- a/crates/atuin/src/command/client/search/inspector/browser.rs
+++ b/crates/atuin/src/command/client/search/inspector/browser.rs
@@ -31,14 +31,54 @@ pub enum View {
     Output,
 }
 
+/// Display strings prepared when a database window is loaded, not on each frame.
+struct Run {
+    id: HistoryId,
+    timestamp: String,
+    exit: String,
+    duration: String,
+    origin: String,
+    context: String,
+    failed: bool,
+}
+
+impl Run {
+    fn new(entry: &History, session: bool, settings: &Settings) -> Self {
+        Self {
+            id: entry.id,
+            timestamp: timestamp(entry, settings),
+            exit: exit_label(entry.exit),
+            duration: Duration::saturating_from_nanos_i64(entry.duration)
+                .display()
+                .largest_unit()
+                .to_string(),
+            origin: origin(entry),
+            context: if session {
+                &entry.command
+            } else {
+                &entry.cwd
+            }
+            .escape_non_printable()
+            .into_owned(),
+            failed: entry.exit > 0,
+        }
+    }
+}
+
 /// Switching views pivots on the selected occurrence, not the original search result.
 #[derive(Default)]
 pub struct Browser {
     pub view: View,
-    entries: Vec<History>,
+    entries: Vec<Run>,
     scope: Option<(View, String)>,
     window_for: Option<HistoryId>,
     table: TableState,
+
+    selected_for: Option<HistoryId>,
+    command: Paragraph<'static>,
+    command_size: (usize, usize),
+    details: Paragraph<'static>,
+    output_heading: Paragraph<'static>,
 
     output: Capture,
     output_scroll: usize,
@@ -48,6 +88,54 @@ pub struct Browser {
 }
 
 impl Browser {
+    /// Settings and theme are fixed for a search session. Only a new occurrence
+    /// needs its command highlighted and its metadata formatted again.
+    pub fn prepare(&mut self, selected: &History, settings: &Settings, theme: &Theme) {
+        if self.selected_for == Some(selected.id) {
+            return;
+        }
+        let styles = Styles::new(theme);
+        let command = command_text(selected, settings.ui.syntax_highlight, theme);
+        self.command_size = (command.width(), command.lines.len());
+
+        let mut heading = command.lines.first().cloned().unwrap_or_default();
+        heading.spans.insert(0, Span::styled("cmd: ", styles.muted));
+        self.output_heading = Paragraph::new(vec![
+            heading,
+            Line::styled(
+                format!(
+                    " {}  ·  {}  ·  exit {}",
+                    timestamp(selected, settings),
+                    origin(selected),
+                    exit_label(selected.exit)
+                ),
+                styles.muted,
+            ),
+        ]);
+
+        self.command = Paragraph::new(command).wrap(Wrap { trim: false });
+        self.details = details(selected, settings, styles);
+        self.selected_for = Some(selected.id);
+    }
+
+    /// Keep command context visible without spending a panel's borders and padding on it.
+    pub fn draw_command(&self, f: &mut Frame<'_>, area: Rect, theme: &Theme) -> Rect {
+        let width = usize::from(area.width.saturating_sub(5).max(1));
+        let wraps = self.command_size.1 > 1 || self.command_size.0 > width;
+        let height = if area.height >= 12 && wraps {
+            2
+        } else {
+            1
+        };
+        let areas = Layout::vertical([Constraint::Length(height), Constraint::Min(0)]).split(area);
+        let columns =
+            Layout::horizontal([Constraint::Length(5), Constraint::Min(0)]).split(areas[0]);
+
+        f.render_widget(Paragraph::new("cmd: ").style(Styles::new(theme).muted), columns[0]);
+        f.render_widget(&self.command, columns[1]);
+        areas[1]
+    }
+
     pub fn select_view(&mut self, view: View) {
         if self.view != view {
             if view == View::Output {
@@ -129,8 +217,13 @@ impl Browser {
         if self.scope.as_ref() != Some(&(self.view, scope.clone()))
             || (at_edge && self.window_for != Some(selected.id))
         {
-            self.entries = db.inspector_history(selected, self.view == View::Session).await?;
-            self.entries.reverse();
+            self.entries = db
+                .inspector_history(selected, self.view == View::Session)
+                .await?
+                .into_iter()
+                .rev()
+                .map(|entry| Run::new(&entry, self.view == View::Session, settings))
+                .collect();
             self.scope = Some((self.view, scope));
             self.window_for = Some(selected.id);
             self.table = TableState::default();
@@ -146,18 +239,10 @@ impl Browser {
         }))
     }
 
-    pub fn draw(
-        &mut self,
-        f: &mut Frame<'_>,
-        chunk: Rect,
-        selected: &History,
-        settings: &Settings,
-        theme: &Theme,
-        bindings: &Bindings,
-    ) {
+    pub fn draw(&mut self, f: &mut Frame<'_>, chunk: Rect, theme: &Theme, bindings: &Bindings) {
         let styles = Styles::new(theme);
         if self.view == View::Output {
-            self.draw_output(f, chunk, selected, settings, theme, bindings);
+            self.draw_output(f, chunk, theme, bindings);
             return;
         }
 
@@ -170,11 +255,11 @@ impl Browser {
             }),
         ])
         .split(chunk);
-        self.draw_list(f, areas[0], settings, styles);
-        draw_details(f, areas[1], selected, settings, styles);
+        self.draw_list(f, areas[0], styles);
+        f.render_widget(&self.details, areas[1]);
     }
 
-    fn draw_list(&mut self, f: &mut Frame<'_>, area: Rect, settings: &Settings, styles: Styles) {
+    fn draw_list(&mut self, f: &mut Frame<'_>, area: Rect, styles: Styles) {
         let session = self.view == View::Session;
         let narrow = area.width < 90;
         let tiny = area.width < 65;
@@ -182,32 +267,22 @@ impl Browser {
         let rows = self.entries.iter().map(|entry| {
             let mut cells = vec![
                 Cell::from(if tiny {
-                    clock(entry, settings)
+                    entry.timestamp.rsplit(' ').next().unwrap_or_default()
                 } else {
-                    timestamp(entry, settings)
+                    entry.timestamp.as_str()
                 })
                 .style(styles.muted),
-                Cell::from(exit_label(entry.exit)).style(if entry.exit > 0 {
+                Cell::from(entry.exit.as_str()).style(if entry.failed {
                     styles.failure
                 } else {
                     styles.muted
                 }),
-                Cell::from(
-                    Duration::saturating_from_nanos_i64(entry.duration)
-                        .display()
-                        .largest_unit()
-                        .to_string(),
-                )
-                .style(styles.muted),
+                Cell::from(entry.duration.as_str()).style(styles.muted),
             ];
             if !narrow {
-                cells.push(Cell::from(origin(entry)).style(styles.muted));
+                cells.push(Cell::from(entry.origin.as_str()).style(styles.muted));
             }
-            cells.push(Cell::from(if session {
-                entry.command.escape_non_printable()
-            } else {
-                entry.cwd.escape_non_printable()
-            }));
+            cells.push(Cell::from(entry.context.as_str()));
             Row::new(cells)
         });
 
@@ -250,15 +325,7 @@ impl Browser {
         f.render_stateful_widget(table, area, &mut self.table);
     }
 
-    fn draw_output(
-        &mut self,
-        f: &mut Frame<'_>,
-        area: Rect,
-        selected: &History,
-        settings: &Settings,
-        theme: &Theme,
-        bindings: &Bindings,
-    ) {
+    fn draw_output(&mut self, f: &mut Frame<'_>, area: Rect, theme: &Theme, bindings: &Bindings) {
         let styles = Styles::new(theme);
         let spacious = area.height >= 10;
         let areas = Layout::vertical([
@@ -272,25 +339,7 @@ impl Browser {
         ])
         .split(area);
 
-        let mut command = command_text(selected, settings.ui.syntax_highlight, theme)
-            .lines
-            .into_iter()
-            .next()
-            .unwrap_or_default();
-        command.spans.insert(0, Span::styled("cmd: ", styles.muted));
-        let heading = vec![
-            command,
-            Line::styled(
-                format!(
-                    " {}  ·  {}  ·  exit {}",
-                    timestamp(selected, settings),
-                    origin(selected),
-                    exit_label(selected.exit)
-                ),
-                styles.muted,
-            ),
-        ];
-        f.render_widget(Paragraph::new(heading), areas[0]);
+        f.render_widget(&self.output_heading, areas[0]);
 
         let status = self.output.status().to_owned();
         let block = panel(format!(" {status} "), styles);
@@ -373,14 +422,6 @@ fn timestamp(entry: &History, settings: &Settings) -> String {
         .unwrap_or_default()
 }
 
-fn clock(entry: &History, settings: &Settings) -> String {
-    entry
-        .timestamp
-        .to_offset(settings.timezone.0)
-        .format(format_description!("[hour]:[minute]:[second]"))
-        .unwrap_or_default()
-}
-
 fn origin(entry: &History) -> String {
     format!(
         "{}@{}",
@@ -396,17 +437,7 @@ fn exit_label(exit: i64) -> String {
     }
 }
 
-fn draw_details(
-    f: &mut Frame<'_>,
-    area: Rect,
-    selected: &History,
-    settings: &Settings,
-    styles: Styles,
-) {
-    if area.height == 0 {
-        return;
-    }
-
+fn details(selected: &History, settings: &Settings, styles: Styles) -> Paragraph<'static> {
     let lines = vec![
         Line::from(vec![
             Span::styled("When  ", styles.label),
@@ -431,41 +462,14 @@ fn draw_details(
         ]),
         Line::from(vec![
             Span::styled("Cwd   ", styles.label),
-            Span::raw(selected.cwd.escape_non_printable()),
+            Span::raw(selected.cwd.escape_non_printable().into_owned()),
         ]),
     ];
 
-    f.render_widget(
-        Paragraph::new(lines)
-            .style(styles.base)
-            .wrap(Wrap { trim: false })
-            .block(panel(" Selected run ", styles)),
-        area,
-    );
-}
-
-/// Keep command context visible without spending a panel's borders and padding on it.
-pub fn draw_command(
-    f: &mut Frame<'_>,
-    area: Rect,
-    history: &History,
-    settings: &Settings,
-    theme: &Theme,
-) -> Rect {
-    let text = command_text(history, settings.ui.syntax_highlight, theme);
-    let width = usize::from(area.width.saturating_sub(5).max(1));
-    let rows = text.lines.iter().map(|line| line.width().max(1).div_ceil(width)).sum::<usize>();
-    let height = if area.height >= 12 && rows > 1 {
-        2
-    } else {
-        1
-    };
-    let areas = Layout::vertical([Constraint::Length(height), Constraint::Min(0)]).split(area);
-    let columns = Layout::horizontal([Constraint::Length(5), Constraint::Min(0)]).split(areas[0]);
-
-    f.render_widget(Paragraph::new("cmd: ").style(Styles::new(theme).muted), columns[0]);
-    f.render_widget(Paragraph::new(text).wrap(Wrap { trim: false }), columns[1]);
-    areas[1]
+    Paragraph::new(lines)
+        .style(styles.base)
+        .wrap(Wrap { trim: false })
+        .block(panel(" Selected run ", styles))
 }
 
 fn command_text(history: &History, highlight: bool, theme: &Theme) -> Text<'static> {
@@ -669,10 +673,12 @@ mod tests {
             (Some(neighbor.id), None)
         );
         assert_eq!(browser.entries[0].id, neighbor.id);
+        assert_eq!(browser.entries[0].context, neighbor.command);
         assert_eq!(browser.table.selected(), Some(1));
         browser.select_view(View::Runs);
         assert_eq!(browser.refresh(&db, &neighbor, &settings).await.unwrap(), (None, None));
         assert_eq!(browser.entries[0].id, neighbor.id);
+        assert_eq!(browser.entries[0].context, neighbor.cwd);
     }
 
     #[rstest]
@@ -688,16 +694,15 @@ mod tests {
         history.duration = 2_000_000_000;
         let mut browser = Browser {
             view,
-            entries: vec![history.clone()],
+            entries: vec![Run::new(&history, view == View::Session, &Settings::utc())],
             ..Browser::default()
         };
         browser.table.select(Some(0));
         let mut terminal = Terminal::new(TestBackend::new(80, 12)).unwrap();
         let mut themes = ThemeManager::new(Some(true), Some(String::new()));
         let theme = themes.load_theme("(none)", None);
-        terminal
-            .draw(|f| browser.draw(f, f.area(), &history, &Settings::utc(), theme, &bindings()))
-            .unwrap();
+        browser.prepare(&history, &Settings::utc(), theme);
+        terminal.draw(|f| browser.draw(f, f.area(), theme, &bindings())).unwrap();
         let rendered: String = terminal
             .backend()
             .buffer()
@@ -715,7 +720,7 @@ mod tests {
     #[case("echo first\necho second", 80, 24, 2)]
     #[case("a long command that wraps across lines", 12, 24, 2)]
     #[case("echo first\necho second", 80, 5, 1)]
-    fn command_header_is_compact(
+    fn command_header_follows_selection_and_stays_compact(
         mut history: History,
         #[case] command: &str,
         #[case] width: u16,
@@ -725,11 +730,15 @@ mod tests {
         let mut terminal = Terminal::new(TestBackend::new(width, height)).unwrap();
         let mut themes = ThemeManager::new(Some(true), Some(String::new()));
         let theme = themes.load_theme("(none)", None);
+        let mut browser = Browser::default();
+        browser.prepare(&history, &Settings::utc(), theme);
+        history.id = HistoryId::new(atuin_common::utils::uuid_v7());
+        history.command = command.into();
+        browser.prepare(&history, &Settings::utc(), theme);
         terminal
             .draw(|f| {
-                history.command = command.into();
                 let area = draw_views(f, f.area(), View::Runs, theme, &bindings());
-                let rest = draw_command(f, area, &history, &Settings::utc(), theme);
+                let rest = browser.draw_command(f, area, theme);
                 assert_eq!(rest.y, rows + 1);
                 assert_eq!(rest.height, height - rows - 1);
             })
@@ -779,7 +788,7 @@ mod tests {
     fn output_back_preserves_list_position(history: History) {
         let mut browser = Browser {
             view: View::Session,
-            entries: vec![history],
+            entries: vec![Run::new(&history, true, &Settings::utc())],
             ..Browser::default()
         };
         browser.table.select(Some(0));
@@ -836,10 +845,8 @@ mod tests {
             ),
             ..Browser::default()
         };
-        let settings = Settings::utc();
-        terminal
-            .draw(|f| browser.draw(f, f.area(), &history, &settings, theme, &bindings()))
-            .unwrap();
+        browser.prepare(&history, &Settings::utc(), theme);
+        terminal.draw(|f| browser.draw(f, f.area(), theme, &bindings())).unwrap();
         assert!(browser.output_max_scroll > 0);
         let first_output = if height >= 10 {
             (2, 3)
@@ -866,9 +873,7 @@ mod tests {
         for _ in 0..6000 {
             browser.scroll_output(true);
         }
-        terminal
-            .draw(|f| browser.draw(f, f.area(), &history, &settings, theme, &bindings()))
-            .unwrap();
+        terminal.draw(|f| browser.draw(f, f.area(), theme, &bindings())).unwrap();
         let rendered: String = terminal
             .backend()
             .buffer()
@@ -900,9 +905,7 @@ mod tests {
         }
         assert_eq!(browser.output_scroll, 0);
         browser.back_from_output();
-        terminal
-            .draw(|f| browser.draw(f, f.area(), &history, &Settings::utc(), theme, &bindings()))
-            .unwrap();
+        terminal.draw(|f| browser.draw(f, f.area(), theme, &bindings())).unwrap();
         assert!(terminal.backend().buffer().content().iter().all(|c| c.bg != Color::Blue));
     }
 }

--- a/crates/atuin/src/command/client/search/inspector/browser.rs
+++ b/crates/atuin/src/command/client/search/inspector/browser.rs
@@ -1,0 +1,880 @@
+use std::time::Duration;
+
+use atuin_client::database::Sqlite;
+use atuin_client::history::{History, HistoryId};
+use atuin_client::settings::Settings;
+use atuin_common::string::EscapeNonPrintablePosixExt as _;
+use atuin_common::time::DurationExt as _;
+use ratatui::Frame;
+use ratatui::backend::FromCrossterm as _;
+use ratatui::layout::{Constraint, Layout, Rect};
+use ratatui::style::{Modifier, Style};
+use ratatui::text::{Line, Span, Text};
+use ratatui::widgets::{
+    Block, BorderType, Borders, Cell, Padding, Paragraph, Row, Table, TableState, Tabs, Wrap,
+};
+use time::macros::format_description;
+use unicode_width::UnicodeWidthStr as _;
+
+use super::bindings::Bindings;
+use super::output::Capture;
+use crate::command::client::search::keybindings::Action;
+use crate::command::client::search::syntax;
+use crate::command::client::theme::{Meaning, Theme};
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub enum View {
+    #[default]
+    Runs,
+    Session,
+    Stats,
+    Output,
+}
+
+/// Switching views pivots on the selected occurrence, not the original search result.
+#[derive(Default)]
+pub struct Browser {
+    pub view: View,
+    entries: Vec<History>,
+    scope: Option<(View, String)>,
+    window_for: Option<HistoryId>,
+    table: TableState,
+    output: Capture,
+    output_scroll: usize,
+    output_max_scroll: usize,
+    output_page_size: usize,
+    output_return: View,
+}
+
+impl Browser {
+    pub fn select_view(&mut self, view: View) {
+        if self.view != view {
+            if view == View::Output {
+                self.output_return = self.view;
+                self.output.reopen();
+            }
+            self.view = view;
+        }
+    }
+
+    pub fn back_from_output(&mut self) {
+        self.view = self.output_return;
+    }
+
+    /// The window is re-centered before the next input event, so its edges describe
+    /// real navigation boundaries, not an arbitrary database page boundary.
+    pub fn list_position(&self) -> (usize, usize) {
+        match self.view {
+            View::Runs | View::Session => (self.table.selected().unwrap_or(0), self.entries.len()),
+            View::Stats => (0, 1),
+            View::Output => (self.output_scroll, self.output_max_scroll + 1),
+        }
+    }
+
+    pub fn scroll_output_page(&mut self, next: bool, half: bool) {
+        let amount = if half {
+            self.output_page_size / 2
+        } else {
+            self.output_page_size.saturating_sub(1)
+        }
+        .max(1);
+        self.output_scroll = if next {
+            self.output_scroll.saturating_add(amount).min(self.output_max_scroll)
+        } else {
+            self.output_scroll.saturating_sub(amount)
+        };
+    }
+
+    pub fn scroll_output_edge(&mut self, end: bool) {
+        self.output_scroll = if end {
+            self.output_max_scroll
+        } else {
+            0
+        };
+    }
+
+    pub fn scroll_output(&mut self, next: bool) {
+        self.output_scroll = if next {
+            self.output_scroll.saturating_add(1).min(self.output_max_scroll)
+        } else {
+            self.output_scroll.saturating_sub(1)
+        };
+    }
+
+    pub async fn refresh(
+        &mut self,
+        db: &Sqlite,
+        selected: &History,
+        settings: &Settings,
+    ) -> eyre::Result<(Option<HistoryId>, Option<HistoryId>)> {
+        if self.view == View::Output {
+            if self.output.poll(selected.id, settings).await {
+                self.output_scroll = 0;
+                self.output_max_scroll = 0;
+            }
+            return Ok((None, None));
+        }
+
+        let scope = if self.view == View::Session {
+            selected.session.clone()
+        } else {
+            selected.command.clone()
+        };
+        let position = self.entries.iter().position(|entry| entry.id == selected.id);
+        let at_edge = position.is_none_or(|i| i == 0 || i + 1 == self.entries.len());
+        if self.scope.as_ref() != Some(&(self.view, scope.clone()))
+            || (at_edge && self.window_for != Some(selected.id))
+        {
+            self.entries = db.inspector_history(selected, self.view == View::Session).await?;
+            self.entries.reverse();
+            self.scope = Some((self.view, scope));
+            self.window_for = Some(selected.id);
+            self.table = TableState::default();
+        }
+        let position = self.entries.iter().position(|entry| entry.id == selected.id);
+        self.table.select(position);
+        Ok(position.map_or((None, None), |i| {
+            (
+                i.checked_sub(1).map(|i| self.entries[i].id),
+                self.entries.get(i + 1).map(|entry| entry.id),
+            )
+        }))
+    }
+
+    pub fn draw(
+        &mut self,
+        f: &mut Frame<'_>,
+        chunk: Rect,
+        selected: &History,
+        settings: &Settings,
+        theme: &Theme,
+        bindings: &Bindings,
+    ) {
+        let styles = Styles::new(theme);
+        if self.view == View::Output {
+            self.draw_output(f, chunk, selected, settings, theme, bindings);
+            return;
+        }
+        let areas = Layout::vertical([
+            Constraint::Min(3),
+            Constraint::Length(if chunk.height >= 10 {
+                5
+            } else {
+                0
+            }),
+        ])
+        .split(chunk);
+        self.draw_list(f, areas[0], settings, styles);
+        draw_details(f, areas[1], selected, settings, styles);
+    }
+
+    fn draw_list(&mut self, f: &mut Frame<'_>, area: Rect, settings: &Settings, styles: Styles) {
+        let session = self.view == View::Session;
+        let narrow = area.width < 90;
+        let tiny = area.width < 65;
+        let rows = self.entries.iter().map(|entry| {
+            let mut cells = vec![
+                Cell::from(if tiny {
+                    clock(entry, settings)
+                } else {
+                    timestamp(entry, settings)
+                })
+                .style(styles.muted),
+                Cell::from(exit_label(entry.exit)).style(if entry.exit > 0 {
+                    styles.failure
+                } else {
+                    styles.muted
+                }),
+                Cell::from(
+                    Duration::saturating_from_nanos_i64(entry.duration)
+                        .display()
+                        .largest_unit()
+                        .to_string(),
+                )
+                .style(styles.muted),
+            ];
+            if !narrow {
+                cells.push(Cell::from(origin(entry)).style(styles.muted));
+            }
+            cells.push(Cell::from(if session {
+                entry.command.escape_non_printable()
+            } else {
+                entry.cwd.escape_non_printable()
+            }));
+            Row::new(cells)
+        });
+        let mut widths = vec![
+            Constraint::Length(if tiny {
+                8
+            } else {
+                19
+            }),
+            Constraint::Length(8),
+            Constraint::Length(8),
+        ];
+        let mut headings = vec!["Time", "Exit", "Duration"];
+        if !narrow {
+            widths.push(Constraint::Length(22));
+            headings.push("User@Host");
+        }
+        widths.push(Constraint::Min(1));
+        headings.push(if session {
+            "Command"
+        } else {
+            "Directory"
+        });
+        let title = if session {
+            " Session "
+        } else {
+            " Runs "
+        };
+        let block = panel(title, styles);
+        let table = Table::new(rows, widths)
+            .header(
+                Row::new(headings).style(styles.label).bottom_margin(u16::from(area.height >= 10)),
+            )
+            .block(block)
+            .style(styles.base)
+            .row_highlight_style(styles.command.add_modifier(Modifier::REVERSED))
+            .highlight_symbol("› ");
+        f.render_stateful_widget(table, area, &mut self.table);
+    }
+
+    fn draw_output(
+        &mut self,
+        f: &mut Frame<'_>,
+        area: Rect,
+        selected: &History,
+        settings: &Settings,
+        theme: &Theme,
+        bindings: &Bindings,
+    ) {
+        let styles = Styles::new(theme);
+        let spacious = area.height >= 10;
+        let areas = Layout::vertical([
+            Constraint::Length(if spacious {
+                2
+            } else {
+                1
+            }),
+            Constraint::Min(1),
+            Constraint::Length(1),
+        ])
+        .split(area);
+        let mut command = command_text(selected, settings.ui.syntax_highlight, theme)
+            .lines
+            .into_iter()
+            .next()
+            .unwrap_or_default();
+        command.spans.insert(0, Span::styled("cmd: ", styles.muted));
+        let heading = vec![
+            command,
+            Line::styled(
+                format!(
+                    " {}  ·  {}  ·  exit {}",
+                    timestamp(selected, settings),
+                    origin(selected),
+                    exit_label(selected.exit)
+                ),
+                styles.muted,
+            ),
+        ];
+        f.render_widget(Paragraph::new(heading), areas[0]);
+        let status = self.output.status().to_owned();
+        let block = panel(format!(" {status} "), styles);
+        // At very small heights, spend the remaining space on output instead of borders.
+        let inner = if spacious {
+            block.inner(areas[1])
+        } else {
+            areas[1]
+        };
+        let rows = self.output.rows(inner.width);
+        self.output_page_size = usize::from(inner.height);
+        self.output_max_scroll = rows.len().saturating_sub(self.output_page_size);
+        self.output_scroll = self.output_scroll.min(self.output_max_scroll);
+        if spacious {
+            let progress = format!(
+                " {}–{} / {} rows ",
+                self.output_scroll + usize::from(!rows.is_empty()),
+                (self.output_scroll + self.output_page_size).min(rows.len()),
+                rows.len()
+            );
+            f.render_widget(block.title_bottom(Line::from(progress).right_aligned()), areas[1]);
+        }
+        let text = if rows.is_empty() {
+            vec![Line::styled(status, styles.muted)]
+        } else {
+            rows.iter().skip(self.output_scroll).take(self.output_page_size).cloned().collect()
+        };
+        f.render_widget(Paragraph::new(text).style(Style::reset()), inner);
+        f.render_widget(
+            Paragraph::new(guide(View::Output, areas[2].width, styles, bindings)),
+            areas[2],
+        );
+    }
+}
+
+#[derive(Clone, Copy)]
+struct Styles {
+    base: Style,
+    muted: Style,
+    label: Style,
+    command: Style,
+    key: Style,
+    failure: Style,
+}
+
+impl Styles {
+    fn new(theme: &Theme) -> Self {
+        let style = |meaning| Style::from_crossterm(theme.as_style(meaning));
+        Self {
+            base: style(Meaning::Base),
+            muted: style(Meaning::Annotation),
+            label: style(Meaning::Annotation).add_modifier(Modifier::BOLD),
+            command: style(Meaning::Important).add_modifier(Modifier::BOLD),
+            key: style(Meaning::Guidance).add_modifier(Modifier::BOLD),
+            failure: style(Meaning::AlertError),
+        }
+    }
+}
+
+fn panel<'a>(title: impl Into<Line<'a>>, styles: Styles) -> Block<'a> {
+    Block::default()
+        .borders(Borders::ALL)
+        .border_type(BorderType::Rounded)
+        .border_style(styles.muted)
+        .title(title)
+        .title_style(styles.label)
+        .padding(Padding::horizontal(1))
+}
+
+fn timestamp(entry: &History, settings: &Settings) -> String {
+    entry
+        .timestamp
+        .to_offset(settings.timezone.0)
+        .format(format_description!("[year]-[month]-[day] [hour]:[minute]:[second]"))
+        .unwrap_or_default()
+}
+
+fn clock(entry: &History, settings: &Settings) -> String {
+    entry
+        .timestamp
+        .to_offset(settings.timezone.0)
+        .format(format_description!("[hour]:[minute]:[second]"))
+        .unwrap_or_default()
+}
+
+fn origin(entry: &History) -> String {
+    format!(
+        "{}@{}",
+        entry.cmd_origin.user().into_inner().escape_non_printable(),
+        entry.cmd_origin.host().into_inner().escape_non_printable()
+    )
+}
+
+fn exit_label(exit: i64) -> String {
+    match exit {
+        n if n < 0 => "Unknown".into(),
+        n => n.to_string(),
+    }
+}
+
+fn draw_details(
+    f: &mut Frame<'_>,
+    area: Rect,
+    selected: &History,
+    settings: &Settings,
+    styles: Styles,
+) {
+    if area.height == 0 {
+        return;
+    }
+    let lines = vec![
+        Line::from(vec![
+            Span::styled("When  ", styles.label),
+            Span::raw(timestamp(selected, settings)),
+            Span::styled("   Exit  ", styles.label),
+            Span::styled(
+                exit_label(selected.exit),
+                if selected.exit > 0 {
+                    styles.failure
+                } else {
+                    styles.base
+                },
+            ),
+            Span::styled("   Took  ", styles.label),
+            Span::raw(Duration::saturating_from_nanos_i64(selected.duration).display().to_string()),
+        ]),
+        Line::from(vec![
+            Span::styled("Host  ", styles.label),
+            Span::raw(origin(selected)),
+            Span::styled("   Shell  ", styles.label),
+            Span::raw(selected.shell.as_deref().unwrap_or("—").escape_non_printable().into_owned()),
+        ]),
+        Line::from(vec![
+            Span::styled("Cwd   ", styles.label),
+            Span::raw(selected.cwd.escape_non_printable()),
+        ]),
+    ];
+    f.render_widget(
+        Paragraph::new(lines)
+            .style(styles.base)
+            .wrap(Wrap { trim: false })
+            .block(panel(" Selected run ", styles)),
+        area,
+    );
+}
+
+/// Keep command context visible without spending a panel's borders and padding on it.
+pub fn draw_command(
+    f: &mut Frame<'_>,
+    area: Rect,
+    history: &History,
+    settings: &Settings,
+    theme: &Theme,
+) -> Rect {
+    let text = command_text(history, settings.ui.syntax_highlight, theme);
+    let width = usize::from(area.width.saturating_sub(5).max(1));
+    let rows = text.lines.iter().map(|line| line.width().max(1).div_ceil(width)).sum::<usize>();
+    let height = if area.height >= 12 && rows > 1 {
+        2
+    } else {
+        1
+    };
+    let areas = Layout::vertical([Constraint::Length(height), Constraint::Min(0)]).split(area);
+    let columns = Layout::horizontal([Constraint::Length(5), Constraint::Min(0)]).split(areas[0]);
+    f.render_widget(Paragraph::new("cmd: ").style(Styles::new(theme).muted), columns[0]);
+    f.render_widget(Paragraph::new(text).wrap(Wrap { trim: false }), columns[1]);
+    areas[1]
+}
+
+fn command_text(history: &History, highlight: bool, theme: &Theme) -> Text<'static> {
+    // Classify the same escaped text we render, so byte offsets still agree for Unicode
+    // and control-character replacements. Parse the whole command to retain multiline context.
+    let text = history
+        .command
+        .lines()
+        .map(|line| line.escape_non_printable().into_owned())
+        .collect::<Vec<_>>()
+        .join("\n");
+    let meanings = if highlight {
+        syntax::classify(&text, history.shell.as_deref())
+    } else {
+        Vec::new()
+    };
+    let fallback = Styles::new(theme).command;
+    let mut lines = vec![Line::default()];
+    for (index, ch) in text.char_indices() {
+        if ch == '\n' {
+            lines.push(Line::default());
+            continue;
+        }
+        let style = meanings
+            .get(index)
+            .map_or(fallback, |meaning| Style::from_crossterm(theme.as_style(*meaning)));
+        let line = lines.last_mut().expect("at least one line");
+        if let Some(span) = line.spans.last_mut()
+            && span.style == style
+        {
+            span.content.to_mut().push(ch);
+        } else {
+            line.spans.push(Span::styled(ch.to_string(), style));
+        }
+    }
+    Text::from(lines)
+}
+
+pub fn input_guide(view: View, width: u16, theme: &Theme, bindings: &Bindings) -> Line<'static> {
+    guide(view, width, Styles::new(theme), bindings)
+}
+
+fn guide(view: View, width: u16, styles: Styles, bindings: &Bindings) -> Line<'static> {
+    use Action::{
+        Delete, Exit, InspectNext, InspectOutput, InspectPrevious, InspectRuns, InspectSession,
+        InspectStats, ReturnSelection, ScrollPageDown, ScrollPageUp, ScrollToBottom, ScrollToTop,
+    };
+    let actions: &[(&[Action], &str)] = match view {
+        View::Runs | View::Session => &[
+            (&[InspectOutput], "output"),
+            (&[InspectPrevious, InspectNext], "select"),
+            (&[ReturnSelection], "edit"),
+            (&[Exit], "search"),
+            (&[InspectRuns, InspectSession, InspectStats], "views"),
+            (&[Delete], "delete"),
+        ],
+        View::Output => &[
+            (&[Exit], "back"),
+            (&[InspectPrevious, InspectNext], "scroll"),
+            (&[ScrollPageUp, ScrollPageDown], "page"),
+            (&[ScrollToTop, ScrollToBottom], "jump"),
+            (&[ReturnSelection], "edit"),
+        ],
+        View::Stats => {
+            &[(&[InspectRuns], "runs"), (&[InspectSession], "session"), (&[Exit], "search")]
+        }
+    };
+    let mut spans = Vec::new();
+    let mut used = 0;
+    for (actions, action) in actions {
+        let key = bindings.group(actions);
+        if key.is_empty() {
+            continue;
+        }
+        let key = format!("<{key}>");
+        let label = format!(": {action}");
+        let separator = if spans.is_empty() {
+            ""
+        } else {
+            ", "
+        };
+        let needed = key.width() + label.width() + separator.len();
+        // Avoid cutting a key or its action in half on narrow terminals.
+        if used + needed > usize::from(width) {
+            break;
+        }
+        spans.push(Span::styled(separator, styles.muted));
+        spans.push(Span::styled(key, styles.key));
+        spans.push(Span::styled(label, styles.muted));
+        used += needed;
+    }
+    Line::from(spans)
+}
+
+pub fn draw_views(
+    f: &mut Frame<'_>,
+    chunk: Rect,
+    view: View,
+    theme: &Theme,
+    bindings: &Bindings,
+) -> Rect {
+    if view == View::Output {
+        return chunk;
+    }
+    let areas = Layout::vertical([Constraint::Length(1), Constraint::Min(0)]).split(chunk);
+    let index = match view {
+        View::Runs => 0,
+        View::Session => 1,
+        View::Stats => 2,
+        View::Output => 3,
+    };
+    f.render_widget(
+        Tabs::new([
+            bindings.title("Runs", &Action::InspectRuns),
+            bindings.title("Session", &Action::InspectSession),
+            bindings.title("Stats", &Action::InspectStats),
+        ])
+        .select(index)
+        .style(Style::from_crossterm(theme.as_style(Meaning::Base)))
+        .highlight_style(
+            Style::from_crossterm(theme.as_style(Meaning::Important))
+                .add_modifier(Modifier::BOLD | Modifier::REVERSED),
+        ),
+        areas[0],
+    );
+    areas[1]
+}
+
+#[cfg(test)]
+mod tests {
+    use atuin_client::theme::ThemeManager;
+    use ratatui::Terminal;
+    use ratatui::backend::TestBackend;
+    use rstest::{fixture, rstest};
+    use time::OffsetDateTime;
+
+    use super::*;
+    use crate::command::client::search::keybindings::EvalContext;
+    use crate::command::client::search::keybindings::defaults::default_inspector_keymap;
+
+    #[fixture]
+    fn bindings() -> Bindings {
+        Bindings::new(&default_inspector_keymap(&Settings::utc()), &EvalContext {
+            cursor_position: 0,
+            input_width: 0,
+            input_byte_len: 0,
+            selected_index: 0,
+            results_len: 1,
+            original_input_empty: false,
+            has_context: false,
+        })
+    }
+
+    #[fixture]
+    fn history() -> History {
+        History::capture()
+            .timestamp(OffsetDateTime::UNIX_EPOCH)
+            .command("echo hello")
+            .cwd("/tmp")
+            .build()
+            .into()
+    }
+
+    #[rstest]
+    #[tokio::test]
+    async fn views_pivot_on_the_selected_occurrence(mut history: History) {
+        let db = Sqlite::in_memory(Duration::from_secs(2)).await.unwrap();
+        history.session = "first".into();
+        db.save(&history).await.unwrap();
+        let mut other_run = history.clone();
+        other_run.id = HistoryId::new(atuin_common::utils::uuid_v7());
+        other_run.timestamp += time::Duration::seconds(1);
+        other_run.session = "second".into();
+        db.save(&other_run).await.unwrap();
+        let mut neighbor = other_run.clone();
+        neighbor.id = HistoryId::new(atuin_common::utils::uuid_v7());
+        neighbor.timestamp += time::Duration::seconds(1);
+        neighbor.command = "pwd".into();
+        db.save(&neighbor).await.unwrap();
+        let mut browser = Browser::default();
+        let settings = Settings::utc();
+        assert_eq!(
+            browser.refresh(&db, &history, &settings).await.unwrap(),
+            (Some(other_run.id), None)
+        );
+        assert_eq!(
+            browser.refresh(&db, &other_run, &settings).await.unwrap(),
+            (None, Some(history.id))
+        );
+        browser.select_view(View::Session);
+        assert_eq!(
+            browser.refresh(&db, &other_run, &settings).await.unwrap(),
+            (Some(neighbor.id), None)
+        );
+        assert_eq!(browser.entries[0].id, neighbor.id);
+        assert_eq!(browser.table.selected(), Some(1));
+        browser.select_view(View::Runs);
+        assert_eq!(browser.refresh(&db, &neighbor, &settings).await.unwrap(), (None, None));
+        assert_eq!(browser.entries[0].id, neighbor.id);
+    }
+
+    #[rstest]
+    #[case(View::Runs, "Directory")]
+    #[case(View::Session, "Command")]
+    fn list_shows_occurrence_metadata(
+        mut history: History,
+        #[case] view: View,
+        #[case] heading: &str,
+    ) {
+        history.cwd = "/tmp/example".into();
+        history.exit = 42;
+        history.duration = 2_000_000_000;
+        let mut browser = Browser {
+            view,
+            entries: vec![history.clone()],
+            ..Browser::default()
+        };
+        browser.table.select(Some(0));
+        let mut terminal = Terminal::new(TestBackend::new(80, 12)).unwrap();
+        let mut themes = ThemeManager::new(Some(true), Some(String::new()));
+        let theme = themes.load_theme("(none)", None);
+        terminal
+            .draw(|f| browser.draw(f, f.area(), &history, &Settings::utc(), theme, &bindings()))
+            .unwrap();
+        let rendered: String = terminal
+            .backend()
+            .buffer()
+            .content()
+            .iter()
+            .map(ratatui::buffer::Cell::symbol)
+            .collect();
+        for text in [heading, "1970-01-01", "42", "2s", "/tmp/example"] {
+            assert!(rendered.contains(text), "missing {text} in {rendered}");
+        }
+    }
+
+    #[rstest]
+    #[case("echo hello", 80, 24, 1)]
+    #[case("echo first\necho second", 80, 24, 2)]
+    #[case("a long command that wraps across lines", 12, 24, 2)]
+    #[case("echo first\necho second", 80, 5, 1)]
+    fn command_header_is_compact(
+        mut history: History,
+        #[case] command: &str,
+        #[case] width: u16,
+        #[case] height: u16,
+        #[case] rows: u16,
+    ) {
+        let mut terminal = Terminal::new(TestBackend::new(width, height)).unwrap();
+        let mut themes = ThemeManager::new(Some(true), Some(String::new()));
+        let theme = themes.load_theme("(none)", None);
+        terminal
+            .draw(|f| {
+                history.command = command.into();
+                let area = draw_views(f, f.area(), View::Runs, theme, &bindings());
+                let rest = draw_command(f, area, &history, &Settings::utc(), theme);
+                assert_eq!(rest.y, rows + 1);
+                assert_eq!(rest.height, height - rows - 1);
+            })
+            .unwrap();
+        let rendered: String = terminal
+            .backend()
+            .buffer()
+            .content()
+            .iter()
+            .map(ratatui::buffer::Cell::symbol)
+            .collect();
+        assert!(!rendered.contains('╭'));
+        assert!(rendered.contains("[r] Runs"));
+        assert_eq!(terminal.backend().buffer()[(0, 1)].symbol(), "c");
+        assert!(rendered.contains("cmd: "));
+    }
+
+    #[rstest]
+    #[case(true)]
+    #[case(false)]
+    fn command_text_is_safe_and_respects_highlighting(
+        mut history: History,
+        #[case] highlight: bool,
+    ) {
+        history.command = "echo héllo\0\ncat '\x1b[31m世界'".into();
+        let mut themes = ThemeManager::new(Some(true), Some(String::new()));
+        let theme = themes.load_theme("(none)", None);
+        let text = command_text(&history, highlight, theme);
+        assert_eq!(text.to_string(), "echo héllo^@\ncat '^[[31m世界'");
+        if highlight {
+            let meaning = syntax::classify("echo", None)[0];
+            assert_eq!(
+                text.lines[0].spans[0].style,
+                Style::from_crossterm(theme.as_style(meaning))
+            );
+        } else {
+            assert!(
+                text.lines
+                    .iter()
+                    .flat_map(|line| &line.spans)
+                    .all(|span| span.style == Styles::new(theme).command)
+            );
+        }
+    }
+
+    #[rstest]
+    fn output_back_preserves_list_position(history: History) {
+        let mut browser = Browser {
+            view: View::Session,
+            entries: vec![history],
+            ..Browser::default()
+        };
+        browser.table.select(Some(0));
+        *browser.table.offset_mut() = 7;
+        browser.select_view(View::Output);
+        browser.back_from_output();
+        assert_eq!(browser.view, View::Session);
+        assert_eq!(browser.table.selected(), Some(0));
+        assert_eq!(browser.table.offset(), 7);
+    }
+
+    #[rstest]
+    fn output_pages_and_edges() {
+        let mut browser = Browser {
+            output_page_size: 20,
+            output_max_scroll: 100,
+            ..Browser::default()
+        };
+        browser.scroll_output_page(true, false);
+        assert_eq!(browser.output_scroll, 19);
+        browser.scroll_output_page(false, false);
+        assert_eq!(browser.output_scroll, 0);
+        browser.scroll_output_page(true, true);
+        assert_eq!(browser.output_scroll, 10);
+        browser.scroll_output_edge(true);
+        assert_eq!(browser.output_scroll, 100);
+        browser.scroll_output_page(true, false);
+        assert_eq!(browser.output_scroll, 100);
+        browser.scroll_output_edge(false);
+        assert_eq!(browser.output_scroll, 0);
+    }
+
+    #[rstest]
+    #[case(20, 5)]
+    #[case(80, 24)]
+    #[case(120, 40)]
+    fn output_wraps_and_scrolls_to_the_end(
+        history: History,
+        #[case] width: u16,
+        #[case] height: u16,
+    ) {
+        use ratatui::style::Color;
+        let mut terminal = Terminal::new(TestBackend::new(width, height)).unwrap();
+        let mut themes = ThemeManager::new(Some(true), Some(String::new()));
+        let theme = themes.load_theme("(none)", None);
+        let mut browser = Browser {
+            view: View::Output,
+            output: Capture::from_text(
+                &format!(
+                    "\x1b[31;44;1m{}\x1b[0m\n\x1b[2J\x1b[H\x1b]52;c;AA==\x07THE END",
+                    "x".repeat(5000)
+                ),
+                "Output · capture truncated",
+            ),
+            ..Browser::default()
+        };
+        let settings = Settings::utc();
+        terminal
+            .draw(|f| browser.draw(f, f.area(), &history, &settings, theme, &bindings()))
+            .unwrap();
+        assert!(browser.output_max_scroll > 0);
+        let first_output = if height >= 10 {
+            (2, 3)
+        } else {
+            (0, 1)
+        };
+        let cell = &terminal.backend().buffer()[first_output];
+        assert_eq!(cell.symbol(), "x");
+        assert_eq!(cell.fg, Color::Red);
+        assert_eq!(cell.bg, Color::Blue);
+        assert!(cell.modifier.contains(Modifier::BOLD));
+        for cell in
+            [&terminal.backend().buffer()[(0, 0)], &terminal.backend().buffer()[(0, height - 1)]]
+        {
+            assert_ne!(cell.bg, Color::Blue);
+            assert_ne!(cell.fg, Color::Red);
+        }
+        if height >= 10 {
+            assert!(
+                browser.output_page_size >= usize::from(height - 5),
+                "output should get almost the whole viewport"
+            );
+        }
+        for _ in 0..6000 {
+            browser.scroll_output(true);
+        }
+        terminal
+            .draw(|f| browser.draw(f, f.area(), &history, &settings, theme, &bindings()))
+            .unwrap();
+        let rendered: String = terminal
+            .backend()
+            .buffer()
+            .content()
+            .iter()
+            .map(ratatui::buffer::Cell::symbol)
+            .collect();
+        assert!(rendered.contains("THE END"));
+        assert!(!rendered.contains('\x1b'));
+        let end = terminal.backend().buffer().content().iter().find(|c| c.symbol() == "T").unwrap();
+        assert_eq!(end.fg, Color::Reset);
+        assert_eq!(end.bg, Color::Reset);
+        assert!(end.modifier.is_empty());
+        assert!(
+            terminal
+                .backend()
+                .buffer()
+                .content()
+                .iter()
+                .any(|c| c.symbol() == "x" && c.fg == ratatui::style::Color::Red)
+        );
+        assert_eq!(browser.output_scroll, browser.output_max_scroll);
+        assert_eq!(
+            browser.list_position(),
+            (browser.output_max_scroll, browser.output_max_scroll + 1)
+        );
+        for _ in 0..6000 {
+            browser.scroll_output(false);
+        }
+        assert_eq!(browser.output_scroll, 0);
+        browser.back_from_output();
+        terminal
+            .draw(|f| browser.draw(f, f.area(), &history, &Settings::utc(), theme, &bindings()))
+            .unwrap();
+        assert!(terminal.backend().buffer().content().iter().all(|c| c.bg != Color::Blue));
+    }
+}

--- a/crates/atuin/src/command/client/search/inspector/browser.rs
+++ b/crates/atuin/src/command/client/search/inspector/browser.rs
@@ -39,6 +39,7 @@ pub struct Browser {
     scope: Option<(View, String)>,
     window_for: Option<HistoryId>,
     table: TableState,
+
     output: Capture,
     output_scroll: usize,
     output_max_scroll: usize,
@@ -78,6 +79,7 @@ impl Browser {
             self.output_page_size.saturating_sub(1)
         }
         .max(1);
+
         self.output_scroll = if next {
             self.output_scroll.saturating_add(amount).min(self.output_max_scroll)
         } else {
@@ -112,6 +114,7 @@ impl Browser {
                 self.output_scroll = 0;
                 self.output_max_scroll = 0;
             }
+
             return Ok((None, None));
         }
 
@@ -122,6 +125,7 @@ impl Browser {
         };
         let position = self.entries.iter().position(|entry| entry.id == selected.id);
         let at_edge = position.is_none_or(|i| i == 0 || i + 1 == self.entries.len());
+
         if self.scope.as_ref() != Some(&(self.view, scope.clone()))
             || (at_edge && self.window_for != Some(selected.id))
         {
@@ -131,6 +135,7 @@ impl Browser {
             self.window_for = Some(selected.id);
             self.table = TableState::default();
         }
+
         let position = self.entries.iter().position(|entry| entry.id == selected.id);
         self.table.select(position);
         Ok(position.map_or((None, None), |i| {
@@ -155,6 +160,7 @@ impl Browser {
             self.draw_output(f, chunk, selected, settings, theme, bindings);
             return;
         }
+
         let areas = Layout::vertical([
             Constraint::Min(3),
             Constraint::Length(if chunk.height >= 10 {
@@ -172,6 +178,7 @@ impl Browser {
         let session = self.view == View::Session;
         let narrow = area.width < 90;
         let tiny = area.width < 65;
+
         let rows = self.entries.iter().map(|entry| {
             let mut cells = vec![
                 Cell::from(if tiny {
@@ -203,6 +210,7 @@ impl Browser {
             }));
             Row::new(cells)
         });
+
         let mut widths = vec![
             Constraint::Length(if tiny {
                 8
@@ -223,6 +231,7 @@ impl Browser {
         } else {
             "Directory"
         });
+
         let title = if session {
             " Session "
         } else {
@@ -237,6 +246,7 @@ impl Browser {
             .style(styles.base)
             .row_highlight_style(styles.command.add_modifier(Modifier::REVERSED))
             .highlight_symbol("› ");
+
         f.render_stateful_widget(table, area, &mut self.table);
     }
 
@@ -261,6 +271,7 @@ impl Browser {
             Constraint::Length(1),
         ])
         .split(area);
+
         let mut command = command_text(selected, settings.ui.syntax_highlight, theme)
             .lines
             .into_iter()
@@ -280,18 +291,22 @@ impl Browser {
             ),
         ];
         f.render_widget(Paragraph::new(heading), areas[0]);
+
         let status = self.output.status().to_owned();
         let block = panel(format!(" {status} "), styles);
+
         // At very small heights, spend the remaining space on output instead of borders.
         let inner = if spacious {
             block.inner(areas[1])
         } else {
             areas[1]
         };
+
         let rows = self.output.rows(inner.width);
         self.output_page_size = usize::from(inner.height);
         self.output_max_scroll = rows.len().saturating_sub(self.output_page_size);
         self.output_scroll = self.output_scroll.min(self.output_max_scroll);
+
         if spacious {
             let progress = format!(
                 " {}–{} / {} rows ",
@@ -301,12 +316,14 @@ impl Browser {
             );
             f.render_widget(block.title_bottom(Line::from(progress).right_aligned()), areas[1]);
         }
+
         let text = if rows.is_empty() {
             vec![Line::styled(status, styles.muted)]
         } else {
             rows.iter().skip(self.output_scroll).take(self.output_page_size).cloned().collect()
         };
         f.render_widget(Paragraph::new(text).style(Style::reset()), inner);
+
         f.render_widget(
             Paragraph::new(guide(View::Output, areas[2].width, styles, bindings)),
             areas[2],
@@ -389,6 +406,7 @@ fn draw_details(
     if area.height == 0 {
         return;
     }
+
     let lines = vec![
         Line::from(vec![
             Span::styled("When  ", styles.label),
@@ -416,6 +434,7 @@ fn draw_details(
             Span::raw(selected.cwd.escape_non_printable()),
         ]),
     ];
+
     f.render_widget(
         Paragraph::new(lines)
             .style(styles.base)
@@ -443,6 +462,7 @@ pub fn draw_command(
     };
     let areas = Layout::vertical([Constraint::Length(height), Constraint::Min(0)]).split(area);
     let columns = Layout::horizontal([Constraint::Length(5), Constraint::Min(0)]).split(areas[0]);
+
     f.render_widget(Paragraph::new("cmd: ").style(Styles::new(theme).muted), columns[0]);
     f.render_widget(Paragraph::new(text).wrap(Wrap { trim: false }), columns[1]);
     areas[1]
@@ -462,6 +482,7 @@ fn command_text(history: &History, highlight: bool, theme: &Theme) -> Text<'stat
     } else {
         Vec::new()
     };
+
     let fallback = Styles::new(theme).command;
     let mut lines = vec![Line::default()];
     for (index, ch) in text.char_indices() {
@@ -469,6 +490,7 @@ fn command_text(history: &History, highlight: bool, theme: &Theme) -> Text<'stat
             lines.push(Line::default());
             continue;
         }
+
         let style = meanings
             .get(index)
             .map_or(fallback, |meaning| Style::from_crossterm(theme.as_style(*meaning)));
@@ -481,6 +503,7 @@ fn command_text(history: &History, highlight: bool, theme: &Theme) -> Text<'stat
             line.spans.push(Span::styled(ch.to_string(), style));
         }
     }
+
     Text::from(lines)
 }
 
@@ -493,6 +516,7 @@ fn guide(view: View, width: u16, styles: Styles, bindings: &Bindings) -> Line<'s
         Delete, Exit, InspectNext, InspectOutput, InspectPrevious, InspectRuns, InspectSession,
         InspectStats, ReturnSelection, ScrollPageDown, ScrollPageUp, ScrollToBottom, ScrollToTop,
     };
+
     let actions: &[(&[Action], &str)] = match view {
         View::Runs | View::Session => &[
             (&[InspectOutput], "output"),
@@ -513,6 +537,7 @@ fn guide(view: View, width: u16, styles: Styles, bindings: &Bindings) -> Line<'s
             &[(&[InspectRuns], "runs"), (&[InspectSession], "session"), (&[Exit], "search")]
         }
     };
+
     let mut spans = Vec::new();
     let mut used = 0;
     for (actions, action) in actions {
@@ -528,15 +553,18 @@ fn guide(view: View, width: u16, styles: Styles, bindings: &Bindings) -> Line<'s
             ", "
         };
         let needed = key.width() + label.width() + separator.len();
+
         // Avoid cutting a key or its action in half on narrow terminals.
         if used + needed > usize::from(width) {
             break;
         }
+
         spans.push(Span::styled(separator, styles.muted));
         spans.push(Span::styled(key, styles.key));
         spans.push(Span::styled(label, styles.muted));
         used += needed;
     }
+
     Line::from(spans)
 }
 

--- a/crates/atuin/src/command/client/search/inspector/output.rs
+++ b/crates/atuin/src/command/client/search/inspector/output.rs
@@ -1,0 +1,351 @@
+use atuin_client::history::HistoryId;
+use atuin_client::settings::Settings;
+use ratatui::text::{Line, Span, Text};
+use tokio::task::JoinHandle;
+
+type LoadedCapture = Result<(Output, String), &'static str>;
+const UNAVAILABLE: &str = "Output unavailable — could not read from the daemon";
+
+/// A cancellable background fetch. Completed captures are immutable and reusable;
+/// missing/unavailable captures are retried only when the reader is reopened.
+#[derive(Default)]
+pub(super) struct Capture {
+    id: Option<HistoryId>,
+    task: Option<JoinHandle<LoadedCapture>>,
+    ready: Option<LoadedCapture>,
+}
+
+impl Capture {
+    pub fn reopen(&mut self) {
+        if matches!(self.ready, Some(Err(_))) {
+            self.id = None;
+        }
+    }
+
+    pub async fn poll(&mut self, id: HistoryId, settings: &Settings) -> bool {
+        let changed = self.id != Some(id);
+        if changed {
+            if let Some(task) = self.task.take() {
+                task.abort();
+            }
+            self.id = Some(id);
+            self.ready = None;
+            let settings = settings.clone();
+            self.task = Some(tokio::spawn(async move { load_output(id, &settings).await }));
+        }
+        // Never await a pending request in the input loop: Esc must remain responsive.
+        if self.task.as_ref().is_some_and(JoinHandle::is_finished) {
+            self.ready = Some(self.task.take().unwrap().await.unwrap_or(Err(UNAVAILABLE)));
+        }
+        changed
+    }
+
+    pub fn status(&self) -> &str {
+        match &self.ready {
+            Some(Ok((_, status))) => status,
+            Some(Err(message)) => message,
+            None => "Loading output…",
+        }
+    }
+
+    pub fn rows(&mut self, width: u16) -> &[Line<'static>] {
+        match &mut self.ready {
+            Some(Ok((output, _))) => output.rows(width),
+            _ => &[],
+        }
+    }
+
+    #[cfg(test)]
+    pub fn from_text(text: &str, status: &str) -> Self {
+        Self {
+            ready: Some(Ok((Output::parse(text), status.into()))),
+            id: None,
+            task: None,
+        }
+    }
+}
+
+impl Drop for Capture {
+    fn drop(&mut self) {
+        if let Some(task) = &self.task {
+            task.abort();
+        }
+    }
+}
+
+#[cfg(feature = "daemon")]
+async fn load_output(id: HistoryId, settings: &Settings) -> LoadedCapture {
+    let result = tokio::time::timeout(std::time::Duration::from_secs(2), async {
+        let mut client = atuin_daemon::HistoryClient::from_settings(settings).await?;
+        client.get_command_output(id, vec![atuin_common::range::PyStyleIdxRange::new(0, -1)]).await
+    })
+    .await;
+    match result {
+        Ok(Ok(Some(output))) => {
+            let text = Output::parse(
+                &output
+                    .chunks
+                    .iter()
+                    .map(|chunk| chunk.content.as_str())
+                    .collect::<Vec<_>>()
+                    .join("\n"),
+            );
+            let status = if output.meta.as_ref().is_some_and(|meta| meta.output_truncated) {
+                "Output · capture truncated"
+            } else if text.is_empty() {
+                "Captured output is empty"
+            } else {
+                "Output"
+            };
+            Ok((text, status.into()))
+        }
+        Ok(Ok(None)) => Err("No output captured for this run"),
+        _ => Err(UNAVAILABLE),
+    }
+}
+
+#[cfg(not(feature = "daemon"))]
+async fn load_output(_id: HistoryId, _settings: &Settings) -> LoadedCapture {
+    Err("Output requires a build with daemon support")
+}
+
+/// Only parsed text and styles reach the renderer; never the original escape sequences.
+#[derive(Default)]
+pub(super) struct Output {
+    text: Text<'static>,
+    width: u16,
+    rows: Vec<Line<'static>>,
+}
+
+impl Output {
+    #[cfg(any(feature = "daemon", test))]
+    pub fn parse(capture: &str) -> Self {
+        use ansi_to_tui::IntoText as _;
+        use ratatui::style::Modifier;
+
+        let mut text = match capture.into_text() {
+            Ok(mut text) => {
+                // The converter consumes the final newline; preserve the trailing row.
+                if capture.ends_with('\n') {
+                    text.lines.push(Line::default());
+                }
+                text
+            }
+            Err(_) => Text::raw(plain_output(capture)),
+        };
+        // Captures should contain only SGR and newlines. Defensively remove any other
+        // controls left by the converter, and don't allow output to blink or conceal text.
+        for span in text.lines.iter_mut().flat_map(|line| &mut line.spans) {
+            span.content.to_mut().retain(|c| !c.is_control());
+            span.style = span
+                .style
+                .remove_modifier(Modifier::SLOW_BLINK | Modifier::RAPID_BLINK | Modifier::HIDDEN);
+        }
+        if text.lines.len() == 1 && text.lines[0].spans.iter().all(|s| s.content.is_empty()) {
+            text.lines.clear();
+        }
+        Self {
+            text,
+            ..Self::default()
+        }
+    }
+
+    #[cfg(feature = "daemon")]
+    pub fn is_empty(&self) -> bool {
+        self.text.lines.is_empty()
+    }
+
+    pub fn rows(&mut self, width: u16) -> &[Line<'static>] {
+        let width = width.max(1);
+        if self.width != width {
+            self.rows.clear();
+            for line in &self.text.lines {
+                // Reuse capture wrapping (including whitespace and wide characters),
+                // then split the already-parsed spans at those same byte boundaries.
+                let plain = line.to_string();
+                let mut spans = line
+                    .spans
+                    .iter()
+                    .filter(|s| !s.content.is_empty())
+                    .map(|s| (s.content.as_ref(), s.style));
+                let mut span = spans.next();
+                for row in vt100::capture::basic_formatted_rows(&plain, width) {
+                    let mut remaining = row.len();
+                    let mut wrapped = Line::default();
+                    while let Some((content, style)) = span
+                        && remaining > 0
+                    {
+                        let end = remaining.min(content.len());
+                        wrapped.spans.push(Span::styled(content[..end].to_owned(), style));
+                        remaining -= end;
+                        span = if end == content.len() {
+                            spans.next()
+                        } else {
+                            Some((&content[end..], style))
+                        };
+                    }
+                    self.rows.push(wrapped);
+                }
+            }
+            self.width = width;
+        }
+        &self.rows
+    }
+}
+
+#[cfg(any(feature = "daemon", test))]
+fn plain_output(output: &str) -> String {
+    vt100::capture::basic_formatted_to_plain(output)
+        .collect::<String>()
+        .chars()
+        .filter(|c| *c == '\n' || !c.is_control())
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use ratatui::style::{Color, Modifier};
+    use rstest::rstest;
+
+    use super::*;
+
+    #[rstest]
+    #[case(true)]
+    #[case(false)]
+    #[tokio::test]
+    async fn loading_is_nonblocking_and_only_failures_retry(#[case] success: bool) {
+        let id = HistoryId::new(atuin_common::utils::uuid_v7());
+        let (sender, receiver) = tokio::sync::oneshot::channel();
+        let mut capture = Capture {
+            id: Some(id),
+            task: Some(tokio::spawn(async move { receiver.await.unwrap() })),
+            ready: None,
+        };
+        let settings = Settings::utc();
+        assert!(
+            !tokio::time::timeout(
+                std::time::Duration::from_millis(100),
+                capture.poll(id, &settings)
+            )
+            .await
+            .unwrap()
+        );
+        assert_eq!(capture.status(), "Loading output…");
+        assert!(capture.rows(80).is_empty());
+        let result = if success {
+            Ok((Output::parse("\x1b[31mred"), "Output".into()))
+        } else {
+            Err(UNAVAILABLE)
+        };
+        assert!(sender.send(result).is_ok());
+        tokio::task::yield_now().await;
+        assert!(!capture.poll(id, &settings).await);
+        assert_eq!(
+            capture.status(),
+            if success {
+                "Output"
+            } else {
+                UNAVAILABLE
+            }
+        );
+        capture.reopen();
+        assert_eq!(capture.id, success.then_some(id));
+        if success {
+            assert!(!capture.poll(id, &settings).await);
+            assert!(capture.task.is_none(), "reopening must not fetch again");
+            assert_eq!(capture.rows(80)[0].spans[0].style.fg, Some(Color::Red));
+        }
+    }
+
+    #[rstest]
+    #[case(false)]
+    #[case(true)]
+    #[tokio::test]
+    async fn dropping_or_replacing_a_capture_cancels_the_request(#[case] replace: bool) {
+        let (sender, receiver) = tokio::sync::oneshot::channel::<()>();
+        let mut capture = Capture {
+            id: Some(HistoryId::new(atuin_common::utils::uuid_v7())),
+            task: Some(tokio::spawn(async move {
+                let _sender = sender;
+                std::future::pending::<LoadedCapture>().await
+            })),
+            ready: None,
+        };
+        tokio::task::yield_now().await;
+        if replace {
+            assert!(
+                capture
+                    .poll(HistoryId::new(atuin_common::utils::uuid_v7()), &Settings::utc())
+                    .await
+            );
+        }
+        drop(capture);
+        assert!(receiver.await.is_err());
+    }
+
+    #[rstest]
+    fn formatting_only() {
+        let mut output = Output::parse("\x1b[1;2;3;4;5;6;7;8;9mvisible");
+        let span = &output.rows(80)[0].spans[0];
+        assert_eq!(span.content, "visible");
+        assert_eq!(
+            span.style.add_modifier,
+            Modifier::BOLD
+                | Modifier::DIM
+                | Modifier::ITALIC
+                | Modifier::UNDERLINED
+                | Modifier::REVERSED
+                | Modifier::CROSSED_OUT
+        );
+    }
+
+    #[rstest]
+    #[case("before\x1b[2J\x1b[H\x1b[?1049h\x1b[?25lafter", "beforeafter")]
+    #[case("before\x1b]52;c;c2VjcmV0\x07after", "beforeafter")]
+    #[case("before\x1b]0;title\x07after", "beforeafter")]
+    #[case("one\x07\x00\x08\x7f\u{009b}two", "onetwo")]
+    #[case("before\x1b[", "before")]
+    #[case("before\x1b[38;2;", "before")]
+    fn non_formatting_controls_are_not_rendered(#[case] input: &str, #[case] expected: &str) {
+        let mut output = Output::parse(input);
+        let rows = output.rows(80);
+        assert_eq!(rows.iter().map(ToString::to_string).collect::<Vec<_>>().join("\n"), expected);
+        assert!(
+            rows.iter().flat_map(|l| &l.spans).all(|s| !s.content.chars().any(char::is_control))
+        );
+    }
+
+    #[rstest]
+    fn styles_survive_wrapping_newlines_and_resize() {
+        let mut output = Output::parse("\x1b[31mabcde\nfgh\x1b[0mi");
+        let rows = output.rows(3);
+        assert_eq!(rows.iter().map(ToString::to_string).collect::<Vec<_>>(), [
+            "abc", "de", "fgh", "i"
+        ]);
+        for row in &rows[..3] {
+            assert_eq!(row.spans[0].style.fg, Some(Color::Red));
+        }
+        assert_eq!(rows[3].spans[0].style.fg, Some(Color::Reset));
+        let rows = output.rows(80);
+        assert_eq!(rows.len(), 2);
+        assert_eq!(rows[1].spans[0].content, "fgh");
+        assert_eq!(rows[1].spans[0].style.fg, Some(Color::Red));
+        assert_eq!(rows[1].spans[1].content, "i");
+        assert_eq!(rows[1].spans[1].style.fg, Some(Color::Reset));
+    }
+
+    #[rstest]
+    fn styled_wrapping_preserves_text() {
+        use proptest::prelude::*;
+
+        proptest!(|(before in "[a-z 彩色é\u{301}\n]{0,80}", after in "[a-z 彩色é\u{301}\n]{0,80}", width in 1u16..80)| {
+            let capture = format!("\x1b[31m{before}\x1b[0m{after}");
+            let plain = format!("{before}{after}");
+            let mut output = Output::parse(&capture);
+            let expected: Vec<_> = if plain.is_empty() { Vec::new() } else {
+                vt100::capture::basic_formatted_rows(&plain, width).collect()
+            };
+            prop_assert_eq!(output.rows(width).iter().map(ToString::to_string).collect::<Vec<_>>(), expected);
+        });
+    }
+}

--- a/crates/atuin/src/command/client/search/inspector/output.rs
+++ b/crates/atuin/src/command/client/search/inspector/output.rs
@@ -28,15 +28,18 @@ impl Capture {
             if let Some(task) = self.task.take() {
                 task.abort();
             }
+
             self.id = Some(id);
             self.ready = None;
             let settings = settings.clone();
             self.task = Some(tokio::spawn(async move { load_output(id, &settings).await }));
         }
+
         // Never await a pending request in the input loop: Esc must remain responsive.
         if self.task.as_ref().is_some_and(JoinHandle::is_finished) {
             self.ready = Some(self.task.take().unwrap().await.unwrap_or(Err(UNAVAILABLE)));
         }
+
         changed
     }
 
@@ -80,6 +83,7 @@ async fn load_output(id: HistoryId, settings: &Settings) -> LoadedCapture {
         client.get_command_output(id, vec![atuin_common::range::PyStyleIdxRange::new(0, -1)]).await
     })
     .await;
+
     match result {
         Ok(Ok(Some(output))) => {
             let text = Output::parse(
@@ -90,6 +94,7 @@ async fn load_output(id: HistoryId, settings: &Settings) -> LoadedCapture {
                     .collect::<Vec<_>>()
                     .join("\n"),
             );
+
             let status = if output.meta.as_ref().is_some_and(|meta| meta.output_truncated) {
                 "Output · capture truncated"
             } else if text.is_empty() {
@@ -97,6 +102,7 @@ async fn load_output(id: HistoryId, settings: &Settings) -> LoadedCapture {
             } else {
                 "Output"
             };
+
             Ok((text, status.into()))
         }
         Ok(Ok(None)) => Err("No output captured for this run"),
@@ -133,6 +139,7 @@ impl Output {
             }
             Err(_) => Text::raw(plain_output(capture)),
         };
+
         // Captures should contain only SGR and newlines. Defensively remove any other
         // controls left by the converter, and don't allow output to blink or conceal text.
         for span in text.lines.iter_mut().flat_map(|line| &mut line.spans) {
@@ -141,9 +148,11 @@ impl Output {
                 .style
                 .remove_modifier(Modifier::SLOW_BLINK | Modifier::RAPID_BLINK | Modifier::HIDDEN);
         }
+
         if text.lines.len() == 1 && text.lines[0].spans.iter().all(|s| s.content.is_empty()) {
             text.lines.clear();
         }
+
         Self {
             text,
             ..Self::default()
@@ -169,9 +178,11 @@ impl Output {
                     .filter(|s| !s.content.is_empty())
                     .map(|s| (s.content.as_ref(), s.style));
                 let mut span = spans.next();
+
                 for row in vt100::capture::basic_formatted_rows(&plain, width) {
                     let mut remaining = row.len();
                     let mut wrapped = Line::default();
+
                     while let Some((content, style)) = span
                         && remaining > 0
                     {
@@ -184,11 +195,13 @@ impl Output {
                             Some((&content[end..], style))
                         };
                     }
+
                     self.rows.push(wrapped);
                 }
             }
             self.width = width;
         }
+
         &self.rows
     }
 }

--- a/crates/atuin/src/command/client/search/interactive.rs
+++ b/crates/atuin/src/command/client/search/interactive.rs
@@ -75,7 +75,7 @@ pub struct InspectingState {
 impl InspectingState {
     pub fn move_to_previous(&mut self) {
         if self.browser.view == InspectorView::Output {
-            self.browser.scroll_output(false);
+            self.browser.scroll_output(false, 1);
         } else if let Some(previous) = self.previous {
             self.current = Some(previous);
         }
@@ -83,7 +83,7 @@ impl InspectingState {
 
     pub fn move_to_next(&mut self) {
         if self.browser.view == InspectorView::Output {
-            self.browser.scroll_output(true);
+            self.browser.scroll_output(true, 1);
         } else if let Some(next) = self.next {
             self.current = Some(next);
         }

--- a/crates/atuin/src/command/client/search/interactive.rs
+++ b/crates/atuin/src/command/client/search/interactive.rs
@@ -38,6 +38,8 @@ use windows_sys::Win32::System::Console::{GetConsoleOutputCP, SetConsoleOutputCP
 use super::cursor::Cursor;
 use super::engines::{AnySearchEngine, SearchEngine, SearchState};
 use super::history_list::{HistoryList, ListState};
+use super::inspector::bindings::Bindings;
+use super::inspector::browser::{Browser, View as InspectorView};
 use crate::VERSION;
 use crate::command::client::search::engines;
 use crate::command::client::search::history_list::HistoryHighlighter;
@@ -51,6 +53,7 @@ pub enum InputAction {
     AcceptInspecting,
     Copy(usize),
     Delete(usize),
+    DeleteInspecting,
     DeleteAllMatching(usize),
     ReturnOriginal,
     ReturnQuery,
@@ -59,30 +62,33 @@ pub enum InputAction {
     SwitchContext(Option<usize>),
 }
 
-#[derive(Clone)]
+#[derive(Default)]
 pub struct InspectingState {
     current: Option<HistoryId>,
     next: Option<HistoryId>,
     previous: Option<HistoryId>,
+    browser: Browser,
 }
 
 impl InspectingState {
     pub fn move_to_previous(&mut self) {
-        let previous = self.previous;
-        self.reset();
-        self.current = previous;
+        if self.browser.view == InspectorView::Output {
+            self.browser.scroll_output(false);
+        } else if let Some(previous) = self.previous {
+            self.current = Some(previous);
+        }
     }
 
     pub fn move_to_next(&mut self) {
-        let next = self.next;
-        self.reset();
-        self.current = next;
+        if self.browser.view == InspectorView::Output {
+            self.browser.scroll_output(true);
+        } else if let Some(next) = self.next {
+            self.current = Some(next);
+        }
     }
 
     pub fn reset(&mut self) {
-        self.current = None;
-        self.next = None;
-        self.previous = None;
+        *self = Self::default();
     }
 }
 
@@ -209,11 +215,11 @@ impl State {
             Err(error) => return Err(error),
         };
 
-        self.inspecting_state = InspectingState {
-            current: None,
-            next: None,
-            previous: None,
-        };
+        // Search results are deduplicated; the inspected occurrence need not be among them.
+        // Context/filter changes while inspecting must not discard that independent selection.
+        if self.tab_index == 0 {
+            self.inspecting_state.reset();
+        }
         self.results_state.select(0);
         self.results_len = results.len();
 
@@ -228,28 +234,26 @@ impl State {
     fn handle_input(&mut self, settings: &Settings, input: &Event) -> InputAction {
         match input {
             Event::Key(k) => self.handle_key_input(settings, k),
-            Event::Mouse(m) => self.handle_mouse_input(*m, settings.invert),
+            Event::Mouse(m) => self.handle_mouse_input(*m, settings),
             Event::Paste(d) => self.handle_paste_input(d),
             _ => InputAction::Continue,
         }
     }
 
-    fn handle_mouse_input(&mut self, input: MouseEvent, inverted: bool) -> InputAction {
-        match (input.kind, inverted) {
-            (event::MouseEventKind::ScrollDown, false)
-            | (event::MouseEventKind::ScrollUp, true) => {
-                self.scroll_down(1);
-            }
-            (event::MouseEventKind::ScrollDown, true)
-            | (event::MouseEventKind::ScrollUp, false) => {
-                self.scroll_up(1);
-            }
-            _ => {}
-        }
-        InputAction::Continue
+    fn handle_mouse_input(&mut self, input: MouseEvent, settings: &Settings) -> InputAction {
+        use super::keybindings::Action;
+        let action = match input.kind {
+            event::MouseEventKind::ScrollDown => Action::SelectNext,
+            event::MouseEventKind::ScrollUp => Action::SelectPrevious,
+            _ => return InputAction::Continue,
+        };
+        self.execute_action(&action, settings)
     }
 
     fn handle_paste_input(&mut self, input: &str) -> InputAction {
+        if self.tab_index == 1 {
+            return InputAction::Continue;
+        }
         for i in input.chars() {
             self.search.input.insert(i);
         }
@@ -333,10 +337,31 @@ impl State {
             )
     }
 
+    fn eval_context(&self) -> super::keybindings::EvalContext {
+        let (selected_index, results_len) = if self.tab_index == 1 {
+            if self.inspecting_state.current.is_some() {
+                self.inspecting_state.browser.list_position()
+            } else {
+                (0, 0)
+            }
+        } else {
+            (self.results_state.selected(), self.results_len)
+        };
+        super::keybindings::EvalContext {
+            cursor_position: self.search.input.position(),
+            input_width: UnicodeWidthStr::width(self.search.input.as_str()),
+            input_byte_len: self.search.input.as_str().len(),
+            selected_index,
+            results_len,
+            original_input_empty: self.original_input_empty,
+            has_context: self.search.custom_context.is_some(),
+        }
+    }
+
     #[must_use]
     fn handle_key_input(&mut self, settings: &Settings, input: &KeyEvent) -> InputAction {
+        use super::keybindings::Action;
         use super::keybindings::key::{KeyCodeValue, KeyInput, SingleKey};
-        use super::keybindings::{Action, EvalContext};
 
         // Skip release events
         if input.kind == event::KeyEventKind::Release {
@@ -346,16 +371,7 @@ impl State {
         // Reset switched_search_mode at start of each key event
         self.switched_search_mode = false;
 
-        // Build evaluation context from current state
-        let ctx = EvalContext {
-            cursor_position: self.search.input.position(),
-            input_width: UnicodeWidthStr::width(self.search.input.as_str()),
-            input_byte_len: self.search.input.as_str().len(),
-            selected_index: self.results_state.selected(),
-            results_len: self.results_len,
-            original_input_empty: self.original_input_empty,
-            has_context: self.search.custom_context.is_some(),
-        };
+        let ctx = self.eval_context();
 
         // Convert KeyEvent to SingleKey
         let Some(single) = SingleKey::from_event(input) else {
@@ -466,6 +482,59 @@ impl State {
         settings: &Settings,
     ) -> InputAction {
         use crate::command::client::search::keybindings::Action;
+
+        if self.tab_index == 1 {
+            match action {
+                Action::Exit => {
+                    if self.inspecting_state.browser.view == InspectorView::Output {
+                        self.inspecting_state.browser.back_from_output();
+                    } else {
+                        self.tab_index = 0;
+                    }
+                    return InputAction::Redraw;
+                }
+                Action::SelectPrevious | Action::SelectNext => {
+                    if *action == Action::SelectNext {
+                        self.inspecting_state.move_to_next();
+                    } else {
+                        self.inspecting_state.move_to_previous();
+                    }
+                    return InputAction::Redraw;
+                }
+                Action::ScrollPageUp
+                | Action::ScrollPageDown
+                | Action::ScrollHalfPageUp
+                | Action::ScrollHalfPageDown => {
+                    let next =
+                        matches!(action, Action::ScrollPageDown | Action::ScrollHalfPageDown);
+                    let half =
+                        matches!(action, Action::ScrollHalfPageUp | Action::ScrollHalfPageDown);
+                    if self.inspecting_state.browser.view == InspectorView::Output {
+                        self.inspecting_state.browser.scroll_output_page(next, half);
+                    } else if next {
+                        self.inspecting_state.move_to_next();
+                    } else {
+                        self.inspecting_state.move_to_previous();
+                    }
+                    return InputAction::Redraw;
+                }
+                Action::ScrollToScreenTop
+                | Action::ScrollToScreenMiddle
+                | Action::ScrollToScreenBottom => {
+                    // Screen-position jumps are search-only; don't move the hidden search list.
+                    return InputAction::Continue;
+                }
+                Action::ScrollToTop | Action::ScrollToBottom => {
+                    if self.inspecting_state.browser.view == InspectorView::Output {
+                        self.inspecting_state
+                            .browser
+                            .scroll_output_edge(matches!(action, Action::ScrollToBottom));
+                    }
+                    return InputAction::Redraw;
+                }
+                _ => {}
+            }
+        }
 
         match action {
             // -- Cursor movement --
@@ -652,10 +721,10 @@ impl State {
 
             // -- Commands --
             Action::Accept => {
+                self.accept = true;
                 if self.tab_index == 1 {
                     return InputAction::AcceptInspecting;
                 }
-                self.accept = true;
                 InputAction::Accept(self.results_state.selected())
             }
             Action::AcceptNth(n) => {
@@ -672,6 +741,7 @@ impl State {
                 InputAction::Accept(self.results_state.selected() + usize::conv(*n))
             }
             Action::Copy => InputAction::Copy(self.results_state.selected()),
+            Action::Delete if self.tab_index == 1 => InputAction::DeleteInspecting,
             Action::Delete => InputAction::Delete(self.results_state.selected()),
             Action::DeleteAll => InputAction::DeleteAllMatching(self.results_state.selected()),
             Action::ReturnOriginal => InputAction::ReturnOriginal,
@@ -694,7 +764,7 @@ impl State {
             Action::ClearContext => InputAction::SwitchContext(None),
             Action::ToggleTab => {
                 self.tab_index = (self.tab_index + 1) % TAB_TITLES.len();
-                InputAction::Continue
+                InputAction::Redraw
             }
 
             // -- Mode changes --
@@ -750,6 +820,19 @@ impl State {
             }
             Action::InspectNext => {
                 self.inspecting_state.move_to_next();
+                InputAction::Redraw
+            }
+            Action::InspectRuns
+            | Action::InspectSession
+            | Action::InspectStats
+            | Action::InspectOutput => {
+                let view = match action {
+                    Action::InspectSession => InspectorView::Session,
+                    Action::InspectStats => InspectorView::Stats,
+                    Action::InspectOutput => InspectorView::Output,
+                    _ => InspectorView::Runs,
+                };
+                self.inspecting_state.browser.select_view(view);
                 InputAction::Redraw
             }
 
@@ -834,7 +917,7 @@ impl State {
         &mut self,
         f: &mut Frame,
         results: &[History],
-        stats: Option<HistoryStats>,
+        stats: Option<&HistoryStats>,
         inspecting: Option<&History>,
         settings: &Settings,
         theme: &Theme,
@@ -855,11 +938,25 @@ impl State {
         f: &mut Frame,
         area: Rect,
         results: &[History],
-        stats: Option<HistoryStats>,
+        stats: Option<&HistoryStats>,
         inspecting: Option<&History>,
         settings: &Settings,
         theme: &Theme,
     ) {
+        let bindings = if self.tab_index == 1 {
+            Bindings::new(&self.keymaps.inspector, &self.eval_context())
+        } else {
+            Bindings::default()
+        };
+        // Output is a focused reader, not another panel beneath the search chrome.
+        if self.tab_index == 1
+            && self.inspecting_state.browser.view == InspectorView::Output
+            && let Some(selected) =
+                inspecting.or_else(|| results.get(self.results_state.selected()))
+        {
+            self.inspecting_state.browser.draw(f, area, selected, settings, theme, &bindings);
+            return;
+        }
         let compactness = to_compactness(f, settings);
         let invert = settings.invert;
         let border_size = match compactness {
@@ -1051,7 +1148,7 @@ impl State {
             }
 
             1 => {
-                if results.is_empty() {
+                if results.is_empty() && inspecting.is_none() {
                     let message = Paragraph::new("Nothing to inspect")
                         .block(
                             Block::new()
@@ -1067,23 +1164,33 @@ impl State {
                         Some(inspecting) => inspecting,
                         None => &results[self.results_state.selected()],
                     };
-                    super::inspector::draw(
+                    let browser = &mut self.inspecting_state.browser;
+                    let chunk = super::inspector::browser::draw_views(
                         f,
                         results_list_chunk,
-                        inspecting,
-                        &stats.expect("Drawing inspector, but no stats"),
-                        settings,
+                        browser.view,
                         theme,
-                        settings.timezone,
+                        &bindings,
                     );
+                    let chunk = super::inspector::browser::draw_command(
+                        f, chunk, inspecting, settings, theme,
+                    );
+                    if browser.view == InspectorView::Stats {
+                        if let Some(stats) = stats {
+                            super::inspector::draw(f, chunk, stats, theme);
+                        }
+                    } else {
+                        browser.draw(f, chunk, inspecting, settings, theme, &bindings);
+                    }
                 }
 
-                // HACK: I'm following up with abstracting this into the UI container, with a
-                // sub-widget for search + for inspector
-                let feedback = Paragraph::new(
-                    "The inspector is new - please give feedback (good, or bad) at https://forum.atuin.sh",
+                let guide = super::inspector::browser::input_guide(
+                    self.inspecting_state.browser.view,
+                    input_chunk.width,
+                    theme,
+                    &bindings,
                 );
-                f.render_widget(feedback, input_chunk);
+                f.render_widget(Paragraph::new(guide), input_chunk);
 
                 return;
             }
@@ -1194,16 +1301,8 @@ impl State {
                 Span::raw(": inspect"),
             ]))),
 
-            1 => Paragraph::new(Text::from(Line::from(vec![
-                Span::styled("<esc>", Style::default().add_modifier(Modifier::BOLD)),
-                Span::raw(": exit"),
-                Span::raw(", "),
-                Span::styled("<ctrl-o>", Style::default().add_modifier(Modifier::BOLD)),
-                Span::raw(": search"),
-                Span::raw(", "),
-                Span::styled("<ctrl-d>", Style::default().add_modifier(Modifier::BOLD)),
-                Span::raw(": delete"),
-            ]))),
+            // The inspector has its own contextual guide at the bottom.
+            1 => Paragraph::default(),
 
             _ => unreachable!("invalid tab index"),
         }
@@ -1852,11 +1951,7 @@ pub async fn history(
         update_needed: None,
         switched_search_mode: false,
         tab_index: 0,
-        inspecting_state: InspectingState {
-            current: None,
-            next: None,
-            previous: None,
-        },
+        inspecting_state: InspectingState::default(),
         keymaps: KeymapSet::from_settings(settings),
         search: SearchState {
             input,
@@ -1901,14 +1996,13 @@ pub async fn history(
     let mut results = app.query_results(&mut db, settings).await?;
 
     let mut stats: Option<HistoryStats> = None;
-    // The id of the history entry `stats` was computed for, so the render loop
-    // only hits the database when the inspected entry actually changes.
-    let mut stats_for: Option<HistoryId> = None;
+    // Aggregates depend on the command, not the selected occurrence.
+    let mut stats_for: Option<String> = None;
     let mut inspecting: Option<History> = None;
     let accept;
     let result = 'render: loop {
         terminal.draw(|f| {
-            app.draw(f, &results, stats.clone(), inspecting.as_ref(), settings, theme, popup_mode);
+            app.draw(f, &results, stats.as_ref(), inspecting.as_ref(), settings, theme, popup_mode);
         })?;
 
         let initial_input = app.search.input.as_str().to_owned();
@@ -1924,6 +2018,18 @@ pub async fn history(
                     loop {
                         match app.handle_input(settings, &event::read()?) {
                             InputAction::Continue => {},
+                            InputAction::DeleteInspecting => {
+                                if let Some(id) = app.inspecting_state.current {
+                                    if let Some(entry) = db.load(id).await? {
+                                        crate::command::client::history::delete_history_entries(
+                                            settings, history_store, &db, [entry],
+                                        ).await?;
+                                    }
+                                    app.tab_index = 0;
+                                    results = app.query_results(&mut db, settings).await?;
+                                    break;
+                                }
+                            },
                             InputAction::Delete(index) => {
                                 if results.is_empty() {
                                     break;
@@ -1952,7 +2058,12 @@ pub async fn history(
                                     break;
                                 }
 
-                                let command = results[index].command.clone();
+                                let command = if app.tab_index == 1 {
+                                    let Some(entry) = inspecting.as_ref() else { break; };
+                                    entry.command.clone()
+                                } else {
+                                    results[index].command.clone()
+                                };
 
                                 // Remove matching entries from the visible results
                                 results.retain(|e| e.command != command);
@@ -1980,7 +2091,10 @@ pub async fn history(
                                 app.tab_index = 0;
                             },
                             InputAction::SwitchContext(index) => {
-                                if let Some(index) = index && let Some(entry) = results.get(index) {
+                                let entry = index.and_then(|index| {
+                                    if app.tab_index == 1 { inspecting.as_ref() } else { results.get(index) }
+                                });
+                                if let Some(entry) = entry {
                                     app.search.custom_context = Some(entry.id);
                                     app.search.context = Context::from_history(entry);
                                     app.search.filter_mode = FilterMode::Session;
@@ -1991,14 +2105,16 @@ pub async fn history(
                                     app.search.context = initial_context.clone();
                                     app.search.filter_mode = default_filter_mode;
                                 }
+                                // Apply the context before consuming a queued accept/navigation key.
+                                break;
                             },
                             InputAction::Redraw => {
-                                if !popup_mode {
+                                // Inspector navigation uses ratatui's diff; clearing on every scroll flickers.
+                                if !popup_mode && app.tab_index != 1 {
                                     terminal.clear()?;
                                 }
-                                terminal.draw(|f| {
-                                    app.draw(f, &results, stats.clone(), inspecting.as_ref(), settings, theme, popup_mode);
-                                })?;
+                                // Refresh the selected occurrence before drawing or accepting another key.
+                                break;
                             },
                             r => {
                                 accept = app.accept;
@@ -2041,11 +2157,11 @@ pub async fn history(
             app.results_state.select(pos);
         }
 
-        let inspecting_id = app.inspecting_state.clone().current;
+        let inspecting_id = app.inspecting_state.current;
         // If inspecting ID is not the current inspecting History, update it.
         match inspecting_id {
             Some(inspecting_id) => {
-                if inspecting.is_none() || inspecting_id != inspecting.clone().unwrap().id {
+                if inspecting.as_ref().is_none_or(|entry| inspecting_id != entry.id) {
                     inspecting = db.load(inspecting_id).await?;
                 }
             }
@@ -2054,33 +2170,28 @@ pub async fn history(
             }
         }
 
+        if app.tab_index == 1 && inspecting.is_none() {
+            inspecting = results.get(app.results_state.selected()).cloned();
+        }
         stats = if app.tab_index == 0 {
             stats_for = None;
             None
-        } else if !results.is_empty() {
-            // If we have stats, then we can indicate next available IDs. This avoids passing
-            // around a database object, or a full stats object.
-            let selected = match inspecting.clone() {
-                Some(insp) => insp,
-                None => results[app.results_state.selected()].clone(),
-            };
-            if stats_for.as_ref() == Some(&selected.id) {
-                // Already computed for this entry - the render loop iterates on every
-                // input event and poll timeout, and stats() is several queries.
-                stats
+        } else if let Some(selected) = inspecting.as_ref() {
+            app.inspecting_state.current = Some(selected.id);
+            if app.inspecting_state.browser.view == InspectorView::Stats {
+                app.inspecting_state.previous = None;
+                app.inspecting_state.next = None;
+                if stats_for.as_deref() == Some(selected.command.as_str()) {
+                    stats
+                } else {
+                    stats_for = Some(selected.command.clone());
+                    Some(db.stats(selected).await?)
+                }
             } else {
-                let stats = db.stats(&selected).await?;
-                stats_for = Some(selected.id);
-                app.inspecting_state.current = Some(selected.id);
-                app.inspecting_state.previous = match stats.previous.clone() {
-                    Some(p) => Some(p.id),
-                    _ => None,
-                };
-                app.inspecting_state.next = match stats.next.clone() {
-                    Some(p) => Some(p.id),
-                    _ => None,
-                };
-                Some(stats)
+                (app.inspecting_state.previous, app.inspecting_state.next) =
+                    app.inspecting_state.browser.refresh(&db, selected, settings).await?;
+                stats_for = None;
+                None
             }
         } else {
             stats_for = None;
@@ -2143,7 +2254,11 @@ pub async fn history(
         }
         InputAction::ReturnOriginal => Ok(String::new()),
         InputAction::Copy(index) => {
-            let cmd = results.swap_remove(index).command;
+            let cmd = if app.tab_index == 1 {
+                inspecting.map(|entry| entry.command).unwrap_or_default()
+            } else {
+                results.swap_remove(index).command
+            };
             if let Err(e) = set_clipboard(cmd) {
                 tracing::warn!(?e, "failed to copy to clipboard");
             }
@@ -2158,6 +2273,7 @@ pub async fn history(
         InputAction::Continue
         | InputAction::Redraw
         | InputAction::Delete(_)
+        | InputAction::DeleteInspecting
         | InputAction::DeleteAllMatching(_)
         | InputAction::SwitchContext(_) => {
             unreachable!("should have been handled!")
@@ -2198,7 +2314,9 @@ mod tests {
     use rstest::{fixture, rstest};
     use time::OffsetDateTime;
 
-    use super::{Compactness, InputAction, InspectingState, KeymapSet, SearchModeState, State};
+    use super::{
+        Compactness, InputAction, InspectingState, InspectorView, KeymapSet, SearchModeState, State,
+    };
     use crate::command::client::search::engines::{self, SearchState};
     use crate::command::client::search::history_list::ListState;
     use crate::command::client::search::keybindings::Action;
@@ -2235,11 +2353,7 @@ mod tests {
             tab_index: 0,
             pending_vim_key: None,
             original_input_empty: false,
-            inspecting_state: InspectingState {
-                current: None,
-                next: None,
-                previous: None,
-            },
+            inspecting_state: InspectingState::default(),
             keymaps: KeymapSet::defaults(&Settings::utc()),
             search: SearchState {
                 input: input.to_string().into(),
@@ -2767,6 +2881,230 @@ mod tests {
         state.tab_index = 1;
         let result = state.execute_action(&Action::Accept, &settings);
         assert!(matches!(result, super::InputAction::AcceptInspecting));
+        assert!(state.accept);
+    }
+
+    #[rstest]
+    fn inspector_enter_opens_output_and_escape_goes_back(
+        #[with(KeymapMode::Emacs, 100, 5)] mut state: State,
+        mut settings: Settings,
+    ) {
+        use ratatui::crossterm::event;
+
+        use crate::command::client::search::keybindings::Action;
+        settings.enter_accept = true;
+        state.keymaps = KeymapSet::from_settings(&settings);
+        state.tab_index = 1;
+        state.inspecting_state.browser.select_view(super::InspectorView::Session);
+        let event = event::Event::Key(event::KeyEvent::new(
+            event::KeyCode::Enter,
+            event::KeyModifiers::NONE,
+        ));
+        assert!(matches!(state.handle_input(&settings, &event), InputAction::Redraw));
+        assert_eq!(state.inspecting_state.browser.view, super::InspectorView::Output);
+        assert!(!state.accept, "Enter in inspector must not execute the command");
+        let _ = state.execute_action(&Action::ScrollPageDown, &settings);
+        assert_eq!(state.results_state.selected(), 5);
+        let _ = state.execute_action(&Action::Exit, &settings);
+        assert_eq!(state.inspecting_state.browser.view, super::InspectorView::Session);
+        assert_eq!(state.tab_index, 1);
+        let _ = state.execute_action(&Action::Exit, &settings);
+        assert_eq!(state.tab_index, 0);
+    }
+
+    #[fixture]
+    async fn inspector_corpus(
+        #[default(3usize)] count: usize,
+        #[default(false)] tied: bool,
+    ) -> (atuin_client::database::Sqlite, Vec<History>) {
+        let db = atuin_client::database::Sqlite::in_memory(std::time::Duration::from_secs(2))
+            .await
+            .unwrap();
+        let mut entries = Vec::new();
+        for i in 0..count {
+            let mut entry: History = History::capture()
+                .timestamp(
+                    OffsetDateTime::UNIX_EPOCH
+                        + time::Duration::seconds(if tied {
+                            0
+                        } else {
+                            i64::try_from(i).unwrap()
+                        }),
+                )
+                .command("echo FIRST")
+                .cwd("/tmp")
+                .build()
+                .into();
+            entry.session = "inspector-test".into();
+            entry.cwd = format!("/tmp/{i}");
+            db.save(&entry).await.unwrap();
+            entries.push(entry);
+        }
+        entries.sort_by_key(|entry| (entry.timestamp, entry.id.to_string()));
+        (db, entries)
+    }
+
+    async fn refresh_inspector(
+        state: &mut State,
+        db: &atuin_client::database::Sqlite,
+        settings: &Settings,
+    ) {
+        if matches!(
+            state.inspecting_state.browser.view,
+            InspectorView::Output | InspectorView::Stats
+        ) {
+            state.inspecting_state.previous = None;
+            state.inspecting_state.next = None;
+            return;
+        }
+        let selected = db.load(state.inspecting_state.current.unwrap()).await.unwrap().unwrap();
+        (state.inspecting_state.previous, state.inspecting_state.next) =
+            state.inspecting_state.browser.refresh(db, &selected, settings).await.unwrap();
+    }
+
+    #[rstest]
+    #[tokio::test]
+    async fn context_refresh_preserves_an_occurrence_missing_from_search(
+        mut state: State,
+        settings: Settings,
+        #[future] inspector_corpus: (atuin_client::database::Sqlite, Vec<History>),
+    ) {
+        let (mut db, entries) = inspector_corpus.await;
+        let mut third = entries[2].clone();
+        third.id = atuin_client::history::HistoryId::new(atuin_common::utils::uuid_v7());
+        third.command = "echo THIRD".into();
+        third.timestamp += time::Duration::seconds(1);
+        db.save(&third).await.unwrap();
+        state.tab_index = 1;
+        state.inspecting_state.current = Some(entries[0].id);
+        state.inspecting_state.browser.select_view(super::InspectorView::Session);
+        state.search.custom_context = Some(entries[0].id);
+        state.search.context = Context::from_history(&entries[0]);
+        state.search.filter_mode = FilterMode::Session;
+        let results = state.query_results(&mut db, &settings).await.unwrap();
+        assert!(
+            !results.iter().any(|entry| entry.id == entries[0].id),
+            "older occurrence should be deduplicated"
+        );
+        refresh_inspector(&mut state, &db, &settings).await;
+        assert_eq!(state.inspecting_state.current, Some(entries[0].id));
+        assert_eq!(state.inspecting_state.browser.view, super::InspectorView::Session);
+        assert!(matches!(
+            state.execute_action(&Action::ReturnSelection, &settings),
+            InputAction::AcceptInspecting
+        ));
+        // Even a filter with no search results must not replace the inspected occurrence.
+        state.search.input = "not in this history".to_owned().into();
+        assert!(state.query_results(&mut db, &settings).await.unwrap().is_empty());
+        assert_eq!(state.inspecting_state.current, Some(entries[0].id));
+        // Ordinary searches still reset the inspector.
+        state.tab_index = 0;
+        state.query_results(&mut db, &settings).await.unwrap();
+        assert!(state.inspecting_state.current.is_none());
+    }
+
+    #[rstest]
+    #[case(InspectorView::Runs)]
+    #[case(InspectorView::Session)]
+    #[tokio::test]
+    async fn conditional_navigation_crosses_windows_in_both_directions(
+        #[with(KeymapMode::Emacs, 1, 0)] mut state: State,
+        settings: Settings,
+        #[case] view: super::InspectorView,
+        #[with(250, true)]
+        #[future]
+        inspector_corpus: (atuin_client::database::Sqlite, Vec<History>),
+    ) {
+        use ratatui::crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+
+        use crate::command::client::search::keybindings::{ConditionExpr, KeyInput, KeyRule};
+        let (db, entries) = inspector_corpus.await;
+        state.tab_index = 1;
+        state.inspecting_state.browser.select_view(view);
+        state.inspecting_state.current = Some(entries.last().unwrap().id);
+        for (key, condition, action) in [
+            ("down", "has-results && !list-at-end", Action::SelectNext),
+            ("up", "!list-at-start", Action::SelectPrevious),
+        ] {
+            state.keymaps.inspector.bind_conditional(KeyInput::parse(key).unwrap(), vec![
+                KeyRule::when(ConditionExpr::parse(condition).unwrap(), action),
+            ]);
+        }
+        refresh_inspector(&mut state, &db, &settings).await;
+        for (key, indices) in [
+            (KeyCode::Down, (0..entries.len()).rev().collect::<Vec<_>>()),
+            (KeyCode::Up, (0..entries.len()).collect()),
+        ] {
+            for index in indices {
+                assert_eq!(state.inspecting_state.current, Some(entries[index].id));
+                let _ = state.handle_key_input(&settings, &KeyEvent::new(key, KeyModifiers::NONE));
+                refresh_inspector(&mut state, &db, &settings).await;
+            }
+        }
+        assert_eq!(state.inspecting_state.current, Some(entries.last().unwrap().id));
+        assert_eq!(state.results_state.selected(), 0);
+        assert_eq!(state.inspecting_state.browser.view, view);
+    }
+
+    #[rstest]
+    #[case(InspectorView::Runs)]
+    #[case(InspectorView::Session)]
+    #[case(InspectorView::Output)]
+    #[case(InspectorView::Stats)]
+    #[tokio::test]
+    async fn mouse_navigation_stays_in_the_inspector(
+        #[with(KeymapMode::Emacs, 100, 5)] mut state: State,
+        mut settings: Settings,
+        #[case] view: super::InspectorView,
+        #[values(false, true)] invert: bool,
+        #[future] inspector_corpus: (atuin_client::database::Sqlite, Vec<History>),
+    ) {
+        use ratatui::crossterm::event::{Event, KeyModifiers, MouseEvent, MouseEventKind};
+        let (db, entries) = inspector_corpus.await;
+        settings.invert = invert;
+        state.tab_index = 1;
+        state.inspecting_state.current = Some(entries[1].id);
+        state.inspecting_state.browser.select_view(view);
+        refresh_inspector(&mut state, &db, &settings).await;
+        for (kind, expected) in
+            [(MouseEventKind::ScrollDown, entries[0].id), (MouseEventKind::ScrollUp, entries[1].id)]
+        {
+            let event = Event::Mouse(MouseEvent {
+                kind,
+                column: 5,
+                row: 10,
+                modifiers: KeyModifiers::NONE,
+            });
+            assert!(matches!(state.handle_input(&settings, &event), InputAction::Redraw));
+            refresh_inspector(&mut state, &db, &settings).await;
+            let expected = if matches!(view, InspectorView::Output | InspectorView::Stats) {
+                entries[1].id
+            } else {
+                expected
+            };
+            assert_eq!(state.inspecting_state.current, Some(expected));
+            assert_eq!(state.results_state.selected(), 5);
+            assert_eq!(state.inspecting_state.browser.view, view);
+        }
+        let _ = state.execute_action(&Action::ScrollToScreenTop, &settings);
+        assert_eq!(state.inspecting_state.current, Some(entries[1].id));
+        assert_eq!(state.results_state.selected(), 5);
+        let input = state.search.input.as_str().to_owned();
+        let _ = state.handle_input(&settings, &Event::Paste("unwanted query".into()));
+        assert_eq!(state.search.input.as_str(), input);
+    }
+
+    #[rstest]
+    fn inspector_delete_targets_the_inspected_occurrence(
+        #[with(KeymapMode::Emacs, 100, 5)] mut state: State,
+        settings: Settings,
+    ) {
+        use crate::command::client::search::keybindings::Action;
+        state.tab_index = 1;
+        assert!(matches!(
+            state.execute_action(&Action::Delete, &settings),
+            super::InputAction::DeleteInspecting
+        ));
     }
 
     #[rstest]
@@ -2784,6 +3122,7 @@ mod tests {
     }
 
     #[cfg(all(feature = "daemon", unix))]
+    #[rstest]
     #[tokio::test]
     async fn unavailable_daemon_fuzzy_retries_with_local_fuzzy() {
         use atuin_client::database::Sqlite;

--- a/crates/atuin/src/command/client/search/interactive.rs
+++ b/crates/atuin/src/command/client/search/interactive.rs
@@ -5,7 +5,7 @@ use std::time::Duration;
 
 use atuin_client::database::{Context, Sqlite, current_context};
 use atuin_client::history::store::HistoryStore;
-use atuin_client::history::{History, HistoryId, HistoryStats};
+use atuin_client::history::{History, HistoryId};
 use atuin_client::settings::{
     CursorStyle, ExitMode, FilterMode, KeymapMode, PreviewStrategy, RequestedSearchMode,
     SearchMode, Settings, UiColumn,
@@ -38,6 +38,7 @@ use windows_sys::Win32::System::Console::{GetConsoleOutputCP, SetConsoleOutputCP
 use super::cursor::Cursor;
 use super::engines::{AnySearchEngine, SearchEngine, SearchState};
 use super::history_list::{HistoryList, ListState};
+use super::inspector::Stats as InspectorStats;
 use super::inspector::bindings::Bindings;
 use super::inspector::browser::{Browser, View as InspectorView};
 use crate::VERSION;
@@ -68,6 +69,7 @@ pub struct InspectingState {
     next: Option<HistoryId>,
     previous: Option<HistoryId>,
     browser: Browser,
+    bindings: Bindings,
 }
 
 impl InspectingState {
@@ -917,7 +919,7 @@ impl State {
         &mut self,
         f: &mut Frame,
         results: &[History],
-        stats: Option<&HistoryStats>,
+        stats: Option<&InspectorStats>,
         inspecting: Option<&History>,
         settings: &Settings,
         theme: &Theme,
@@ -938,23 +940,18 @@ impl State {
         f: &mut Frame,
         area: Rect,
         results: &[History],
-        stats: Option<&HistoryStats>,
+        stats: Option<&InspectorStats>,
         inspecting: Option<&History>,
         settings: &Settings,
         theme: &Theme,
     ) {
-        let bindings = if self.tab_index == 1 {
-            Bindings::new(&self.keymaps.inspector, &self.eval_context())
-        } else {
-            Bindings::default()
-        };
+        let bindings = &self.inspecting_state.bindings;
         // Output is a focused reader, not another panel beneath the search chrome.
         if self.tab_index == 1
             && self.inspecting_state.browser.view == InspectorView::Output
-            && let Some(selected) =
-                inspecting.or_else(|| results.get(self.results_state.selected()))
+            && inspecting.or_else(|| results.get(self.results_state.selected())).is_some()
         {
-            self.inspecting_state.browser.draw(f, area, selected, settings, theme, &bindings);
+            self.inspecting_state.browser.draw(f, area, theme, bindings);
             return;
         }
         let compactness = to_compactness(f, settings);
@@ -1160,27 +1157,21 @@ impl State {
                         .alignment(Alignment::Center);
                     f.render_widget(message, results_list_chunk);
                 } else {
-                    let inspecting = match inspecting {
-                        Some(inspecting) => inspecting,
-                        None => &results[self.results_state.selected()],
-                    };
                     let browser = &mut self.inspecting_state.browser;
                     let chunk = super::inspector::browser::draw_views(
                         f,
                         results_list_chunk,
                         browser.view,
                         theme,
-                        &bindings,
+                        bindings,
                     );
-                    let chunk = super::inspector::browser::draw_command(
-                        f, chunk, inspecting, settings, theme,
-                    );
+                    let chunk = browser.draw_command(f, chunk, theme);
                     if browser.view == InspectorView::Stats {
                         if let Some(stats) = stats {
                             super::inspector::draw(f, chunk, stats, theme);
                         }
                     } else {
-                        browser.draw(f, chunk, inspecting, settings, theme, &bindings);
+                        browser.draw(f, chunk, theme, bindings);
                     }
                 }
 
@@ -1188,7 +1179,7 @@ impl State {
                     self.inspecting_state.browser.view,
                     input_chunk.width,
                     theme,
-                    &bindings,
+                    bindings,
                 );
                 f.render_widget(Paragraph::new(guide), input_chunk);
 
@@ -1995,12 +1986,22 @@ pub async fn history(
 
     let mut results = app.query_results(&mut db, settings).await?;
 
-    let mut stats: Option<HistoryStats> = None;
+    let mut stats: Option<InspectorStats> = None;
     // Aggregates depend on the command, not the selected occurrence.
     let mut stats_for: Option<String> = None;
     let mut inspecting: Option<History> = None;
     let accept;
     let result = 'render: loop {
+        if app.tab_index == 1 {
+            let context = app.eval_context();
+            app.inspecting_state.bindings.update(&app.keymaps.inspector, &context);
+            if let Some(selected) =
+                inspecting.as_ref().or_else(|| results.get(app.results_state.selected()))
+            {
+                app.inspecting_state.browser.prepare(selected, settings, theme);
+            }
+        }
+
         terminal.draw(|f| {
             app.draw(f, &results, stats.as_ref(), inspecting.as_ref(), settings, theme, popup_mode);
         })?;
@@ -2185,7 +2186,7 @@ pub async fn history(
                     stats
                 } else {
                     stats_for = Some(selected.command.clone());
-                    Some(db.stats(selected).await?)
+                    Some(db.stats(selected).await?.into())
                 }
             } else {
                 (app.inspecting_state.previous, app.inspecting_state.next) =

--- a/crates/atuin/src/command/client/search/keybindings/actions.rs
+++ b/crates/atuin/src/command/client/search/keybindings/actions.rs
@@ -70,6 +70,10 @@ pub enum Action {
     // Inspector
     InspectPrevious,
     InspectNext,
+    InspectRuns,
+    InspectSession,
+    InspectStats,
+    InspectOutput,
 
     // Special
     Noop,
@@ -148,6 +152,10 @@ impl Action {
 
             "inspect-previous" => Ok(Action::InspectPrevious),
             "inspect-next" => Ok(Action::InspectNext),
+            "inspect-runs" => Ok(Action::InspectRuns),
+            "inspect-session" => Ok(Action::InspectSession),
+            "inspect-stats" => Ok(Action::InspectStats),
+            "inspect-output" => Ok(Action::InspectOutput),
 
             "noop" => Ok(Action::Noop),
 
@@ -215,6 +223,10 @@ impl Action {
 
             Action::InspectPrevious => "inspect-previous".to_string(),
             Action::InspectNext => "inspect-next".to_string(),
+            Action::InspectRuns => "inspect-runs".to_string(),
+            Action::InspectSession => "inspect-session".to_string(),
+            Action::InspectStats => "inspect-stats".to_string(),
+            Action::InspectOutput => "inspect-output".to_string(),
 
             Action::Noop => "noop".to_string(),
         }

--- a/crates/atuin/src/command/client/search/keybindings/conditions.rs
+++ b/crates/atuin/src/command/client/search/keybindings/conditions.rs
@@ -39,6 +39,7 @@ pub enum ConditionExpr {
 
 /// Context needed to evaluate conditions. This is a pure snapshot of state —
 /// no references to mutable data.
+#[derive(Clone, Copy, PartialEq, Eq)]
 pub struct EvalContext {
     /// Current cursor position (unicode width units).
     pub cursor_position: usize,
@@ -404,26 +405,26 @@ mod tests {
 
     // -- Atom evaluation (carried over from Phase 0) --
 
-    #[test]
+    #[rstest]
     fn atom_cursor_at_start() {
         assert!(ConditionAtom::CursorAtStart.evaluate(&ctx(0, 5, 5, 0, 10)));
         assert!(!ConditionAtom::CursorAtStart.evaluate(&ctx(3, 5, 5, 0, 10)));
     }
 
-    #[test]
+    #[rstest]
     fn atom_cursor_at_end() {
         assert!(ConditionAtom::CursorAtEnd.evaluate(&ctx(5, 5, 5, 0, 10)));
         assert!(!ConditionAtom::CursorAtEnd.evaluate(&ctx(3, 5, 5, 0, 10)));
         assert!(ConditionAtom::CursorAtEnd.evaluate(&ctx(0, 0, 0, 0, 10)));
     }
 
-    #[test]
+    #[rstest]
     fn atom_input_empty() {
         assert!(ConditionAtom::InputEmpty.evaluate(&ctx(0, 0, 0, 0, 10)));
         assert!(!ConditionAtom::InputEmpty.evaluate(&ctx(0, 5, 5, 0, 10)));
     }
 
-    #[test]
+    #[rstest]
     fn atom_original_input_empty() {
         // original_input_empty = true
         assert!(
@@ -439,21 +440,21 @@ mod tests {
         );
     }
 
-    #[test]
+    #[rstest]
     fn atom_list_at_end() {
         assert!(ConditionAtom::ListAtEnd.evaluate(&ctx(0, 0, 0, 99, 100)));
         assert!(!ConditionAtom::ListAtEnd.evaluate(&ctx(0, 0, 0, 50, 100)));
         assert!(ConditionAtom::ListAtEnd.evaluate(&ctx(0, 0, 0, 0, 0)));
     }
 
-    #[test]
+    #[rstest]
     fn atom_list_at_start() {
         assert!(ConditionAtom::ListAtStart.evaluate(&ctx(0, 0, 0, 0, 100)));
         assert!(!ConditionAtom::ListAtStart.evaluate(&ctx(0, 0, 0, 50, 100)));
         assert!(ConditionAtom::ListAtStart.evaluate(&ctx(0, 0, 0, 0, 0)));
     }
 
-    #[test]
+    #[rstest]
     fn atom_no_results_and_has_results() {
         assert!(ConditionAtom::NoResults.evaluate(&ctx(0, 0, 0, 0, 0)));
         assert!(!ConditionAtom::NoResults.evaluate(&ctx(0, 0, 0, 0, 5)));
@@ -461,7 +462,7 @@ mod tests {
         assert!(!ConditionAtom::HasResults.evaluate(&ctx(0, 0, 0, 0, 0)));
     }
 
-    #[test]
+    #[rstest]
     fn atom_has_context() {
         let mut context = ctx(0, 0, 0, 0, 0);
         assert!(!ConditionAtom::HasContext.evaluate(&context));
@@ -483,7 +484,7 @@ mod tests {
         assert_eq!(c.as_str(), s);
     }
 
-    #[test]
+    #[rstest]
     fn atom_parse_unknown() {
         assert!(ConditionAtom::from_str("unknown-condition").is_err());
     }
@@ -556,7 +557,7 @@ mod tests {
         assert_eq!(expr, expected);
     }
 
-    #[test]
+    #[rstest]
     fn parse_whitespace_tolerance() {
         let a = ConditionExpr::parse("cursor-at-start||input-empty").unwrap();
         let b = ConditionExpr::parse("cursor-at-start || input-empty").unwrap();
@@ -576,7 +577,7 @@ mod tests {
 
     // -- Expression evaluation --
 
-    #[test]
+    #[rstest]
     fn eval_not() {
         let expr = ConditionExpr::parse("!no-results").unwrap();
         // Has results → !no-results is true
@@ -585,7 +586,7 @@ mod tests {
         assert!(!expr.evaluate(&ctx(0, 0, 0, 0, 0)));
     }
 
-    #[test]
+    #[rstest]
     fn eval_and() {
         let expr = ConditionExpr::parse("cursor-at-start && input-empty").unwrap();
         // Both true
@@ -596,7 +597,7 @@ mod tests {
         assert!(!expr.evaluate(&ctx(3, 5, 5, 0, 10)));
     }
 
-    #[test]
+    #[rstest]
     fn eval_or() {
         let expr = ConditionExpr::parse("list-at-start || no-results").unwrap();
         // list at bottom (selected=0)
@@ -607,7 +608,7 @@ mod tests {
         assert!(!expr.evaluate(&ctx(0, 0, 0, 5, 10)));
     }
 
-    #[test]
+    #[rstest]
     fn eval_complex_nested() {
         // (cursor-at-start && !input-empty) || no-results
         let expr = ConditionExpr::parse("(cursor-at-start && !input-empty) || no-results").unwrap();
@@ -641,7 +642,7 @@ mod tests {
         assert_eq!(expr.to_string(), expected);
     }
 
-    #[test]
+    #[rstest]
     fn display_parens_when_needed() {
         // (a || b) && c — the Or inside And needs parens
         let expr = ConditionExpr::Atom(ConditionAtom::CursorAtStart)
@@ -650,7 +651,7 @@ mod tests {
         assert_eq!(expr.to_string(), "(cursor-at-start || input-empty) && no-results");
     }
 
-    #[test]
+    #[rstest]
     fn display_no_parens_when_not_needed() {
         // a || b && c — no parens needed (and binds tighter)
         let inner_and = ConditionExpr::Atom(ConditionAtom::InputEmpty)
@@ -677,7 +678,7 @@ mod tests {
 
     // -- Serde --
 
-    #[test]
+    #[rstest]
     fn serde_simple_atom() {
         let expr = ConditionExpr::Atom(ConditionAtom::CursorAtStart);
         let json = serde_json::to_string(&expr).unwrap();
@@ -686,7 +687,7 @@ mod tests {
         assert_eq!(parsed, expr);
     }
 
-    #[test]
+    #[rstest]
     fn serde_compound_expression() {
         let json = "\"cursor-at-start && !input-empty\"";
         let parsed: ConditionExpr = serde_json::from_str(json).unwrap();
@@ -697,7 +698,7 @@ mod tests {
         assert_eq!(parsed, expected);
     }
 
-    #[test]
+    #[rstest]
     fn serde_round_trip() {
         let expr = ConditionExpr::parse("(cursor-at-start && !input-empty) || no-results").unwrap();
         let json = serde_json::to_string(&expr).unwrap();
@@ -707,7 +708,7 @@ mod tests {
 
     // -- From<ConditionAtom> --
 
-    #[test]
+    #[rstest]
     fn from_atom_into_expr() {
         let expr: ConditionExpr = ConditionAtom::CursorAtStart.into();
         assert_eq!(expr, ConditionExpr::Atom(ConditionAtom::CursorAtStart));
@@ -715,7 +716,7 @@ mod tests {
 
     // -- Builder helpers --
 
-    #[test]
+    #[rstest]
     fn builder_chain() {
         let expr = ConditionExpr::from(ConditionAtom::CursorAtStart)
             .and(ConditionExpr::from(ConditionAtom::InputEmpty).not())

--- a/crates/atuin/src/command/client/search/keybindings/defaults.rs
+++ b/crates/atuin/src/command/client/search/keybindings/defaults.rs
@@ -351,22 +351,24 @@ pub fn default_inspector_keymap(settings: &Settings) -> Keymap {
     let prefix_char = settings.keys.prefix.chars().next().unwrap_or('a');
     km.bind(key(&format!("ctrl-{prefix_char}")), Action::EnterPrefixMode);
 
-    // Accept behavior respects enter_accept setting
-    let accept = if settings.enter_accept {
-        Action::Accept
-    } else {
-        Action::ReturnSelection
-    };
-    km.bind(key("enter"), accept);
+    // Inspection is non-executing: Enter opens output; Tab returns the command for editing.
+    km.bind(key("enter"), Action::InspectOutput);
 
     // Inspector-specific: delete history entry
     km.bind(key("ctrl-d"), Action::Delete);
 
-    // Inspector navigation
+    km.bind(key("r"), Action::InspectRuns);
+    km.bind(key("s"), Action::InspectSession);
+    km.bind(key("t"), Action::InspectStats);
+    km.bind(key("o"), Action::InspectOutput);
+
+    // Inspector navigation (scrolls text in the output view)
     km.bind(key("up"), Action::InspectPrevious);
     km.bind(key("down"), Action::InspectNext);
-    km.bind(key("pageup"), Action::InspectPrevious);
-    km.bind(key("pagedown"), Action::InspectNext);
+    km.bind(key("pageup"), Action::ScrollPageUp);
+    km.bind(key("pagedown"), Action::ScrollPageDown);
+    km.bind(key("home"), Action::ScrollToTop);
+    km.bind(key("end"), Action::ScrollToBottom);
 
     // For vim users, add j/k navigation
     if matches!(settings.keymap_mode, KeymapMode::VimNormal | KeymapMode::VimInsert) {
@@ -577,7 +579,7 @@ mod tests {
         assert_eq!(km.resolve(&key(k), &ctx), Some(expected));
     }
 
-    #[test]
+    #[rstest]
     fn emacs_enter_accept_true_uses_accept() {
         let mut settings = default_settings();
         settings.enter_accept = true;
@@ -619,7 +621,7 @@ mod tests {
         assert_eq!(km.resolve(&key(k), &ctx), Some(expected));
     }
 
-    #[test]
+    #[rstest]
     fn vim_normal_enter_accept_true_uses_accept() {
         let mut settings = default_settings();
         settings.enter_accept = true;
@@ -653,11 +655,17 @@ mod tests {
     // -- Inspector keymap tests --
 
     #[rstest]
+    #[case::runs("r", 0, 0, 0, 10, Action::InspectRuns)]
+    #[case::session("s", 0, 0, 0, 10, Action::InspectSession)]
+    #[case::stats("t", 0, 0, 0, 10, Action::InspectStats)]
+    #[case::output("o", 0, 0, 0, 10, Action::InspectOutput)]
     #[case::ctrl_d_deletes("ctrl-d", 0, 0, 0, 10, Action::Delete)]
     #[case::up_inspects_previous("up", 0, 0, 0, 10, Action::InspectPrevious)]
     #[case::down_inspects_next("down", 0, 0, 0, 10, Action::InspectNext)]
     #[case::esc_exits("esc", 0, 0, 0, 10, Action::Exit)]
-    // enter_accept=false → ReturnSelection
+    #[case::enter_opens_output("enter", 0, 0, 0, 10, Action::InspectOutput)]
+    #[case::pageup_scrolls("pageup", 0, 0, 0, 10, Action::ScrollPageUp)]
+    #[case::pagedown_scrolls("pagedown", 0, 0, 0, 10, Action::ScrollPageDown)]
     #[case::tab_returns_selection("tab", 0, 0, 0, 10, Action::ReturnSelection)]
     #[case::prefix_key_enters_prefix("ctrl-a", 0, 0, 0, 10, Action::EnterPrefixMode)]
     fn inspector_keymap_resolves(
@@ -694,7 +702,7 @@ mod tests {
 
     // -- KeymapSet tests --
 
-    #[test]
+    #[rstest]
     fn keymap_set_defaults_builds() {
         let settings = default_settings();
         let set = KeymapSet::defaults(&settings);
@@ -710,7 +718,7 @@ mod tests {
 
     // -- Settings-dependent behavior --
 
-    #[test]
+    #[rstest]
     fn custom_prefix_char() {
         let mut settings = default_settings();
         settings.keys.prefix = "x".to_string();
@@ -723,7 +731,7 @@ mod tests {
         assert_eq!(km.resolve(&key("ctrl-a"), &ctx), Some(Action::CursorStart));
     }
 
-    #[test]
+    #[rstest]
     fn ctrl_n_shortcuts_changes_numeric_modifier() {
         let mut settings = default_settings();
         settings.ctrl_n_shortcuts = true;
@@ -736,7 +744,7 @@ mod tests {
         assert_eq!(km.resolve(&key("alt-1"), &ctx), None);
     }
 
-    #[test]
+    #[rstest]
     fn default_alt_numeric_shortcuts() {
         let settings = default_settings();
         let km = default_emacs_keymap(&settings);
@@ -750,7 +758,7 @@ mod tests {
     // Config parsing and merging tests
     // -----------------------------------------------------------------------
 
-    #[test]
+    #[rstest]
     fn parse_simple_binding_config() {
         use atuin_client::settings::KeyBindingConfig;
         let cfg = KeyBindingConfig::Simple("accept".to_string());
@@ -760,7 +768,7 @@ mod tests {
         assert_eq!(binding.rules[0].action, Action::Accept);
     }
 
-    #[test]
+    #[rstest]
     fn parse_conditional_binding_config() {
         use atuin_client::settings::{KeyBindingConfig, KeyRuleConfig};
         let cfg = KeyBindingConfig::Rules(vec![
@@ -781,14 +789,14 @@ mod tests {
         assert_eq!(binding.rules[1].action, Action::CursorLeft);
     }
 
-    #[test]
+    #[rstest]
     fn parse_binding_config_invalid_action() {
         use atuin_client::settings::KeyBindingConfig;
         let cfg = KeyBindingConfig::Simple("not-a-real-action".to_string());
         assert!(super::parse_binding_config(&cfg).is_err());
     }
 
-    #[test]
+    #[rstest]
     fn parse_binding_config_invalid_condition() {
         use atuin_client::settings::{KeyBindingConfig, KeyRuleConfig};
         let cfg = KeyBindingConfig::Rules(vec![KeyRuleConfig {
@@ -798,7 +806,7 @@ mod tests {
         assert!(super::parse_binding_config(&cfg).is_err());
     }
 
-    #[test]
+    #[rstest]
     fn config_override_replaces_key() {
         use std::collections::HashMap;
 
@@ -819,7 +827,7 @@ mod tests {
         assert_eq!(set.emacs.resolve(&key("ctrl-c"), &ctx), Some(Action::Exit));
     }
 
-    #[test]
+    #[rstest]
     fn config_override_preserves_unoverridden_keys() {
         use std::collections::HashMap;
 
@@ -839,7 +847,7 @@ mod tests {
         assert_eq!(set.emacs.resolve(&key("enter"), &ctx), Some(Action::ReturnSelection));
     }
 
-    #[test]
+    #[rstest]
     fn config_conditional_override() {
         use std::collections::HashMap;
 
@@ -872,7 +880,7 @@ mod tests {
         assert_eq!(set.emacs.resolve(&key("up"), &ctx), Some(Action::SelectPrevious));
     }
 
-    #[test]
+    #[rstest]
     fn from_settings_with_empty_config_equals_defaults() {
         let settings = default_settings();
         let defaults = KeymapSet::defaults(&settings);
@@ -894,7 +902,7 @@ mod tests {
     // Phase 5: [keys] vs [keymap] backward compatibility
     // -----------------------------------------------------------------------
 
-    #[test]
+    #[rstest]
     fn keymap_overrides_ignore_keys_section() {
         use atuin_client::settings::KeyBindingConfig;
 
@@ -933,7 +941,7 @@ mod tests {
         );
     }
 
-    #[test]
+    #[rstest]
     fn keymap_present_resets_to_standard_keys_defaults() {
         use atuin_client::settings::KeyBindingConfig;
 
@@ -973,7 +981,7 @@ mod tests {
         );
     }
 
-    #[test]
+    #[rstest]
     fn keys_has_non_default_values_detection() {
         use atuin_client::settings::Keys;
 
@@ -989,7 +997,7 @@ mod tests {
         assert!(modified.has_non_default_values());
     }
 
-    #[test]
+    #[rstest]
     fn original_input_empty_condition_in_config() {
         use std::collections::HashMap;
 

--- a/docs/docs/configuration/advanced-key-binding.md
+++ b/docs/docs/configuration/advanced-key-binding.md
@@ -183,9 +183,9 @@ Actions are specified as kebab-case strings.
 | `scroll-page-down` | Scroll a full page down |
 | `scroll-to-top` | Jump to the top of the list |
 | `scroll-to-bottom` | Jump to the bottom of the list |
-| `scroll-to-screen-top` | Jump to the top of the visible screen |
-| `scroll-to-screen-middle` | Jump to the middle of the visible screen |
-| `scroll-to-screen-bottom` | Jump to the bottom of the visible screen |
+| `scroll-to-screen-top` | Jump to the top of the visible search results |
+| `scroll-to-screen-middle` | Jump to the middle of the visible search results |
+| `scroll-to-screen-bottom` | Jump to the bottom of the visible search results |
 
 Note: `select-next` and `select-previous` respect the `invert` setting. When `invert` is true, the visual direction is flipped.
 
@@ -229,8 +229,15 @@ The difference between `accept` and `return-selection`: `accept` runs the comman
 
 | Action | Description |
 |--------|-------------|
-| `inspect-previous` | Inspect the previous entry (in the inspector tab) |
-| `inspect-next` | Inspect the next entry (in the inspector tab) |
+| `inspect-previous` | Inspect the previous entry in the current view, or scroll output up |
+| `inspect-next` | Inspect the next entry in the current view, or scroll output down |
+| `inspect-runs` | View individual executions of the selected command |
+| `inspect-session` | View commands in the selected run's session |
+| `inspect-stats` | View command statistics and charts |
+| `inspect-output` | View captured output with colours and text formatting for the selected run |
+
+In the inspector, list conditions refer to Runs/Session rather than the search results.
+In Output, `list-at-start` and `list-at-end` refer to the reader's scroll boundaries.
 
 ### Special
 

--- a/docs/docs/configuration/advanced-key-binding.md
+++ b/docs/docs/configuration/advanced-key-binding.md
@@ -229,15 +229,15 @@ The difference between `accept` and `return-selection`: `accept` runs the comman
 
 | Action | Description |
 |--------|-------------|
-| `inspect-previous` | Inspect the previous entry in the current view, or scroll output up |
-| `inspect-next` | Inspect the next entry in the current view, or scroll output down |
-| `inspect-runs` | View individual executions of the selected command |
-| `inspect-session` | View commands in the selected run's session |
-| `inspect-stats` | View command statistics and charts |
-| `inspect-output` | View captured output with colours and text formatting for the selected run |
+| `inspect-previous` | Select the row above, or scroll output up |
+| `inspect-next` | Select the row below, or scroll output down |
+| `inspect-runs` | Open Runs |
+| `inspect-session` | Open Session |
+| `inspect-stats` | Open Stats |
+| `inspect-output` | Open captured output |
 
-In the inspector, list conditions refer to Runs/Session rather than the search results.
-In Output, `list-at-start` and `list-at-end` refer to the reader's scroll boundaries.
+List conditions apply to the current inspector view, not the search results.
+In Output, start/end conditions describe scroll boundaries.
 
 ### Special
 

--- a/docs/docs/configuration/key-binding.md
+++ b/docs/docs/configuration/key-binding.md
@@ -290,42 +290,25 @@ If vim is enabled in the config (see [`keymap_mode`](config.md#keymap_mode)), th
 
 
 ### Inspector
-Open the inspector with Ctrl + o. It starts in **Runs**, showing individual executions
-of the exact command (not deduplicated), **newest first**. **Session** shows commands
-in the selected run's session, also newest first. Switching views keeps that run
-selected. **Stats** is aggregate-only: total runs, success rate (known exit codes),
-average runtime, exit-code distribution, weekday activity, and monthly mean runtime.
-It covers live occurrences of the exact command across hosts and sessions, without
-repeating the per-run details. Select an occurrence in Runs or Session to browse its output.
 
-The footer's **`<enter>: output`** hint opens a focused **Output** reader for the
-selected run; **Esc** returns
-to the same list and selection. Enter does **not** execute a command in the inspector,
-regardless of `enter_accept`; use **Tab** to put the command into the shell for editing.
+Open with **Ctrl + o**. **Runs** lists executions of the selected command;
+**Session** lists commands in that run's session. Both are newest first.
+**Stats** shows aggregate statistics.
 
-Output preserves captured colours and text formatting without replaying terminal control
-sequences. Blinking and hidden text are disabled. Long lines wrap, and the reader
-shows scroll position and missing, empty, unavailable, or truncated capture states.
-Output is fetched from the local daemon in the background when opened. The current
-successful capture is cached; reopening retries missing or unavailable captures. The mouse wheel navigates the current list or scrolls the output reader.
+Captured output requires the local daemon and preserves colours and formatting.
+By default, **Enter** opens output instead of executing the command, regardless of
+`enter_accept`. **Esc** returns to the same selection.
 
-The selector and footer reflect your configured inspector keybindings. The shortcuts
-below are the defaults.
-
-| Shortcut  | Action                                        |
-| --------- | --------------------------------------------- |
-| Esc       | Back from output to the previous inspector view; otherwise back to search |
-| Ctrl + o  | Close the inspector, returning to search view |
-| Ctrl + d  | Delete the inspected item from the history    |
-| r         | View runs of the selected command            |
-| s         | View the selected run's session               |
-| t         | View statistics and charts                    |
-| o         | View the selected run's captured output       |
-| ↑         | Select the row above, or scroll output up     |
-| ↓         | Select the row below, or scroll output down   |
-| j / k     | Navigate items (when vim mode is enabled)     |
-| Enter     | Open captured output for the selected run     |
-| Page Up / Page Down | Scroll output a page at a time (one item in lists) |
-| Home / End | Jump to the start / end of output            |
-| Ctrl + c  | Close Atuin and return to the shell           |
-| Tab       | Select current item and edit                  |
+| Default shortcut | Action |
+| ---------------- | ------ |
+| r / s / t | Switch to Runs / Session / Stats |
+| Enter / o | Open captured output |
+| ↑ / ↓ or mouse wheel | Select a row or scroll output |
+| j / k | Navigate in vim mode |
+| Page Up / Page Down | Scroll output a page (one row in lists) |
+| Home / End | Jump to the start / end of output |
+| Esc | Back to the inspector or search |
+| Ctrl + o | Back to search |
+| Ctrl + d | Delete the selected run |
+| Tab | Edit the selected command in the shell, without executing it |
+| Ctrl + c | Close Atuin |

--- a/docs/docs/configuration/key-binding.md
+++ b/docs/docs/configuration/key-binding.md
@@ -290,17 +290,42 @@ If vim is enabled in the config (see [`keymap_mode`](config.md#keymap_mode)), th
 
 
 ### Inspector
-Open the inspector with Ctrl + o
+Open the inspector with Ctrl + o. It starts in **Runs**, showing individual executions
+of the exact command (not deduplicated), **newest first**. **Session** shows commands
+in the selected run's session, also newest first. Switching views keeps that run
+selected. **Stats** is aggregate-only: total runs, success rate (known exit codes),
+average runtime, exit-code distribution, weekday activity, and monthly mean runtime.
+It covers live occurrences of the exact command across hosts and sessions, without
+repeating the per-run details. Select an occurrence in Runs or Session to browse its output.
+
+The footer's **`<enter>: output`** hint opens a focused **Output** reader for the
+selected run; **Esc** returns
+to the same list and selection. Enter does **not** execute a command in the inspector,
+regardless of `enter_accept`; use **Tab** to put the command into the shell for editing.
+
+Output preserves captured colours and text formatting without replaying terminal control
+sequences. Blinking and hidden text are disabled. Long lines wrap, and the reader
+shows scroll position and missing, empty, unavailable, or truncated capture states.
+Output is fetched from the local daemon in the background when opened. The current
+successful capture is cached; reopening retries missing or unavailable captures. The mouse wheel navigates the current list or scrolls the output reader.
+
+The selector and footer reflect your configured inspector keybindings. The shortcuts
+below are the defaults.
 
 | Shortcut  | Action                                        |
 | --------- | --------------------------------------------- |
-| Esc       | Close the inspector, returning to the shell   |
+| Esc       | Back from output to the previous inspector view; otherwise back to search |
 | Ctrl + o  | Close the inspector, returning to search view |
 | Ctrl + d  | Delete the inspected item from the history    |
-| ↑         | Inspect the previous item in the history      |
-| ↓         | Inspect the next item in the history          |
-| Page Up   | Inspect the previous item in the history      |
-| Page Down | Inspect the next item in the history          |
+| r         | View runs of the selected command            |
+| s         | View the selected run's session               |
+| t         | View statistics and charts                    |
+| o         | View the selected run's captured output       |
+| ↑         | Select the row above, or scroll output up     |
+| ↓         | Select the row below, or scroll output down   |
 | j / k     | Navigate items (when vim mode is enabled)     |
-| Enter     | Execute selected item (respects `enter_accept`) |
+| Enter     | Open captured output for the selected run     |
+| Page Up / Page Down | Scroll output a page at a time (one item in lists) |
+| Home / End | Jump to the start / end of output            |
+| Ctrl + c  | Close Atuin and return to the shell           |
 | Tab       | Select current item and edit                  |


### PR DESCRIPTION
This change incorporates much of the feedback we have had about the inspector so far; users can easily explore past occurrences of a command, or switch to view other commands from the same session. 

We also show the actual output of the command here, too

## Checks
- [ ] I am happy for maintainers to push small adjustments to this PR, to speed up the review cycle
- [ ] I have checked that there are no existing pull requests for the same thing
