### PR TITLE
chore(release): prepare for release 18.22.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,66 @@
 
 All notable changes to this project will be documented in this file.
 
+## 18.22.0
+
+### Bug Fixes
+
+- *(daemon)* Periodically flush captured command output to disk ([#4070](https://github.com/atuinsh/atuin/issues/4070))
+- *(daemon)* Stream large DeleteHistory requests ([#4076](https://github.com/atuinsh/atuin/issues/4076))
+- *(daemon)* Delete captured output when history entries are deleted ([#4074](https://github.com/atuinsh/atuin/issues/4074))
+- *(nix)* Export OpenSSL lib for LD_LIBRARY_PATH in nix devshell ([#4018](https://github.com/atuinsh/atuin/issues/4018))
+- *(pty-proxy)* Make PTY proxy aware of other PTYs ([#4079](https://github.com/atuinsh/atuin/issues/4079))
+- *(server)* Wrap multi-write DB operations in transactions ([#4088](https://github.com/atuinsh/atuin/issues/4088))
+- *(server)* Emit HTTP access logs at INFO and compile in debug tracing ([#4087](https://github.com/atuinsh/atuin/issues/4087))
+- *(sync)* Expand a packfile whose range is a hole below the store head ([#4085](https://github.com/atuinsh/atuin/issues/4085))
+- Normalize output of `atuin --version` ([#4038](https://github.com/atuinsh/atuin/issues/4038))
+- Make `atuin ai init` a no-op instead of erroring ([#4040](https://github.com/atuinsh/atuin/issues/4040))
+- Do not try to decrypt plaintext records ([#4057](https://github.com/atuinsh/atuin/issues/4057))
+- Behavior of PTY proxy on terminal resizes ([#4061](https://github.com/atuinsh/atuin/issues/4061))
+- Build error ([#4094](https://github.com/atuinsh/atuin/issues/4094))
+
+### Features
+
+- *(daemon)* Daemon owns History Deletion ([#4045](https://github.com/atuinsh/atuin/issues/4045))
+- *(mcp)* Make agents actually use the atuin MCP server ([#4050](https://github.com/atuinsh/atuin/issues/4050))
+- *(pty-proxy)* Keep the start and end of command captures that exceed the max size ([#4092](https://github.com/atuinsh/atuin/issues/4092))
+- *(pty-proxy)* Mirror the CWD of the PTY proxy child ([#4091](https://github.com/atuinsh/atuin/issues/4091))
+- Implement command capture and remove semantic.rs ([#4048](https://github.com/atuinsh/atuin/issues/4048))
+- Simplify semantic captures ([#4065](https://github.com/atuinsh/atuin/issues/4065))
+- Store terminal size in command captures ([#4072](https://github.com/atuinsh/atuin/issues/4072))
+- Version Stored Output Capture and Avoid PB on disk ([#4068](https://github.com/atuinsh/atuin/issues/4068))
+- Redact secrets from captured command output ([#4071](https://github.com/atuinsh/atuin/issues/4071))
+- Rework inspector and add output view ([#4090](https://github.com/atuinsh/atuin/issues/4090))
+- Add [output_capture] settings ([#4069](https://github.com/atuinsh/atuin/issues/4069))
+
+### Miscellaneous Tasks
+
+- *(ci)* Limit concurrency of workflows on same branch ([#4073](https://github.com/atuinsh/atuin/issues/4073))
+- Lift dependencies into top-level Cargo.toml ([#4042](https://github.com/atuinsh/atuin/issues/4042))
+- Sort dependencies in `Cargo.toml`s ([#4046](https://github.com/atuinsh/atuin/issues/4046))
+- Enable Clippy cast warnings ([#4049](https://github.com/atuinsh/atuin/issues/4049))
+- Temporary workaround for flaky test ([#4083](https://github.com/atuinsh/atuin/issues/4083))
+- Emit proptest regression artifacts so CI failures are reproducible ([#4084](https://github.com/atuinsh/atuin/issues/4084))
+- Lockfile bumps ([#4089](https://github.com/atuinsh/atuin/issues/4089))
+- Don't fail if we can't capture output ([#4086](https://github.com/atuinsh/atuin/issues/4086))
+- Link to upstream rustix issue in atuin-pty-proxy ([#4093](https://github.com/atuinsh/atuin/issues/4093))
+
+### Refactor
+
+- *(daemon)* Manage sync inside of the daemon ([#4055](https://github.com/atuinsh/atuin/issues/4055))
+- *(daemon)* Split output capture into fjall and nop backends ([#4082](https://github.com/atuinsh/atuin/issues/4082))
+- *(deps)* Bump mkdocs-material from 9.7.0 to 9.7.7 in /docs in the uv group across 1 directory ([#4059](https://github.com/atuinsh/atuin/issues/4059))
+- *(deps)* Bump vale-cli/vale-action from 2.1.2 to 3.0.0 ([#3887](https://github.com/atuinsh/atuin/issues/3887))
+- *(deps)* Bump rpassword from 7.4.0 to 7.5.0 in the cargo group across 1 directory ([#3877](https://github.com/atuinsh/atuin/issues/3877))
+- *(history)* Make HistoryId a Copy Uuid ([#4013](https://github.com/atuinsh/atuin/issues/4013))
+- Clean up the history service and fix minor bugs
+
+### Testing
+
+- *(daemon)* Adversarial test suites with new daemon ([#4058](https://github.com/atuinsh/atuin/issues/4058))
+- E2e pty test harness ([#4075](https://github.com/atuinsh/atuin/issues/4075))
+- Filtered commands leave no captured output ([#4081](https://github.com/atuinsh/atuin/issues/4081))
+
 ## 18.21.0
 
 ### Bug Fixes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -254,7 +254,7 @@ checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "atuin"
-version = "18.21.0"
+version = "18.22.0"
 dependencies = [
  "ansi-to-tui",
  "arboard",
@@ -327,7 +327,7 @@ dependencies = [
 
 [[package]]
 name = "atuin-ai"
-version = "18.21.0"
+version = "18.22.0"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -390,7 +390,7 @@ dependencies = [
 
 [[package]]
 name = "atuin-client"
-version = "18.21.0"
+version = "18.22.0"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -456,7 +456,7 @@ dependencies = [
 
 [[package]]
 name = "atuin-common"
-version = "18.21.0"
+version = "18.22.0"
 dependencies = [
  "atuin-vt100",
  "base64",
@@ -505,7 +505,7 @@ dependencies = [
 
 [[package]]
 name = "atuin-daemon"
-version = "18.21.0"
+version = "18.22.0"
 dependencies = [
  "atuin-client",
  "atuin-common",
@@ -553,7 +553,7 @@ dependencies = [
 
 [[package]]
 name = "atuin-domain"
-version = "18.21.0"
+version = "18.22.0"
 dependencies = [
  "async-trait",
  "atuin-common",
@@ -588,7 +588,7 @@ dependencies = [
 
 [[package]]
 name = "atuin-dotfiles"
-version = "18.21.0"
+version = "18.22.0"
 dependencies = [
  "atuin-client",
  "atuin-common",
@@ -606,7 +606,7 @@ dependencies = [
 
 [[package]]
 name = "atuin-history"
-version = "18.21.0"
+version = "18.22.0"
 dependencies = [
  "atuin-client",
  "codspeed-divan-compat",
@@ -621,7 +621,7 @@ dependencies = [
 
 [[package]]
 name = "atuin-kv"
-version = "18.21.0"
+version = "18.22.0"
 dependencies = [
  "atuin-client",
  "atuin-common",
@@ -641,7 +641,7 @@ dependencies = [
 
 [[package]]
 name = "atuin-pty-proxy"
-version = "18.21.0"
+version = "18.22.0"
 dependencies = [
  "atuin-client",
  "atuin-common",
@@ -662,7 +662,7 @@ dependencies = [
 
 [[package]]
 name = "atuin-scripts"
-version = "18.21.0"
+version = "18.22.0"
 dependencies = [
  "atuin-client",
  "atuin-common",
@@ -703,7 +703,7 @@ dependencies = [
 
 [[package]]
 name = "atuin-server"
-version = "18.21.0"
+version = "18.22.0"
 dependencies = [
  "argon2",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = ["crates/*"]
 exclude = ["ui/backend"]
 
 [workspace.package]
-version = "18.21.0"
+version = "18.22.0"
 authors = ["Ellie Huxtable <ellie@atuin.sh>"]
 rust-version = "1.98.0"
 license = "MIT"
@@ -13,17 +13,17 @@ repository = "https://github.com/atuinsh/atuin"
 readme = "README.md"
 
 [workspace.dependencies]
-atuin-ai = { path = "crates/atuin-ai", version = "18.21.0", default-features = false }
-atuin-client = { path = "crates/atuin-client", version = "18.21.0" }
-atuin-common = { path = "crates/atuin-common", version = "18.21.0" }
-atuin-daemon = { path = "crates/atuin-daemon", version = "18.21.0", default-features = false }
-atuin-domain = { path = "crates/atuin-domain", version = "18.21.0" }
-atuin-dotfiles = { path = "crates/atuin-dotfiles", version = "18.21.0" }
-atuin-history = { path = "crates/atuin-history", version = "18.21.0" }
-atuin-kv = { path = "crates/atuin-kv", version = "18.21.0" }
-atuin-pty-proxy = { path = "crates/atuin-pty-proxy", version = "18.21.0", default-features = false }
-atuin-scripts = { path = "crates/atuin-scripts", version = "18.21.0" }
-atuin-server = { path = "crates/atuin-server", version = "18.21.0" }
+atuin-ai = { path = "crates/atuin-ai", version = "18.22.0", default-features = false }
+atuin-client = { path = "crates/atuin-client", version = "18.22.0" }
+atuin-common = { path = "crates/atuin-common", version = "18.22.0" }
+atuin-daemon = { path = "crates/atuin-daemon", version = "18.22.0", default-features = false }
+atuin-domain = { path = "crates/atuin-domain", version = "18.22.0" }
+atuin-dotfiles = { path = "crates/atuin-dotfiles", version = "18.22.0" }
+atuin-history = { path = "crates/atuin-history", version = "18.22.0" }
+atuin-kv = { path = "crates/atuin-kv", version = "18.22.0" }
+atuin-pty-proxy = { path = "crates/atuin-pty-proxy", version = "18.22.0", default-features = false }
+atuin-scripts = { path = "crates/atuin-scripts", version = "18.22.0" }
+atuin-server = { path = "crates/atuin-server", version = "18.22.0" }
 atuin-vt100 = "0.19"
 
 ansi-to-tui = { version = "8.0.1", default-features = false }

--- a/crates/atuin-server/Cargo.toml
+++ b/crates/atuin-server/Cargo.toml
@@ -59,7 +59,7 @@ uuid = { workspace = true }
 # TODO(taylordotfish): in Rust 1.99 we can change this to `workspace = true`
 atuin-client = {
     path = "../atuin-client",
-    version = "18.21.0",
+    version = "18.22.0",
     default-features = false,
     features = ["sync"],
 }

--- a/crates/atuin/Cargo.toml
+++ b/crates/atuin/Cargo.toml
@@ -77,7 +77,7 @@ atuin-ai = { workspace = true, optional = true }
 # TODO(taylordotfish): in Rust 1.99 we can change this to `workspace = true`
 atuin-client = {
     path = "../atuin-client",
-    version = "18.21.0",
+    version = "18.22.0",
     optional = true,
     default-features = false,
 }


### PR DESCRIPTION

### Bug Fixes

- *(daemon)* Periodically flush captured command output to disk ([#4070](https://github.com/atuinsh/atuin/issues/4070))
- *(daemon)* Stream large DeleteHistory requests ([#4076](https://github.com/atuinsh/atuin/issues/4076))
- *(daemon)* Delete captured output when history entries are deleted ([#4074](https://github.com/atuinsh/atuin/issues/4074))
- *(nix)* Export OpenSSL lib for LD_LIBRARY_PATH in nix devshell ([#4018](https://github.com/atuinsh/atuin/issues/4018))
- *(pty-proxy)* Make PTY proxy aware of other PTYs ([#4079](https://github.com/atuinsh/atuin/issues/4079))
- *(server)* Wrap multi-write DB operations in transactions ([#4088](https://github.com/atuinsh/atuin/issues/4088))
- *(server)* Emit HTTP access logs at INFO and compile in debug tracing ([#4087](https://github.com/atuinsh/atuin/issues/4087))
- *(sync)* Expand a packfile whose range is a hole below the store head ([#4085](https://github.com/atuinsh/atuin/issues/4085))
- Normalize output of `atuin --version` ([#4038](https://github.com/atuinsh/atuin/issues/4038))
- Make `atuin ai init` a no-op instead of erroring ([#4040](https://github.com/atuinsh/atuin/issues/4040))
- Do not try to decrypt plaintext records ([#4057](https://github.com/atuinsh/atuin/issues/4057))
- Behavior of PTY proxy on terminal resizes ([#4061](https://github.com/atuinsh/atuin/issues/4061))
- Build error ([#4094](https://github.com/atuinsh/atuin/issues/4094))

### Features

- *(daemon)* Daemon owns History Deletion ([#4045](https://github.com/atuinsh/atuin/issues/4045))
- *(mcp)* Make agents actually use the atuin MCP server ([#4050](https://github.com/atuinsh/atuin/issues/4050))
- *(pty-proxy)* Keep the start and end of command captures that exceed the max size ([#4092](https://github.com/atuinsh/atuin/issues/4092))
- *(pty-proxy)* Mirror the CWD of the PTY proxy child ([#4091](https://github.com/atuinsh/atuin/issues/4091))
- Implement command capture and remove semantic.rs ([#4048](https://github.com/atuinsh/atuin/issues/4048))
- Simplify semantic captures ([#4065](https://github.com/atuinsh/atuin/issues/4065))
- Store terminal size in command captures ([#4072](https://github.com/atuinsh/atuin/issues/4072))
- Version Stored Output Capture and Avoid PB on disk ([#4068](https://github.com/atuinsh/atuin/issues/4068))
- Redact secrets from captured command output ([#4071](https://github.com/atuinsh/atuin/issues/4071))
- Rework inspector and add output view ([#4090](https://github.com/atuinsh/atuin/issues/4090))
- Add [output_capture] settings ([#4069](https://github.com/atuinsh/atuin/issues/4069))

### Miscellaneous Tasks

- *(ci)* Limit concurrency of workflows on same branch ([#4073](https://github.com/atuinsh/atuin/issues/4073))
- Lift dependencies into top-level Cargo.toml ([#4042](https://github.com/atuinsh/atuin/issues/4042))
- Sort dependencies in `Cargo.toml`s ([#4046](https://github.com/atuinsh/atuin/issues/4046))
- Enable Clippy cast warnings ([#4049](https://github.com/atuinsh/atuin/issues/4049))
- Temporary workaround for flaky test ([#4083](https://github.com/atuinsh/atuin/issues/4083))
- Emit proptest regression artifacts so CI failures are reproducible ([#4084](https://github.com/atuinsh/atuin/issues/4084))
- Lockfile bumps ([#4089](https://github.com/atuinsh/atuin/issues/4089))
- Don't fail if we can't capture output ([#4086](https://github.com/atuinsh/atuin/issues/4086))
- Link to upstream rustix issue in atuin-pty-proxy ([#4093](https://github.com/atuinsh/atuin/issues/4093))

### Refactor

- *(daemon)* Manage sync inside of the daemon ([#4055](https://github.com/atuinsh/atuin/issues/4055))
- *(daemon)* Split output capture into fjall and nop backends ([#4082](https://github.com/atuinsh/atuin/issues/4082))
- *(deps)* Bump mkdocs-material from 9.7.0 to 9.7.7 in /docs in the uv group across 1 directory ([#4059](https://github.com/atuinsh/atuin/issues/4059))
- *(deps)* Bump vale-cli/vale-action from 2.1.2 to 3.0.0 ([#3887](https://github.com/atuinsh/atuin/issues/3887))
- *(deps)* Bump rpassword from 7.4.0 to 7.5.0 in the cargo group across 1 directory ([#3877](https://github.com/atuinsh/atuin/issues/3877))
- *(history)* Make HistoryId a Copy Uuid ([#4013](https://github.com/atuinsh/atuin/issues/4013))
- Clean up the history service and fix minor bugs

### Testing

- *(daemon)* Adversarial test suites with new daemon ([#4058](https://github.com/atuinsh/atuin/issues/4058))
- E2e pty test harness ([#4075](https://github.com/atuinsh/atuin/issues/4075))
- Filtered commands leave no captured output ([#4081](https://github.com/atuinsh/atuin/issues/4081))