### PR TITLE
fix(pty-proxy): resolve zsh --shell to an absolute path with :c

### DIFF
--- a/crates/atuin-pty-proxy/src/pty_proxy.rs
+++ b/crates/atuin-pty-proxy/src/pty_proxy.rs
@@ -185,9 +185,12 @@ then
     # Prefer ZSH_ARGZERO (zsh 5.3+) -- it preserves the path zsh was
     # invoked with -- and fall back to PATH lookup otherwise. Login shells
     # set argv[0] to "-zsh", and ZSH_ARGZERO keeps that leading dash, so
-    # strip it (${var#-}) before passing it along.
+    # strip it (${var#-}) before passing it along. ZSH_ARGZERO may also be
+    # a bare command name ("zsh") rather than a path; the :c modifier
+    # resolves that to an absolute path via $PATH, leaves an absolute path
+    # unchanged, and leaves an unresolvable name as-is.
     _atuin_pty_proxy_zsh="${ZSH_ARGZERO:-$(command -v zsh)}"
-    exec atuin pty-proxy --shell "${_atuin_pty_proxy_zsh#-}"
+    exec atuin pty-proxy --shell "${${_atuin_pty_proxy_zsh#-}:c}"
   else
     exec atuin pty-proxy
   fi
@@ -293,10 +296,11 @@ mod tests {
     fn init_scripts_forward_shell_path() {
         let posix = init_script(Shell::Bash);
         assert!(posix.contains(r#"exec atuin pty-proxy --shell "$BASH""#));
-        // zsh: capture ZSH_ARGZERO (with PATH fallback), then strip the
-        // leading dash present on login shells before forwarding the path.
+        // zsh: capture ZSH_ARGZERO (with PATH fallback), strip the leading
+        // dash present on login shells, then resolve a bare command name to
+        // an absolute path with the :c modifier before forwarding it.
         assert!(posix.contains(r#"_atuin_pty_proxy_zsh="${ZSH_ARGZERO:-$(command -v zsh)}""#));
-        assert!(posix.contains(r#"exec atuin pty-proxy --shell "${_atuin_pty_proxy_zsh#-}""#));
+        assert!(posix.contains(r#"exec atuin pty-proxy --shell "${${_atuin_pty_proxy_zsh#-}:c}""#));
 
         let fish = init_script(Shell::Fish);
         assert!(fish.contains("exec atuin pty-proxy --shell (status fish-path)"));


### PR DESCRIPTION
Super small fix for #3606 - It just adds `:c` to whatever $ZSH_ARGZERO has been resolved to.

This turns bare word `zsh` in to an absolute path, and leaves already absolute paths alone (even paths that don't exist which should fail anyway).

There is already work in progress to fix this issue in #3757, but this 2-byte fix silences a super annoying warning and keeps $SHELL as is.

## Checks
- [x] I am happy for maintainers to push small adjustments to this PR, to speed up the review cycle
- [x] I have checked that there are no existing pull requests for the same thing
