### PR TITLE
chore: bump sysinfo to 0.39.6

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1436,16 +1436,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "crossbeam-deque"
-version = "0.8.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5181e0de7b61eb03a81e347d6dd8797bae9da5146707b51077e2d71a54ec0ceb"
-dependencies = [
- "crossbeam-epoch",
- "crossbeam-utils",
-]
-
-[[package]]
 name = "crossbeam-epoch"
 version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3594,6 +3584,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc2-io-kit"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33fafba39597d6dc1fb709123dfa8289d39406734be322956a69f0931c73bb15"
+dependencies = [
+ "libc",
+ "objc2-core-foundation",
+]
+
+[[package]]
 name = "objc2-io-surface"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3602,6 +3602,17 @@ dependencies = [
  "bitflags 2.13.0",
  "objc2",
  "objc2-core-foundation",
+]
+
+[[package]]
+name = "objc2-open-directory"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb82bed227edf5201dfedf072bba4015a33d3d4a98519837295a90f0a23f676d"
+dependencies = [
+ "objc2",
+ "objc2-core-foundation",
+ "objc2-foundation",
 ]
 
 [[package]]
@@ -4515,26 +4526,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "498cd0dc59d73224351ee52a95fee0f1a617a2eae0e7d9d720cc622c73a54186"
 dependencies = [
  "bitflags 2.13.0",
-]
-
-[[package]]
-name = "rayon"
-version = "1.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb39b166781f92d482534ef4b4b1b2568f42613b53e5b6c160e24cfbfa30926d"
-dependencies = [
- "either",
- "rayon-core",
-]
-
-[[package]]
-name = "rayon-core"
-version = "1.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
-dependencies = [
- "crossbeam-deque",
- "crossbeam-utils",
 ]
 
 [[package]]
@@ -5684,17 +5675,17 @@ dependencies = [
 
 [[package]]
 name = "sysinfo"
-version = "0.30.13"
+version = "0.39.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a5b4ddaee55fb2bea2bf0e5000747e5f5c0de765e5a5ff87f4cd106439f4bb3"
+checksum = "d2071df9448915b71c4fe6d25deaf1c22f12bd234f01540b77312bb8e41361e6"
 dependencies = [
- "cfg-if",
- "core-foundation-sys",
  "libc",
+ "memchr",
  "ntapi",
- "once_cell",
- "rayon",
- "windows 0.52.0",
+ "objc2-core-foundation",
+ "objc2-io-kit",
+ "objc2-open-directory",
+ "windows 0.62.2",
 ]
 
 [[package]]
@@ -6925,25 +6916,27 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows"
-version = "0.52.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e48a53791691ab099e5e2ad123536d0fff50652600abaf43bbf952894110d0be"
-dependencies = [
- "windows-core 0.52.0",
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows"
 version = "0.61.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9babd3a767a4c1aef6900409f85f5d53ce2544ccdfaa86dad48c91782c6d6893"
 dependencies = [
- "windows-collections",
+ "windows-collections 0.2.0",
  "windows-core 0.61.2",
- "windows-future",
+ "windows-future 0.2.1",
  "windows-link 0.1.3",
- "windows-numerics",
+ "windows-numerics 0.2.0",
+]
+
+[[package]]
+name = "windows"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "527fadee13e0c05939a6a05d5bd6eec6cd2e3dbd648b9f8e447c6518133d8580"
+dependencies = [
+ "windows-collections 0.3.2",
+ "windows-core 0.62.2",
+ "windows-future 0.3.2",
+ "windows-numerics 0.3.1",
 ]
 
 [[package]]
@@ -6956,12 +6949,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "windows-core"
-version = "0.52.0"
+name = "windows-collections"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
+checksum = "23b2d95af1a8a14a3c7367e1ed4fc9c20e0a26e79551b1454d72583c97cc6610"
 dependencies = [
- "windows-targets 0.52.6",
+ "windows-core 0.62.2",
 ]
 
 [[package]]
@@ -6998,7 +6991,18 @@ checksum = "fc6a41e98427b19fe4b73c550f060b59fa592d7d686537eebf9385621bfbad8e"
 dependencies = [
  "windows-core 0.61.2",
  "windows-link 0.1.3",
- "windows-threading",
+ "windows-threading 0.1.0",
+]
+
+[[package]]
+name = "windows-future"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1d6f90251fe18a279739e78025bd6ddc52a7e22f921070ccdc67dde84c605cb"
+dependencies = [
+ "windows-core 0.62.2",
+ "windows-link 0.2.1",
+ "windows-threading 0.2.1",
 ]
 
 [[package]]
@@ -7043,6 +7047,16 @@ checksum = "9150af68066c4c5c07ddc0ce30421554771e528bde427614c61038bc2c92c2b1"
 dependencies = [
  "windows-core 0.61.2",
  "windows-link 0.1.3",
+]
+
+[[package]]
+name = "windows-numerics"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e2e40844ac143cdb44aead537bbf727de9b044e107a0f1220392177d15b0f26"
+dependencies = [
+ "windows-core 0.62.2",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -7157,6 +7171,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b66463ad2e0ea3bbf808b7f1d371311c80e115c0b71d60efc142cafbcfb057a6"
 dependencies = [
  "windows-link 0.1.3",
+]
+
+[[package]]
+name = "windows-threading"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3949bd5b99cafdf1c7ca86b43ca564028dfe27d66958f2470940f73d86d75b37"
+dependencies = [
+ "windows-link 0.2.1",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -141,7 +141,7 @@ sql-builder = "3"
 sqlx = { version = "0.9", features = ["runtime-tokio", "time", "uuid"] }
 strum = { version = "0.27", features = ["strum_macros"] }
 strum_macros = "0.28"
-sysinfo = "0.30.7"
+sysinfo = "0.39.6"
 tempfile = { version = "3.19" }
 thiserror = "2"
 time = { version = "0.3.47", features = ["serde-human-readable", "macros", "local-offset"] }

--- a/crates/atuin-common/src/os/unix/process.rs
+++ b/crates/atuin-common/src/os/unix/process.rs
@@ -64,7 +64,7 @@ pub fn is_alive(pid: Pid) -> bool {
 pub fn process_start_time(pid: Pid) -> Option<u64> {
     let pid = sysinfo::Pid::from_u32(pid.as_raw_nonzero().get().unsigned_abs());
     let mut system = sysinfo::System::new();
-    if system.refresh_process(pid) {
+    if system.refresh_processes(sysinfo::ProcessesToUpdate::Some(&[pid]), true) > 0 {
         system.process(pid).map(sysinfo::Process::start_time)
     } else {
         None
@@ -89,10 +89,12 @@ pub fn cwd(pid: Pid) -> Option<PathBuf> {
 fn cwd_generic(pid: u32) -> Option<PathBuf> {
     let pid = sysinfo::Pid::from_u32(pid);
     let mut system = sysinfo::System::new();
-    if !system.refresh_process_specifics(
-        pid,
-        sysinfo::ProcessRefreshKind::new().with_cwd(sysinfo::UpdateKind::Always),
-    ) {
+    if system.refresh_processes_specifics(
+        sysinfo::ProcessesToUpdate::Some(&[pid]),
+        true,
+        sysinfo::ProcessRefreshKind::nothing().with_cwd(sysinfo::UpdateKind::Always),
+    ) == 0
+    {
         return None;
     }
     system.process(pid)?.cwd().map(Into::into)

--- a/crates/atuin-common/src/shell.rs
+++ b/crates/atuin-common/src/shell.rs
@@ -48,7 +48,7 @@ impl Shell {
             .process(process.parent().expect("Atuin running with no parent!"))
             .expect("Process with parent pid does not exist");
 
-        let shell = parent.name().trim().to_lowercase();
+        let shell = parent.name().to_string_lossy().trim().to_lowercase();
         let shell = shell.strip_prefix('-').unwrap_or(&shell);
 
         Self::from_string(shell)
@@ -166,7 +166,7 @@ pub fn shell_name(parent: Option<&Process>) -> String {
             .expect("Process with parent pid does not exist")
     };
 
-    let shell = parent.name().trim().to_lowercase();
+    let shell = parent.name().to_string_lossy().trim().to_lowercase();
     let shell = shell.strip_prefix('-').unwrap_or(&shell);
 
     shell.to_string()

--- a/crates/atuin-common/src/string.rs
+++ b/crates/atuin-common/src/string.rs
@@ -63,11 +63,13 @@ impl<T: AsRef<str> + ?Sized> NormalizeDiacriticsExt for T {}
 /// Extension trait for owned strings providing an empty-string fallback.
 pub trait NonEmptyOrExt: Sized {
     /// Return the string if it is non-empty, otherwise `value`.
+    #[must_use]
     fn nonempty_or(self, value: Self) -> Self {
         self.nonempty_or_else(|| value)
     }
 
     /// Same as [`Self::nonempty_or`] but takes a factory function.
+    #[must_use]
     fn nonempty_or_else(self, default: impl FnOnce() -> Self) -> Self;
 }
 

--- a/crates/atuin-common/src/string.rs
+++ b/crates/atuin-common/src/string.rs
@@ -61,15 +61,50 @@ pub trait NormalizeDiacriticsExt: AsRef<str> {
 impl<T: AsRef<str> + ?Sized> NormalizeDiacriticsExt for T {}
 
 /// Extension trait for owned strings providing an empty-string fallback.
-pub trait NonEmptyOrExt {
+pub trait NonEmptyOrExt: Sized {
     /// Return the string if it is non-empty, otherwise `value`.
-    fn nonempty_or<S: Into<String>>(self, value: S) -> String;
+    fn nonempty_or(self, value: Self) -> Self {
+        self.nonempty_or_else(|| value)
+    }
+
+    /// Same as [`Self::nonempty_or`] but takes a factory function.
+    fn nonempty_or_else(self, default: impl FnOnce() -> Self) -> Self;
 }
 
 impl NonEmptyOrExt for String {
-    fn nonempty_or<S: Into<Self>>(self, value: S) -> Self {
+    fn nonempty_or_else(self, default: impl FnOnce() -> Self) -> Self {
         if self.is_empty() {
-            value.into()
+            default()
+        } else {
+            self
+        }
+    }
+}
+
+impl NonEmptyOrExt for &str {
+    fn nonempty_or_else(self, default: impl FnOnce() -> Self) -> Self {
+        if self.is_empty() {
+            default()
+        } else {
+            self
+        }
+    }
+}
+
+impl<T> NonEmptyOrExt for &[T] {
+    fn nonempty_or_else(self, default: impl FnOnce() -> Self) -> Self {
+        if self.is_empty() {
+            default()
+        } else {
+            self
+        }
+    }
+}
+
+impl<T> NonEmptyOrExt for Vec<T> {
+    fn nonempty_or_else(self, default: impl FnOnce() -> Self) -> Self {
+        if self.is_empty() {
+            default()
         } else {
             self
         }
@@ -173,7 +208,7 @@ mod tests {
     #[case::empty("", "fallback")]
     #[case::non_empty("value", "value")]
     fn nonempty_or_falls_back_only_when_empty(#[case] input: &str, #[case] expected: &str) {
-        assert_eq!(input.to_string().nonempty_or("fallback"), expected);
+        assert_eq!(input.to_string().nonempty_or_else(|| "fallback".into()), expected);
     }
 
     #[test]

--- a/crates/atuin-common/src/string.rs
+++ b/crates/atuin-common/src/string.rs
@@ -68,7 +68,11 @@ pub trait NonEmptyOrExt {
 
 impl NonEmptyOrExt for String {
     fn nonempty_or<S: Into<Self>>(self, value: S) -> Self {
-        if self.is_empty() { value.into() } else { self }
+        if self.is_empty() {
+            value.into()
+        } else {
+            self
+        }
     }
 }
 

--- a/crates/atuin-common/src/string.rs
+++ b/crates/atuin-common/src/string.rs
@@ -60,6 +60,18 @@ pub trait NormalizeDiacriticsExt: AsRef<str> {
 
 impl<T: AsRef<str> + ?Sized> NormalizeDiacriticsExt for T {}
 
+/// Extension trait for owned strings providing an empty-string fallback.
+pub trait NonEmptyOrExt {
+    /// Return the string if it is non-empty, otherwise `value`.
+    fn nonempty_or<S: Into<String>>(self, value: S) -> String;
+}
+
+impl NonEmptyOrExt for String {
+    fn nonempty_or<S: Into<Self>>(self, value: S) -> Self {
+        if self.is_empty() { value.into() } else { self }
+    }
+}
+
 /// Extension trait for [`Url`] to render a `Debug` representation with any
 /// password redacted.
 pub trait FormatSafeUrlExt {
@@ -119,7 +131,7 @@ mod tests {
     use rstest::rstest;
     use url::Url;
 
-    use super::{FormatSafeUrlExt, NormalizeDiacriticsExt, TruncateCharsExt};
+    use super::{FormatSafeUrlExt, NonEmptyOrExt, NormalizeDiacriticsExt, TruncateCharsExt};
 
     #[rstest]
     #[case::empty("", "")]
@@ -151,6 +163,13 @@ mod tests {
         let out = input.truncate_chars(max);
         assert_eq!(out, expected);
         assert!(out.chars().count() <= max);
+    }
+
+    #[rstest]
+    #[case::empty("", "fallback")]
+    #[case::non_empty("value", "value")]
+    fn nonempty_or_falls_back_only_when_empty(#[case] input: &str, #[case] expected: &str) {
+        assert_eq!(input.to_string().nonempty_or("fallback"), expected);
     }
 
     #[test]

--- a/crates/atuin/src/command/client/doctor.rs
+++ b/crates/atuin/src/command/client/doctor.rs
@@ -8,6 +8,7 @@ use atuin_client::database::Sqlite;
 use atuin_client::settings::Settings;
 use atuin_common::path::PathExt;
 use atuin_common::shell::{Shell, shell_name};
+use atuin_common::string::NonEmptyOrExt as _;
 use colored::Colorize;
 use eyre::Result;
 use serde::Serialize;
@@ -235,7 +236,7 @@ impl SystemInfo {
 
         Self {
             os: System::name().unwrap_or_else(|| "unknown".to_string()),
-            arch: System::cpu_arch(),
+            arch: System::cpu_arch().nonempty_or("unknown"),
             version: System::os_version().unwrap_or_else(|| "unknown".to_string()),
             disks,
         }

--- a/crates/atuin/src/command/client/doctor.rs
+++ b/crates/atuin/src/command/client/doctor.rs
@@ -236,7 +236,7 @@ impl SystemInfo {
 
         Self {
             os: System::name().unwrap_or_else(|| "unknown".to_string()),
-            arch: System::cpu_arch().nonempty_or("unknown"),
+            arch: System::cpu_arch().nonempty_or_else(|| "unknown".into()),
             version: System::os_version().unwrap_or_else(|| "unknown".to_string()),
             disks,
         }

--- a/crates/atuin/src/command/client/doctor.rs
+++ b/crates/atuin/src/command/client/doctor.rs
@@ -235,7 +235,7 @@ impl SystemInfo {
 
         Self {
             os: System::name().unwrap_or_else(|| "unknown".to_string()),
-            arch: System::cpu_arch().unwrap_or_else(|| "unknown".to_string()),
+            arch: System::cpu_arch(),
             version: System::os_version().unwrap_or_else(|| "unknown".to_string()),
             disks,
         }


### PR DESCRIPTION
This will allow @nc7s to drop https://salsa.debian.org/debian/atuin/-/blob/debian/sid/debian/patches/upgrade-sysinfo-0.30-0.39.patch?ref_type=heads.

We probably should've done this way back when anyways =)