### PR TITLE
fix(opencode): support opencode V2 plugin API

### DIFF
--- a/crates/atuin/contrib/opencode/atuin.ts
+++ b/crates/atuin/contrib/opencode/atuin.ts
@@ -7,29 +7,40 @@
  * Install with:
  *   atuin hook install opencode
  *
+ * Then make sure the plugin SDK is installed:
+ *
+ *   npm --prefix ~/.config/opencode install --save-exact @opencode/plugin
+ *
  * Then restart opencode.
+ *
+ * This file supports both opencode V1 (>= 1.18.29) and V2 from a single
+ * default export: V1 calls `server()` and uses the returned hooks, while V2
+ * reads the `id` and `setup()` definition and ignores `server()`.
+ * See https://opencode.ai/v2/docs/build/plugins/migrate-v1.
  */
 
-import type { Plugin } from "@opencode-ai/plugin";
+import { Plugin as V2Plugin } from "@opencode/plugin";
+import type { Plugin as V1Plugin } from "@opencode-ai/plugin";
 import { spawn } from "node:child_process";
 
 const ATUIN_AUTHOR = "opencode";
 const ATUIN_TIMEOUT_MS = 10_000;
 
-// opencode's shell tool keeps the id `bash` for compatibility, even though its
-// module is named `shell`.
-const BASH_TOOL = "bash";
+// opencode's shell tool kept the id `bash` for compatibility for a long time;
+// newer releases call it `shell`. The V2 hooks accept either; the V1 hooks
+// keep the original `bash` check.
+const SHELL_TOOLS = new Set(["bash", "shell"]);
 
 // A command that did not exit on its own reports a null exit code, so
 // substitute the conventional code for each of the two ways that happens.
 const EXIT_ABORTED = 130;
 const EXIT_TIMED_OUT = 124;
 
-// A denied command reaches neither `shell.env` nor `tool.execute.after`, so its
-// proposal is never claimed and would sit in the map for the life of the
-// session. Bound the map to cap that. Evicting the oldest can in principle drop
-// a command still waiting at its permission prompt, which just goes unrecorded,
-// but only a handful of calls are ever genuinely in flight at once.
+// A denied command is proposed but never runs, so its proposal is never
+// claimed and would sit in the map for the life of the session. Bound the map
+// to cap that. Evicting the oldest can in principle drop a command still
+// waiting at its permission prompt, which just goes unrecorded, but only a
+// handful of calls are ever genuinely in flight at once.
 const MAX_PROPOSED = 128;
 
 interface Proposal {
@@ -47,17 +58,11 @@ interface AtuinResult {
 	stdout: string;
 }
 
-interface ToolOutput {
-	output: string;
-	metadata: unknown;
-}
-
 /**
  * Run Atuin, resolving rather than rejecting on every failure.
  *
  * Spawned without a shell: a recorded command is arbitrary text that has to
- * reach Atuin as a single argv entry unmangled, which rules out the Bun shell
- * the plugin API hands us.
+ * reach Atuin as a single argv entry unmangled.
  */
 function atuin(args: string[], cwd: string): Promise<AtuinResult> {
 	return new Promise((resolve) => {
@@ -111,13 +116,42 @@ async function startHistory(
 	return historyId.length > 0 ? historyId : undefined;
 }
 
+function toProposal(args: unknown): Proposal | undefined {
+	const { command, description } = (args ?? {}) as {
+		command?: unknown;
+		description?: unknown;
+	};
+	if (typeof command !== "string" || command.length === 0) return undefined;
+	return {
+		command,
+		intent:
+			typeof description === "string" && description.length > 0
+				? description
+				: undefined,
+	};
+}
+
+function rememberProposal(proposed: Map<string, Proposal>, callID: string, args: unknown) {
+	const proposal = toProposal(args);
+	if (!proposal) return;
+
+	if (proposed.size >= MAX_PROPOSED) {
+		const oldest = proposed.keys().next().value;
+		if (oldest !== undefined) proposed.delete(oldest);
+	}
+
+	proposed.set(callID, proposal);
+}
+
+function exitFromMetadata(metadata: unknown): number | undefined {
+	const exit = (metadata as { exit?: unknown } | undefined)?.exit;
+	return typeof exit === "number" ? exit : undefined;
+}
+
 // The tool records an abort or a timeout in its output text rather than as an
 // exit code, so string matching is the only way to tell the two apart.
-function exitCodeFrom(output: ToolOutput): number {
-	const exit = (output.metadata as { exit?: unknown } | undefined)?.exit;
-	if (typeof exit === "number") return exit;
-
-	const text = typeof output.output === "string" ? output.output : "";
+function exitCodeFromText(text: unknown): number {
+	if (typeof text !== "string") return 1;
 	if (text.includes("User aborted the command")) return EXIT_ABORTED;
 	if (/exceeding timeout \d+ ms/.test(text)) return EXIT_TIMED_OUT;
 	return 1;
@@ -133,35 +167,103 @@ async function swallowFailures(work: () => void | Promise<void>): Promise<void> 
 	}
 }
 
-// opencode treats every export of a plugin file as a plugin function and fails
-// to load the file if one is not, so keep this the only export.
-export const AtuinPlugin: Plugin = async ({ directory }) => {
+const v2 = V2Plugin.define({
+	id: "atuin",
+	async setup(ctx) {
+		// Commands opencode has proposed but that have not started yet, keyed
+		// by tool call ID.
+		const proposed = new Map<string, Proposal>();
+		// Atuin history IDs for commands that did start, keyed by tool call ID.
+		const running = new Map<string, Entry>();
+
+		// Unlike V1's `shell.env`, the V2 `create.before` shell hook carries
+		// no tool call ID, only the command about to run and its resolved
+		// working directory. Claim the oldest pending proposal with the same
+		// command text. Shells opencode did not run for a tool call have no
+		// matching proposal and are skipped.
+		async function claim(command: string, cwd: string) {
+			for (const [callID, proposal] of proposed) {
+				if (proposal.command !== command) continue;
+				proposed.delete(callID);
+
+				const historyId = await startHistory(cwd, proposal);
+				if (historyId) running.set(callID, { historyId, cwd });
+				return;
+			}
+		}
+
+		async function finish(
+			callID: string,
+			event:
+				| { status: "completed"; result: { output?: unknown; metadata?: unknown } }
+				| { status: "error"; error: { message: string; metadata?: unknown } },
+		) {
+			proposed.delete(callID);
+
+			const entry = running.get(callID);
+			if (!entry) return;
+			running.delete(callID);
+
+			const exit =
+				event.status === "completed"
+					? (exitFromMetadata(event.result.metadata) ??
+						exitCodeFromText(event.result.output))
+					: (exitFromMetadata(event.error.metadata) ??
+						exitCodeFromText(event.error.message));
+
+			await atuin(
+				["history", "end", entry.historyId, "--exit", String(exit)],
+				entry.cwd,
+			);
+		}
+
+		// Fires when the tool is invoked, before it runs, so only remember
+		// the command here. Starting an entry would record commands the user
+		// went on to deny.
+		await ctx.tool.hook("execute.before", (event) =>
+			swallowFailures(() => {
+				if (!SHELL_TOOLS.has(event.tool)) return;
+				rememberProposal(proposed, String(event.id), event.input);
+			}),
+		);
+
+		// The only hook that runs after the permission prompt but before the
+		// command does, and the only one given the resolved working directory.
+		await ctx.shell.hook("create.before", (event) =>
+			swallowFailures(() => claim(event.command, event.cwd)),
+		);
+
+		// Fires when the tool call completes or fails. Abort and timeout
+		// surface here with a distinctive message but no usable exit code.
+		await ctx.tool.hook("execute.after", (event) =>
+			swallowFailures(() => {
+				if (!SHELL_TOOLS.has(event.tool)) return;
+				if (event.status === "completed") {
+					const result = event.result as {
+						output?: unknown;
+						metadata?: unknown;
+					};
+					return finish(String(event.id), { status: "completed", result });
+				}
+				const error = event.error as { message: string; metadata?: unknown };
+				return finish(String(event.id), { status: "error", error });
+			}),
+		);
+	},
+});
+
+// V1 implementation, kept for opencode 1.x. V1's `shell.env` hook carries the
+// tool call ID, so the claim step is an exact lookup: the only hook that runs
+// after the permission prompt but before the command does is also the only
+// one given both the resolved working directory and the call ID. It also
+// fires for user-run shells and for PTY sessions, which opencode did not run;
+// those are skipped because they have no proposal to claim.
+const server: V1Plugin = async ({ directory }) => {
 	// Commands opencode has proposed but is not yet cleared to run, keyed by
 	// tool call ID.
 	const proposed = new Map<string, Proposal>();
 	// Atuin history IDs for commands that did start, keyed by tool call ID.
 	const running = new Map<string, Entry>();
-
-	function propose(callID: string, args: unknown) {
-		const { command, description } = (args ?? {}) as {
-			command?: unknown;
-			description?: unknown;
-		};
-		if (typeof command !== "string" || command.length === 0) return;
-
-		if (proposed.size >= MAX_PROPOSED) {
-			const oldest = proposed.keys().next().value;
-			if (oldest !== undefined) proposed.delete(oldest);
-		}
-
-		proposed.set(callID, {
-			command,
-			intent:
-				typeof description === "string" && description.length > 0
-					? description
-					: undefined,
-		});
-	}
 
 	async function start(callID: string, cwd: string) {
 		const proposal = proposed.get(callID);
@@ -172,7 +274,7 @@ export const AtuinPlugin: Plugin = async ({ directory }) => {
 		if (historyId) running.set(callID, { historyId, cwd });
 	}
 
-	async function finish(callID: string, output: ToolOutput) {
+	async function finish(callID: string, output: { output: string; metadata: unknown }) {
 		proposed.delete(callID);
 
 		const entry = running.get(callID);
@@ -185,7 +287,9 @@ export const AtuinPlugin: Plugin = async ({ directory }) => {
 				"end",
 				entry.historyId,
 				"--exit",
-				String(exitCodeFrom(output)),
+				String(
+					exitFromMetadata(output.metadata) ?? exitCodeFromText(output.output),
+				),
 			],
 			entry.cwd,
 		);
@@ -196,8 +300,8 @@ export const AtuinPlugin: Plugin = async ({ directory }) => {
 		// Starting an entry would record commands the user went on to deny.
 		"tool.execute.before": (input, output) =>
 			swallowFailures(() => {
-				if (input.tool !== BASH_TOOL) return;
-				propose(input.callID, output.args);
+				if (input.tool !== "bash") return;
+				rememberProposal(proposed, input.callID, output.args);
 			}),
 
 		// The only hook that runs after the permission prompt but before the
@@ -215,8 +319,13 @@ export const AtuinPlugin: Plugin = async ({ directory }) => {
 		// which skip this hook and leave the entry open.
 		"tool.execute.after": (input, output) =>
 			swallowFailures(() => {
-				if (input.tool !== BASH_TOOL) return;
+				if (input.tool !== "bash") return;
 				return finish(input.callID, output);
 			}),
 	};
+};
+
+export default {
+	...v2,
+	server,
 };

--- a/docs/docs/guide/agent-hooks.md
+++ b/docs/docs/guide/agent-hooks.md
@@ -106,6 +106,13 @@ atuin hook install opencode
 
 This writes Atuin's plugin to `~/.config/opencode/plugins/atuin.ts`, or to `$XDG_CONFIG_HOME/opencode/plugins/atuin.ts` if you have set `XDG_CONFIG_HOME`.
 
+The plugin imports the opencode plugin SDK, which opencode does not install for file plugins, so install it once inside your opencode config directory (opencode 1.x needs nothing more than this at runtime; the legacy `server()` implementation it uses is type-only):
+
+```shell
+# or $XDG_CONFIG_HOME/opencode if you have XDG_CONFIG_HOME set
+npm --prefix ~/.config/opencode install --save-exact @opencode/plugin
+```
+
 Then restart opencode. The plugin records every `bash` tool command with author `opencode`, using the tool's description as the entry's intent when opencode supplies one.
 
 Two details are worth knowing:


### PR DESCRIPTION
The opencode template only exports a V1 named plugin function (`export const AtuinPlugin`), so opencode 2.x refuses to load it and no agent commands are recorded:

```
failed to load plugin target=.../plugins/atuin.ts cause="... Plugin must export a default definition with an id and an effect or setup function. (cause: SchemaError(Missing key at [\"default\"]))"
```

This default-exports one definition serving both APIs, per https://opencode.ai/v2/docs/build/plugins/migrate-v1: V1 (>= 1.18.29) calls `server()`, V2 reads `id` + `setup()` and ignores `server()`.

Notes on the V2 port:
- Same propose/claim/finish flow. V2's `shell.create.before` carries no tool call ID, only the command and its resolved cwd, so the claim matches the oldest pending proposal with equal command text (V1's `shell.env` allowed an exact call-ID lookup).
- Accepts the shell tool under either the legacy `bash` id or the newer `shell` id.
- Users also need the V2 SDK resolvable from the plugin file, e.g. `npm --prefix ~/.config/opencode install --save-exact @opencode/plugin` (the installer manages no node deps, same as the V1 `@opencode-ai/plugin` import before it).

Verified: strict `tsc` clean on the template; `setup()` exercised against stubbed tool/shell hooks with a stub `atuin` binary (start with `--intent`, end with correct exit incl. 130 on abort, denied/unmatched commands unrecorded). The V1 `server()` half is the previous logic verbatim and is shape-checked only — I have no V1 binary to run it against.