### PR TITLE
chore: lower MSRV to 1.95

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -195,6 +195,44 @@ jobs:
       - name: Run cargo check (client only)
         run: cargo check --no-default-features --features client --workspace
 
+  msrv:
+    name: MSRV (1.95.0)
+    runs-on: depot-ubuntu-24.04
+
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Install OpenSSL dev libraries (Linux)
+        if: runner.os == 'Linux'
+        uses: awalsh128/cache-apt-pkgs-action@v1.6.3
+        with:
+          packages: libssl-dev pkg-config
+          version: 1.0
+
+      - name: Install MSRV rust
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: 1.95.0
+
+      - uses: actions/cache@v6
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-msrv-${{ hashFiles('**/Cargo.lock') }}
+
+      # Verifies the declared MSRV (workspace.package.rust-version) still holds
+      # with all features enabled. --all-features isn't a strict superset (it
+      # skips `cfg(not(feature))` and no-default-features paths), but atuin's
+      # features are additive, so this catches MSRV regressions cheaply.
+      - name: Check MSRV (all features)
+        # rust-toolchain.toml pins the dev toolchain and outranks dtolnay's
+        # `rustup default`, so force the MSRV toolchain explicitly here.
+        env:
+          RUSTUP_TOOLCHAIN: 1.95.0
+        run: cargo check --locked --workspace --all-features
+
   integration-test:
     runs-on: depot-ubuntu-24.04
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1832,9 +1832,9 @@ checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
 name = "easy-cast"
-version = "0.7.1"
+version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eae1c5aaf1bfdc24a9b5bf6daf3afee62c478afe08706a6bd9fd996f73630494"
+checksum = "23f40539c229fc2e4674bdecdf24bfcc2cb83631ca911c78a035fa9f2381c32b"
 
 [[package]]
 name = "ed25519"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,10 +62,12 @@ derive_more = {
 }
 directories = "6.0.0"
 divan = { version = "5.0.1", package = "codspeed-divan-compat" }
-# easy-cast 0.5.5+ raises its MSRV to 1.96 (for the CastTo/cast_to API, which we
-# don't use). The lockfile keeps us on 0.5.4 (MSRV 1.79); the `msrv` CI job runs
-# --locked, so an accidental bump would fail there.
-easy-cast = "0.5.4"
+# easy-cast 0.5.5+ raises its MSRV to 1.96.
+#
+# The assert_nonzero feature patches a bug fixed in:
+# https://github.com/kas-gui/easy-cast/pull/52
+# which was released in 0.6.0
+easy-cast = { version = "0.5.4", features = ["assert_nonzero"] }
 enum_dispatch = "0.3"
 eventsource-stream = "0.2"
 eye_declare = "0.6.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ exclude = ["ui/backend"]
 [workspace.package]
 version = "18.22.0"
 authors = ["Ellie Huxtable <ellie@atuin.sh>"]
-rust-version = "1.98.0"
+rust-version = "1.95.0"
 license = "MIT"
 homepage = "https://atuin.sh"
 repository = "https://github.com/atuinsh/atuin"
@@ -62,7 +62,10 @@ derive_more = {
 }
 directories = "6.0.0"
 divan = { version = "5.0.1", package = "codspeed-divan-compat" }
-easy-cast = "0.7.1"
+# easy-cast 0.5.5+ raises its MSRV to 1.96 (for the CastTo/cast_to API, which we
+# don't use). The lockfile keeps us on 0.5.4 (MSRV 1.79); the `msrv` CI job runs
+# --locked, so an accidental bump would fail there.
+easy-cast = "0.5.4"
 enum_dispatch = "0.3"
 eventsource-stream = "0.2"
 eye_declare = "0.6.4"

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@
   <a href="https://crates.io/crates/atuin"><img src="https://img.shields.io/crates/v/atuin.svg?style=flat-square" /></a>
   <a href="https://crates.io/crates/atuin"><img src="https://img.shields.io/crates/d/atuin.svg?style=flat-square" /></a>
   <a href="https://github.com/atuinsh/atuin/blob/main/LICENSE"><img src="https://img.shields.io/crates/l/atuin.svg?style=flat-square" /></a>
+  <a href="https://github.com/atuinsh/atuin/blob/main/Cargo.toml"><img src="https://img.shields.io/badge/MSRV-1.95.0-blue?style=flat-square" alt="Minimum Supported Rust Version 1.95.0" /></a>
   <a href="https://app.codspeed.io/atuinsh/atuin?utm_source=badge"><img src="https://img.shields.io/endpoint?url=https://codspeed.io/badge.json" alt="CodSpeed"/></a>
   <a href="https://discord.gg/Fq8bJSKPHh"><img src="https://img.shields.io/discord/954121165239115808" /></a>
   <a rel="me" href="https://hachyderm.io/@atuin"><img src="https://img.shields.io/mastodon/follow/109944632283122560?domain=https%3A%2F%2Fhachyderm.io&style=social"/></a>

--- a/crates/atuin-ai/src/tui/view/mod.rs
+++ b/crates/atuin-ai/src/tui/view/mod.rs
@@ -6,7 +6,7 @@
 //! app's keymap, not here — elements are display-only.
 
 use atuin_common::path::DisplayRichExt;
-use easy_cast::{Cast, CastTo, Conv, Nearest};
+use easy_cast::{Cast, CastFloat, Conv};
 use eye_declare::{
     AnyElement, Element, ElementExt, Fluent, Markdown, MarkdownStyles, Spinner, col, empty,
     markdown, row, spinner, text, viewport,
@@ -790,8 +790,7 @@ pub fn status_bar_view(
         return left.any();
     };
 
-    let filled: usize =
-        ((pct / 100.0).clamp(0.0, 1.0) * f64::conv(USAGE_BAR_WIDTH)).cast_to(Nearest);
+    let filled: usize = ((pct / 100.0).clamp(0.0, 1.0) * f64::conv(USAGE_BAR_WIDTH)).cast_nearest();
     let bar_filled = "█".repeat(filled);
     let bar_empty = "░".repeat(USAGE_BAR_WIDTH - filled);
     let pct_text = format!(" {pct:.0}%");

--- a/crates/atuin-client/src/database.rs
+++ b/crates/atuin-client/src/database.rs
@@ -8,7 +8,7 @@ use atuin_common::filter::{self, OrFilter};
 use atuin_common::time::OffsetDateTimeExt;
 use atuin_common::{db, utils};
 use atuin_domain::record::{CmdOrigin, UNKNOWN_USER};
-use easy_cast::{CastTo, Conv, Nearest, Trunc};
+use easy_cast::{CastFloat, Conv};
 use itertools::Itertools;
 use sql_builder::bind::Bind;
 use sql_builder::{SqlBuilder, SqlName, esc, quote};
@@ -1060,11 +1060,11 @@ impl Sqlite {
         )?;
 
         let duration_over_time =
-            duration_over_time.iter().map(|f| (f.0.clone(), f.1.cast_to(Nearest))).collect();
+            duration_over_time.iter().map(|f| (f.0.clone(), f.1.cast_nearest())).collect();
 
         Ok(HistoryStats {
             total: u64::conv(total.0),
-            average_duration: average.0.cast_to(Trunc),
+            average_duration: average.0.cast_trunc(),
             exits,
             day_of_week,
             duration_over_time,

--- a/crates/atuin-client/src/import/resh.rs
+++ b/crates/atuin-client/src/import/resh.rs
@@ -5,7 +5,7 @@ use atuin_common::time::OffsetDateTimeExt;
 use atuin_common::utils::uuid_v7;
 use atuin_domain::record::{CmdHost, CmdOrigin, CmdUser};
 use directories::UserDirs;
-use easy_cast::{CastTo, Floor, Nearest};
+use easy_cast::CastFloat;
 use eyre::{Result, eyre};
 use serde::Deserialize;
 use time::OffsetDateTime;
@@ -108,9 +108,9 @@ impl Importer for Resh {
             };
 
             let try_to_time = |realtime: f64| {
-                let secs: i64 = realtime.try_cast_to(Floor).ok()?;
+                let secs: i64 = realtime.try_cast_floor().ok()?;
                 let nanosecs: i64 =
-                    (realtime.fract() * 1_000_000_000_f64).try_cast_to(Nearest).ok()?;
+                    (realtime.fract() * 1_000_000_000_f64).try_cast_nearest().ok()?;
                 OffsetDateTime::from_timespec(i128::from(secs), i128::from(nanosecs)).ok()
             };
             let start = try_to_time(entry.realtime_before);

--- a/crates/atuin-client/src/import/xonsh.rs
+++ b/crates/atuin-client/src/import/xonsh.rs
@@ -6,7 +6,7 @@ use async_trait::async_trait;
 use atuin_common::time::OffsetDateTimeExt;
 use atuin_domain::record::CmdOrigin;
 use directories::BaseDirs;
-use easy_cast::{CastTo, Trunc};
+use easy_cast::CastFloat;
 use eyre::{Result, eyre};
 use serde::Deserialize;
 use time::OffsetDateTime;
@@ -131,13 +131,13 @@ impl Importer for Xonsh {
             for cmd in session.cmds {
                 let (start, end) = cmd.ts;
                 let timestamp = (start * 1_000_000_000_f64)
-                    .try_cast_to(Trunc)
+                    .try_cast_trunc()
                     .ok()
                     .and_then(|nanos: i128| OffsetDateTime::from_unix_nanos(nanos).ok())
                     .unwrap_or(OffsetDateTime::UNIX_EPOCH);
 
                 let duration = ((end - start) * 1_000_000_000_f64)
-                    .try_cast_to(Trunc)
+                    .try_cast_trunc()
                     .unwrap_or(HistoryImported::DEFAULT_DURATION);
 
                 let entry = History::import()

--- a/crates/atuin-client/src/import/xonsh_sqlite.rs
+++ b/crates/atuin-client/src/import/xonsh_sqlite.rs
@@ -6,7 +6,7 @@ use atuin_common::db;
 use atuin_common::time::OffsetDateTimeExt;
 use atuin_domain::record::CmdOrigin;
 use directories::BaseDirs;
-use easy_cast::{CastTo, Conv, Trunc};
+use easy_cast::{CastFloat, Conv};
 use eyre::{Result, eyre};
 use futures::TryStreamExt;
 use sqlx::sqlite::SqlitePool;
@@ -33,7 +33,7 @@ struct HistDbEntry {
 impl HistDbEntry {
     fn into_hist_with_cmd_origin(self, cmd_origin: CmdOrigin) -> History {
         let timestamp = (self.tsb * 1_000_000_000_f64)
-            .try_cast_to(Trunc)
+            .try_cast_trunc()
             .ok()
             .and_then(|nanos: i128| OffsetDateTime::from_unix_nanos(nanos).ok())
             .unwrap_or(OffsetDateTime::UNIX_EPOCH);
@@ -50,7 +50,7 @@ impl HistDbEntry {
         let session_ts = Timestamp::from_unix(NoContext, session_ts_seconds, session_ts_nanos);
         let session_id = Uuid::new_v7(session_ts).to_string();
         let duration = ((self.tse - self.tsb) * 1_000_000_000_f64)
-            .try_cast_to(Trunc)
+            .try_cast_trunc()
             .unwrap_or(HistoryImported::DEFAULT_DURATION);
 
         History::import()

--- a/crates/atuin-common/src/range/py_style.rs
+++ b/crates/atuin-common/src/range/py_style.rs
@@ -50,7 +50,7 @@ impl PyStyleIdxRange {
         };
 
         let start = norm(self.start).unwrap_or_default().clamp(0, len);
-        let end = norm(self.end).map_or_default(|n| n.saturating_add(1)).clamp(start, len);
+        let end = norm(self.end).map(|n| n.saturating_add(1)).unwrap_or_default().clamp(start, len);
         usize::conv(start)..usize::conv(end)
     }
 

--- a/crates/atuin-common/src/string.rs
+++ b/crates/atuin-common/src/string.rs
@@ -153,7 +153,7 @@ mod tests {
         assert!(out.chars().count() <= max);
     }
 
-    #[test]
+    #[rstest]
     fn truncate_chars_returns_the_original_slice_when_it_fits() {
         let s = "borrow me";
         assert!(std::ptr::eq(s.truncate_chars(100), s));

--- a/crates/atuin-daemon/src/grpc/history/pb.rs
+++ b/crates/atuin-daemon/src/grpc/history/pb.rs
@@ -436,15 +436,14 @@ impl GetCommandOutputResponse {
 
         Self {
             chunks,
-            total_bytes: u64::try_from(
-                capture
-                    .output_start
-                    .len()
-                    .saturating_add(capture.output_end.as_ref().map_or_default(|end| end.len())),
-            )
+            total_bytes: u64::try_from(capture.output_start.len().saturating_add(
+                capture.output_end.as_ref().map(|end| end.len()).unwrap_or_default(),
+            ))
             .unwrap_or(u64::MAX),
             total_lines: u64::try_from(
-                lines_start.len().saturating_add(lines_end.map_or_default(|lines| lines.len())),
+                lines_start
+                    .len()
+                    .saturating_add(lines_end.map(|lines| lines.len()).unwrap_or_default()),
             )
             .unwrap_or(u64::MAX),
             truncated,


### PR DESCRIPTION
Worth noting that downgrading `easy-cast` here reverted two fixes in easy-cast:

- 0.6.0: Fix unsafe code in NonZero conversion on input values which wrap to zero https://github.com/kas-gui/easy-cast/pull/52/changes
- 0.6.0: Fix: allow overflow of large u128 values to f32::INFINITY https://github.com/kas-gui/easy-cast/pull/51/changes

We do not use any of these features, so it's probably fine for now.