### PR TITLE
docs: hide pty-proxy from the help command list

### DIFF
--- a/crates/atuin/src/command/mod.rs
+++ b/crates/atuin/src/command/mod.rs
@@ -22,8 +22,9 @@ pub enum AtuinCmd {
     Client(client::Cmd),
 
     /// PTY proxy for atuin
+    // Plumbing: spawned by the shell integration to capture command output; not for interactive use.
     #[cfg(feature = "pty-proxy")]
-    #[command(alias = "hex")]
+    #[command(alias = "hex", hide = true)]
     PtyProxy(atuin_pty_proxy::PtyProxy),
 
     /// Generate a UUID


### PR DESCRIPTION
I argue that `pty-proxy` is not something that should be user facing. I could not come up with a single use-case where the user would want to run this manually.

@taylordotfish disagrees, so I split this into a separate PR that we can discuss on.

The arguments on both sides are:

**In favor of this PR**:
  - The CLI interface is overwhelming as-is. One less command makes it less overwhelming.
  - Running `atuin pty-proxy` _appears_ to do nothing -- run it and you don't see anything change: no output, no printout, nothing. This leads a user one of two ways:
    * Either they go `atuin pty-proxy --help` to learn more.
    * Or they shrug their shoulders and say "wow what a useless thing, must be something vestigial".
  - There is precedent for hiding commands -- lots of the `shell` integrations are hidden.
  - @markovejnovic's mental model is that nobody _wants_ the `pty-proxy`. `pty-proxy` is something people _need_ in order to get access to features they _want_. Effectively, it's a mechanism for users to get access to command capture, graceful refreshing of the pty, etc. which are things they _want_. Consequently, `pty-proxy` feels like an implementation detail of the larger application, so it shouldn't be publicly exposed.
    
**Against this PR**:
  - Some users (us, developers, were singled-out) run `atuin pty-proxy`, so it's useful to describe that this is something atuin does.
  
  
I leave this PR open and the comment discussion as a spot to debate this. @taylordotfish, please add any other points you might have had that I haven't done justice.