### PR TITLE
chore(deps): dependency version bumps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -353,11 +353,9 @@ dependencies = [
  "glob-match",
  "imara-diff",
  "parking_lot",
- "pretty_assertions",
  "pulldown-cmark",
  "ratatui",
  "ratatui-core",
- "ratatui-widgets",
  "regex",
  "reqwest",
  "rmcp",
@@ -375,7 +373,6 @@ dependencies = [
  "toml",
  "toml_edit",
  "tracing",
- "tracing-appender",
  "tracing-subscriber",
  "tree-sitter",
  "tree-sitter-bash",
@@ -428,7 +425,6 @@ dependencies = [
  "rusty_paseto",
  "semver",
  "serde",
- "serde_bytes",
  "serde_json",
  "serde_regex",
  "serde_with",
@@ -440,7 +436,6 @@ dependencies = [
  "tempfile",
  "thiserror 2.0.19",
  "time",
- "tiny-bip39",
  "tokio",
  "toml",
  "tracing",
@@ -448,9 +443,7 @@ dependencies = [
  "typed-builder",
  "url",
  "uuid",
- "whoami",
  "wiremock",
- "zeroize",
  "zstd",
 ]
 
@@ -541,10 +534,8 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "tonic",
- "tonic-build",
  "tonic-prost",
  "tonic-prost-build",
- "tonic-types",
  "tower",
  "tracing",
  "tracing-subscriber",
@@ -627,7 +618,6 @@ dependencies = [
  "atuin-domain",
  "derive_more",
  "eyre",
- "pretty_assertions",
  "rmp",
  "rstest",
  "semver",
@@ -670,7 +660,6 @@ dependencies = [
  "easy-cast",
  "eyre",
  "minijinja",
- "pretty_assertions",
  "rmp",
  "rstest",
  "semver",
@@ -1949,9 +1938,9 @@ dependencies = [
 
 [[package]]
 name = "eye_declare"
-version = "0.6.4"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b213867877c012beaf72f3e7295510a43efe0c285ff3fa1d99cc4e641879ba99"
+checksum = "c9d82f1f1422761dc7630fa2b8c52f4e11f87dc2308fd2e577176d0542d0eacd"
 dependencies = [
  "crossterm",
  "eye_declare_engine",
@@ -1966,9 +1955,9 @@ dependencies = [
 
 [[package]]
 name = "eye_declare_engine"
-version = "0.6.4"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9f766ef1f5a9f08cd0759b3aff638c69cca8d8b99545b390531c7e9cd9a367f"
+checksum = "199fcf8b7e20444380bd20226490c4ba54a19ec13966dc2aab39862a0f55dd86"
 dependencies = [
  "ratatui-core",
  "ratatui-widgets",
@@ -2131,9 +2120,12 @@ dependencies = [
 
 [[package]]
 name = "frizbee"
-version = "0.12.0"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0633b457eaadb5bcbee26b5b4cad3196ae4b18cfc968a353e19e7c1a944e56a"
+checksum = "19435f276a44d90570cb403d22fbe4b20c80eabc134f718d6ec0ae888eb47edc"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "fs-err"
@@ -4679,13 +4671,13 @@ dependencies = [
 
 [[package]]
 name = "rmcp"
-version = "2.1.0"
+version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f00a32c3b81b7b254076a65abd5ab2551209146713ba38f73818657e865e9433"
+checksum = "b88db56b8ae316560e9e868b6b978ea940f27cb883323fc90e07435e44158f5c"
 dependencies = [
- "async-trait",
  "chrono",
  "futures",
+ "indexmap 2.14.0",
  "pastey",
  "pin-project-lite",
  "schemars 1.2.1",
@@ -4695,6 +4687,7 @@ dependencies = [
  "tokio",
  "tokio-util",
  "tracing",
+ "uuid",
 ]
 
 [[package]]
@@ -4719,9 +4712,9 @@ dependencies = [
 
 [[package]]
 name = "rstest"
-version = "0.26.1"
+version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5a3193c063baaa2a95a33f03035c8a72b83d97a54916055ba22d35ed3839d49"
+checksum = "948203e6d13b83e51a90d7cf236dd58a0065f23f4b902f00f306e7eb2bd09b9c"
 dependencies = [
  "futures-timer",
  "futures-util",
@@ -4730,9 +4723,9 @@ dependencies = [
 
 [[package]]
 name = "rstest_macros"
-version = "0.26.1"
+version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c845311f0ff7951c5506121a9ad75aec44d083c31583b2ea5a30bcb0b0abba0"
+checksum = "a8d92eaf7b6e51e12471d71ddc72608e7151573de44099aacfbb1128177c0da4"
 dependencies = [
  "cfg-if",
  "glob",
@@ -5001,16 +4994,6 @@ checksum = "4148590afebada386688f18773da617792bf2ef03ffc1e4cbd2b1d45b023e0ba"
 dependencies = [
  "serde_core",
  "serde_derive",
-]
-
-[[package]]
-name = "serde_bytes"
-version = "0.11.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5d440709e79d88e51ac01c4b72fc6cb7314017bb7da9eeff678aa94c10e3ea8"
-dependencies = [
- "serde",
- "serde_core",
 ]
 
 [[package]]
@@ -5824,9 +5807,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.49"
+version = "0.3.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "711a53c2d47bbd818258c498c8dbfe186a2526c631495cfe7e078567f86b8469"
+checksum = "cdb87b95ec50ddfa440816d227a17b2ccbdda963a316a727fda0fc4334f7d134"
 dependencies = [
  "deranged",
  "libc",
@@ -5846,9 +5829,9 @@ checksum = "9e1c906769ad99c88eaa54e728060edef082f8e358ff32030cb7c7d315e81109"
 
 [[package]]
 name = "time-macros"
-version = "0.2.29"
+version = "0.2.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71c652a3727a9cbb9a02f707f530b618ce00d0ccd762009c8c23bd191df3c17d"
+checksum = "7e689342a48d2ea927c87ea50cabf8594854bf940e9310208848d680d668ed85"
 dependencies = [
  "num-conv",
  "time-core",
@@ -6083,17 +6066,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tonic-types"
-version = "0.14.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73ab1b02061f83d519bba3caa167f88f261ef05720ab8ebc954ade70de3348e8"
-dependencies = [
- "prost",
- "prost-types",
- "tonic",
-]
-
-[[package]]
 name = "tower"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6278,13 +6250,12 @@ dependencies = [
 
 [[package]]
 name = "tree-sitter"
-version = "0.26.8"
+version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "887bd495d0582c5e3e0d8ece2233666169fa56a9644d172fc22ad179ab2d0538"
+checksum = "2038684e0058edba0d17302619f62eabce4a8e11c6ac59506996a8d79848851d"
 dependencies = [
  "cc",
  "regex",
- "regex-syntax",
  "serde_json",
  "streaming-iterator",
  "tree-sitter-language",
@@ -6312,9 +6283,9 @@ dependencies = [
 
 [[package]]
 name = "tree-sitter-language"
-version = "0.1.7"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "009994f150cc0cd50ff54917d5bc8bffe8cad10ca10d81c34da2ec421ae61782"
+checksum = "ca0d1bf6fdd806e43ae5198f82f527056d359def39e54e67a0f478ac09dac081"
 
 [[package]]
 name = "tree-sitter-powershell"
@@ -6345,9 +6316,9 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "tui-textarea-2"
-version = "0.10.2"
+version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74a31ca0965e3ff6a7ac5ecb02b20a88b4f68ebf138d8ae438e8510b27a1f00f"
+checksum = "fdf2865f7f32ae9e779f6185986fd920fa6b00ac878e906927ec7e78d32316ed"
 dependencies = [
  "crossterm",
  "portable-atomic",
@@ -7373,9 +7344,9 @@ checksum = "fdd20c5420375476fbd4394763288da7eb0cc0b8c11deed431a91562af7335d3"
 
 [[package]]
 name = "yaml-rust2"
-version = "0.11.0"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "631a50d867fafb7093e709d75aaee9e0e0d5deb934021fcea25ac2fe09edc51e"
+checksum = "b36710ce3a279cfce8465dbab826f161675a262950b922cb2c3663852dfe9eb0"
 dependencies = [
  "arraydeque",
  "encoding_rs",
@@ -7531,9 +7502,9 @@ dependencies = [
 
 [[package]]
 name = "zstd-sys"
-version = "2.0.16+zstd.1.5.7"
+version = "2.1.0+zstd.1.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91e19ebc2adc8f83e43039e79776e3fda8ca919132d68a1fed6a5faca2683748"
+checksum = "0ef0a8027ec3ee71300ab3bcbcd0393f434aa72b91ca6d635a39941deae8eea0"
 dependencies = [
  "cc",
  "pkg-config",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,11 +28,13 @@ atuin-vt100 = "0.19"
 
 ansi-to-tui = { version = "8.0.1", default-features = false }
 arboard = { version = "3.4", default-features = false }
+# held at 0.5: rusty_paserk 0.5.0 pins argon2 0.5; bumping would add a 2nd copy
 argon2 = "0.5"
 async-stream = "0.3"
 async-trait = "0.1.58"
 axoupdater = "0.10"
 axum = "0.8"
+# held at 0.22: sqlx-postgres 0.9 pins base64 0.22; bumping would add a 2nd copy
 base64 = "0.22"
 bytesize = { version = "2.7", features = ["serde"] }
 chrono = "0.4"
@@ -70,11 +72,11 @@ divan = { version = "5.0.1", package = "codspeed-divan-compat" }
 easy-cast = { version = "0.5.4", features = ["assert_nonzero"] }
 enum_dispatch = "0.3"
 eventsource-stream = "0.2"
-eye_declare = "0.6.4"
-eye_declare_engine = { version = "0.6.4", features = ["test-util"] }
+eye_declare = "0.7.1"
+eye_declare_engine = { version = "0.7.1", features = ["test-util"] }
 eyre = "0.6"
 fjall = { version = "3.1" }
-frizbee = "0.12.0"
+frizbee = "0.13.0"
 fs-err = "3.1"
 futures = "0.3"
 futures-util = "0.3"
@@ -98,7 +100,6 @@ metrics = "0.24"
 metrics-exporter-prometheus = { version = "0.18", default-features = false }
 minijinja = "2.9.0"
 minspan = "0.1.5"
-nix = { version = "0.30.1", features = ["signal"] }
 norm = { version = "0.1.1", features = ["fzf-v2"] }
 notify = "8"
 opentelemetry = "0.32"
@@ -116,7 +117,6 @@ pulldown-cmark = "0.13.0"
 rand = { version = "0.8.5", features = ["std"] }
 ratatui = "0.30.0"
 ratatui-core = "0.1"
-ratatui-widgets = "0.3"
 regex = "1.10.5"
 reqwest = {
     version = "0.13",
@@ -124,10 +124,10 @@ reqwest = {
     features = ["json", "native-tls", "stream", "gzip", "zstd"],
 }
 reqwest-middleware = "0.5"
-rmcp = { version = "2.1.0", default-features = false, features = ["server", "transport-io"] }
+rmcp = { version = "3.3.0", default-features = false, features = ["server", "transport-io"] }
 rmp = "0.8.14"
 rpassword = "7.0"
-rstest = "0.26.1"
+rstest = "0.27.0"
 runtime-format = "0.1.3"
 rustix = { version = "1.1.4", features = ["process", "fs", "pty", "termios", "stdio"] }
 rusty_paserk = { version = "0.5.0", default-features = false, features = ["v4", "serde"] }
@@ -135,12 +135,12 @@ rusty_paserk = { version = "0.5.0", default-features = false, features = ["v4", 
 rusty_paseto = { version = "0.8.0", default-features = false }
 semver = "1.0.20"
 serde = { version = "1.0.202", features = ["derive"] }
-serde_bytes = "0.11"
 serde_json = "1.0.119"
 serde_regex = "1.1.0"
 serde_with = "3.8.1"
 shellexpand = "3"
 shlex = "2.0.1"
+# held at 0.3: crossterm 0.29 pins signal-hook 0.3; bumping would add a 2nd copy
 signal-hook = "0.3"
 sql-builder = "3"
 sqlx = { version = "0.9", features = ["runtime-tokio", "time", "uuid"] }
@@ -149,7 +149,9 @@ strum_macros = "0.28"
 sysinfo = "0.39.6"
 tempfile = { version = "3.19" }
 thiserror = "2"
-time = { version = "0.3.47", features = ["serde-human-readable", "macros", "local-offset"] }
+# 0.3.55 fixes the from_unix_timestamp_nanos overflow (time-rs/time#802) that
+# OffsetDateTimeExt's helpers rely on upstream to reject.
+time = { version = "0.3.55", features = ["serde-human-readable", "macros", "local-offset"] }
 tiny-bip39 = "2"
 tracing = { version = "0.1", features = ["release_max_level_debug"] }
 tokio = { version = "1", features = ["full"] }
@@ -158,11 +160,10 @@ tokio-util = { version = "0.7", features = ["rt"] }
 toml = "1.1"
 toml_edit = "0.25.4"
 tonic = "0.14"
-tonic-build = "0.14"
 tonic-prost = "0.14"
 tonic-prost-build = "0.14"
-tonic-types = "0.14"
 tower = "0.5"
+# held at 0.6: reqwest 0.13 pins tower-http 0.6; bumping would add a 2nd copy
 tower-http = { version = "0.6", features = ["trace"] }
 tracing-appender = "0.2.4"
 tracing-futures = { version = "0.2", features = ["futures-03"] }
@@ -172,11 +173,11 @@ tracing-subscriber = {
     features = ["ansi", "fmt", "registry", "env-filter", "json"],
 }
 tracing-tree = "0.4"
-tree-sitter = "0.26.8"
+tree-sitter = "0.27.0"
 tree-sitter-bash = "0.25.1"
 tree-sitter-fish = "3.6.0"
 tree-sitter-powershell = "0.26.4"
-tui-textarea-2 = "0.10.2"
+tui-textarea-2 = "0.13.2"
 typed-builder = "0.23.2"
 unicode-segmentation = "1.11.0"
 unicode-width = "0.2"
@@ -189,8 +190,10 @@ windows-sys = {
 }
 wiremock = "0.6"
 xxhash-rust = { version = "0.8", features = ["xxh3"] }
+# held at 0.11: 0.12 pulls hashlink 0.12 (a 2nd copy vs sqlx's 0.11) + an encoding_rs/multiversion subtree
 yaml-rust2 = "0.11"
 zeroize = "1"
+# held at 0.13: compression-codecs (via reqwest) pins zstd 0.13; bumping would add a 2nd copy
 zstd = "0.13"
 
 # The profile that 'cargo dist' will build with

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -149,8 +149,6 @@ strum_macros = "0.28"
 sysinfo = "0.39.6"
 tempfile = { version = "3.19" }
 thiserror = "2"
-# 0.3.55 fixes the from_unix_timestamp_nanos overflow (time-rs/time#802) that
-# OffsetDateTimeExt's helpers rely on upstream to reject.
 time = { version = "0.3.55", features = ["serde-human-readable", "macros", "local-offset"] }
 tiny-bip39 = "2"
 tracing = { version = "0.1", features = ["release_max_level_debug"] }

--- a/clippy.toml
+++ b/clippy.toml
@@ -11,17 +11,6 @@ reason = "panics on overflow; use atuin_common::time::DurationExt::try_new"
 path = "std::time::Duration::from_secs_f64"
 reason = "panics on NaN/negative/overflow; use Duration::try_from_secs_f64"
 
-# https://github.com/time-rs/time/issues/802
-[[disallowed-methods]]
-path = "time::OffsetDateTime::from_unix_timestamp_nanos"
-reason = """wraps out-of-range input to a valid-looking wrong date (time-rs/time#802); use \
-    atuin_common::time::OffsetDateTimeExt::from_unix_nanos"""
-
-[[disallowed-methods]]
-path = "time::UtcDateTime::from_unix_timestamp_nanos"
-reason = """same truncation bug as OffsetDateTime (time-rs/time#802); range-check the full i128 \
-    before converting"""
-
 [[disallowed-types]]
 path = "std::sync::Mutex"
 reason = "use parking_lot::Mutex which is faster"

--- a/crates/atuin-ai/Cargo.toml
+++ b/crates/atuin-ai/Cargo.toml
@@ -35,7 +35,6 @@ easy-cast = { workspace = true }
 enum_dispatch = { workspace = true }
 eventsource-stream = { workspace = true }
 eye_declare = { workspace = true }
-eye_declare_engine = { workspace = true }
 eyre = { workspace = true }
 fs-err = { workspace = true }
 futures = { workspace = true }
@@ -45,7 +44,6 @@ parking_lot = { workspace = true }
 pulldown-cmark = { workspace = true }
 ratatui = { workspace = true }
 ratatui-core = { workspace = true }
-ratatui-widgets = { workspace = true }
 regex = { workspace = true }
 reqwest = { workspace = true }
 rmcp = { workspace = true }
@@ -60,7 +58,6 @@ tokio = { workspace = true }
 toml = { workspace = true }
 toml_edit = { workspace = true }
 tracing = { workspace = true }
-tracing-appender = { workspace = true }
 tracing-subscriber = { workspace = true, features = ["ansi", "fmt", "registry", "env-filter"] }
 tree-sitter = { workspace = true, optional = true }
 tree-sitter-bash = { workspace = true, optional = true }
@@ -76,7 +73,7 @@ strum = { workspace = true }
 strum_macros = { workspace = true }
 
 [dev-dependencies]
-pretty_assertions = { workspace = true }
+eye_declare_engine = { workspace = true }
 rstest = { workspace = true }
 
 [lints]

--- a/crates/atuin-ai/src/mcp.rs
+++ b/crates/atuin-ai/src/mcp.rs
@@ -14,8 +14,9 @@ use atuin_client::database::Sqlite;
 use atuin_client::history::{AUTHOR_FILTER_ALL_AGENT, AUTHOR_FILTER_ALL_USER, KNOWN_AGENTS};
 use eyre::Result;
 use rmcp::model::{
-    CallToolRequestParams, CallToolResult, ContentBlock, ErrorData, Implementation,
-    ListToolsResult, PaginatedRequestParams, ServerCapabilities, ServerInfo, Tool, ToolAnnotations,
+    CallToolRequestParams, CallToolResponse, CallToolResult, ContentBlock, ErrorData,
+    Implementation, ListToolsResult, PaginatedRequestParams, ServerCapabilities, ServerInfo, Tool,
+    ToolAnnotations,
 };
 use rmcp::service::RequestContext;
 use rmcp::{RoleServer, ServerHandler, ServiceExt};
@@ -83,7 +84,7 @@ impl ServerHandler for AtuinMcp {
         &self,
         request: CallToolRequestParams,
         _context: RequestContext<RoleServer>,
-    ) -> Result<CallToolResult, ErrorData> {
+    ) -> Result<CallToolResponse, ErrorData> {
         let arguments = Value::Object(request.arguments.unwrap_or_default());
         let outcome = match request.name.as_ref() {
             "atuin_history" => {
@@ -103,7 +104,7 @@ impl ServerHandler for AtuinMcp {
             }
         };
 
-        Ok(match outcome {
+        let result = match outcome {
             ToolOutcome::Success(text) => CallToolResult::success(vec![ContentBlock::text(text)]),
             ToolOutcome::Error(text) => CallToolResult::error(vec![ContentBlock::text(text)]),
             // The atuin tools only produce Success/Error; fall back to the
@@ -111,7 +112,8 @@ impl ServerHandler for AtuinMcp {
             outcome @ ToolOutcome::Structured { .. } => {
                 CallToolResult::success(vec![ContentBlock::text(outcome.format_for_llm(None))])
             }
-        })
+        };
+        Ok(result.into())
     }
 }
 

--- a/crates/atuin-ai/src/tui/app.rs
+++ b/crates/atuin-ai/src/tui/app.rs
@@ -1017,6 +1017,7 @@ impl App for AiApp {
                     InputEvent::Paste(s) => {
                         self.input.get_mut().insert_str(s);
                     }
+                    _ => {}
                 }
                 self.refresh_slash();
             }

--- a/crates/atuin-client/Cargo.toml
+++ b/crates/atuin-client/Cargo.toml
@@ -63,8 +63,6 @@ tracing-futures = { workspace = true }
 typed-builder = { workspace = true }
 url = { workspace = true }
 uuid = { workspace = true }
-whoami = { workspace = true }
-zeroize = { workspace = true }
 
 # encryption
 rusty_paserk = { workspace = true }
@@ -74,7 +72,6 @@ rusty_paseto = { workspace = true }
 indicatif = { workspace = true }
 reqwest = { workspace = true, optional = true }
 reqwest-middleware = { workspace = true, optional = true, features = ["json", "query"] }
-tiny-bip39 = { workspace = true }
 
 # theme
 crossterm = { workspace = true, features = ["serde"] }
@@ -84,7 +81,6 @@ strum_macros = { workspace = true }
 
 # packfile
 zstd = { workspace = true }
-serde_bytes = { workspace = true }
 
 [dev-dependencies]
 # This crate's tests require the `test-utils` feature in atuin-common.

--- a/crates/atuin-client/src/import/xonsh.rs
+++ b/crates/atuin-client/src/import/xonsh.rs
@@ -3,7 +3,6 @@ use std::fs::{self, File};
 use std::path::{Path, PathBuf};
 
 use async_trait::async_trait;
-use atuin_common::time::OffsetDateTimeExt;
 use atuin_domain::record::CmdOrigin;
 use directories::BaseDirs;
 use easy_cast::CastFloat;
@@ -133,7 +132,7 @@ impl Importer for Xonsh {
                 let timestamp = (start * 1_000_000_000_f64)
                     .try_cast_trunc()
                     .ok()
-                    .and_then(|nanos: i128| OffsetDateTime::from_unix_nanos(nanos).ok())
+                    .and_then(|nanos: i128| OffsetDateTime::from_unix_timestamp_nanos(nanos).ok())
                     .unwrap_or(OffsetDateTime::UNIX_EPOCH);
 
                 let duration = ((end - start) * 1_000_000_000_f64)

--- a/crates/atuin-client/src/import/xonsh_sqlite.rs
+++ b/crates/atuin-client/src/import/xonsh_sqlite.rs
@@ -3,7 +3,6 @@ use std::path::PathBuf;
 
 use async_trait::async_trait;
 use atuin_common::db;
-use atuin_common::time::OffsetDateTimeExt;
 use atuin_domain::record::CmdOrigin;
 use directories::BaseDirs;
 use easy_cast::{CastFloat, Conv};
@@ -35,7 +34,7 @@ impl HistDbEntry {
         let timestamp = (self.tsb * 1_000_000_000_f64)
             .try_cast_trunc()
             .ok()
-            .and_then(|nanos: i128| OffsetDateTime::from_unix_nanos(nanos).ok())
+            .and_then(|nanos: i128| OffsetDateTime::from_unix_timestamp_nanos(nanos).ok())
             .unwrap_or(OffsetDateTime::UNIX_EPOCH);
 
         #[expect(

--- a/crates/atuin-common/src/time.rs
+++ b/crates/atuin-common/src/time.rs
@@ -6,7 +6,7 @@ mod utc_offset;
 
 pub use duration::{DurationDisplay, DurationExt, DurationOverflow, DurationStyle};
 pub use offset_date_time::{
-    OffsetDateTimeDisplay, OffsetDateTimeExt, OffsetDateTimeStyle, TimespecOutOfRange,
-    TimestampOutOfRange, YMD_HM, YMD_HMS,
+    OffsetDateTimeDisplay, OffsetDateTimeExt, OffsetDateTimeStyle, TimespecOutOfRange, YMD_HM,
+    YMD_HMS,
 };
 pub use utc_offset::{TimezoneDecodingError, UtcOffsetExt, UtcOffsetSpec};

--- a/crates/atuin-common/src/time/offset_date_time.rs
+++ b/crates/atuin-common/src/time/offset_date_time.rs
@@ -11,16 +11,6 @@ const MIN_UNIX_NANOS: i128 = -377_705_116_800 * 1_000_000_000;
 /// Highest `time::OffsetDateTime` can represent (unix)`9999-12-31 23:59:59.999_999_999 UTC`.
 const MAX_UNIX_NANOS: i128 = 253_402_300_799 * 1_000_000_000 + 999_999_999;
 
-/// Returned when an instant cannot be represented by an [`OffsetDateTime`].
-///
-/// [`OffsetDateTime::from_unix_timestamp_nanos`] reports some of these as a *successful* conversion
-/// to the wrong date -- see <https://github.com/time-rs/time/issues/802>.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, thiserror::Error)]
-#[error("timestamp of {nanos}ns since the unix epoch is out of range")]
-pub struct TimestampOutOfRange {
-    pub nanos: i128,
-}
-
 /// Returned when a seconds/nanoseconds pair cannot be represented by an [`OffsetDateTime`].
 #[derive(Debug, Clone, Copy, PartialEq, Eq, thiserror::Error)]
 #[error("timespec of {secs}s + {nsecs}ns is out of range")]
@@ -31,9 +21,6 @@ pub struct TimespecOutOfRange {
 
 /// Utilities for operating on [`OffsetDateTime`]s.
 pub trait OffsetDateTimeExt {
-    /// Build an [`OffsetDateTime`] from nanoseconds since the unix epoch.
-    fn from_unix_nanos(nanos: i128) -> Result<OffsetDateTime, TimestampOutOfRange>;
-
     /// Build an [`OffsetDateTime`] from an `i64` count of nanoseconds since the unix epoch.
     fn from_unix_nanos_i64(nanos: i64) -> OffsetDateTime;
 
@@ -42,12 +29,6 @@ pub trait OffsetDateTimeExt {
 
     /// Build an [`OffsetDateTime`] from a seconds/nanoseconds pair counted from the unix epoch.
     fn from_timespec(secs: i128, nsecs: i128) -> Result<OffsetDateTime, TimespecOutOfRange>;
-
-    /// Nanoseconds since the unix epoch as an `i64`. Fails outside roughly 1677..2262 AD.
-    fn try_unix_nanos_i64(self) -> Result<i64, TimestampOutOfRange>;
-
-    /// Nanoseconds since the unix epoch as a `u64`. Fails before 1970 and after roughly 2554 AD.
-    fn try_unix_nanos_u64(self) -> Result<u64, TimestampOutOfRange>;
 
     /// How much time has passed since `earlier`, clamped to zero if it is in the future.
     fn saturating_duration_since(self, earlier: OffsetDateTime) -> std::time::Duration;
@@ -134,22 +115,13 @@ const _: () = assert!(
 );
 
 impl OffsetDateTimeExt for OffsetDateTime {
-    #[allow(clippy::disallowed_methods)]
-    fn from_unix_nanos(nanos: i128) -> Result<OffsetDateTime, TimestampOutOfRange> {
-        if !(MIN_UNIX_NANOS..=MAX_UNIX_NANOS).contains(&nanos) {
-            return Err(TimestampOutOfRange { nanos });
-        }
-
-        Self::from_unix_timestamp_nanos(nanos).map_err(|_| TimestampOutOfRange { nanos })
-    }
-
     fn from_unix_nanos_i64(nanos: i64) -> OffsetDateTime {
-        Self::from_unix_nanos(i128::from(nanos))
+        Self::from_unix_timestamp_nanos(i128::from(nanos))
             .expect("the full i64 nanosecond range is representable; asserted at compile time")
     }
 
     fn from_unix_nanos_u64(nanos: u64) -> OffsetDateTime {
-        Self::from_unix_nanos(i128::from(nanos))
+        Self::from_unix_timestamp_nanos(i128::from(nanos))
             .expect("the full u64 nanosecond range is representable; asserted at compile time")
     }
 
@@ -161,17 +133,7 @@ impl OffsetDateTimeExt for OffsetDateTime {
             .and_then(|n| n.checked_add(nsecs))
             .ok_or_else(out_of_range)?;
 
-        Self::from_unix_nanos(nanos).map_err(|_| out_of_range())
-    }
-
-    fn try_unix_nanos_i64(self) -> Result<i64, TimestampOutOfRange> {
-        let nanos = self.unix_timestamp_nanos();
-        i64::try_from(nanos).map_err(|_| TimestampOutOfRange { nanos })
-    }
-
-    fn try_unix_nanos_u64(self) -> Result<u64, TimestampOutOfRange> {
-        let nanos = self.unix_timestamp_nanos();
-        u64::try_from(nanos).map_err(|_| TimestampOutOfRange { nanos })
+        Self::from_unix_timestamp_nanos(nanos).map_err(|_| out_of_range())
     }
 
     fn saturating_duration_since(self, earlier: OffsetDateTime) -> std::time::Duration {
@@ -278,33 +240,6 @@ mod tests {
         assert_eq!(now.saturating_duration_since(earlier).as_secs(), expected_secs);
     }
 
-    #[rstest]
-    #[case::epoch(0)]
-    #[case::typical(1_639_162_832_500_000_000)]
-    #[case::max_i64(i64::MAX)]
-    fn try_unix_nanos_i64_round_trips(#[case] nanos: i64) {
-        let t = OffsetDateTime::from_unix_nanos_i64(nanos);
-        assert_eq!(t.try_unix_nanos_i64(), Ok(nanos));
-    }
-
-    #[rstest]
-    #[case::epoch(0)]
-    #[case::typical(1_639_162_832_500_000_000)]
-    #[case::max_u64(u64::MAX)]
-    fn try_unix_nanos_u64_round_trips(#[case] nanos: u64) {
-        let t = OffsetDateTime::from_unix_nanos_u64(nanos);
-        assert_eq!(t.try_unix_nanos_u64(), Ok(nanos));
-    }
-
-    #[test]
-    fn try_unix_nanos_u64_rejects_pre_epoch() {
-        // the silent `as u64` wrap this replaces turned this into ~2554 AD
-        let before_epoch = OffsetDateTime::from_unix_nanos_i64(-1);
-        assert!(before_epoch.try_unix_nanos_u64().is_err());
-        // ...but it is perfectly fine as an i64
-        assert_eq!(before_epoch.try_unix_nanos_i64(), Ok(-1));
-    }
-
     #[test]
     fn datetime_formats_render_as_documented() {
         let t = OffsetDateTime::from_unix_nanos_i64(1_705_934_107_000_000_000);
@@ -324,17 +259,6 @@ mod tests {
     fn display_matches_the_format_descriptors(#[case] t: OffsetDateTime) {
         assert_eq!(t.display().ymd_hms().to_string(), t.format(YMD_HMS).unwrap());
         assert_eq!(t.display().ymd_hm().to_string(), t.format(YMD_HM).unwrap());
-    }
-
-    #[allow(clippy::disallowed_methods)]
-    #[test]
-    fn from_timespec_guards_a_hole_upstream_still_has() {
-        let two_pow_64: i128 = 1 << 64;
-        assert!(
-            OffsetDateTime::from_unix_timestamp_nanos(two_pow_64 * 1_000_000_000).is_ok(),
-            "precondition: upstream still wraps here"
-        );
-        assert!(OffsetDateTime::from_timespec(two_pow_64, 0).is_err());
     }
 
     proptest! {
@@ -358,9 +282,8 @@ mod tests {
             }
         }
 
-        /// Where upstream is sound (no `i64` truncation), we agree with it exactly.
-        /// This pins the helper to `time`'s own semantics rather than just to itself.
-        #[allow(clippy::disallowed_methods)]
+        /// Where upstream is sound, we agree with it exactly. This pins the helper to
+        /// `time`'s own semantics rather than just to itself.
         #[test]
         fn from_timespec_agrees_with_upstream_in_the_sound_range(
             secs in -400_000_000_000i128..=400_000_000_000,

--- a/crates/atuin-daemon/Cargo.toml
+++ b/crates/atuin-daemon/Cargo.toml
@@ -42,7 +42,6 @@ tokio = { workspace = true }
 tokio-stream = { workspace = true, features = ["sync"] }
 tonic = { workspace = true }
 tonic-prost = { workspace = true }
-tonic-types = { workspace = true }
 tower = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
@@ -59,7 +58,6 @@ tempfile = { workspace = true }
 
 [build-dependencies]
 protox = { workspace = true }
-tonic-build = { workspace = true }
 tonic-prost-build = { workspace = true }
 
 [lints]

--- a/crates/atuin-kv/Cargo.toml
+++ b/crates/atuin-kv/Cargo.toml
@@ -18,7 +18,6 @@ atuin-domain = { workspace = true }
 
 derive_more = { workspace = true }
 eyre = { workspace = true }
-pretty_assertions = { workspace = true }
 rmp = { workspace = true }
 semver = { workspace = true }
 sqlx = { workspace = true }

--- a/crates/atuin-scripts/Cargo.toml
+++ b/crates/atuin-scripts/Cargo.toml
@@ -20,7 +20,6 @@ derive_more = { workspace = true }
 easy-cast = { workspace = true }
 eyre = { workspace = true }
 minijinja = { workspace = true }
-pretty_assertions = { workspace = true }
 rmp = { workspace = true }
 semver = { workspace = true }
 serde = { workspace = true }

--- a/crates/atuin/src/command/client/search/syntax.rs
+++ b/crates/atuin/src/command/client/search/syntax.rs
@@ -137,7 +137,7 @@ fn highlight_powershell(node: tree_sitter::Node, src: &[u8], meanings: &mut [Mea
     let mut captures = cursor.captures(&HIGHLIGHTS_QUERY, node, src);
 
     while let Some((m, capture_index)) = captures.next() {
-        let capture = m.captures[*capture_index];
+        let capture = m.captures()[*capture_index];
         let capture_name = HIGHLIGHTS_QUERY.capture_names()[usize::conv(capture.index)];
 
         let meaning = match capture_name {


### PR DESCRIPTION
## Drop-in major bumps (no code change)

`base64` 0.22→0.23 · `frizbee` 0.12→0.13 · `rstest` 0.26→0.27 · `signal-hook` 0.3→0.4 · `tower-http` 0.6→0.7 · `tui-textarea-2` 0.10→0.13 · `yaml-rust2` 0.11→0.12 · `zstd` 0.13→0.14 ·

---

## Migrated major bumps (breaking API changes)

### `argon2` 0.5 → 0.6
- `PasswordHasher::hash_password` **dropped its salt argument**. The PHC output string (`$argon2id$v=19$m=…$salt$hash`) is compatible.

### `rmcp` 2.1 → 3.3
- `ServerHandler::call_tool` now returns **`CallToolResponse`** (an enum: `Complete(CallToolResult)` / `InputRequired` / `Task`) instead of `CallToolResult` directly.

### `eye_declare` 0.6 → 0.7
- `InputEvent` is now `#[non_exhaustive]`, so the exhaustive `match event { Key … , Paste … }` no longer compiles.

### `tree-sitter` 0.26 → 0.27
- `QueryMatch::captures` became a **private field**; a public `captures()` accessor replaced direct field access.

---

## Held (a dependency of ours pins the old major)

Both carry an inline comment in `Cargo.toml` and were verified against the blocker's latest release:

- **`libsqlite3-sys`** (0.30 → 0.38 available): `sqlx-sqlite` 0.9 (our sqlx) requires `>=0.30.1, <0.38`, and the single `links = "sqlite3"` forbids a second native version. Bumping is impossible until sqlx widens its range.
- **`rusty_paseto`** (0.8 → 0.10 available): `rusty_paserk` 0.5.0 (its own latest) still requires `rusty_paseto ^0.8`. Bumping only duplicates majors.

---

## Removed the `time-rs/time#802` workaround layer
