### PR TITLE
feat(hooks): capture Antigravity (agy) shell commands

### DIFF
--- a/crates/atuin-client/src/history.rs
+++ b/crates/atuin-client/src/history.rs
@@ -26,7 +26,8 @@ pub use capture::CommandCapture;
 /// Known AI agent author values. Used by [`History::is_agent`] to guess who ran a command when the
 /// entry does not state it, and so when matching against [`AuthorPattern::AllAgent`] and
 /// [`AuthorPattern::AllUser`].
-pub const KNOWN_AGENTS: &[&str] = &["claude-code", "codex", "copilot", "opencode", "pi"];
+pub const KNOWN_AGENTS: &[&str] =
+    &["antigravity", "claude-code", "codex", "copilot", "opencode", "pi"];
 
 /// The spelling of [`AuthorPattern::AllUser`] on the command line and in the MCP tool schema.
 pub const AUTHOR_FILTER_ALL_USER: &str = "$all-user";

--- a/crates/atuin/src/command/client/hook.rs
+++ b/crates/atuin/src/command/client/hook.rs
@@ -19,6 +19,9 @@ mod wire;
 use event::HookEvent;
 
 const HOOK_EVENT_TYPES: &[&str] = &["PreToolUse", "PostToolUse", "PostToolUseFailure"];
+/// Antigravity has no `PostToolUseFailure` event; a failed tool call arrives
+/// as `PostToolUse` with a non-empty `error` string instead.
+const AGY_HOOK_EVENT_TYPES: &[&str] = &["PreToolUse", "PostToolUse"];
 const PI_EXTENSION_SOURCE: &str = include_str!("../../../contrib/pi/atuin.ts");
 const OPENCODE_PLUGIN_SOURCE: &str = include_str!("../../../contrib/opencode/atuin.ts");
 
@@ -27,6 +30,12 @@ enum InstallKind {
         config_path: &'static [&'static str],
         hook_command: &'static str,
         matcher: &'static str,
+        /// Where the hook entries live: under a top-level `hooks` object
+        /// (Claude Code, Codex) or under a named container object
+        /// (Antigravity maps hook names to event configurations).
+        container: Option<&'static str>,
+        /// Which lifecycle events to install entries for.
+        events: &'static [&'static str],
     },
     /// An agent that loads TypeScript extensions from a directory, rather than
     /// invoking `atuin hook <agent>` from its config.
@@ -36,6 +45,17 @@ enum InstallKind {
         /// How the user makes the agent pick the file up.
         reload_hint: &'static str,
     },
+}
+
+/// The wire format an agent's hook events arrive in.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum HookFormat {
+    /// `{hook_event_name, tool_name, tool_use_id, tool_input, tool_response}`.
+    Claude,
+    /// `{hookEventName, toolCall: {name, args: {CommandLine}}, conversationId,
+    /// stepIdx, error}`. Antigravity additionally requires an answer on
+    /// stdout: `{"decision": "allow"}` for `PreToolUse`, `{}` afterwards.
+    Agy,
 }
 
 /// The directory an agent's [`InstallKind`] path is relative to.
@@ -57,6 +77,7 @@ struct AgentSpec {
     actor_name: &'static str,
     path_root: PathRoot,
     install_kind: InstallKind,
+    hook_format: HookFormat,
 }
 
 const CLAUDE_CODE: AgentSpec = AgentSpec {
@@ -67,7 +88,10 @@ const CLAUDE_CODE: AgentSpec = AgentSpec {
         config_path: &[".claude", "settings.json"],
         hook_command: "atuin hook claude-code",
         matcher: "Bash",
+        container: None,
+        events: HOOK_EVENT_TYPES,
     },
+    hook_format: HookFormat::Claude,
 };
 
 const CODEX: AgentSpec = AgentSpec {
@@ -78,7 +102,24 @@ const CODEX: AgentSpec = AgentSpec {
         config_path: &[".codex", "hooks.json"],
         hook_command: "atuin hook codex",
         matcher: "^Bash$",
+        container: None,
+        events: HOOK_EVENT_TYPES,
     },
+    hook_format: HookFormat::Claude,
+};
+
+const AGY: AgentSpec = AgentSpec {
+    aliases: &["agy", "antigravity"],
+    actor_name: "antigravity",
+    path_root: PathRoot::Home,
+    install_kind: InstallKind::JsonHooks {
+        config_path: &[".gemini", "config", "hooks.json"],
+        hook_command: "atuin hook agy",
+        matcher: "run_command",
+        container: Some("atuin"),
+        events: AGY_HOOK_EVENT_TYPES,
+    },
+    hook_format: HookFormat::Agy,
 };
 
 const PI: AgentSpec = AgentSpec {
@@ -90,6 +131,7 @@ const PI: AgentSpec = AgentSpec {
         source: PI_EXTENSION_SOURCE,
         reload_hint: "Reload pi with `/reload` or restart pi.",
     },
+    hook_format: HookFormat::Claude,
 };
 
 const OPENCODE: AgentSpec = AgentSpec {
@@ -101,9 +143,10 @@ const OPENCODE: AgentSpec = AgentSpec {
         source: OPENCODE_PLUGIN_SOURCE,
         reload_hint: "Restart opencode to load the plugin.",
     },
+    hook_format: HookFormat::Claude,
 };
 
-const AGENTS: &[&AgentSpec] = &[&CLAUDE_CODE, &CODEX, &OPENCODE, &PI];
+const AGENTS: &[&AgentSpec] = &[&AGY, &CLAUDE_CODE, &CODEX, &OPENCODE, &PI];
 
 struct Agent(&'static AgentSpec);
 
@@ -111,9 +154,9 @@ impl Agent {
     fn from_name(name: &str) -> Result<Self> {
         AGENTS.iter().copied().find(|spec| spec.aliases.contains(&name)).map(Self).ok_or_else(
             || {
-                eyre::eyre!(
-                    "unknown agent: {name}. Supported agents: claude-code, codex, opencode, pi"
-                )
+                let supported =
+                    AGENTS.iter().map(|spec| spec.aliases[0]).collect::<Vec<_>>().join(", ");
+                eyre::eyre!("unknown agent: {name}. Supported agents: {supported}")
             },
         )
     }
@@ -194,7 +237,27 @@ async fn handle(agent_name: &str, settings: &Settings) -> Result<()> {
         return Ok(());
     }
 
+    // Antigravity requires an answer on stdout for every invocation: allow
+    // pre-tool-use hooks (including ones for tools Atuin ignores) and acknowledge
+    // everything else with an empty object.
+    if agent.0.hook_format == HookFormat::Agy {
+        let (is_pre, event) = HookEvent::from_agy_json_str(&input)?;
+        if is_pre {
+            println!(r#"{{"decision":"allow"}}"#);
+        } else {
+            println!("{{}}");
+        }
+        return handle_event(settings, &agent, event).await;
+    }
+
     match HookEvent::from_json_str(&input)? {
+        Some(event) => handle_event(settings, &agent, Some(event)).await,
+        None => Ok(()),
+    }
+}
+
+async fn handle_event(settings: &Settings, agent: &Agent, event: Option<HookEvent>) -> Result<()> {
+    match event {
         Some(HookEvent::Start {
             command,
             intent,
@@ -236,6 +299,8 @@ fn install(agent_name: &str) -> Result<()> {
             config_path,
             hook_command: _,
             matcher: _,
+            container: _,
+            events: _,
         } => {
             let config_path = agent.path(config_path);
 
@@ -304,12 +369,30 @@ fn add_hook_entries(hooks: &mut Value, agent: &Agent) -> Result<()> {
         config_path: _,
         hook_command,
         matcher,
+        container,
+        events,
     } = agent.install_kind()
     else {
         bail!("agent does not use JSON hooks");
     };
 
-    for event_type in HOOK_EVENT_TYPES {
+    // Claude Code and Codex keep hook entries under a top-level `hooks`
+    // object; Antigravity maps hook names to event configurations, so entries
+    // live under a named container instead.
+    let hooks = match container {
+        Some(name) => hooks
+            .as_object_mut()
+            .ok_or_else(|| eyre::eyre!("config is not a JSON object"))?
+            .entry(*name)
+            .or_insert_with(|| Value::Object(serde_json::Map::new())),
+        None => hooks
+            .as_object_mut()
+            .ok_or_else(|| eyre::eyre!("config is not a JSON object"))?
+            .entry("hooks")
+            .or_insert_with(|| Value::Object(serde_json::Map::new())),
+    };
+
+    for event_type in *events {
         let event_hooks = hooks
             .as_object_mut()
             .ok_or_else(|| eyre::eyre!("hooks is not a JSON object"))?
@@ -353,7 +436,7 @@ mod tests {
     use crate::Atuin;
     use crate::command::{AtuinCmd, client};
 
-    #[test]
+    #[rstest]
     fn parse_hook_agent_command() {
         let cmd = Cmd::try_parse_from(["hook", "codex"]).unwrap();
 
@@ -382,9 +465,19 @@ mod tests {
         assert!(matches!(agent.install_kind(), InstallKind::Extension { .. }));
     }
 
+    #[rstest]
+    #[case::agy("agy")]
+    #[case::antigravity("antigravity")]
+    fn agent_from_name_supports_antigravity(#[case] agent_name: &str) {
+        let agent = Agent::from_name(agent_name).unwrap();
+        assert_eq!(agent.actor_name(), "antigravity");
+        assert!(matches!(agent.install_kind(), InstallKind::JsonHooks { .. }));
+        assert_eq!(agent.0.hook_format, HookFormat::Agy);
+    }
+
     /// An agent missing from `KNOWN_AGENTS` would be installable but invisible
     /// to `$all-agent`, and would pollute `$all-user` with its commands.
-    #[test]
+    #[rstest]
     fn every_agent_author_is_a_known_agent() {
         for spec in AGENTS {
             assert!(
@@ -406,8 +499,59 @@ mod tests {
         assert_eq!(xdg_config_home(var.map(OsString::from)), expected);
     }
 
+    /// Antigravity maps hook names to event configurations, so entries live
+    /// under a named container — not under a top-level `hooks` object like
+    /// Claude Code — and only for the two events Antigravity sends.
+    #[rstest]
+    fn agy_install_writes_named_container() {
+        let agent = Agent::from_name("agy").unwrap();
+        let mut root = serde_json::Value::Object(serde_json::Map::new());
+        add_hook_entries(&mut root, &agent).unwrap();
+
+        assert!(root.get("hooks").is_none(), "must not write a Claude-style hooks object");
+        let container = root.get("atuin").expect("must write the atuin container");
+        for event_type in ["PreToolUse", "PostToolUse"] {
+            let entries = container
+                .get(event_type)
+                .and_then(Value::as_array)
+                .expect("event must hold an array of entries");
+            assert_eq!(entries.len(), 1);
+            assert_eq!(entries[0].get("matcher").and_then(Value::as_str), Some("run_command"));
+            let hook = entries[0]
+                .get("hooks")
+                .and_then(Value::as_array)
+                .and_then(|hooks| hooks.first())
+                .expect("entry must hold a hook");
+            assert_eq!(hook.get("type").and_then(Value::as_str), Some("command"));
+            assert_eq!(hook.get("command").and_then(Value::as_str), Some("atuin hook agy"));
+        }
+        assert!(
+            container.get("PostToolUseFailure").is_none(),
+            "Antigravity sends no PostToolUseFailure"
+        );
+    }
+
+    /// Installing twice is idempotent: the second run finds the entries and
+    /// skips them instead of duplicating.
+    #[rstest]
+    fn agy_install_is_idempotent() {
+        let agent = Agent::from_name("antigravity").unwrap();
+        let mut root = serde_json::Value::Object(serde_json::Map::new());
+        add_hook_entries(&mut root, &agent).unwrap();
+        add_hook_entries(&mut root, &agent).unwrap();
+
+        let container = root.get("atuin").expect("must write the atuin container");
+        for event_type in ["PreToolUse", "PostToolUse"] {
+            let entries = container
+                .get(event_type)
+                .and_then(Value::as_array)
+                .expect("event must hold an array of entries");
+            assert_eq!(entries.len(), 1, "{event_type} must not duplicate entries");
+        }
+    }
+
     /// opencode reads plugins from its XDG config directory, not from `$HOME`.
-    #[test]
+    #[rstest]
     fn opencode_plugin_is_rooted_in_the_xdg_config_dir() {
         let agent = Agent::from_name("opencode").unwrap();
         let InstallKind::Extension { extension_path, .. } = agent.install_kind() else {
@@ -421,7 +565,7 @@ mod tests {
         assert!(installed.ends_with("opencode/plugins/atuin.ts"));
     }
 
-    #[test]
+    #[rstest]
     fn parse_top_level_hook_command() {
         let cmd = Atuin::try_parse_from(["atuin", "hook", "codex"]).unwrap();
 

--- a/crates/atuin/src/command/client/hook/event.rs
+++ b/crates/atuin/src/command/client/hook/event.rs
@@ -7,7 +7,7 @@
 use atuin_common::string::NonNulStr;
 use serde_json::error::Category;
 
-use super::wire::{HookEventName, WireHookEvent, WireToolName};
+use super::wire::{AgyEventName, AgyHookEvent, HookEventName, WireHookEvent, WireToolName};
 
 /// Why a hook payload could not be parsed.
 ///
@@ -110,6 +110,79 @@ impl HookEvent {
                 column: err.column(),
                 source: err,
             }),
+        }
+    }
+
+    /// Parse a raw Antigravity hook payload into a [`HookEvent`], or `None`
+    /// when there is nothing to record.
+    ///
+    /// Returns whether the event was a `PreToolUse`, which the caller needs
+    /// even when there is nothing to record: Antigravity requires every
+    /// `PreToolUse` hook to answer `{"decision": "allow"}` on stdout (and
+    /// `{}` for `PostToolUse`), including invocations for tools Atuin ignores.
+    ///
+    /// Antigravity sends no tool-use id, so a start is correlated with its end
+    /// through `conversationId` plus `stepIdx`, and completion carries no
+    /// numeric exit code — a non-empty `error` string means exit 1.
+    pub fn from_agy_json_str(input: &str) -> Result<(bool, Option<Self>), ParseError> {
+        let wire = match serde_json::from_str::<AgyHookEvent>(input) {
+            Ok(wire) => wire,
+            Err(err) if err.classify() == Category::Data => {
+                return Ok((false, None));
+            }
+            Err(err) => {
+                return Err(ParseError::MalformedJson {
+                    line: err.line(),
+                    column: err.column(),
+                    source: err,
+                });
+            }
+        };
+
+        let is_pre = matches!(wire.event_name, AgyEventName::PreToolUse);
+        Ok((is_pre, Self::from_agy(wire)))
+    }
+
+    /// Reduce a decoded Antigravity wire event to a [`HookEvent`], or `None`
+    /// when we don't care about the given event.
+    ///
+    /// We **don't** care about:
+    ///   - Non-`run_command` tool invocations.
+    ///   - Tool invocations missing a command, a conversation id, or a step index:
+    ///     a start could never be matched to its end without all three.
+    fn from_agy(wire: AgyHookEvent) -> Option<Self> {
+        let tool_use_id = match (wire.conversation_id, wire.step_idx) {
+            (Some(conversation_id), Some(step_idx)) if !conversation_id.is_empty() => {
+                format!("{conversation_id}-{step_idx}")
+            }
+            _ => return None,
+        };
+
+        match wire.event_name {
+            AgyEventName::PreToolUse => {
+                let command = wire
+                    .tool_call
+                    .as_ref()
+                    .filter(|call| call.name.as_deref() == Some("run_command"))
+                    .and_then(|call| call.args.as_ref())
+                    .and_then(|args| args.command_line.clone())
+                    .filter(|command| !command.is_empty())?;
+
+                // Antigravity's pre-tool-use args carry no description.
+                Some(HookEvent::Start {
+                    command,
+                    intent: None,
+                    tool_use_id,
+                })
+            }
+            AgyEventName::PostToolUse => {
+                let failed = wire.error.as_deref().is_some_and(|error| !error.is_empty());
+                Some(HookEvent::End {
+                    tool_use_id,
+                    exit: i64::from(failed),
+                })
+            }
+            AgyEventName::Other => None,
         }
     }
 }
@@ -291,6 +364,146 @@ mod tests {
     )]
     fn parses_agent_event(#[case] input: serde_json::Value, #[case] expected: Option<HookEvent>) {
         assert_eq!(HookEvent::from_json_str(&input.to_string()).unwrap(), expected);
+    }
+
+    /// Antigravity payloads decode through [`HookEvent::from_agy_json_str`],
+    /// which additionally reports whether the event was a `PreToolUse` — the
+    /// caller needs that even for skipped events to answer Antigravity's
+    /// mandatory stdout contract.
+    #[rstest]
+    #[case::agy_pre_run_command_starts(
+        json!({
+            "hookEventName": "PreToolUse",
+            "toolCall": {"name": "run_command", "args": {"CommandLine": "npm test", "Cwd": "/workspace"}},
+            "stepIdx": 19,
+            "conversationId": "ec33ebf9",
+        }),
+        (true, Some(HookEvent::Start {
+            command: non_nul("npm test"),
+            intent: None,
+            tool_use_id: "ec33ebf9-19".into(),
+        }))
+    )]
+    // Antigravity's pre-tool-use args carry no description, so there is never
+    // an intent.
+    #[case::agy_pre_has_no_intent(
+        json!({
+            "hookEventName": "PreToolUse",
+            "toolCall": {"name": "run_command", "args": {"CommandLine": "ls"}},
+            "stepIdx": 0,
+            "conversationId": "conv",
+        }),
+        (true, Some(HookEvent::Start {
+            command: non_nul("ls"),
+            intent: None,
+            tool_use_id: "conv-0".into(),
+        }))
+    )]
+    // Non-shell tools are never recorded, but still count as pre-tool-use for
+    // the stdout answer.
+    #[case::agy_pre_other_tool_skipped_but_pre(
+        json!({
+            "hookEventName": "PreToolUse",
+            "toolCall": {"name": "list_dir", "args": {"DirectoryPath": "/tmp"}},
+            "stepIdx": 4,
+            "conversationId": "conv",
+        }),
+        (true, None)
+    )]
+    // A missing tool call has nothing to record.
+    #[case::agy_pre_missing_tool_call_skipped(
+        json!({
+            "hookEventName": "PreToolUse",
+            "stepIdx": 4,
+            "conversationId": "conv",
+        }),
+        (true, None)
+    )]
+    // Without a conversation id a start could never be matched to its end.
+    #[case::agy_pre_missing_conversation_skipped(
+        json!({
+            "hookEventName": "PreToolUse",
+            "toolCall": {"name": "run_command", "args": {"CommandLine": "ls"}},
+            "stepIdx": 4,
+        }),
+        (true, None)
+    )]
+    // Without a step index a start could never be matched to its end.
+    #[case::agy_pre_missing_step_skipped(
+        json!({
+            "hookEventName": "PreToolUse",
+            "toolCall": {"name": "run_command", "args": {"CommandLine": "ls"}},
+            "conversationId": "conv",
+        }),
+        (true, None)
+    )]
+    // An empty command has nothing to record.
+    #[case::agy_pre_empty_command_skipped(
+        json!({
+            "hookEventName": "PreToolUse",
+            "toolCall": {"name": "run_command", "args": {"CommandLine": ""}},
+            "stepIdx": 4,
+            "conversationId": "conv",
+        }),
+        (true, None)
+    )]
+    // A successful post-tool-use (empty error) records exit 0.
+    #[case::agy_post_success_exits_zero(
+        json!({
+            "hookEventName": "PostToolUse",
+            "toolCall": {"name": "run_command", "args": {"CommandLine": "npm test"}},
+            "stepIdx": 5,
+            "error": "",
+            "conversationId": "ec33ebf9",
+        }),
+        (false, Some(HookEvent::End { tool_use_id: "ec33ebf9-5".into(), exit: 0 }))
+    )]
+    // A missing error field also means success.
+    #[case::agy_post_missing_error_exits_zero(
+        json!({
+            "hookEventName": "PostToolUse",
+            "toolCall": {"name": "run_command", "args": {"CommandLine": "ls"}},
+            "stepIdx": 5,
+            "conversationId": "conv",
+        }),
+        (false, Some(HookEvent::End { tool_use_id: "conv-5".into(), exit: 0 }))
+    )]
+    // A non-empty error string records exit 1; Antigravity sends no numeric code.
+    #[case::agy_post_error_exits_one(
+        json!({
+            "hookEventName": "PostToolUse",
+            "toolCall": {"name": "run_command", "args": {"CommandLine": "false"}},
+            "stepIdx": 5,
+            "error": "exit status 1",
+            "conversationId": "conv",
+        }),
+        (false, Some(HookEvent::End { tool_use_id: "conv-5".into(), exit: 1 }))
+    )]
+    // An event name we don't model is ignored and is not pre-tool-use.
+    #[case::agy_unknown_event_skipped(
+        json!({
+            "hookEventName": "Stop",
+            "stepIdx": 5,
+            "conversationId": "conv",
+        }),
+        (false, None)
+    )]
+    // A Claude-shaped payload carries no hookEventName, so the Antigravity
+    // parser skips it rather than cross-reading another agent's events.
+    #[case::agy_parser_ignores_claude_payload(
+        json!({
+            "hook_event_name": "PreToolUse",
+            "tool_name": "Bash",
+            "tool_input": {"command": "ls"},
+            "tool_use_id": "toolu_abc123"
+        }),
+        (false, None)
+    )]
+    fn parses_agy_event(
+        #[case] input: serde_json::Value,
+        #[case] expected: (bool, Option<HookEvent>),
+    ) {
+        assert_eq!(HookEvent::from_agy_json_str(&input.to_string()).unwrap(), expected);
     }
 
     /// Well-formed JSON that isn't a hook event we model is skipped, not an

--- a/crates/atuin/src/command/client/hook/wire.rs
+++ b/crates/atuin/src/command/client/hook/wire.rs
@@ -62,3 +62,64 @@ pub struct WireToolResponse {
     #[serde(rename = "exitCode", default)]
     pub exit_code: Option<i64>,
 }
+
+/// A hook event as Antigravity (`agy`) serializes it on stdin.
+///
+/// Same lifecycle vocabulary as Claude Code (`PreToolUse`/`PostToolUse`) but a
+/// different shape: camelCase keys, the tool call nested under `toolCall`, the
+/// command under `toolCall.args.CommandLine`, and no tool-use id — a start is
+/// correlated with its end through `conversationId` plus `stepIdx`. Completion
+/// carries no numeric exit code, only an `error` string that is empty on
+/// success. See <https://antigravity.google/docs/hooks/>.
+#[derive(Debug, Deserialize)]
+pub struct AgyHookEvent {
+    /// The lifecycle stage. An unrecognized value decodes to [`AgyEventName::Other`].
+    #[serde(rename = "hookEventName")]
+    pub event_name: AgyEventName,
+    /// The proposed or executed tool call. Present on `PreToolUse`/`PostToolUse`.
+    #[serde(rename = "toolCall", default)]
+    pub tool_call: Option<AgyToolCall>,
+    /// Correlates a command's start and end across two hook invocations,
+    /// together with [`AgyHookEvent::step_idx`].
+    #[serde(rename = "conversationId", default)]
+    pub conversation_id: Option<String>,
+    /// The 0-based index of the current step in the trajectory.
+    #[serde(rename = "stepIdx", default)]
+    pub step_idx: Option<i64>,
+    /// Detailed runtime error message when the tool call failed. Empty or
+    /// absent on success. Present on `PostToolUse`; absent elsewhere.
+    #[serde(default)]
+    pub error: Option<String>,
+}
+
+/// The lifecycle stage an Antigravity event represents.
+///
+/// The wire values are `PascalCase` and match these variant names exactly.
+/// Unrecognized values map to [`AgyEventName::Other`] so future or
+/// agent-specific events are skipped rather than rejected.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize)]
+pub enum AgyEventName {
+    PreToolUse,
+    PostToolUse,
+    #[serde(other)]
+    Other,
+}
+
+/// See [`AgyHookEvent::tool_call`].
+#[derive(Debug, Deserialize)]
+pub struct AgyToolCall {
+    /// The tool being executed. We only record `run_command`.
+    #[serde(default)]
+    pub name: Option<String>,
+    /// The arguments passed to the tool.
+    #[serde(default)]
+    pub args: Option<AgyToolArgs>,
+}
+
+/// See [`AgyToolCall::args`].
+#[derive(Debug, Deserialize)]
+pub struct AgyToolArgs {
+    /// The shell command line. Present on `PreToolUse` for `run_command`.
+    #[serde(rename = "CommandLine", default)]
+    pub command_line: Option<NonNulStr>,
+}

--- a/docs/docs/guide/agent-hooks.md
+++ b/docs/docs/guide/agent-hooks.md
@@ -1,12 +1,15 @@
 # AI Agent Hooks
 
-Atuin can capture commands run by AI coding agents (like Claude Code, Codex, opencode, and pi) alongside your regular shell history. Atuin tags each command with the agent that ran it, so you can filter your history by author.
+Atuin can capture commands run by AI coding agents (like Claude Code, Codex, opencode, pi, and Antigravity) alongside your regular shell history. Atuin tags each command with the agent that ran it, so you can filter your history by author.
 
 ## Quick Start
 
 Install hooks for your agent, then restart or reload the agent:
 
 ```shell
+# Antigravity (agy)
+atuin hook install agy
+
 # Claude Code
 atuin hook install claude-code
 
@@ -30,6 +33,7 @@ When `atuin hook install` runs, it writes the agent's config file or extension t
 
 | Agent | Config file / extension |
 |-------|-------------------------|
+| Antigravity | `~/.gemini/config/hooks.json` |
 | Claude Code | `~/.claude/settings.json` |
 | Codex | `~/.codex/hooks.json` |
 | opencode | `~/.config/opencode/plugins/atuin.ts` |
@@ -76,11 +80,24 @@ atuin search -- ''
 atuin search --author '$all-agent' -- ''
 ```
 
-Currently recognized agent names are: `claude-code`, `codex`, `copilot`, `opencode`, and `pi`.
+Currently recognized agent names are: `antigravity`, `claude-code`, `codex`, `copilot`, `opencode`, and `pi`.
 
 ## Supported Agents
 
 For support tiers, see [Supported platforms](../support.md).
+
+### Antigravity
+
+```shell
+atuin hook install agy
+```
+
+This adds hook entries to `~/.gemini/config/hooks.json`. Antigravity calls `atuin hook agy` on each `run_command` tool use, passing the event as JSON on `stdin`, and the hook answers `{"decision": "allow"}` so tool execution is never gated.
+
+Two details are worth knowing:
+
+- Antigravity sends no tool-use id, so a command's start is matched to its end through the conversation id plus the step index, and completion carries no numeric exit code: an empty `error` records exit 0, anything else records exit 1.
+- The hook answers `allow` unconditionally — Atuin observes but never gates execution. Entries open at `PreToolUse`; a command denied at the permission prompt may never reach `PostToolUse`, leaving its entry open.
 
 ### Claude Code
 


### PR DESCRIPTION
Antigravity (`agy`) loads `PreToolUse`/`PostToolUse` hooks from `hooks.json`, but `atuin hook install agy` answers `unknown agent` — and pointing its hook command at the Claude handler would silently record nothing: every field that matters differs (camelCase `hookEventName`, the tool call nested under `toolCall` with the command at `toolCall.args.CommandLine`, no tool-use id, no numeric exit code), and Antigravity requires a decision answer on stdout that atuin never prints.

This adds an `agy`/`antigravity` agent:

- Dedicated wire parser: starts entries for `run_command` with a non-empty `CommandLine`, correlates start/end through `conversationId` plus `stepIdx`, derives exit 0/1 from the `error` string.
- Stdout contract: `{"decision": "allow"}` on `PreToolUse` (Atuin observes but never gates, including for tools it ignores), `{}` afterwards.
- Installer writes entries under a named `atuin` container in `~/.gemini/config/hooks.json` (Antigravity maps hook names to event configurations, not a top-level `hooks` object), only for the two events Antigravity sends.
- Registers `antigravity` as a known agent; docs updated alongside the rest.

Verified: 17 new unit tests (parse matrix, container shape, idempotent install) pass with the existing 53 hook tests and the full `atuin-client` suite; `cargo clippy --tests -- -D warnings` clean; `cargo +nightly fmt --check` clean. Also smoke-tested the built binary end to end: a `PreToolUse`/`PostToolUse` pair for `echo smoke-test-123` printed the right stdout contract and produced a correctly closed history entry (since removed).