### PR TITLE
feat: report output-capture store state in atuin doctor

### DIFF
--- a/crates/atuin-daemon/proto/history.proto
+++ b/crates/atuin-daemon/proto/history.proto
@@ -237,6 +237,37 @@ message OutputChunk {
   string content = 2;
 }
 
+// Request for a snapshot of the command-output capture store's state. Takes no arguments.
+message GetOutputCaptureStatsRequest {}
+
+// A snapshot of the capture store's state.
+message GetOutputCaptureStatsReply {
+  string version = 1;
+  uint32 protocol = 2;
+  // Present when a persistent store is active; absent when capture is disabled (the store
+  // could not be opened and the daemon fell back to a no-op backend).
+  optional OutputCaptureStore store = 3;
+}
+
+// Size and contents of the durable capture store.
+message OutputCaptureStore {
+  // Exact number of captures currently stored.
+  uint64 stored_captures = 1;
+  // On-disk size, in bytes, of the store's FLUSHED segments (post-compression). Recent captures
+  // may still be sitting in the daemon's in-memory memtable, which is not counted here and is
+  // only rotated to disk at a 64 MiB threshold -- so a small, active store can legitimately
+  // report 0 even though captures have been written.
+  uint64 disk_bytes = 2;
+  // Creation time (unix ms) of the oldest / newest stored capture, from the UUIDv7 ids. Absent
+  // when the store is empty.
+  optional uint64 oldest_capture_unix_ms = 3;
+  optional uint64 newest_capture_unix_ms = 4;
+  // Absolute path of the store directory on the daemon host.
+  string store_path = 5;
+  // Keyspace/schema name, e.g. "output_capture_v2".
+  string schema = 6;
+}
+
 service History {
   rpc StartHistory(StartHistoryRequest) returns (StartHistoryReply);
 
@@ -275,4 +306,7 @@ service History {
   // Returns:
   //  - `tonic::Status::not_found` if the given output is not found.
   rpc GetCommandOutput(GetCommandOutputRequest) returns (GetCommandOutputResponse);
+
+  // Report a snapshot of the command-output capture store's state (size, count, time span).
+  rpc GetOutputCaptureStats(GetOutputCaptureStatsRequest) returns (GetOutputCaptureStatsReply);
 }

--- a/crates/atuin-daemon/src/client.rs
+++ b/crates/atuin-daemon/src/client.rs
@@ -23,7 +23,8 @@ use crate::grpc::history::pb::history_client::HistoryClient as HistoryServiceCli
 use crate::grpc::history::pb::{
     AuthorKind, CancelHistoryReply, CancelHistoryRequest, CommandCapture, CommandCaptureMeta,
     DeleteHistoryReply, DeleteHistoryRequest, EndHistoryReply, EndHistoryRequest,
-    GetCommandOutputRequest, GetCommandOutputResponse, RebuildHistoryReply, RebuildHistoryRequest,
+    GetCommandOutputRequest, GetCommandOutputResponse, GetOutputCaptureStatsReply,
+    GetOutputCaptureStatsRequest, RebuildHistoryReply, RebuildHistoryRequest,
     RegisterCommandOutputRequest, ShutdownRequest, StartHistoryReply, StartHistoryRequest,
     StatusReply, StatusRequest, TailHistoryReply, TailHistoryRequest,
 };
@@ -253,6 +254,15 @@ impl HistoryClient {
             Err(status) if status.code() == Code::NotFound => Ok(None),
             Err(status) => Err(status.into()),
         }
+    }
+
+    /// Fetch a snapshot of the daemon's output-capture store state.
+    pub async fn output_capture_stats(&mut self) -> Result<GetOutputCaptureStatsReply> {
+        Ok(self
+            .client
+            .get_output_capture_stats(GetOutputCaptureStatsRequest {})
+            .await?
+            .into_inner())
     }
 }
 

--- a/crates/atuin-daemon/src/grpc/history/mod.rs
+++ b/crates/atuin-daemon/src/grpc/history/mod.rs
@@ -18,10 +18,11 @@ use crate::grpc::history::pb::history_server::History as GrpcService;
 use crate::grpc::history::pb::{
     CancelHistoryReply, CancelHistoryRequest, DeleteHistoryReply, DeleteHistoryRequest,
     DeleteHistoryStreamExt, EndHistoryReply, EndHistoryRequest, GetCommandOutputRequest,
-    GetCommandOutputResponse, Lagged, RebuildHistoryReply, RebuildHistoryRequest,
-    RegisterCommandOutputRequest, RegisterCommandOutputResponse, ShutdownReply, ShutdownRequest,
-    StartHistoryReply, StartHistoryRequest, StatusReply, StatusRequest, TailHistoryEvent,
-    TailHistoryReply, TailHistoryRequest,
+    GetCommandOutputResponse, GetOutputCaptureStatsReply, GetOutputCaptureStatsRequest, Lagged,
+    RebuildHistoryReply, RebuildHistoryRequest, RegisterCommandOutputRequest,
+    RegisterCommandOutputResponse, ShutdownReply, ShutdownRequest, StartHistoryReply,
+    StartHistoryRequest, StatusReply, StatusRequest, TailHistoryEvent, TailHistoryReply,
+    TailHistoryRequest,
 };
 use crate::history_journal::HistoryJournal;
 
@@ -231,7 +232,7 @@ use crate::history_journal::HistoryJournal;
 /// **Note that you should never change the `Shutdown` and `Status` RPCs as they do not have the
 /// protocol version guards.** They are **assumed** to be stable and if you want to modify them, you
 /// **must** use the `reserved` keyword.
-const DAEMON_PROTOCOL_VERSION: u32 = 2;
+const DAEMON_PROTOCOL_VERSION: u32 = 3;
 
 /// The History gRPC service.
 ///
@@ -446,5 +447,18 @@ impl GrpcService for Service {
             })?;
 
         Ok(Response::new(GetCommandOutputResponse::build(&capture.into(), request.output_ranges())))
+    }
+
+    #[instrument(skip_all, level = Level::TRACE)]
+    async fn get_output_capture_stats(
+        &self,
+        _request: Request<GetOutputCaptureStatsRequest>,
+    ) -> Result<Response<GetOutputCaptureStatsReply>, Status> {
+        let store = self.journal.output_capture_stats().await?;
+        Ok(Response::new(GetOutputCaptureStatsReply {
+            version: env!("CARGO_PKG_VERSION").to_string(),
+            protocol: DAEMON_PROTOCOL_VERSION,
+            store: store.map(Into::into),
+        }))
     }
 }

--- a/crates/atuin-daemon/src/grpc/history/pb.rs
+++ b/crates/atuin-daemon/src/grpc/history/pb.rs
@@ -27,7 +27,7 @@ use crate::history_journal::{
     CmdCancelError, CmdDeleteError, CmdEvent, CmdFinishError, CmdRebuildError, GetCmdInFlightError,
     RegisterOutputError,
 };
-use crate::output_capture::{CaptureError, GetOutputError};
+use crate::output_capture::{CaptureError, GetOutputError, OutputCaptureStats};
 
 impl From<DomainHistoryId> for HistoryId {
     fn from(value: DomainHistoryId) -> Self {
@@ -475,6 +475,19 @@ impl GetCommandOutputResponse {
     }
 }
 
+impl From<OutputCaptureStats> for OutputCaptureStore {
+    fn from(stats: OutputCaptureStats) -> Self {
+        Self {
+            stored_captures: stats.stored_captures,
+            disk_bytes: stats.disk_bytes,
+            oldest_capture_unix_ms: stats.oldest_capture_unix_ms,
+            newest_capture_unix_ms: stats.newest_capture_unix_ms,
+            store_path: stats.store_path.to_string_lossy().into_owned(),
+            schema: stats.schema.to_string(),
+        }
+    }
+}
+
 invalid_argument_errors!(
     IdParseError,
     StartHistoryRequestParseError,
@@ -490,6 +503,7 @@ versioned_messages!(
     CancelHistoryReply,
     DeleteHistoryReply,
     RebuildHistoryReply,
+    GetOutputCaptureStatsReply,
 );
 
 internal_errors!(GetOutputError);

--- a/crates/atuin-daemon/src/history_journal.rs
+++ b/crates/atuin-daemon/src/history_journal.rs
@@ -98,7 +98,7 @@ use tokio_stream::wrappers::BroadcastStream;
 use tracing::field::Empty;
 use tracing::{Instrument, Span};
 
-use crate::output_capture::{CaptureError, GetOutputError, OutputCapture};
+use crate::output_capture::{CaptureError, GetOutputError, OutputCapture, OutputCaptureStats};
 use crate::search::SearchIndex;
 
 /// An event describing a change in the lifecycle of a command.
@@ -642,6 +642,11 @@ impl HistoryJournal {
         id: HistoryId,
     ) -> Result<Option<CommandCapture>, GetOutputError> {
         self.output_capture.get(id).await
+    }
+
+    /// Statistics about the durable output-capture store, or `None` when capture is disabled.
+    pub async fn output_capture_stats(&self) -> Result<Option<OutputCaptureStats>, GetOutputError> {
+        self.output_capture.stats().await
     }
 
     /// Create a new stream of [`CmdEvent`] objects.

--- a/crates/atuin-daemon/src/lib.rs
+++ b/crates/atuin-daemon/src/lib.rs
@@ -31,7 +31,7 @@ pub use history_journal::{
     GetCmdInFlightError, HistoryJournal, RegisterOutputError,
 };
 pub use output_capture::{
-    BackendKind, CaptureError, DeleteOutputError, GetOutputError, OutputCapture,
+    BackendKind, CaptureError, DeleteOutputError, GetOutputError, OutputCapture, OutputCaptureStats,
 };
 
 /// Boot the daemon using the new component-based architecture.

--- a/crates/atuin-daemon/src/output_capture/backend/failing.rs
+++ b/crates/atuin-daemon/src/output_capture/backend/failing.rs
@@ -1,6 +1,8 @@
 use atuin_client::history::{CommandCapture, HistoryId};
 
-use super::{Backend, BackendError, CaptureError, DeleteOutputError, GetOutputError};
+use super::{
+    Backend, BackendError, CaptureError, DeleteOutputError, GetOutputError, OutputCaptureStats,
+};
 
 /// A [`Backend`] whose every operation fails, standing in for a broken output store.
 ///
@@ -25,5 +27,9 @@ impl Backend for FailingBackend {
 
     async fn remove(&self, _ids: Vec<HistoryId>) -> Result<(), DeleteOutputError> {
         Err(DeleteOutputError::Storage(unavailable()))
+    }
+
+    async fn stats(&self) -> Result<Option<OutputCaptureStats>, GetOutputError> {
+        Err(GetOutputError::Storage("failing backend".into()))
     }
 }

--- a/crates/atuin-daemon/src/output_capture/backend/fjall/mod.rs
+++ b/crates/atuin-daemon/src/output_capture/backend/fjall/mod.rs
@@ -14,6 +14,7 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::Duration;
 
 use atuin_client::history::{CommandCapture, HistoryId};
+use easy_cast::Conv;
 use fjall::{OptimisticTxDatabase, OptimisticTxKeyspace, PersistMode, Readable};
 use schema::{Schema as _, SchemaV2};
 use tokio::task::JoinHandle;
@@ -230,6 +231,57 @@ impl Backend for FjallBackend {
         .await
         .expect("output-capture delete task panicked")
     }
+
+    async fn stats(&self) -> Result<Option<super::OutputCaptureStats>, GetOutputError> {
+        let keyspace = self.keyspace.clone();
+        tokio::task::spawn_blocking(move || {
+            // Exact live-entry count. O(n) over the keyspace index — acceptable for a diagnostic,
+            // and honest: `approximate_len()` over-counts after deletes (tombstones).
+            let stored_captures = u64::conv(
+                keyspace.inner().len().map_err(|err| GetOutputError::Storage(Box::new(err)))?,
+            );
+
+            // On-disk footprint of this keyspace, post-LZ4 (differs from any uncompressed sum).
+            let disk_bytes = keyspace.inner().disk_space();
+
+            // History ids are UUIDv7; their bytes sort in creation order, so the first and last
+            // keys are the oldest and newest captures.
+            let oldest_capture_unix_ms = keyspace
+                .first_key_value()
+                .map(fjall::Guard::key)
+                .transpose()
+                .map_err(|err| GetOutputError::Storage(Box::new(err)))?
+                .and_then(|key| key_to_unix_ms(key.as_ref()));
+            let newest_capture_unix_ms = keyspace
+                .last_key_value()
+                .map(fjall::Guard::key)
+                .transpose()
+                .map_err(|err| GetOutputError::Storage(Box::new(err)))?
+                .and_then(|key| key_to_unix_ms(key.as_ref()));
+
+            Ok(Some(super::OutputCaptureStats {
+                stored_captures,
+                disk_bytes,
+                oldest_capture_unix_ms,
+                newest_capture_unix_ms,
+                store_path: keyspace.path(),
+                schema: ActiveSchema::NAME,
+            }))
+        })
+        .await
+        .expect("output-capture stats task panicked")
+    }
+}
+
+/// Decode the creation time (unix ms) embedded in a UUIDv7 history-id key.
+///
+/// Returns `None` for keys that are not a 16-byte UUIDv7 (e.g. a test id built from a plain
+/// `u128`), so a non-v7 id degrades to "unknown" rather than a bogus timestamp.
+fn key_to_unix_ms(key: &[u8]) -> Option<u64> {
+    let bytes: [u8; 16] = key.try_into().ok()?;
+    let ts = uuid::Uuid::from_bytes(bytes).get_timestamp()?;
+    let (secs, subsec_nanos) = ts.to_unix();
+    Some(secs.saturating_mul(1000).saturating_add(u64::from(subsec_nanos) / 1_000_000))
 }
 
 #[cfg(test)]
@@ -247,6 +299,12 @@ mod tests {
 
     fn hid(n: u128) -> HistoryId {
         HistoryId::from_bytes(*Uuid::from_u128(n).as_bytes())
+    }
+
+    /// A history id backed by a real UUIDv7, so its embedded creation time is decodable. The
+    /// module's `hid(n)` builds a plain `Uuid::from_u128`, which is not v7 and has no timestamp.
+    fn hid_v7() -> HistoryId {
+        HistoryId::from_bytes(*atuin_common::utils::uuid_v7().as_bytes())
     }
 
     fn cap(output: &str) -> CommandCapture {
@@ -389,5 +447,31 @@ mod tests {
         assert!(store.get(hid(1)).await.expect("get").is_none());
         // Re-removing an already-removed id alongside an absent one is still Ok.
         store.remove(vec![hid(1), hid(9)]).await.expect("remove again");
+    }
+
+    #[tokio::test]
+    async fn stats_counts_sizes_and_time_range() {
+        let (store, _dir) = temp_backend();
+
+        // An empty store reports itself as an active fjall store with nothing in it.
+        let stats = store.stats().await.expect("stats").expect("fjall backend reports stats");
+        assert_eq!(stats.stored_captures, 0);
+        assert_eq!(stats.oldest_capture_unix_ms, None);
+        assert_eq!(stats.newest_capture_unix_ms, None);
+        assert_eq!(stats.schema, "output_capture_v2");
+
+        store.capture(hid_v7(), cap("first")).await.expect("capture");
+        store.capture(hid_v7(), cap("second")).await.expect("capture");
+
+        // `disk_space()` only counts flushed segments, and two tiny captures never cross the
+        // (64 MiB default) memtable threshold on their own; force the flush fjall's own tests use.
+        store.keyspace.inner().rotate_memtable_and_wait().expect("flush memtable to disk");
+        let stats = store.stats().await.expect("stats").expect("present");
+        assert_eq!(stats.stored_captures, 2);
+        assert!(stats.disk_bytes > 0, "a non-empty keyspace occupies disk");
+        // Keys sort in creation order, so the first key's time is never after the last key's.
+        let oldest = stats.oldest_capture_unix_ms.expect("v7 ids decode to a time");
+        let newest = stats.newest_capture_unix_ms.expect("v7 ids decode to a time");
+        assert!(oldest <= newest);
     }
 }

--- a/crates/atuin-daemon/src/output_capture/backend/mod.rs
+++ b/crates/atuin-daemon/src/output_capture/backend/mod.rs
@@ -35,6 +35,23 @@ pub enum DeleteOutputError {
     Storage(#[source] BackendError),
 }
 
+/// A point-in-time snapshot of the durable capture store's size and contents.
+#[derive(Debug, Clone)]
+pub struct OutputCaptureStats {
+    /// Exact number of captures currently stored.
+    pub stored_captures: u64,
+    /// On-disk size of the store's keyspace, in bytes (post-compression).
+    pub disk_bytes: u64,
+    /// Creation time (unix ms) of the oldest / newest stored capture, decoded from the UUIDv7
+    /// history-id keys. `None` when the store is empty (or an id is not a UUIDv7).
+    pub oldest_capture_unix_ms: Option<u64>,
+    pub newest_capture_unix_ms: Option<u64>,
+    /// Absolute path of the store directory.
+    pub store_path: std::path::PathBuf,
+    /// Keyspace/schema name, e.g. `"output_capture_v2"`.
+    pub schema: &'static str,
+}
+
 #[enum_dispatch]
 #[allow(async_fn_in_trait, reason = "only used within our code and we don't need it to be Send")]
 pub trait Backend {
@@ -44,6 +61,9 @@ pub trait Backend {
 
     /// Forget the captured output of every history id in `ids`. Absent ids are ignored.
     async fn remove(&self, ids: Vec<HistoryId>) -> Result<(), DeleteOutputError>;
+
+    /// Store-wide statistics, or `None` for a backend that does not persist (the nop backend).
+    async fn stats(&self) -> Result<Option<OutputCaptureStats>, GetOutputError>;
 }
 
 #[enum_dispatch(Backend)]

--- a/crates/atuin-daemon/src/output_capture/backend/nop.rs
+++ b/crates/atuin-daemon/src/output_capture/backend/nop.rs
@@ -1,6 +1,6 @@
 use atuin_client::history::{CommandCapture, HistoryId};
 
-use super::{Backend, CaptureError, DeleteOutputError, GetOutputError};
+use super::{Backend, CaptureError, DeleteOutputError, GetOutputError, OutputCaptureStats};
 
 /// [`Backend`] implementation which does nothing. All output capture is discarded.
 #[derive(Debug, Clone, Copy)]
@@ -17,5 +17,9 @@ impl Backend for NopBackend {
 
     async fn remove(&self, _ids: Vec<HistoryId>) -> Result<(), DeleteOutputError> {
         Ok(())
+    }
+
+    async fn stats(&self) -> Result<Option<OutputCaptureStats>, GetOutputError> {
+        Ok(None)
     }
 }

--- a/crates/atuin-daemon/src/output_capture/mod.rs
+++ b/crates/atuin-daemon/src/output_capture/mod.rs
@@ -2,7 +2,9 @@ mod backend;
 
 use atuin_client::history::{CommandCapture, HistoryId};
 use backend::{AnyBackend, Backend as _, FjallBackend, NopBackend};
-pub use backend::{BackendKind, CaptureError, DeleteOutputError, GetOutputError};
+pub use backend::{
+    BackendKind, CaptureError, DeleteOutputError, GetOutputError, OutputCaptureStats,
+};
 use tracing::error;
 
 /// [`OutputCapture`] is the core engine responsible for collecting command output.
@@ -65,6 +67,11 @@ impl OutputCapture {
 
     pub async fn get(&self, id: HistoryId) -> Result<Option<CommandCapture>, GetOutputError> {
         self.backend.get(id).await
+    }
+
+    /// Store-wide statistics, or `None` when capture is disabled (the nop backend).
+    pub async fn stats(&self) -> Result<Option<OutputCaptureStats>, GetOutputError> {
+        self.backend.stats().await
     }
 
     /// Forget the captured output of every history id in `ids`.
@@ -143,5 +150,12 @@ mod tests {
     async fn remove_on_the_nop_backend_is_ok() {
         let store = OutputCapture::nop();
         store.remove([hid(1), hid(2)]).await.expect("remove is discarded, not failed");
+    }
+
+    #[tokio::test]
+    async fn nop_store_reports_no_stats() {
+        // A disabled store distinguishes itself by having no stats at all; the gRPC layer relies
+        // on that `None` to report the store as disabled rather than as an empty live store.
+        assert!(OutputCapture::nop().stats().await.expect("stats").is_none());
     }
 }

--- a/crates/atuin-daemon/tests/history_delete.rs
+++ b/crates/atuin-daemon/tests/history_delete.rs
@@ -92,7 +92,7 @@ async fn delete_reports_every_id_it_processed(
     let reply = client.delete_history(ids.clone()).await.unwrap();
 
     assert_eq!(reply.deleted, expected_deleted);
-    assert_eq!(reply.protocol, 2);
+    assert_eq!(reply.protocol, 3);
     assert_eq!(env.active_rows().await, 0, "no named row may survive");
     for id in &persisted {
         assert!(env.history_db.load(*id).await.unwrap().is_none());

--- a/crates/atuin-daemon/tests/history_rebuild.rs
+++ b/crates/atuin-daemon/tests/history_rebuild.rs
@@ -37,7 +37,7 @@ async fn rebuild_rederives_rows_from_the_store(#[future(awt)] env: TestEnv) {
     *env.index.write().await = SearchIndex::default();
 
     let reply = client.rebuild_history().await.unwrap();
-    assert_eq!(reply.protocol, 2);
+    assert_eq!(reply.protocol, 3);
 
     assert_eq!(env.active_ids().await, HashSet::from([lost, db_only.id]));
     assert_eq!(env.index_hits("lost-from-db").await, vec![lost]);

--- a/crates/atuin-daemon/tests/lifecycle.rs
+++ b/crates/atuin-daemon/tests/lifecycle.rs
@@ -26,7 +26,7 @@ async fn test_status(#[future(awt)] env: TestEnv) {
     let status = client.status().await.unwrap();
     assert!(status.healthy);
     assert_eq!(status.version, env!("CARGO_PKG_VERSION"));
-    assert_eq!(status.protocol, 2);
+    assert_eq!(status.protocol, 3);
     assert!(status.pid > 0);
 }
 
@@ -288,7 +288,7 @@ async fn test_delete_history_removes_entry(#[future(awt)] env: TestEnv) {
 
     let reply = client.delete_history(vec![id]).await.unwrap();
     assert_eq!(reply.deleted, 1);
-    assert_eq!(reply.protocol, 2);
+    assert_eq!(reply.protocol, 3);
     assert_eq!(env.active_rows().await, 0);
 
     // Deleting an already-deleted id still succeeds (idempotent), counting the record write.
@@ -303,11 +303,37 @@ async fn test_rebuild_history(#[future(awt)] env: TestEnv) {
     env.record(&mut client, "echo before-rebuild").await;
 
     let reply = client.rebuild_history().await.unwrap();
-    assert_eq!(reply.protocol, 2);
+    assert_eq!(reply.protocol, 3);
 
     // The journal keeps working after a rebuild.
     let id = env.record(&mut client, "echo after-rebuild").await;
     assert_eq!(client.delete_history(vec![id]).await.unwrap().deleted, 1);
+}
+
+#[rstest]
+#[tokio::test]
+async fn test_output_capture_stats(#[future(awt)] env: TestEnv) {
+    let mut client = env.history_client().await;
+
+    // Empty store: reachable, active (fjall), nothing stored.
+    let empty = client.output_capture_stats().await.unwrap();
+    assert_eq!(empty.protocol, 3);
+    let store = empty.store.expect("fjall store is active");
+    assert_eq!(store.stored_captures, 0);
+    assert!(store.oldest_capture_unix_ms.is_none());
+    assert_eq!(store.schema, "output_capture_v2");
+
+    // Record a command (real UUIDv7 id) and register its output.
+    let id = env.record(&mut client, "echo hello").await;
+    client.register_command_output(id, "hello", None, 5, 80, 24).await.unwrap();
+
+    let after = client.output_capture_stats().await.unwrap().store.expect("active");
+    assert_eq!(after.stored_captures, 1);
+    // `disk_bytes` counts only flushed on-disk segments; fjall only rotates its memtable to disk
+    // at a 64 MiB threshold, so one small capture legitimately still reports 0 here.
+    // The single capture is both oldest and newest, and its time comes from the v7 id.
+    let oldest = after.oldest_capture_unix_ms.expect("v7 id yields a timestamp");
+    assert_eq!(Some(oldest), after.newest_capture_unix_ms);
 }
 
 #[rstest]

--- a/crates/atuin/src/command/client/daemon.rs
+++ b/crates/atuin/src/command/client/daemon.rs
@@ -13,6 +13,7 @@ use atuin_client::record::sqlite_store::SqliteStore;
 use atuin_client::settings::Settings;
 use atuin_common::futures::Backoff;
 use atuin_daemon::client::{DaemonClientErrorKind, HistoryClient, classify_error};
+use atuin_daemon::grpc::history::pb::OutputCaptureStore;
 use clap::Subcommand;
 #[cfg(unix)]
 use daemonize::Daemonize;
@@ -246,6 +247,38 @@ async fn probe(settings: &Settings) -> Probe {
             }
         }
         Err(err) => Probe::Unreachable(err),
+    }
+}
+
+/// The daemon's output-capture store state, as seen by a strictly read-only probe.
+pub(super) enum OutputCaptureReport {
+    /// The store is live; carries its statistics.
+    Active(OutputCaptureStore),
+    /// The daemon is reachable but its store failed to open (nop backend).
+    Disabled,
+    /// The daemon is reachable but its version/protocol does not match ours.
+    NeedsRestart(String),
+    /// The daemon could not be reached.
+    NotRunning,
+    /// The stats RPC returned an error.
+    Error(String),
+}
+
+/// Read the daemon's output-capture store state without ever restarting it.
+///
+/// `atuin doctor` must stay side-effect-free, so this reuses the read-only `probe` (which
+/// already version-gates via the wire-stable Status RPC) rather than `ready_client`, which would
+/// shut a stale daemon down.
+pub(super) async fn output_capture_report(settings: &Settings) -> OutputCaptureReport {
+    match probe(settings).await {
+        Probe::Ready(mut client) => match client.output_capture_stats().await {
+            Ok(reply) => {
+                reply.store.map_or(OutputCaptureReport::Disabled, OutputCaptureReport::Active)
+            }
+            Err(err) => OutputCaptureReport::Error(err.to_string()),
+        },
+        Probe::NeedsRestart(reason) => OutputCaptureReport::NeedsRestart(reason),
+        Probe::Unreachable(_) => OutputCaptureReport::NotRunning,
     }
 }
 

--- a/crates/atuin/src/command/client/daemon.rs
+++ b/crates/atuin/src/command/client/daemon.rs
@@ -100,7 +100,7 @@ impl Cmd {
 }
 
 const DAEMON_VERSION: &str = env!("CARGO_PKG_VERSION");
-const DAEMON_PROTOCOL_VERSION: u32 = 2;
+const DAEMON_PROTOCOL_VERSION: u32 = 3;
 const STARTUP_POLL: Duration = Duration::from_millis(40);
 const LOCK_POLL: Duration = Duration::from_millis(20);
 const LEGACY_DAEMON_RESTART_MESSAGE: &str = "legacy daemon detected; restart daemon manually";

--- a/crates/atuin/src/command/client/doctor.rs
+++ b/crates/atuin/src/command/client/doctor.rs
@@ -367,10 +367,91 @@ impl AtuinInfo {
 }
 
 #[derive(Debug, Serialize)]
+struct OutputCaptureInfo {
+    /// One of: active, disabled, daemon-disabled, daemon-not-running, daemon-outdated, error,
+    /// unsupported.
+    status: String,
+    detail: Option<String>,
+    store: Option<OutputCaptureStoreInfo>,
+}
+
+#[derive(Debug, Serialize)]
+struct OutputCaptureStoreInfo {
+    stored_captures: u64,
+    disk_bytes_flushed: u64,
+    oldest_capture: Option<String>,
+    newest_capture: Option<String>,
+    store_path: String,
+    schema: String,
+}
+
+/// Render a unix-millisecond timestamp as an RFC3339 UTC string, or `None` if it is out of range.
+fn format_capture_time(unix_ms: u64) -> Option<String> {
+    use atuin_common::time::OffsetDateTimeExt;
+    use time::OffsetDateTime;
+    use time::format_description::well_known::Rfc3339;
+    let nanos = i128::from(unix_ms).checked_mul(1_000_000)?;
+    OffsetDateTime::from_unix_nanos(nanos).ok()?.format(&Rfc3339).ok()
+}
+
+impl OutputCaptureInfo {
+    fn status(status: &str, detail: &str) -> Self {
+        Self { status: status.to_string(), detail: Some(detail.to_string()), store: None }
+    }
+
+    #[cfg(feature = "daemon")]
+    async fn new(settings: &Settings) -> Self {
+        use super::daemon::{OutputCaptureReport, output_capture_report};
+
+        if !settings.daemon.enabled {
+            return Self::status(
+                "daemon-disabled",
+                "the daemon is disabled in settings; enable it to capture command output",
+            );
+        }
+
+        match output_capture_report(settings).await {
+            OutputCaptureReport::Active(store) => Self {
+                status: "active".to_string(),
+                detail: None,
+                store: Some(OutputCaptureStoreInfo {
+                    stored_captures: store.stored_captures,
+                    disk_bytes_flushed: store.disk_bytes,
+                    oldest_capture: store.oldest_capture_unix_ms.and_then(format_capture_time),
+                    newest_capture: store.newest_capture_unix_ms.and_then(format_capture_time),
+                    store_path: store.store_path,
+                    schema: store.schema,
+                }),
+            },
+            OutputCaptureReport::Disabled => Self::status(
+                "disabled",
+                "the daemon could not open its capture store; command output is not being saved",
+            ),
+            OutputCaptureReport::NeedsRestart(reason) => {
+                Self { status: "daemon-outdated".to_string(), detail: Some(reason), store: None }
+            }
+            OutputCaptureReport::NotRunning => Self::status(
+                "daemon-not-running",
+                "the daemon is not running; start it with `atuin daemon start`",
+            ),
+            OutputCaptureReport::Error(msg) => {
+                Self { status: "error".to_string(), detail: Some(msg), store: None }
+            }
+        }
+    }
+
+    #[cfg(not(feature = "daemon"))]
+    async fn new(_settings: &Settings) -> Self {
+        Self::status("unsupported", "this atuin build was compiled without daemon support")
+    }
+}
+
+#[derive(Debug, Serialize)]
 struct DoctorDump {
     pub atuin: AtuinInfo,
     pub shell: ShellInfo,
     pub system: SystemInfo,
+    pub output_capture: OutputCaptureInfo,
 }
 
 impl DoctorDump {
@@ -379,6 +460,7 @@ impl DoctorDump {
             atuin: AtuinInfo::new(settings).await,
             shell: ShellInfo::new(),
             system: SystemInfo::new(),
+            output_capture: OutputCaptureInfo::new(settings).await,
         }
     }
 }
@@ -426,6 +508,17 @@ fn checks(info: &DoctorDump) {
             println!("{blesh_integration_error}");
         }
     }
+
+    if info.output_capture.status == "disabled" {
+        println!(
+            "{}",
+            "[Output capture] The daemon could not open its capture store, so command output is \
+             not being saved. Check the daemon logs and the permissions on the output-capture \
+             directory."
+                .bold()
+                .red()
+        );
+    }
 }
 
 #[instrument(level = "trace", skip_all, err)]
@@ -442,4 +535,18 @@ pub async fn run(settings: &Settings) -> Result<()> {
     println!("{dump}");
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn format_capture_time_renders_rfc3339_utc() {
+        // 2021-01-01T00:00:00Z is 1_609_459_200_000 ms since the epoch.
+        assert_eq!(
+            format_capture_time(1_609_459_200_000).as_deref(),
+            Some("2021-01-01T00:00:00Z"),
+        );
+    }
 }


### PR DESCRIPTION
## What

Adds an `output_capture` section to `atuin doctor` that asks the daemon — over a new read-only gRPC method — for the live state of its command-output capture store, and renders it in the doctor dump with a warning when the store is unhealthy.

`atuin doctor` previously never talked to the daemon; this is the first section that does, and it degrades gracefully whenever the daemon is disabled, not running, or on an older protocol. It connects via the existing read-only `probe()` and **never starts or restarts the daemon**.

## How it's built (3 commits)

- **`Backend::stats` → `OutputCaptureStats`** (`atuin-daemon`): computes store stats on demand from the fjall keyspace — exact count, on-disk (flushed-segment) bytes, oldest/newest capture time decoded from the time-ordered UUIDv7 keys, store path, schema. The `nop` backend returns `None`, which the upper layers read as "store disabled".
- **`GetOutputCaptureStats` RPC**: a new read-only method on the `History` service (proto + domain↔proto conversion + journal wrapper + handler + client). Additive and wire-compatible; bumps `DAEMON_PROTOCOL_VERSION` 2 → 3 in lockstep (both consts + the five hardcoded test tripwires), per the module's compatibility doc.
- **doctor section**: maps the probe result to a status taxonomy (`active` / `disabled` / `daemon-disabled` / `daemon-not-running` / `daemon-outdated` / `error` / `unsupported`), renders the `store` stats when active, and emits a bold-red `checks()` warning when the store failed to open.

Example (`active`):

```json
"output_capture": {
  "status": "active",
  "detail": null,
  "store": {
    "stored_captures": 42,
    "disk_bytes_flushed": 1048576,
    "oldest_capture": "2026-08-14T09:12:03Z",
    "newest_capture": "2026-09-09T11:42:55Z",
    "store_path": ".../output-capture/keyspaces/1",
    "schema": "output_capture_v2"
  }
}
```

## Note on `disk_bytes_flushed`

fjall's `disk_space()` counts only flushed on-disk segments; recent captures live in the in-memory memtable until a 64 MiB rotation. So a small store can legitimately report `0` here — hence the field name and the proto-comment caveat. `stored_captures` (which reads through the memtable) is the reliable "how much is stored" signal. A directory-size walk was considered and rejected: fjall preallocates a ~64 MiB journal whose logical size a walk would count, over-reporting instead of under-reporting.

## Testing

- `atuin-daemon`: lib 101/101, lifecycle 20/20 (incl. a new `GetOutputCaptureStats` round-trip test), history_delete 22/22, history_rebuild 5/5 — all green after the protocol bump.
- `atuin`: `format_capture_time` RFC3339 unit test; builds clean both with `--features daemon` and without the daemon feature.
- Manual: verified the `daemon-not-running → active → daemon-not-running` transitions against a live isolated daemon (no interactive capture generated, so `stored_captures` stayed 0 in that spot-check).

## Follow-ups (non-blocking — why this is a draft)

- A pure `OutputCaptureReport → OutputCaptureInfo` mapping unit test, to lock the `checks()` status-string coupling (the degradation paths are currently only manually verified).
- A flushed-only caveat on the domain `OutputCaptureStats.disk_bytes` doc comment (the proto + doctor layers already carry it).
- Minor test-only cleanups: reuse `failing.rs`'s `unavailable()` helper; the `#[doc(hidden)] rotate_memtable_and_wait()` test hook is fragile under a caret fjall dep; a redundant `use easy_cast::Conv;` in the fjall test module.

## Checks
- [ ] I am happy for maintainers to push small adjustments to this PR, to speed up the review cycle
- [ ] I have checked that there are no existing pull requests for the same thing

https://claude.ai/code/session_01CUqQqbExtqdy3j3S2zbcbh
