### PR TITLE
chore: replace daemonize with daemonix

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -276,7 +276,7 @@ dependencies = [
  "clap_complete_nushell",
  "colored 2.2.0",
  "crossterm",
- "daemonize",
+ "daemonix",
  "derive_more",
  "easy-cast",
  "enum_dispatch",
@@ -1591,10 +1591,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "daemonize"
-version = "0.5.0"
+name = "daemonix"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab8bfdaacb3c887a54d41bdf48d3af8873b3f5566469f8ba21b92057509f116e"
+checksum = "f0b747381562a10fd2104e9333ad72fe5158d79de81b64426fc9e229c6d3fb38"
 dependencies = [
  "libc",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,7 @@ colored = "2.0.4"
 config = { version = "0.15.8", default-features = false, features = ["toml"] }
 crossterm = "0.29.0"
 crypto_secretbox = "0.1.1"
-daemonize = "0.5.0"
+daemonix = "0.1.0"
 dashmap = "6.1.0"
 derive_more = {
     version = "2",

--- a/crates/atuin/Cargo.toml
+++ b/crates/atuin/Cargo.toml
@@ -144,7 +144,7 @@ arboard = { workspace = true, optional = true }
 arboard = { workspace = true, optional = true, features = ["wayland-data-control"] }
 
 [target.'cfg(unix)'.dependencies]
-daemonize = { workspace = true }
+daemonix = { workspace = true }
 
 # Enable tree-sitter shell parsing on platforms where tree-sitter's bundled C
 # compiles cleanly. tree-sitter 0.26's portable/endian.h fails on illumos,

--- a/crates/atuin/src/command/client/daemon.rs
+++ b/crates/atuin/src/command/client/daemon.rs
@@ -15,7 +15,7 @@ use atuin_common::futures::Backoff;
 use atuin_daemon::client::{DaemonClientErrorKind, HistoryClient, classify_error};
 use clap::Subcommand;
 #[cfg(unix)]
-use daemonize::Daemonize;
+use daemonix::Daemonize;
 use eyre::{Result, WrapErr, bail, eyre};
 
 #[derive(clap::Args, Debug)]

--- a/deny.toml
+++ b/deny.toml
@@ -19,8 +19,6 @@ ignore = [
     # No upstream patch. Runs only on client, no severe concern.
     "RUSTSEC-2026-0194",
     "RUSTSEC-2026-0195",
-    # daemonize (RUSTSEC-2025-0069): unmaintained, no maintained replacement.
-    "RUSTSEC-2025-0069",
 ]
 
 [licenses]
@@ -51,7 +49,10 @@ highlight = "all"
 workspace-default-features = "allow"
 external-default-features = "allow"
 allow = []
-deny = []
+deny = [
+    # Unmaintained with an unfixed UB bug (RUSTSEC-2025-0069). Replaced by daemonix.
+    { crate = "daemonize", use-instead = "daemonix" },
+]
 skip = []
 skip-tree = []
 


### PR DESCRIPTION
`daemonize` is unmaintained (RUSTSEC-2025-0069) and carries an unmerged fix for a known UB bug — the maintainer is unresponsive. `daemonix` is `daemonize 0.5.0` **plus that UB fix**, with an identical API, so this is a true drop-in.