### PR TITLE
feat(pty-proxy): mirror the CWD of the PTY proxy child

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -635,6 +635,7 @@ dependencies = [
  "crossterm",
  "easy-cast",
  "eyre",
+ "libc",
  "parking_lot",
  "portable-pty",
  "rstest",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -71,6 +71,7 @@ indicatif = "0.18.0"
 interim = { version = "0.2.0", features = ["time_0_3"] }
 itertools = "0.15.0"
 lasso = { version = "0.7", features = ["multi-threaded"] }
+libc = "0.2"
 # Version range mirrors sqlx-sqlite's so cargo unifies both to a single
 # `links = "sqlite3"` package (one bundled SQLite).
 libsqlite3-sys = ">=0.30.1, <0.38.0"

--- a/crates/atuin-common/src/os/unix/process.rs
+++ b/crates/atuin-common/src/os/unix/process.rs
@@ -79,16 +79,23 @@ pub fn cwd(pid: Pid) -> Option<PathBuf> {
     if cfg!(target_os = "linux") {
         std::fs::read_link(format!("/proc/{pid}/cwd")).ok()
     } else {
-        let pid = sysinfo::Pid::from_u32(pid);
-        let mut system = sysinfo::System::new();
-        if !system.refresh_process_specifics(
-            pid,
-            sysinfo::ProcessRefreshKind::new().with_cmd(sysinfo::UpdateKind::Always),
-        ) {
-            return None;
-        }
-        system.process(pid)?.cwd().map(Into::into)
+        cwd_generic(pid)
     }
+}
+
+/// Implementation of [`cwd`] that works on all Unix-like systems.
+///
+/// Linux has a specific, more efficient implementation.
+fn cwd_generic(pid: u32) -> Option<PathBuf> {
+    let pid = sysinfo::Pid::from_u32(pid);
+    let mut system = sysinfo::System::new();
+    if !system.refresh_process_specifics(
+        pid,
+        sysinfo::ProcessRefreshKind::new().with_cwd(sysinfo::UpdateKind::Always),
+    ) {
+        return None;
+    }
+    system.process(pid)?.cwd().map(Into::into)
 }
 
 #[cfg(test)]
@@ -107,8 +114,24 @@ mod tests {
         (child, pid)
     }
 
+    /// Wait for `read` to return `expected`, then report what it last returned.
+    ///
+    /// A child chdirs somewhere between fork and exec, so it may not have arrived yet.
+    fn settles_on(
+        expected: &std::path::Path,
+        mut read: impl FnMut() -> Option<PathBuf>,
+    ) -> Option<PathBuf> {
+        let deadline = Instant::now() + Duration::from_secs(10);
+        loop {
+            let found = read();
+            if found.as_deref() == Some(expected) || Instant::now() >= deadline {
+                return found;
+            }
+            std::thread::sleep(Duration::from_millis(10));
+        }
+    }
+
     #[rstest]
-    #[cfg_attr(target_os = "macos", ignore)] // TODO
     fn reads_the_working_directory_of_another_process() {
         let dir = tempfile::tempdir().unwrap();
         // The temporary directory may sit behind a symlink (/tmp on macOS), and a working
@@ -116,74 +139,30 @@ mod tests {
         let expected = dir.path().canonicalize().unwrap();
         let (mut child, pid) = sleeper(dir.path());
 
-        // The child chdirs somewhere between fork and exec, so it may not be there yet.
-        let deadline = Instant::now() + Duration::from_secs(10);
-        while cwd(pid).as_deref() != Some(expected.as_path()) && Instant::now() < deadline {
-            std::thread::sleep(Duration::from_millis(10));
-        }
-        let found = cwd(pid);
+        let found = settles_on(&expected, || cwd(pid));
 
         child.kill().unwrap();
         child.wait().unwrap();
         assert_eq!(found.as_deref(), Some(expected.as_path()));
     }
 
-    /// TODO: TEMPORARY diagnostic for the macOS failure, to be deleted once it is fixed.
-    #[cfg(target_os = "macos")]
-    #[test]
-    fn cwd_layers() {
-        use sysinfo::{ProcessRefreshKind, System, UpdateKind};
-
+    #[rstest]
+    fn the_generic_lookup_reads_the_working_directory_too() {
+        // Linux takes the /proc route, so without this the portable route would go untested
+        // until it reached a platform that has no choice but to use it.
         let dir = tempfile::tempdir().unwrap();
         let expected = dir.path().canonicalize().unwrap();
-        let (mut child, pid) = sleeper(dir.path());
-        std::thread::sleep(Duration::from_millis(500));
-        let sysinfo_pid = sysinfo::Pid::from_u32(child.id());
-        let me = Pid::from_raw(std::process::id().cast_signed()).unwrap();
+        let (mut child, _) = sleeper(dir.path());
+        let pid = child.id();
 
-        println!("expected                  {}", expected.display());
-        println!("cwd(child)                {:?}", cwd(pid));
-        println!("cwd(self)                 {:?}", cwd(me));
-
-        let mut narrow = System::new();
-        let refreshed = narrow.refresh_process_specifics(
-            sysinfo_pid,
-            ProcessRefreshKind::new().with_cwd(UpdateKind::Always),
-        );
-        println!("cwd-only refresh          {refreshed}");
-        println!("cwd-only found            {}", narrow.process(sysinfo_pid).is_some());
-        println!(
-            "cwd-only name             {:?}",
-            narrow.process(sysinfo_pid).map(sysinfo::Process::name)
-        );
-        println!(
-            "cwd-only exe              {:?}",
-            narrow.process(sysinfo_pid).and_then(sysinfo::Process::exe)
-        );
-        println!(
-            "cwd-only cwd              {:?}",
-            narrow.process(sysinfo_pid).and_then(sysinfo::Process::cwd)
-        );
-
-        let mut wide = System::new();
-        let refreshed = wide.refresh_process_specifics(
-            sysinfo_pid,
-            ProcessRefreshKind::everything().with_cwd(UpdateKind::Always),
-        );
-        println!("wide refresh              {refreshed}");
-        println!("wide found                {}", wide.process(sysinfo_pid).is_some());
-        println!(
-            "wide cwd                  {:?}",
-            wide.process(sysinfo_pid).and_then(sysinfo::Process::cwd)
-        );
+        let found = settles_on(&expected, || cwd_generic(pid));
 
         child.kill().unwrap();
         child.wait().unwrap();
-        panic!();
+        assert_eq!(found.as_deref(), Some(expected.as_path()));
     }
 
     #[rstest]
-    #[cfg_attr(target_os = "macos", ignore)] // TODO
     fn a_process_that_has_gone_has_no_working_directory() {
         let dir = tempfile::tempdir().unwrap();
         let (mut child, pid) = sleeper(dir.path());

--- a/crates/atuin-common/src/os/unix/process.rs
+++ b/crates/atuin-common/src/os/unix/process.rs
@@ -131,7 +131,6 @@ mod tests {
     ///
     ///     cargo test -p atuin-common --features os -- --ignored --nocapture cwd_layers
     #[test]
-    #[ignore = "diagnostic, run explicitly"]
     fn cwd_layers() {
         use sysinfo::{ProcessRefreshKind, System, UpdateKind};
 

--- a/crates/atuin-common/src/os/unix/process.rs
+++ b/crates/atuin-common/src/os/unix/process.rs
@@ -127,6 +127,61 @@ mod tests {
         assert_eq!(found.as_deref(), Some(expected.as_path()));
     }
 
+    /// TEMPORARY diagnostic for the macOS failure, to be deleted once it is fixed.
+    ///
+    ///     cargo test -p atuin-common --features os -- --ignored --nocapture cwd_layers
+    #[test]
+    #[ignore = "diagnostic, run explicitly"]
+    fn cwd_layers() {
+        use sysinfo::{ProcessRefreshKind, System, UpdateKind};
+
+        let dir = tempfile::tempdir().unwrap();
+        let expected = dir.path().canonicalize().unwrap();
+        let (mut child, pid) = sleeper(dir.path());
+        std::thread::sleep(Duration::from_millis(500));
+        let sysinfo_pid = sysinfo::Pid::from_u32(child.id());
+        let me = Pid::from_raw(std::process::id().cast_signed()).unwrap();
+
+        println!("expected                  {}", expected.display());
+        println!("cwd(child)                {:?}", cwd(pid));
+        println!("cwd(self)                 {:?}", cwd(me));
+
+        let mut narrow = System::new();
+        let refreshed = narrow.refresh_process_specifics(
+            sysinfo_pid,
+            ProcessRefreshKind::new().with_cwd(UpdateKind::Always),
+        );
+        println!("cwd-only refresh          {refreshed}");
+        println!("cwd-only found            {}", narrow.process(sysinfo_pid).is_some());
+        println!(
+            "cwd-only name             {:?}",
+            narrow.process(sysinfo_pid).map(sysinfo::Process::name)
+        );
+        println!(
+            "cwd-only exe              {:?}",
+            narrow.process(sysinfo_pid).and_then(sysinfo::Process::exe)
+        );
+        println!(
+            "cwd-only cwd              {:?}",
+            narrow.process(sysinfo_pid).and_then(sysinfo::Process::cwd)
+        );
+
+        let mut wide = System::new();
+        let refreshed = wide.refresh_process_specifics(
+            sysinfo_pid,
+            ProcessRefreshKind::everything().with_cwd(UpdateKind::Always),
+        );
+        println!("wide refresh              {refreshed}");
+        println!("wide found                {}", wide.process(sysinfo_pid).is_some());
+        println!(
+            "wide cwd                  {:?}",
+            wide.process(sysinfo_pid).and_then(sysinfo::Process::cwd)
+        );
+
+        child.kill().unwrap();
+        child.wait().unwrap();
+    }
+
     #[rstest]
     fn a_process_that_has_gone_has_no_working_directory() {
         let dir = tempfile::tempdir().unwrap();

--- a/crates/atuin-common/src/os/unix/process.rs
+++ b/crates/atuin-common/src/os/unix/process.rs
@@ -1,6 +1,7 @@
 //! Utilities for operating on processes.
 
 use std::ops::ControlFlow;
+use std::path::PathBuf;
 use std::time::Duration;
 
 use rustix::io::Errno;
@@ -67,5 +68,72 @@ pub fn process_start_time(pid: Pid) -> Option<u64> {
         system.process(pid).map(sysinfo::Process::start_time)
     } else {
         None
+    }
+}
+
+/// Get a process's current working directory.
+#[must_use]
+pub fn cwd(pid: Pid) -> Option<PathBuf> {
+    let pid = u32::try_from(pid.as_raw_pid()).ok()?;
+
+    if cfg!(target_os = "linux") {
+        std::fs::read_link(format!("/proc/{pid}/cwd")).ok()
+    } else {
+        let pid = sysinfo::Pid::from_u32(pid);
+        let mut system = sysinfo::System::new();
+        if !system.refresh_process_specifics(
+            pid,
+            sysinfo::ProcessRefreshKind::new().with_cmd(sysinfo::UpdateKind::Always),
+        ) {
+            return None;
+        }
+        system.process(pid)?.cwd().map(Into::into)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::process::{Child, Command};
+    use std::time::{Duration, Instant};
+
+    use rstest::rstest;
+
+    use super::*;
+
+    /// Spawn a process that sits still in `dir`.
+    fn sleeper(dir: &std::path::Path) -> (Child, Pid) {
+        let child = Command::new("sleep").arg("30").current_dir(dir).spawn().unwrap();
+        let pid = Pid::from_raw(child.id().cast_signed()).unwrap();
+        (child, pid)
+    }
+
+    #[rstest]
+    fn reads_the_working_directory_of_another_process() {
+        let dir = tempfile::tempdir().unwrap();
+        // The temporary directory may sit behind a symlink (/tmp on macOS), and a working
+        // directory never does.
+        let expected = dir.path().canonicalize().unwrap();
+        let (mut child, pid) = sleeper(dir.path());
+
+        // The child chdirs somewhere between fork and exec, so it may not be there yet.
+        let deadline = Instant::now() + Duration::from_secs(10);
+        while cwd(pid).as_deref() != Some(expected.as_path()) && Instant::now() < deadline {
+            std::thread::sleep(Duration::from_millis(10));
+        }
+        let found = cwd(pid);
+
+        child.kill().unwrap();
+        child.wait().unwrap();
+        assert_eq!(found.as_deref(), Some(expected.as_path()));
+    }
+
+    #[rstest]
+    fn a_process_that_has_gone_has_no_working_directory() {
+        let dir = tempfile::tempdir().unwrap();
+        let (mut child, pid) = sleeper(dir.path());
+        child.kill().unwrap();
+        child.wait().unwrap();
+
+        assert_eq!(cwd(pid), None);
     }
 }

--- a/crates/atuin-common/src/os/unix/process.rs
+++ b/crates/atuin-common/src/os/unix/process.rs
@@ -179,6 +179,7 @@ mod tests {
 
         child.kill().unwrap();
         child.wait().unwrap();
+        panic!();
     }
 
     #[rstest]

--- a/crates/atuin-common/src/os/unix/process.rs
+++ b/crates/atuin-common/src/os/unix/process.rs
@@ -108,6 +108,7 @@ mod tests {
     }
 
     #[rstest]
+    #[cfg_attr(target_os = "macos", ignore)] // TODO
     fn reads_the_working_directory_of_another_process() {
         let dir = tempfile::tempdir().unwrap();
         // The temporary directory may sit behind a symlink (/tmp on macOS), and a working
@@ -127,9 +128,8 @@ mod tests {
         assert_eq!(found.as_deref(), Some(expected.as_path()));
     }
 
-    /// TEMPORARY diagnostic for the macOS failure, to be deleted once it is fixed.
-    ///
-    ///     cargo test -p atuin-common --features os -- --ignored --nocapture cwd_layers
+    /// TODO: TEMPORARY diagnostic for the macOS failure, to be deleted once it is fixed.
+    #[cfg(target_os = "macos")]
     #[test]
     fn cwd_layers() {
         use sysinfo::{ProcessRefreshKind, System, UpdateKind};
@@ -182,6 +182,7 @@ mod tests {
     }
 
     #[rstest]
+    #[cfg_attr(target_os = "macos", ignore)] // TODO
     fn a_process_that_has_gone_has_no_working_directory() {
         let dir = tempfile::tempdir().unwrap();
         let (mut child, pid) = sleeper(dir.path());

--- a/crates/atuin-pty-proxy/Cargo.toml
+++ b/crates/atuin-pty-proxy/Cargo.toml
@@ -22,13 +22,13 @@ atuin-vt100 = { workspace = true }
 crossterm = { workspace = true }
 eyre = { workspace = true }
 portable-pty = { workspace = true }
+rustix = { workspace = true }
 signal-hook = { workspace = true }
 thiserror = { workspace = true }
 
 [dev-dependencies]
 parking_lot = { workspace = true }
 rstest = { workspace = true }
-rustix = { workspace = true }
 tempfile = { workspace = true }
 
 [lints]

--- a/crates/atuin-pty-proxy/Cargo.toml
+++ b/crates/atuin-pty-proxy/Cargo.toml
@@ -21,6 +21,7 @@ atuin-common = { workspace = true, features = ["ansi", "os"] }
 atuin-vt100 = { workspace = true }
 crossterm = { workspace = true }
 eyre = { workspace = true }
+libc = { workspace = true }
 portable-pty = { workspace = true }
 rustix = { workspace = true }
 signal-hook = { workspace = true }

--- a/crates/atuin-pty-proxy/src/cwd_updater.rs
+++ b/crates/atuin-pty-proxy/src/cwd_updater.rs
@@ -1,0 +1,297 @@
+//! Updates this PTY proxy's CWD to match the CWD of its child.
+//!
+//! This is necessary to enable programs like tmux to detect the CWD of the child.
+
+use std::os::fd::{AsFd, BorrowedFd, OwnedFd};
+use std::path::PathBuf;
+use std::sync::mpsc::{self, RecvTimeoutError, SyncSender};
+use std::time::Duration;
+
+use atuin_common::os::unix::process;
+use portable_pty::MasterPty;
+use rustix::process::Pid;
+
+/// The minimum amount of time between successive CWD updates.
+///
+/// Updating the CWD requires a syscall, so this is used to reduce the performance impact.
+const MIN_UPDATE_DELAY: Duration = Duration::from_millis(100);
+
+/// The maximum amount of time between successive CWD updates.
+///
+/// The CWD will be updated at least this often, even if the updater receives no explicit signal to
+/// perform an update.
+const MAX_UPDATE_DELAY: Duration = Duration::from_secs(1);
+
+/// Get an [`OwnedFd`] from a [`MasterPty`].
+fn pty_parent_fd(parent: &dyn MasterPty) -> Option<OwnedFd> {
+    let raw_fd = parent.as_raw_fd()?;
+    // SAFETY: `parent` owns the underlying FD, and it cannot be dropped while this function runs
+    // because we hold a reference to it.
+    unsafe { BorrowedFd::borrow_raw(raw_fd) }.try_clone_to_owned().ok()
+}
+
+/// Get the CWD of the PTY proxy child.
+///
+/// This tries to obtain the CWD of the foreground process in the process group, which is what
+/// programs like tmux do. If that fails, we fall back to querying the CWD of the top-level PTY
+/// proxy child.
+fn pty_cwd(parent: Option<BorrowedFd<'_>>, child: Option<Pid>) -> Option<PathBuf> {
+    let parent = parent.and_then(|parent| rustix::termios::tcgetpgrp(parent).ok());
+    [parent, child].into_iter().flatten().find_map(process::cwd)
+}
+
+/// Updates this process's CWD to match the PTY proxy child's CWD.
+pub struct CwdUpdater {
+    /// Used to tell the update thread to update the CWD now.
+    tx: SyncSender<()>,
+}
+
+impl CwdUpdater {
+    /// Start updating this process's CWD to match the PTY proxy child's.
+    ///
+    /// `master` is the PTY proxy's master PTY. `shell` is the PID of the PTY's child process, if
+    /// available.
+    ///
+    /// Returns a [`CwdUpdater`] that can be used to signal the update thread to update the CWD now.
+    pub fn new(master: &dyn MasterPty, child: Option<Pid>) -> Self {
+        let (tx, rx) = mpsc::sync_channel(1);
+        let parent = pty_parent_fd(master);
+
+        std::thread::spawn(move || {
+            let mut cwd = None;
+            let mut set_cwd = |new_cwd: PathBuf| {
+                if cwd.as_deref().is_some_and(|p| p == new_cwd) {
+                    return;
+                }
+                if std::env::set_current_dir(&new_cwd).is_ok() {
+                    cwd = Some(new_cwd);
+                }
+            };
+
+            let timeout_after_min_delay = MAX_UPDATE_DELAY - MIN_UPDATE_DELAY;
+            let mut timeout = MAX_UPDATE_DELAY;
+            loop {
+                match rx.recv_timeout(timeout) {
+                    Ok(()) => {}
+                    Err(RecvTimeoutError::Timeout) => {}
+                    Err(RecvTimeoutError::Disconnected) => return,
+                }
+
+                loop {
+                    if let Some(new_cwd) = pty_cwd(parent.as_ref().map(AsFd::as_fd), child) {
+                        set_cwd(new_cwd);
+                    }
+                    std::thread::sleep(MIN_UPDATE_DELAY);
+                    if rx.try_iter().count() == 0 {
+                        timeout = timeout_after_min_delay;
+                        break;
+                    }
+                }
+            }
+        });
+
+        Self { tx }
+    }
+
+    /// Tell the updater to update this process's CWD to match that of the PTY proxy child.
+    pub fn update(&self) {
+        // A full channel isn't an error; it means the updater has already been signaled to run.
+        let _ = self.tx.try_send(());
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::io::Write;
+    use std::path::Path;
+    use std::process::Command;
+    use std::time::{Duration, Instant};
+
+    use portable_pty::{CommandBuilder, PtyPair, PtySize, native_pty_system};
+    use rstest::rstest;
+
+    use super::*;
+
+    /// Wait for `read` to return `expected`, then report what it last returned.
+    fn settles_on<T: PartialEq>(expected: &T, mut read: impl FnMut() -> T) -> T {
+        let deadline = Instant::now() + Duration::from_secs(10);
+        loop {
+            let found = read();
+            if found == *expected || Instant::now() >= deadline {
+                return found;
+            }
+            std::thread::sleep(Duration::from_millis(10));
+        }
+    }
+
+    /// Open a pty that nothing has claimed as its controlling terminal.
+    fn open_pty() -> PtyPair {
+        native_pty_system()
+            .openpty(PtySize {
+                rows: 24,
+                cols: 80,
+                pixel_width: 0,
+                pixel_height: 0,
+            })
+            .expect("failed to open pty")
+    }
+
+    /// Spawn `/bin/sh` on `pair`, in `cwd`, waiting for input.
+    fn spawn_shell(pair: &PtyPair, cwd: &Path) -> Box<dyn portable_pty::Child + Send + Sync> {
+        let mut cmd = CommandBuilder::new("/bin/sh");
+        cmd.cwd(cwd);
+        pair.slave.spawn_command(cmd).expect("failed to spawn shell")
+    }
+
+    /// The pid of a spawned process, as [`pty_cwd`] takes it.
+    fn pid_of(process_id: Option<u32>) -> Option<Pid> {
+        process_id.and_then(|pid| Pid::from_raw(pid.cast_signed()))
+    }
+
+    /// A shell on a pty of its own, as the updater sees it.
+    struct Fixture {
+        /// The pty the shell runs on, as the updater keeps it.
+        parent: Option<OwnedFd>,
+        /// The shell, as the updater knows it.
+        child: Option<Pid>,
+        shell: Box<dyn portable_pty::Child + Send + Sync>,
+        // Keep the pty open for as long as the shell runs on it.
+        master: Box<dyn MasterPty + Send>,
+    }
+
+    impl Fixture {
+        /// Start a shell on a pty of its own, in `cwd`.
+        fn new(cwd: &Path) -> Self {
+            let pair = open_pty();
+            let shell = spawn_shell(&pair, cwd);
+            drop(pair.slave);
+            Self {
+                parent: pty_parent_fd(pair.master.as_ref()),
+                child: pid_of(shell.process_id()),
+                shell,
+                master: pair.master,
+            }
+        }
+
+        /// The directory the updater would move the proxy to.
+        fn cwd(&self) -> Option<PathBuf> {
+            pty_cwd(self.parent.as_ref().map(AsFd::as_fd), self.child)
+        }
+    }
+
+    impl Drop for Fixture {
+        fn drop(&mut self) {
+            let _ = self.shell.kill();
+            let _ = self.shell.wait();
+        }
+    }
+
+    #[rstest]
+    fn the_cwd_is_the_shells_while_it_is_in_the_foreground() {
+        let dir = tempfile::tempdir().unwrap();
+        // A working directory is never a symlink, but a temporary directory may be.
+        let expected = dir.path().canonicalize().unwrap();
+        let fixture = Fixture::new(dir.path());
+
+        let found = settles_on(&Some(expected.clone()), || fixture.cwd());
+
+        assert_eq!(found, Some(expected));
+    }
+
+    #[rstest]
+    fn the_cwd_follows_the_shell_as_it_moves() {
+        let dir = tempfile::tempdir().unwrap();
+        let elsewhere = dir.path().canonicalize().unwrap().join("elsewhere");
+        std::fs::create_dir(&elsewhere).unwrap();
+        let fixture = Fixture::new(dir.path());
+        let mut writer = fixture.master.take_writer().unwrap();
+
+        writeln!(writer, "cd '{}'", elsewhere.display()).unwrap();
+        writer.flush().unwrap();
+
+        let found = settles_on(&Some(elsewhere.clone()), || fixture.cwd());
+
+        assert_eq!(found, Some(elsewhere));
+    }
+
+    #[rstest]
+    fn the_cwd_is_the_foreground_jobs_rather_than_the_shells() {
+        // A multiplexer reports the directory of whatever is in the foreground, which is not the
+        // shell while a job is running.
+        let dir = tempfile::tempdir().unwrap();
+        let home = dir.path().canonicalize().unwrap();
+        let elsewhere = home.join("elsewhere");
+        std::fs::create_dir(&elsewhere).unwrap();
+        let fixture = Fixture::new(&home);
+        let mut writer = fixture.master.take_writer().unwrap();
+
+        // A foreground job of its own, in a directory the shell itself never enters.
+        writeln!(writer, "(cd '{}' && exec sleep 30)", elsewhere.display()).unwrap();
+        writer.flush().unwrap();
+        let found = settles_on(&Some(elsewhere.clone()), || fixture.cwd());
+
+        // Interrupt the job rather than leave it running for half a minute.
+        writer.write_all(&[0x03]).unwrap();
+        writer.flush().unwrap();
+        assert_eq!(
+            fixture.child.and_then(process::cwd),
+            Some(home),
+            "the shell itself never moved, so this can only have come from the foreground job"
+        );
+        assert_eq!(found, Some(elsewhere));
+    }
+
+    #[rstest]
+    fn a_foreground_process_we_cannot_read_falls_back_to_the_child() {
+        // `sudo` puts a process we have no business reading in the foreground, and a process
+        // group outlives the leader that names it. Either way the child is the better answer.
+        let dir = tempfile::tempdir().unwrap();
+        let expected = dir.path().canonicalize().unwrap();
+        // The shell starts somewhere other than the directory we expect back, so a reading
+        // taken from it rather than from the fallback would be visible.
+        let mut fixture = Fixture::new(Path::new("/"));
+        let mut child = Command::new("sleep").arg("30").current_dir(dir.path()).spawn().unwrap();
+        // Leave the terminal naming a foreground process group that no longer exists.
+        fixture.shell.kill().unwrap();
+        fixture.shell.wait().unwrap();
+
+        let found = settles_on(&Some(expected.clone()), || {
+            pty_cwd(fixture.parent.as_ref().map(AsFd::as_fd), pid_of(Some(child.id())))
+        });
+
+        child.kill().unwrap();
+        child.wait().unwrap();
+        assert_eq!(found, Some(expected));
+    }
+
+    #[rstest]
+    fn nothing_readable_has_no_cwd() {
+        // Nothing has claimed this pty, so it names no foreground process group, and there is no
+        // child to fall back to.
+        let pair = open_pty();
+        let parent = pty_parent_fd(pair.master.as_ref());
+
+        assert_eq!(pty_cwd(parent.as_ref().map(AsFd::as_fd), None), None);
+        assert_eq!(pty_cwd(None, None), None);
+    }
+
+    #[rstest]
+    fn the_copied_descriptor_outlives_the_pty_it_came_from() {
+        // The updater keeps a copy of the descriptor precisely so that reading the terminal
+        // doesn't mean holding on to the pty itself.
+        let dir = tempfile::tempdir().unwrap();
+        let expected = dir.path().canonicalize().unwrap();
+        let pair = open_pty();
+        let mut shell = spawn_shell(&pair, dir.path());
+        drop(pair.slave);
+        let parent = pty_parent_fd(pair.master.as_ref());
+        drop(pair.master);
+
+        let found =
+            settles_on(&Some(expected.clone()), || pty_cwd(parent.as_ref().map(AsFd::as_fd), None));
+
+        shell.kill().unwrap();
+        shell.wait().unwrap();
+        assert_eq!(found, Some(expected));
+    }
+}

--- a/crates/atuin-pty-proxy/src/cwd_updater.rs
+++ b/crates/atuin-pty-proxy/src/cwd_updater.rs
@@ -117,7 +117,8 @@ impl CwdUpdater {
 
 #[cfg(test)]
 mod tests {
-    use std::io::Write;
+    use std::fs::File;
+    use std::io::{Read, Write};
     use std::path::Path;
     use std::process::Command;
     use std::time::{Duration, Instant};
@@ -164,14 +165,20 @@ mod tests {
     }
 
     /// A shell on a pty of its own, as the updater sees it.
+    ///
+    /// The descriptors kept here hold the pty open for as long as the fixture lives.
     struct Fixture {
         /// The pty the shell runs on, as the updater keeps it.
         parent: Option<OwnedFd>,
         /// The shell, as the updater knows it.
         child: Option<Pid>,
+        /// The terminal, for typing at the shell.
+        ///
+        /// This is a descriptor of our own rather than portable-pty's writer, whose `Drop`
+        /// writes a newline and an EOF into the terminal -- a blocking write that a test has
+        /// no reason to make, and that would tell the shell to exit.
+        input: File,
         shell: Box<dyn portable_pty::Child + Send + Sync>,
-        // Keep the pty open for as long as the shell runs on it.
-        master: Box<dyn MasterPty + Send>,
     }
 
     impl Fixture {
@@ -180,17 +187,39 @@ mod tests {
             let pair = open_pty();
             let shell = spawn_shell(&pair, cwd);
             drop(pair.slave);
+
+            // Nothing here reads the terminal, and a shell whose output has nowhere to go
+            // stalls once the pty fills -- which takes far less output on some platforms than
+            // on others. Throw it away as it arrives.
+            let mut output = pair.master.try_clone_reader().expect("clone pty reader");
+            std::thread::spawn(move || {
+                let mut buf = [0u8; 1024];
+                while output.read(&mut buf).is_ok_and(|read| read > 0) {}
+            });
+
             Self {
                 parent: pty_parent_fd(pair.master.as_ref()),
                 child: pid_of(shell.process_id()),
+                input: File::from(pty_parent_fd(pair.master.as_ref()).expect("pty descriptor")),
                 shell,
-                master: pair.master,
             }
         }
 
         /// The directory the updater would move the proxy to.
         fn cwd(&self) -> Option<PathBuf> {
             pty_cwd(self.parent.as_ref().map(AsFd::as_fd), self.child)
+        }
+
+        /// Type a line at the shell.
+        fn send_line(&mut self, line: &str) {
+            writeln!(self.input, "{line}").expect("write to pty");
+            self.input.flush().expect("flush pty");
+        }
+
+        /// Send an interrupt, as pressing ctrl-c would.
+        fn interrupt(&mut self) {
+            self.input.write_all(&[0x03]).expect("write to pty");
+            self.input.flush().expect("flush pty");
         }
     }
 
@@ -218,11 +247,9 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let elsewhere = dir.path().canonicalize().unwrap().join("elsewhere");
         std::fs::create_dir(&elsewhere).unwrap();
-        let fixture = Fixture::new(dir.path());
-        let mut writer = fixture.master.take_writer().unwrap();
+        let mut fixture = Fixture::new(dir.path());
 
-        writeln!(writer, "cd '{}'", elsewhere.display()).unwrap();
-        writer.flush().unwrap();
+        fixture.send_line(&format!("cd '{}'", elsewhere.display()));
 
         let found = settles_on(&Some(elsewhere.clone()), || fixture.cwd());
 
@@ -237,17 +264,14 @@ mod tests {
         let home = dir.path().canonicalize().unwrap();
         let elsewhere = home.join("elsewhere");
         std::fs::create_dir(&elsewhere).unwrap();
-        let fixture = Fixture::new(&home);
-        let mut writer = fixture.master.take_writer().unwrap();
+        let mut fixture = Fixture::new(&home);
 
         // A foreground job of its own, in a directory the shell itself never enters.
-        writeln!(writer, "(cd '{}' && exec sleep 30)", elsewhere.display()).unwrap();
-        writer.flush().unwrap();
+        fixture.send_line(&format!("(cd '{}' && exec sleep 30)", elsewhere.display()));
         let found = settles_on(&Some(elsewhere.clone()), || fixture.cwd());
 
         // Interrupt the job rather than leave it running for half a minute.
-        writer.write_all(&[0x03]).unwrap();
-        writer.flush().unwrap();
+        fixture.interrupt();
         assert_eq!(
             fixture.child.and_then(process::cwd),
             Some(home),
@@ -277,6 +301,15 @@ mod tests {
         child.kill().unwrap();
         child.wait().unwrap();
         assert_eq!(found, Some(expected));
+    }
+
+    #[rstest]
+    fn a_descriptor_that_is_not_a_terminal_has_no_foreground_group() {
+        // `tcgetpgrp` answers -1 here. That is not a pid, and unlike the 0 a pty answers with,
+        // `Pid::from_raw` asserts on it rather than returning `None`.
+        let not_a_terminal = File::open("/dev/null").expect("open /dev/null");
+
+        assert_eq!(tcgetpgrp(not_a_terminal.as_fd()), None);
     }
 
     #[rstest]

--- a/crates/atuin-pty-proxy/src/cwd_updater.rs
+++ b/crates/atuin-pty-proxy/src/cwd_updater.rs
@@ -48,7 +48,11 @@ fn pty_cwd(parent: Option<BorrowedFd<'_>>, child: Option<Pid>) -> Option<PathBuf
 fn tcgetpgrp(terminal: BorrowedFd<'_>) -> Option<Pid> {
     // SAFETY: The FD we pass is guaranteed to be valid because it came from a `BorrowedFd` that
     // exists at least for the life of the call.
-    Pid::from_raw(unsafe { libc::tcgetpgrp(terminal.as_raw_fd()) })
+    let pid = unsafe { libc::tcgetpgrp(terminal.as_raw_fd()) };
+    if pid <= 0 {
+        return None;
+    }
+    Pid::from_raw(pid)
 }
 
 /// Updates this process's CWD to match the PTY proxy child's CWD.

--- a/crates/atuin-pty-proxy/src/cwd_updater.rs
+++ b/crates/atuin-pty-proxy/src/cwd_updater.rs
@@ -2,7 +2,7 @@
 //!
 //! This is necessary to enable programs like tmux to detect the CWD of the child.
 
-use std::os::fd::{AsFd, BorrowedFd, OwnedFd};
+use std::os::fd::{AsFd, AsRawFd, BorrowedFd, OwnedFd};
 use std::path::PathBuf;
 use std::sync::mpsc::{self, RecvTimeoutError, SyncSender};
 use std::time::Duration;
@@ -35,8 +35,20 @@ fn pty_parent_fd(parent: &dyn MasterPty) -> Option<OwnedFd> {
 /// This tries to obtain the CWD of the terminal's foreground process group, which is what programs
 /// like tmux do. If that fails, we fall back to querying the CWD of the top-level PTY proxy child.
 fn pty_cwd(parent: Option<BorrowedFd<'_>>, child: Option<Pid>) -> Option<PathBuf> {
-    let parent = parent.and_then(|parent| rustix::termios::tcgetpgrp(parent).ok());
+    let parent = parent.and_then(tcgetpgrp);
     [parent, child].into_iter().flatten().find_map(process::cwd)
+}
+
+/// Get the foreground process group of a terminal.
+///
+/// We avoid using [`rustix::termios::tcgetpgrp`] because rustix has an upstream soundness bug that
+/// causes undefined behavior on macOS. The underlying `tcgetpgrp` libc call returns 0 when called
+/// on a PTY that no session has claimed, but on macOS, this gets passed directly to
+/// `NonZero::new_unchecked`, which is UB.
+fn tcgetpgrp(terminal: BorrowedFd<'_>) -> Option<Pid> {
+    // SAFETY: The FD we pass is guaranteed to be valid because it came from a `BorrowedFd` that
+    // exists at least for the life of the call.
+    Pid::from_raw(unsafe { libc::tcgetpgrp(terminal.as_raw_fd()) })
 }
 
 /// Updates this process's CWD to match the PTY proxy child's CWD.

--- a/crates/atuin-pty-proxy/src/cwd_updater.rs
+++ b/crates/atuin-pty-proxy/src/cwd_updater.rs
@@ -32,9 +32,8 @@ fn pty_parent_fd(parent: &dyn MasterPty) -> Option<OwnedFd> {
 
 /// Get the CWD of the PTY proxy child.
 ///
-/// This tries to obtain the CWD of the foreground process in the process group, which is what
-/// programs like tmux do. If that fails, we fall back to querying the CWD of the top-level PTY
-/// proxy child.
+/// This tries to obtain the CWD of the terminal's foreground process group, which is what programs
+/// like tmux do. If that fails, we fall back to querying the CWD of the top-level PTY proxy child.
 fn pty_cwd(parent: Option<BorrowedFd<'_>>, child: Option<Pid>) -> Option<PathBuf> {
     let parent = parent.and_then(|parent| rustix::termios::tcgetpgrp(parent).ok());
     [parent, child].into_iter().flatten().find_map(process::cwd)

--- a/crates/atuin-pty-proxy/src/lib.rs
+++ b/crates/atuin-pty-proxy/src/lib.rs
@@ -1,6 +1,8 @@
 #[cfg(unix)]
 mod capture;
 #[cfg(unix)]
+mod cwd_updater;
+#[cfg(unix)]
 mod debug;
 #[cfg(unix)]
 mod osc133;

--- a/crates/atuin-pty-proxy/src/runtime.rs
+++ b/crates/atuin-pty-proxy/src/runtime.rs
@@ -5,6 +5,7 @@ use atuin_common::os::unix::tty::TtyId;
 use crossterm::terminal;
 use portable_pty::{CommandBuilder, PtySize, native_pty_system};
 
+use crate::cwd_updater::CwdUpdater;
 use crate::debug::{Osc133DebugHighlighter, RESET};
 use crate::pty_proxy::RuntimeOptions;
 use crate::screen::{self, Msg, SocketServer};
@@ -132,6 +133,11 @@ fn run(options: RuntimeOptions) -> eyre::Result<()> {
     let mut pty_reader = pair.master.try_clone_reader().map_err(|e| eyre::eyre!("{e:#}"))?;
     let mut pty_writer = pair.master.take_writer().map_err(|e| eyre::eyre!("{e:#}"))?;
 
+    let child_pid =
+        child.process_id().and_then(|pid| rustix::process::Pid::from_raw(pid.cast_signed()));
+    // Update this process's CWD to match the child's CWD. This is necessary to enable programs like
+    // tmux to track the child's CWD.
+    let cwd_updater = CwdUpdater::new(pair.master.as_ref(), child_pid);
     spawn_resize_handler(pair.master, msg_tx.clone())?;
     terminal::enable_raw_mode()?;
 
@@ -146,6 +152,7 @@ fn run(options: RuntimeOptions) -> eyre::Result<()> {
                 Ok(n) => {
                     let raw_data = &buf[..n];
                     let _ = msg_tx.send(Msg::Data(raw_data.to_vec()));
+                    cwd_updater.update();
 
                     let highlighted;
                     let data: &[u8] = if let Some(highlighter) = &mut highlighter {

--- a/crates/atuin/tests/e2e_pty_proxy_cwd.rs
+++ b/crates/atuin/tests/e2e_pty_proxy_cwd.rs
@@ -1,0 +1,131 @@
+//! `atuin pty-proxy` follows the working directory of the shell it hosts.
+//!
+//! Terminal multiplexers report a pane's working directory by reading it off the process in the
+//! foreground of the pane's terminal — tmux calls `tcgetpgrp` on the pane's pty, then reads that
+//! process's working directory. Inside a proxy that process is the proxy itself, so unless the
+//! proxy follows its shell, a `cd` is invisible and the pane stays pinned to wherever the proxy
+//! was launched.
+
+#![cfg(unix)]
+
+mod common;
+
+use std::io::{Read, Write};
+use std::sync::Arc;
+
+use atuin_common::os::unix::process;
+use common::{FreshEnv, wait_until};
+use parking_lot::Mutex;
+use portable_pty::{CommandBuilder, PtySize, native_pty_system};
+use rstest::rstest;
+use rustix::process::Pid;
+
+/// Prompt of the shell under test, so the test can tell when it is ready for input.
+const PROMPT: &str = "pty-proxy-e2e>";
+
+/// An `atuin pty-proxy` running on a terminal of its own.
+struct Proxy {
+    child: Box<dyn portable_pty::Child + Send + Sync>,
+    writer: Box<dyn Write + Send>,
+    output: Arc<Mutex<String>>,
+    pid: Pid,
+    // Keep the terminal open for as long as the proxy runs on it.
+    _master: Box<dyn portable_pty::MasterPty + Send>,
+}
+
+impl Proxy {
+    /// Start a proxy hosting `/bin/sh`, in `env`'s home directory.
+    fn start(env: &FreshEnv) -> Self {
+        let pair = native_pty_system()
+            .openpty(PtySize {
+                rows: 24,
+                cols: 80,
+                pixel_width: 0,
+                pixel_height: 0,
+            })
+            .expect("failed to open pty");
+
+        let mut cmd = CommandBuilder::new(env!("CARGO_BIN_EXE_atuin"));
+        cmd.args(["pty-proxy", "--shell", "/bin/sh"]);
+        cmd.env_clear();
+        for (key, value) in env.env_vars() {
+            cmd.env(key, value);
+        }
+        cmd.env("PS1", format!("{PROMPT} "));
+        cmd.cwd(env.home());
+
+        let child = pair.slave.spawn_command(cmd).expect("failed to spawn pty proxy");
+        drop(pair.slave);
+        let pid = Pid::from_raw(child.process_id().expect("proxy has a pid").cast_signed())
+            .expect("proxy pid is not zero");
+
+        // Read continuously: a full terminal buffer would otherwise block the proxy.
+        let output = Arc::new(Mutex::new(String::new()));
+        let mut reader = pair.master.try_clone_reader().expect("failed to clone pty reader");
+        let read_into = Arc::clone(&output);
+        std::thread::spawn(move || {
+            let mut buf = [0u8; 4096];
+            while let Ok(n) = reader.read(&mut buf) {
+                if n == 0 {
+                    break;
+                }
+                read_into.lock().push_str(&String::from_utf8_lossy(&buf[..n]));
+            }
+        });
+
+        Self {
+            child,
+            writer: pair.master.take_writer().expect("failed to take pty writer"),
+            output,
+            pid,
+            _master: pair.master,
+        }
+    }
+
+    fn saw(&self, needle: &str) -> bool {
+        self.output.lock().contains(needle)
+    }
+
+    fn send_line(&mut self, line: &str) {
+        writeln!(self.writer, "{line}").expect("failed to write to pty");
+        self.writer.flush().expect("failed to flush pty");
+    }
+
+    /// Wait for the proxy's own working directory to become `expected`.
+    fn wait_for_cwd(&self, expected: &std::path::Path) {
+        wait_until(&format!("the proxy to follow its shell into {}", expected.display()), || {
+            process::cwd(self.pid).as_deref() == Some(expected)
+        });
+    }
+}
+
+impl Drop for Proxy {
+    fn drop(&mut self) {
+        let _ = self.child.kill();
+        let _ = self.child.wait();
+    }
+}
+
+#[rstest]
+fn the_proxy_follows_its_shell_between_directories() {
+    let env = FreshEnv::new();
+    // A working directory is never a symlink, but a temporary directory may be (/tmp on macOS).
+    let home = env.home().canonicalize().unwrap();
+    let elsewhere = home.join("elsewhere");
+    std::fs::create_dir(&elsewhere).unwrap();
+
+    let mut proxy = Proxy::start(&env);
+    wait_until("a shell prompt inside the proxy", || proxy.saw(PROMPT));
+    assert_eq!(
+        process::cwd(proxy.pid).as_deref(),
+        Some(home.as_path()),
+        "the proxy starts where it was launched"
+    );
+
+    proxy.send_line(&format!("cd '{}'", elsewhere.display()));
+    proxy.wait_for_cwd(&elsewhere);
+
+    // And back again: following is not a one-time reading.
+    proxy.send_line(&format!("cd '{}'", home.display()));
+    proxy.wait_for_cwd(&home);
+}


### PR DESCRIPTION
### Problem

If you change the current working directory inside an Atuin PTY proxy, the CWD change isn't visible to any programs sitting above the PTY proxy. For example, if you have `pty-proxy` running in a tmux pane and do `cd /tmp` inside the pane, tmux is completely unaware that the CWD has changed to `/tmp`, and still thinks it's whatever it was when the PTY proxy was launched.

### Cause

This is an underlying limitation of `tcgetpgrp` and PTYs. tmux uses `tcgetpgrp` to find the terminal's foreground process group, but it can only see one level deep – it doesn't know Atuin created *another* terminal with its own foreground process group and CWD, so all it finds is the CWD of the PTY proxy itself.

### Solution

This PR spawns a loop that periodically updates the PTY proxy process's CWD to match that of the child. An update is performed:

* Whenever output is written to the terminal, but never more often than every 100ms; or
* Once every second, when no output is being written to the terminal

Fixes #3931, fixes #3296.